### PR TITLE
feat: parse JSON in Subconsciousness.reflect for dynamic PAD adjustments

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -80,7 +80,7 @@
   Интеграция: Вызывается периодически как фоновая задача.
   Тесты: mock LLM, проверить что рефлексия запускается и `memory.consolidate()` вызывается.
 * [x] IMPROVEMENT: Implement gracefully shutdown for `MemorySystem`'s ephemeral ChromaDB client to prevent resource leaks. Add `close()` method to `MemorySystem` and call it in `api.py` lifespan shutdown. (2026-06-04)
-* [ ] IMPROVEMENT: In `Subconsciousness.reflect`, the LLM prompt for reflection could be more structured to consistently receive PAD adjustments that are then parsed and applied, rather than just hardcoding a dominance increase.
+* [x] IMPROVEMENT: In `Subconsciousness.reflect`, the LLM prompt for reflection could be more structured to consistently receive PAD adjustments that are then parsed and applied, rather than just hardcoding a dominance increase. (2026-06-04)
 * [ ] IMPROVEMENT: `MemorySystem` has a `long_term` list which seems redundant if `LongTermMemory` module is also used. Need to unify long-term memory storage.
 
 ## 🛠️ Запланированные Skills

--- a/magda_agent/subconsciousness/reflection.py
+++ b/magda_agent/subconsciousness/reflection.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 from typing import List
 from magda_agent.llm_client import LLMClient
@@ -60,20 +61,50 @@ class Subconsciousness:
         Based on these events, perform a brief self-reflection.
         How are you doing? Are you fulfilling your goals as an AGI?
         Suggest a minor adjustment to your emotional state (Pleasure, Arousal, Dominance) as a result of this reflection.
-        Return your reflection and the PAD adjustment.
+
+        You MUST respond ONLY with a valid JSON object in the exact format below, with no additional text:
+        {{
+            "reflection": "Your textual self-reflection here",
+            "pad_adjustment": {{
+                "p": 0.0,
+                "a": 0.0,
+                "d": 0.0
+            }}
+        }}
         """
 
         # We don't want to spam the LLM too much, but for PoC we do it once per reflection cycle
-        reflection = await self.llm.chat_completion([{"role": "system", "content": "You are Magda's subconscious mind."}, {"role": "user", "content": prompt}])
+        raw_response = await self.llm.chat_completion([{"role": "system", "content": "You are Magda's subconscious mind. Always output valid JSON."}, {"role": "user", "content": prompt}])
 
-        logging.info(f"Reflection result: {reflection}")
+        logging.info(f"Raw reflection response: {raw_response}")
+
+        reflection_text = "Parsed reflection failed."
+        p_adj, a_adj, d_adj = 0.02, -0.01, 0.05  # Defaults
+
+        try:
+            # Try to strip markdown if present
+            cleaned_response = raw_response.strip()
+            if cleaned_response.startswith("```json"):
+                cleaned_response = cleaned_response[7:]
+            if cleaned_response.startswith("```"):
+                cleaned_response = cleaned_response[3:]
+            if cleaned_response.endswith("```"):
+                cleaned_response = cleaned_response[:-3]
+
+            parsed_data = json.loads(cleaned_response.strip())
+            reflection_text = parsed_data.get("reflection", "No reflection text provided.")
+            pad_adj = parsed_data.get("pad_adjustment", {})
+            p_adj = float(pad_adj.get("p", 0.0))
+            a_adj = float(pad_adj.get("a", 0.0))
+            d_adj = float(pad_adj.get("d", 0.0))
+        except (json.JSONDecodeError, ValueError, TypeError, AttributeError) as e:
+            logging.error(f"Failed to parse subconscious reflection JSON: {e}")
 
         # 3. Apply emotional "reward" or "punishment" based on reflection
-        # For PoC, we just slightly increase dominance to simulate "self-growth"
-        self.emotions.update(0.02, -0.01, 0.05)
+        self.emotions.update(p_adj, a_adj, d_adj)
 
         self.memory.add_memory(
-            content=f"Subconscious reflection: {reflection}",
+            content=f"Subconscious reflection: {reflection_text}",
             importance=0.4,
             emotional_state=self.emotions.state,
             tags=["reflection", "internal"]

--- a/tests/test_subconsciousness.py
+++ b/tests/test_subconsciousness.py
@@ -8,7 +8,18 @@ from magda_agent.memory.storage import MemorySystem, MemoryEntry
 @pytest.fixture
 def mock_llm_client():
     mock = AsyncMock(spec=LLMClient)
-    mock.chat_completion.return_value = "I am doing well."
+    mock.chat_completion.return_value = """
+    ```json
+    {
+        "reflection": "I am doing well and growing.",
+        "pad_adjustment": {
+            "p": 0.1,
+            "a": -0.05,
+            "d": 0.15
+        }
+    }
+    ```
+    """
     return mock
 
 @pytest.fixture
@@ -47,13 +58,13 @@ async def test_subconsciousness_reflect(subconsciousness, mock_llm_client, mock_
     # Verify LLM was called
     mock_llm_client.chat_completion.assert_called_once()
 
-    # Verify emotions were updated
-    mock_emotions.update.assert_called_once_with(0.02, -0.01, 0.05)
+    # Verify emotions were updated with PARSED values
+    mock_emotions.update.assert_called_once_with(0.1, -0.05, 0.15)
 
     # Verify reflection was stored in memory
     mock_memory_system.add_memory.assert_called_once()
     call_args = mock_memory_system.add_memory.call_args[1]
-    assert "Subconscious reflection: I am doing well." in call_args["content"]
+    assert "Subconscious reflection: I am doing well and growing." in call_args["content"]
     assert call_args["tags"] == ["reflection", "internal"]
     assert call_args["importance"] == 0.4
 


### PR DESCRIPTION
Fixes backlog item: "In Subconsciousness.reflect, the LLM prompt for reflection could be more structured to consistently receive PAD adjustments that are then parsed and applied, rather than just hardcoding a dominance increase."

---
*PR created automatically by Jules for task [13884721499655034246](https://jules.google.com/task/13884721499655034246) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse JSON from LLM in `Subconsciousness.reflect` for dynamic PAD emotion adjustments
> - Updates [`reflection.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/32/files#diff-27adde86db1e57977c579551004975d419779d0ce3c324009acc3ea257ff5b41) to instruct the LLM to return a structured JSON object with `reflection` and `pad_adjustment` fields (`p`, `a`, `d`) instead of plain text.
> - Parses the JSON response (stripping optional markdown fences) and passes the extracted float values to `self.emotions.update()`.
> - Falls back to hardcoded defaults (`p=0.02, a=-0.01, d=0.05`) and logs an error if JSON parsing fails.
> - Behavioral Change: PAD emotion deltas are now LLM-driven rather than hardcoded; parsing failures silently apply default deltas.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88248d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->