### PR TITLE
Extract Consciousness to microservice

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -6,7 +6,8 @@
 
 ## 🟡 Важно
 * [x] FEATURE: Добавить возможность поиска в интернете.
-* [ ] ARCHITECTURE: Вынести `Consciousness` в отдельный микросервис.
+* [x] ARCHITECTURE: Вынести `Consciousness` в отдельный микросервис.
 
 ## ✅ Выполнено
+* [x] ARCHITECTURE: Вынести `Consciousness` в отдельный микросервис.
 * [x] SECURITY: Изолировать system_execute_code — заменить голый exec() на subprocess с таймаутом 10 сек и без доступа к сети. Код не должен иметь доступ к файловой системе за пределами /tmp/sandbox/ (2026-06-03)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,25 @@
 version: '3.8'
 
 services:
-  magda_bot:
+  magda_consciousness:
     build: .
+    command: uvicorn magda_agent.consciousness.api:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
     env_file:
       - .env
+    environment:
+      - PYTHONPATH=/app
+    restart: unless-stopped
+
+  magda_bot:
+    build: .
+    command: python magda_agent/main.py
+    env_file:
+      - .env
+    environment:
+      - CONSCIOUSNESS_URL=http://magda_consciousness:8000
+      - PYTHONPATH=/app
+    depends_on:
+      - magda_consciousness
     restart: unless-stopped

--- a/magda_agent/consciousness/api.py
+++ b/magda_agent/consciousness/api.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Dict, Any
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.emotions.engine import EmotionalEngine
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.skills import initialize_skills
+from magda_agent.consciousness.core import Consciousness
+from magda_agent.subconsciousness.reflection import Subconsciousness
+
+# Global Instances
+llm_client = LLMClient()
+emotional_engine = EmotionalEngine()
+memory_system = MemorySystem()
+skill_registry = initialize_skills()
+
+consciousness = Consciousness(
+    llm=llm_client,
+    emotions=emotional_engine,
+    memory=memory_system,
+    skills=skill_registry
+)
+
+subconsciousness = Subconsciousness(
+    llm=llm_client,
+    emotions=emotional_engine,
+    memory=memory_system,
+    interval=300 # Reflect every 5 minutes in production
+)
+
+subconsciousness_task = None
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global subconsciousness_task
+    # Startup
+    logging.info("Starting Consciousness Microservice...")
+    subconsciousness_task = asyncio.create_task(subconsciousness.start())
+    yield
+    # Shutdown
+    logging.info("Shutting down Consciousness Microservice...")
+    await subconsciousness.stop()
+    if subconsciousness_task:
+        subconsciousness_task.cancel()
+        try:
+            await subconsciousness_task
+        except asyncio.CancelledError:
+            pass
+
+app = FastAPI(lifespan=lifespan, title="Magda Consciousness Service")
+
+class ProcessRequest(BaseModel):
+    text: str
+
+class ProcessResponse(BaseModel):
+    response: str
+
+@app.post("/process", response_model=ProcessResponse)
+async def process_input(req: ProcessRequest):
+    if not req.text:
+        raise HTTPException(status_code=400, detail="Text cannot be empty")
+    try:
+        response_text = await consciousness.process_input(req.text)
+        return ProcessResponse(response=response_text)
+    except Exception as e:
+        logging.error(f"Error processing input: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/state")
+async def get_state() -> Dict[str, Any]:
+    try:
+        state_text = consciousness.get_internal_state()
+        return {"state": state_text}
+    except Exception as e:
+        logging.error(f"Error getting state: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+if __name__ == "__main__":
+    import uvicorn
+    logging.basicConfig(level=logging.INFO)
+    uvicorn.run("magda_agent.consciousness.api:app", host="0.0.0.0", port=8000, reload=True)

--- a/magda_agent/main.py
+++ b/magda_agent/main.py
@@ -10,35 +10,11 @@ from aiogram.enums import ParseMode
 from aiogram.filters import CommandStart, Command
 from aiogram.types import Message, ErrorEvent
 
-from magda_agent.llm_client import LLMClient
-from magda_agent.emotions.engine import EmotionalEngine
-from magda_agent.memory.storage import MemorySystem
-from magda_agent.skills import initialize_skills
-from magda_agent.consciousness.core import Consciousness
-from magda_agent.subconsciousness.reflection import Subconsciousness
-
-# Initialize Components
-llm_client = LLMClient()
-emotional_engine = EmotionalEngine()
-memory_system = MemorySystem()
-skill_registry = initialize_skills()
-
-consciousness = Consciousness(
-    llm=llm_client,
-    emotions=emotional_engine,
-    memory=memory_system,
-    skills=skill_registry
-)
-
-subconsciousness = Subconsciousness(
-    llm=llm_client,
-    emotions=emotional_engine,
-    memory=memory_system,
-    interval=300 # Reflect every 5 minutes in production
-)
+import httpx
 
 # Initialize Bot and Dispatcher
 BOT_TOKEN = os.getenv("BOT_TOKEN", "dummy_token")
+CONSCIOUSNESS_URL = os.getenv("CONSCIOUSNESS_URL", "http://localhost:8000")
 
 class WhitelistMiddleware(BaseMiddleware):
     def __init__(self):
@@ -77,7 +53,15 @@ async def command_start_handler(message: Message) -> None:
 @dp.message(Command("state"))
 async def command_state_handler(message: Message) -> None:
     """Returns the internal state of the agent."""
-    state_info = consciousness.get_internal_state()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{CONSCIOUSNESS_URL}/state", timeout=10.0)
+            resp.raise_for_status()
+            state_info = resp.json().get("state", "Unknown state")
+    except Exception as e:
+        logging.error(f"Error fetching state from consciousness service: {e}")
+        state_info = f"Error fetching state: {e}"
+
     await message.answer(f"<b>My Internal State:</b>\n<pre>{state_info}</pre>")
 
 @dp.message()
@@ -90,14 +74,23 @@ async def main_message_handler(message: Message) -> None:
     await message.bot.send_chat_action(chat_id=message.chat.id, action="typing")
 
     # Process through consciousness
-    response = await consciousness.process_input(message.text)
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{CONSCIOUSNESS_URL}/process",
+                json={"text": message.text},
+                timeout=60.0
+            )
+            resp.raise_for_status()
+            response = resp.json().get("response", "No response returned.")
+    except Exception as e:
+        logging.error(f"Error calling consciousness service: {e}")
+        response = "Sorry, I am having trouble connecting to my cognitive systems right now."
+
     await message.answer(response)
 
 async def main() -> None:
     bot = Bot(token=BOT_TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
-
-    # Start Subconsciousness in background
-    asyncio.create_task(subconsciousness.start())
 
     # Start Polling
     logging.info("Magda Agent is starting...")
@@ -112,5 +105,3 @@ if __name__ == "__main__":
             logging.info("Magda Agent stopped.")
     else:
         logging.info("Dummy token detected. Running in test mode.")
-        # Minimal verification that modules are linked
-        print(consciousness.get_internal_state())

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ pydantic-settings==2.7.0
 duckduckgo-search
 openai
 pytest-asyncio
+fastapi
+uvicorn
+httpx
+pytest-httpx

--- a/tests/test_consciousness_api.py
+++ b/tests/test_consciousness_api.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, AsyncMock, MagicMock
+from magda_agent.consciousness.api import app
+
+client = TestClient(app)
+
+def test_get_state():
+    with patch("magda_agent.consciousness.api.consciousness") as mock_consciousness:
+        mock_consciousness.get_internal_state.return_value = "Mocked State"
+
+        response = client.get("/state")
+        assert response.status_code == 200
+        assert response.json() == {"state": "Mocked State"}
+
+def test_process_input():
+    with patch("magda_agent.consciousness.api.consciousness") as mock_consciousness:
+        mock_consciousness.process_input = AsyncMock(return_value="Mocked Response")
+
+        response = client.post("/process", json={"text": "Hello Magda"})
+        assert response.status_code == 200
+        assert response.json() == {"response": "Mocked Response"}
+        mock_consciousness.process_input.assert_called_once_with("Hello Magda")
+
+def test_process_input_empty_text():
+    response = client.post("/process", json={"text": ""})
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Text cannot be empty"


### PR DESCRIPTION
Extracts the Consciousness logic from the main monolithic bot script and moves it to a dedicated FastAPI microservice to improve architectural separation.

Key changes:
- Created `magda_agent/consciousness/api.py` serving as the microservice entry point.
- Configured FastAPI `lifespan` hook to manage the `Subconsciousness` reflection loop as a background task.
- Updated the Telegram bot (`magda_agent/main.py`) to process messages and state requests by forwarding them to the consciousness microservice via HTTP requests (`httpx`).
- Modified `docker-compose.yml` to run the consciousness service and injected the configuration.
- Added tests in `tests/test_consciousness_api.py`.
- Checked off the "ARCHITECTURE" task in `backlog.md`.

---
*PR created automatically by Jules for task [634792724327554956](https://jules.google.com/task/634792724327554956) started by @kazah4359-lgtm*