### PR TITLE
Implement Insula module for interoception

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -11,6 +11,12 @@
 
 ## 🧠 Архитектура мозга
 
+* [x] MODULE: **Insula (Инсула)** — модуль `magda_agent/emotions/insula.py`. (2026-06-04)
+  Интеграция с внутренними состояниями агента для генерации эмоциональных откликов.
+  Метод `process_interoception(energy, boredom)` рассчитывает влияние внутреннего состояния на эмоции.
+  Интеграция: Вызывается в Consciousness после обновления Hypothalamus, передавая результаты в EmotionalEngine.
+  Тесты: mock LLM, проверить логику сдвигов valence, arousal, dominance в зависимости от energy и boredom.
+
 * [x] MODULE: **Prefrontal Cortex (Планировщик)** — модуль `magda_agent/planning/planner.py`. (2026-06-03)
   Разбивает сложные запросы пользователя на последовательность шагов (план).
   Выбирает какие Skills использовать для каждого шага.

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -19,6 +19,7 @@ from magda_agent.metacognition.evaluator import Evaluator
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.thalamus.router import Thalamus
 from magda_agent.drives.hypothalamus import Hypothalamus
+from magda_agent.emotions.insula import Insula
 
 logging.basicConfig(level=logging.INFO)
 
@@ -33,6 +34,7 @@ evaluator = Evaluator(llm=llm_client, memory=memory_system)
 attachment_model = AttachmentModel()
 thalamus = Thalamus()
 hypothalamus = Hypothalamus()
+insula = Insula()
 
 consciousness = Consciousness(
     llm=llm_client,
@@ -45,7 +47,8 @@ consciousness = Consciousness(
     habit_tracker=habit_tracker,
     attachment=attachment_model,
     thalamus=thalamus,
-    hypothalamus=hypothalamus
+    hypothalamus=hypothalamus,
+    insula=insula
 )
 
 subconsciousness = Subconsciousness(

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -12,6 +12,7 @@ from magda_agent.emotions.attachment import AttachmentModel
 from magda_agent.thalamus.router import Thalamus
 from magda_agent.action.selector import BasalGanglia
 from magda_agent.drives.hypothalamus import Hypothalamus
+from magda_agent.emotions.insula import Insula
 
 class Consciousness:
     """
@@ -31,7 +32,8 @@ class Consciousness:
         attachment: Optional[AttachmentModel] = None,
         thalamus: Optional[Thalamus] = None,
         basal_ganglia: Optional[BasalGanglia] = None,
-        hypothalamus: Optional[Hypothalamus] = None
+        hypothalamus: Optional[Hypothalamus] = None,
+        insula: Optional[Insula] = None
     ):
         self.llm = llm
         self.emotions = emotions
@@ -45,6 +47,7 @@ class Consciousness:
         self.thalamus = thalamus
         self.basal_ganglia = basal_ganglia
         self.hypothalamus = hypothalamus
+        self.insula = insula
 
     async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
@@ -58,6 +61,13 @@ class Consciousness:
 
         if self.hypothalamus:
             self.hypothalamus.update(1.0) # High activity processing input
+
+            if self.insula:
+                v_shift, a_shift, d_shift = self.insula.process_interoception(
+                    self.hypothalamus.energy,
+                    self.hypothalamus.boredom
+                )
+                self.emotions.update(v_shift, a_shift, d_shift)
 
         # 2. Memory Retrieval
         relevant_memories = self.memory.retrieve_relevant(user_input, user_id=user_id)

--- a/magda_agent/emotions/insula.py
+++ b/magda_agent/emotions/insula.py
@@ -1,0 +1,42 @@
+from typing import Tuple
+
+class Insula:
+    """
+    Insula (Инсула / Островковая доля) module.
+    Responsible for interoception and integrating internal bodily states (like energy and boredom)
+    into emotional shifts (valence, arousal, dominance).
+    """
+
+    def process_interoception(self, energy: float, boredom: float) -> Tuple[float, float, float]:
+        """
+        Calculates emotional shifts based on current internal states.
+
+        Args:
+            energy (float): Current energy level (0.0 to 1.0)
+            boredom (float): Current boredom level (0.0 to 1.0)
+
+        Returns:
+            Tuple[float, float, float]: (valence_shift, arousal_shift, dominance_shift)
+        """
+        valence_shift = 0.0
+        arousal_shift = 0.0
+        dominance_shift = 0.0
+
+        # Low energy leads to negative valence, lower arousal, and lower dominance
+        if energy < 0.3:
+            valence_shift -= 0.05
+            arousal_shift -= 0.05
+            dominance_shift -= 0.05
+
+        # High energy can boost arousal and dominance slightly
+        elif energy > 0.8:
+            arousal_shift += 0.02
+            dominance_shift += 0.02
+
+        # High boredom leads to negative valence, lower arousal, and lower dominance
+        if boredom > 0.7:
+            valence_shift -= 0.05
+            arousal_shift -= 0.02
+            dominance_shift -= 0.02
+
+        return valence_shift, arousal_shift, dominance_shift

--- a/tests/test_insula.py
+++ b/tests/test_insula.py
@@ -1,0 +1,45 @@
+import pytest
+from magda_agent.emotions.insula import Insula
+
+def test_process_interoception_low_energy():
+    insula = Insula()
+    # Test low energy
+    v_shift, a_shift, d_shift = insula.process_interoception(energy=0.2, boredom=0.5)
+    assert v_shift == -0.05
+    assert a_shift == -0.05
+    assert d_shift == -0.05
+
+def test_process_interoception_high_energy():
+    insula = Insula()
+    # Test high energy
+    v_shift, a_shift, d_shift = insula.process_interoception(energy=0.9, boredom=0.5)
+    assert v_shift == 0.0
+    assert a_shift == 0.02
+    assert d_shift == 0.02
+
+def test_process_interoception_high_boredom():
+    insula = Insula()
+    # Test high boredom (normal energy)
+    v_shift, a_shift, d_shift = insula.process_interoception(energy=0.5, boredom=0.8)
+    assert v_shift == -0.05
+    assert a_shift == -0.02
+    assert d_shift == -0.02
+
+def test_process_interoception_normal_state():
+    insula = Insula()
+    # Normal energy and boredom should result in zero shifts
+    v_shift, a_shift, d_shift = insula.process_interoception(energy=0.5, boredom=0.5)
+    assert v_shift == 0.0
+    assert a_shift == 0.0
+    assert d_shift == 0.0
+
+def test_process_interoception_low_energy_and_high_boredom():
+    insula = Insula()
+    # Test combination of low energy and high boredom
+    v_shift, a_shift, d_shift = insula.process_interoception(energy=0.2, boredom=0.8)
+    # Valence: -0.05 (energy) - 0.05 (boredom) = -0.1
+    # Arousal: -0.05 (energy) - 0.02 (boredom) = -0.07
+    # Dominance: -0.05 (energy) - 0.02 (boredom) = -0.07
+    assert v_shift == pytest.approx(-0.1)
+    assert a_shift == pytest.approx(-0.07)
+    assert d_shift == pytest.approx(-0.07)


### PR DESCRIPTION
Implemented the Insula (Инсула / Островковая доля) module for the Magda AI agent's brain architecture. This module integrates internal bodily states, such as energy and boredom from the Hypothalamus, and translates them into emotional shifts (valence, arousal, dominance) for the Emotional Engine. The module has been fully integrated into the Consciousness event loop in `core.py` and the `api.py` pipeline. Covered with rigorous unit tests and verified successfully without regressions.

---
*PR created automatically by Jules for task [10063108741613767786](https://jules.google.com/task/10063108741613767786) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `Insula` module for interoceptive emotion shifts
> - Adds [insula.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/36/files#diff-6415668bbfee0f5e546aa1b033ff1199c01c5c25feec4c12d937c6a650573564) with `Insula.process_interoception(energy, boredom)`, which returns deterministic `(valence, arousal, dominance)` shifts based on low energy (<0.3), high energy (>0.8), and high boredom (>0.7) thresholds.
> - Wires `Insula` into `Consciousness.process_input` so that after each `Hypothalamus` update, interoceptive shifts are applied to the emotional state via `self.emotions.update`.
> - Unit tests in [test_insula.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/36/files#diff-95d1a0474877f3e8d6362cf783689c7cdc5ecc83f0af392ab9f2f330bf87494d) cover the five main cases: low energy, high energy, high boredom, normal state, and combined low energy with high boredom.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83b16ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->