### PR TITLE
Make skill imports cross-platform

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -89,7 +89,7 @@
     },
     {
       "id": "cross-platform-skill-imports",
-      "status": "todo",
+      "status": "done",
       "area": "stabilization",
       "risk": "low",
       "title": "Make skill imports cross-platform",

--- a/magda_agent/skills/system_execute_code.py
+++ b/magda_agent/skills/system_execute_code.py
@@ -1,10 +1,18 @@
 import subprocess
 import tempfile
 import os
-import resource
+
+try:
+    import resource
+    HAS_RESOURCE = True
+except ImportError:
+    HAS_RESOURCE = False
 
 def set_limits():
     """Set resource limits for the subprocess to prevent fork bombs and restrict resources."""
+    if not HAS_RESOURCE:
+        return
+
     # Limit to 0 to prevent creating new processes (effectively blocking subprocess/os.system bypasses)
     try:
         resource.setrlimit(resource.RLIMIT_NPROC, (0, 0))
@@ -86,14 +94,21 @@ except Exception as e:
 
         cmd = ["python3", wrapper_path]
 
+        kwargs = {
+            'stdout': subprocess.PIPE,
+            'stderr': subprocess.STDOUT,
+            'text': True,
+            'timeout': 10.0,
+            'cwd': sandbox_dir,
+        }
+
+        # preexec_fn is not supported on Windows
+        if os.name != 'nt' and HAS_RESOURCE:
+            kwargs['preexec_fn'] = set_limits
+
         result = subprocess.run(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            timeout=10.0,
-            cwd=sandbox_dir,
-            preexec_fn=set_limits # Apply resource limits before executing
+            **kwargs
         )
         return result.stdout
     except subprocess.TimeoutExpired as e:


### PR DESCRIPTION
This change updates `magda_agent/skills/system_execute_code.py` to prevent Linux-only sandbox dependencies from breaking the import of `magda_agent.skills` on non-Linux environments.

- Wrapped `import resource` in a `try-except ImportError` block.
- Conditionally apply `preexec_fn=set_limits` in `subprocess.run` only if the `resource` module was successfully imported and the platform is not Windows (i.e. `os.name != 'nt'`).
- The `cross-platform-skill-imports` task status in `agent_tasks.json` has been updated to `"done"`.

---
*PR created automatically by Jules for task [2958126942142858929](https://jules.google.com/task/2958126942142858929) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make skill imports cross-platform by guarding `resource` module usage in `system_execute_code`
> - Guards the import of the Unix-only `resource` module with a `HAS_RESOURCE` flag in [system_execute_code.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/44/files#diff-160a16aacf772d02a18753c0419df3951089c311f139fa13903a2d36d840c34d), allowing the module to load on Windows.
> - `set_limits` becomes a no-op when `HAS_RESOURCE` is `False`, and `preexec_fn` is omitted from `subprocess.run` on Windows (`os.name == 'nt'`) to avoid a `ValueError`.
> - Behavioral Change: on Windows, no resource limits (RLIMIT_NPROC, RLIMIT_AS) are applied to subprocesses; all other parameters (stdout capture, timeout, cwd) remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 963124a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->