### PR TITLE
feat(brainstem): implement autonomous reflex module for emergency commands

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -70,6 +70,12 @@
   Интеграция: Consciousness вызывает обновление drives при обработке ввода.
   Тесты: проверить логику обновления (уменьшение энергии, изменение скуки) и границы.
 
+* [x] MODULE: **Brainstem (Ствол мозга - Автономные рефлексы)** — модуль `magda_agent/reflexes/brainstem.py`. (2026-06-04)
+  Обрабатывает экстренные команды (stop, help, emergency) для быстрого ответа в обход LLM.
+  Метод `process_reflex(text)` — возвращает быстрый ответ или None.
+  Интеграция: Вызывается в Consciousness сразу после Thalamus.
+  Тесты: проверить, что при экстренных командах возвращается быстрый ответ, а обычные запросы идут дальше.
+
 ---
 
 ## ✅ Выполнено
@@ -101,6 +107,7 @@
 * [x] IMPROVEMENT: In `Subconsciousness.reflect`, the LLM prompt for reflection could be more structured to consistently receive PAD adjustments that are then parsed and applied, rather than just hardcoding a dominance increase. (2026-06-04)
 * [ ] IMPROVEMENT: `MemorySystem` has a `long_term` list which seems redundant if `LongTermMemory` module is also used. Need to unify long-term memory storage.
 
+* [ ] BUG: `Brainstem` integration in `Consciousness.process_input` does not halt long-running skills gracefully upon a 'stop' command. Need to implement a cancellation token or mechanism for active background tasks when a stop reflex is triggered. (2026-06-04)
 ## 🛠️ Запланированные Skills
 
 * [x] SKILL: **Omnichannel Provider (Работа с провайдерами)** — модуль `magda_agent/skills/omnichannel.py`. (2026-06-04)

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -13,6 +13,7 @@ from magda_agent.thalamus.router import Thalamus
 from magda_agent.action.selector import BasalGanglia
 from magda_agent.drives.hypothalamus import Hypothalamus
 from magda_agent.emotions.insula import Insula
+from magda_agent.reflexes.brainstem import Brainstem
 
 class Consciousness:
     """
@@ -33,7 +34,8 @@ class Consciousness:
         thalamus: Optional[Thalamus] = None,
         basal_ganglia: Optional[BasalGanglia] = None,
         hypothalamus: Optional[Hypothalamus] = None,
-        insula: Optional[Insula] = None
+        insula: Optional[Insula] = None,
+        brainstem: Optional[Brainstem] = None
     ):
         self.llm = llm
         self.emotions = emotions
@@ -48,12 +50,20 @@ class Consciousness:
         self.basal_ganglia = basal_ganglia
         self.hypothalamus = hypothalamus
         self.insula = insula
+        self.brainstem = brainstem
 
     async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
 
         if self.thalamus and not self.thalamus.filter_input(user_input):
             return "Message ignored by Thalamus."
+
+        # 0. Brainstem Autonomic Reflexes
+        if self.brainstem:
+            reflex_response = self.brainstem.process_reflex(user_input)
+            if reflex_response:
+                logging.info(f"Brainstem reflex triggered for: {user_input}")
+                return reflex_response
 
         # 1. Perception & Emotion Update (Initial reaction)
         # For simplicity, we just slightly increase arousal when receiving input

--- a/magda_agent/reflexes/brainstem.py
+++ b/magda_agent/reflexes/brainstem.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+class Brainstem:
+    """
+    Brainstem module (Ствол мозга - Автономные рефлексы).
+    Handles immediate autonomous responses to emergency commands like "stop", "help", or "emergency",
+    bypassing the conscious processing (LLM) for rapid reaction.
+    """
+
+    def process_reflex(self, text: str) -> Optional[str]:
+        """
+        Process the input text to see if it triggers an autonomous reflex.
+
+        Args:
+            text (str): The input text from the user.
+
+        Returns:
+            Optional[str]: A rapid response string if a reflex is triggered, else None.
+        """
+        if not text:
+            return None
+
+        lower_text = text.lower().strip()
+
+        if lower_text in ["stop", "стоп"]:
+            return "Emergency Stop triggered. Halting current processes."
+        elif lower_text in ["help", "помощь", "emergency", "экстренно"]:
+            return "Emergency Assistance reflex triggered. How can I help you immediately?"
+
+        return None

--- a/tests/test_brainstem.py
+++ b/tests/test_brainstem.py
@@ -1,0 +1,83 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.reflexes.brainstem import Brainstem
+from magda_agent.consciousness.core import Consciousness
+
+def test_brainstem_reflex_stop():
+    brainstem = Brainstem()
+    response = brainstem.process_reflex("stop")
+    assert response == "Emergency Stop triggered. Halting current processes."
+
+    response_ru = brainstem.process_reflex(" СТОП ")
+    assert response_ru == "Emergency Stop triggered. Halting current processes."
+
+def test_brainstem_reflex_help():
+    brainstem = Brainstem()
+    response = brainstem.process_reflex("help")
+    assert response == "Emergency Assistance reflex triggered. How can I help you immediately?"
+
+    response_ru = brainstem.process_reflex("помощь")
+    assert response_ru == "Emergency Assistance reflex triggered. How can I help you immediately?"
+
+def test_brainstem_no_reflex():
+    brainstem = Brainstem()
+    response = brainstem.process_reflex("hello how are you")
+    assert response is None
+
+    response_empty = brainstem.process_reflex("")
+    assert response_empty is None
+
+@pytest.mark.asyncio
+async def test_brainstem_integration():
+    # Setup mocks
+    mock_llm = MagicMock()
+    mock_emotions = MagicMock()
+    mock_memory = MagicMock()
+    mock_skills = MagicMock()
+
+    brainstem = Brainstem()
+
+    core = Consciousness(
+        llm=mock_llm,
+        emotions=mock_emotions,
+        memory=mock_memory,
+        skills=mock_skills,
+        brainstem=brainstem
+    )
+
+    # Test triggering reflex
+    response = await core.process_input("stop")
+
+    # Verify we got the early return reflex response
+    assert response == "Emergency Stop triggered. Halting current processes."
+
+    # Verify core did NOT process further
+    mock_emotions.update.assert_not_called()
+    mock_llm.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_brainstem_integration_no_reflex():
+    # Setup mocks
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value="mock response")
+    mock_emotions = MagicMock()
+    mock_memory = MagicMock()
+    mock_skills = MagicMock()
+
+    brainstem = Brainstem()
+
+    core = Consciousness(
+        llm=mock_llm,
+        emotions=mock_emotions,
+        memory=mock_memory,
+        skills=mock_skills,
+        brainstem=brainstem
+    )
+
+    # Test no reflex
+    response = await core.process_input("hello")
+
+    # Verify core processed normally
+    assert response == "mock response"
+    mock_emotions.update.assert_called()
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Added a new `Brainstem` module for handling autonomous reflexes (like "stop" or "help") that bypasses standard LLM processing. This allows the AI agent to react immediately to emergency commands. Integrated it into the core `Consciousness` loop and added extensive mock-based testing. Updated the project backlog and documented a potential bug relating to long-running task cancellation.

---
*PR created automatically by Jules for task [15306072623336751379](https://jules.google.com/task/15306072623336751379) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add autonomous reflex module to `Consciousness` for emergency commands
> - Adds a new [`Brainstem`](https://github.com/kazah4359-lgtm/Magda-agent/pull/37/files#diff-f5c678f2be8bca5c8a4e2ecfd5bf7ffd4d413cb08979a002cf3acd0488d030dc) class with a `process_reflex(text)` method that returns canned responses for stop/help/emergency inputs in English and Russian, and `None` otherwise.
> - Integrates `Brainstem` into [`Consciousness.process_input`](https://github.com/kazah4359-lgtm/Magda-agent/pull/37/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) as an optional early-exit check: matching inputs return immediately, bypassing emotion updates and LLM calls.
> - Unit and async integration tests in [`tests/test_brainstem.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/37/files#diff-5b44720900e41f3c02c6aa76bd4b576e51eefabf57bc8310e5eef9cb14ccbca7) cover reflex and non-reflex paths in both languages.
> - Behavioral Change: when `Brainstem` is provided, recognized emergency inputs never reach the LLM or emotion subsystem.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e039f01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->