### PR TITLE
Add Codex worker bridge

### DIFF
--- a/.github/workflows/jules_next_task.yml
+++ b/.github/workflows/jules_next_task.yml
@@ -24,7 +24,7 @@ jobs:
           You are building a digital brain for Magda AI Agent (Python, asyncio, aiogram Telegram bot).
 
           TASK:
-          1. Read docs/cognitive_architecture.md and docs/jules_autonomous_loop.md to understand the target cognitive architecture and autonomous operating model.
+          1. Read AGENTS.md, docs/cognitive_architecture.md, docs/jules_autonomous_loop.md, and docs/codex_worker_plan.md to understand the target cognitive architecture, autonomous operating model, and Codex worker surface.
           2. Open agent_tasks.json in the repo root.
           3. Check replenishment_policy. If no "todo" tasks remain, or fewer than minimum_todo_tasks remain, first add a batch of new low/medium-risk "todo" tasks from docs/cognitive_architecture.md, failing tests, TODO comments, and current architecture gaps.
           4. Find the FIRST task with status "todo".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Magda Agent - Codex/Jules Working Guide
+
+This repository is an experimental cognitive agent with a Jules/Codex self-improvement loop.
+
+## Source Priority
+
+Before changing code, read these files in order:
+
+1. `agent_tasks.json`
+2. `docs/jules_autonomous_loop.md`
+3. `docs/cognitive_architecture.md`
+4. `docs/hermes_inspired_feature_plan.md`
+5. `docs/codex_worker_plan.md`
+6. `backlog.md`
+
+Use `agent_tasks.json` as the machine-readable source of truth. Markdown backlog files are secondary compatibility surfaces.
+
+## Task Selection
+
+Use the Codex bridge when possible:
+
+```bash
+python -m magda_agent.codex_bridge validate
+python -m magda_agent.codex_bridge next-task
+python -m magda_agent.codex_bridge render-prompt
+```
+
+Pick the first task with status `todo` unless it is blocked by high/critical risk.
+
+If fewer than `replenishment_policy.minimum_todo_tasks` tasks remain, add a batch of low/medium-risk tasks from the docs and current failure signals instead of asking the user what to do next.
+
+## Risk Rules
+
+Do not modify these without explicit task permission and review:
+
+- `.github/workflows/**`
+- `requirements.txt`
+- Docker/deployment files
+- sandbox or code execution policy
+- secrets/env handling
+- auto-merge permissions
+- external messaging providers
+
+Keep one task id per PR.
+
+## Validation
+
+For manifest/docs/governance changes:
+
+```bash
+python scripts/validate_agent_tasks.py agent_tasks.json
+```
+
+For code changes, add focused tests and run the smallest useful pytest target first. Full `pytest` may require Linux/Docker and all dependencies.
+
+## Local Environment Notes
+
+The current codebase has platform-sensitive areas:
+
+- `magda_agent.skills.system_execute_code` historically depended on Linux-only `resource`.
+- ChromaDB is required by memory modules.
+- Speech dependencies are heavy and should remain optional where possible.
+
+Prefer stdlib-only tools for repository automation.
+

--- a/README.md
+++ b/README.md
@@ -5,14 +5,27 @@ Magda Agent is an experimental cognitive agent built around a Telegram interface
 ## Self-Improvement Loop
 
 - Target architecture: [docs/cognitive_architecture.md](docs/cognitive_architecture.md)
+- Codex worker plan: [docs/codex_worker_plan.md](docs/codex_worker_plan.md)
 - Machine-readable task queue: [agent_tasks.json](agent_tasks.json)
 - Task manifest validator: `python scripts/validate_agent_tasks.py agent_tasks.json`
 
 Jules should read `agent_tasks.json` first, implement the first task with status `todo`, keep the task pool replenished according to `replenishment_policy`, and update the task status after completing a PR.
 
+## Codex Bridge
+
+Magda exposes a lightweight stdlib-only bridge that Codex/Jules can use without importing the full Telegram/FastAPI/memory stack:
+
+```bash
+python -m magda_agent.codex_bridge validate
+python -m magda_agent.codex_bridge status
+python -m magda_agent.codex_bridge next-task
+python -m magda_agent.codex_bridge render-prompt
+```
+
 ## Local Checks
 
 ```bash
 python scripts/validate_agent_tasks.py agent_tasks.json
+python -m magda_agent.codex_bridge status
 pytest
 ```

--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3,6 +3,8 @@
   "project": "magda-agent",
   "task_source_priority": [
     "agent_tasks.json",
+    "AGENTS.md",
+    "docs/codex_worker_plan.md",
     "backlog.md"
   ],
   "risk_levels": [
@@ -85,6 +87,113 @@
         "docs/jules_autonomous_loop.md exists",
         "agent_tasks.json includes autonomous_loop_policy",
         "task queue defines concrete stabilization work before larger cognitive modules"
+      ]
+    },
+    {
+      "id": "codex-worker-plan-and-bridge",
+      "status": "done",
+      "area": "codex",
+      "risk": "low",
+      "title": "Add Codex worker plan and bridge CLI",
+      "description": "Document how Magda should work through Codex and add a stdlib-only CLI that lets Codex validate the task manifest, inspect queue status, fetch the next task and render focused prompts.",
+      "allowed_paths": [
+        "AGENTS.md",
+        "magda_agent/codex_bridge.py",
+        "docs/codex_worker_plan.md",
+        "docs/**",
+        "agent_tasks.json",
+        "README.md"
+      ],
+      "acceptance": [
+        "AGENTS.md describes Codex/Jules repo instructions",
+        "docs/codex_worker_plan.md exists",
+        "python -m magda_agent.codex_bridge validate works",
+        "python -m magda_agent.codex_bridge next-task prints the next todo task",
+        "python -m magda_agent.codex_bridge render-prompt renders a scoped task prompt"
+      ]
+    },
+    {
+      "id": "codex-bridge-tests",
+      "status": "todo",
+      "area": "codex",
+      "risk": "low",
+      "title": "Add focused tests for Codex bridge CLI",
+      "description": "Cover the stdlib-only Codex bridge commands so task selection, prompt rendering and queue status remain stable.",
+      "allowed_paths": [
+        "magda_agent/codex_bridge.py",
+        "tests/test_codex_bridge.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "status reports total todo count and replenishment flag",
+        "next-task returns the first todo task",
+        "render-prompt includes task id, allowed paths and acceptance criteria",
+        "validate command delegates to scripts/validate_agent_tasks.py"
+      ]
+    },
+    {
+      "id": "codex-worker-skill-prompt-only",
+      "status": "todo",
+      "area": "codex",
+      "risk": "medium",
+      "title": "Add Codex worker skill in prompt-only mode",
+      "description": "Expose a safe skill that renders a Codex-ready task prompt without launching external Codex processes or creating PRs.",
+      "allowed_paths": [
+        "magda_agent/skills/codex_worker.py",
+        "magda_agent/skills/__init__.py",
+        "magda_agent/skills/registry.py",
+        "tests/test_codex_worker.py",
+        "docs/codex_worker_plan.md",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "codex_worker skill accepts optional task_id",
+        "skill returns a prompt generated from agent_tasks.json",
+        "skill does not execute shell commands or network calls",
+        "skill metadata marks it as low side-effect prompt-only capability"
+      ]
+    },
+    {
+      "id": "codex-pr-review-renderer",
+      "status": "todo",
+      "area": "codex",
+      "risk": "medium",
+      "title": "Add Codex PR review prompt renderer",
+      "description": "Create a renderer that turns a PR diff summary into a Codex/CriticAgent review prompt focused on regressions, risks and missing tests.",
+      "allowed_paths": [
+        "magda_agent/codex_bridge.py",
+        "magda_agent/metacognition/**",
+        "tests/test_codex_bridge.py",
+        "docs/codex_worker_plan.md",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "renderer accepts PR title, changed files and diff summary",
+        "prompt asks for findings first, ordered by severity",
+        "prompt includes risk and missing-test sections",
+        "renderer is deterministic and does not call external APIs"
+      ]
+    },
+    {
+      "id": "task-claim-locking",
+      "status": "todo",
+      "area": "governance",
+      "risk": "medium",
+      "title": "Add task claim and lock fields for multiple workers",
+      "description": "Extend agent_tasks.json schema so Jules, Codex and future workers do not accidentally take the same task at the same time.",
+      "allowed_paths": [
+        "agent_tasks.json",
+        "scripts/validate_agent_tasks.py",
+        "tests/test_agent_tasks.py",
+        "magda_agent/codex_bridge.py",
+        "docs/jules_autonomous_loop.md",
+        "docs/codex_worker_plan.md"
+      ],
+      "acceptance": [
+        "tasks may include claimed_by and claimed_at fields",
+        "validator rejects stale or malformed claim metadata when present",
+        "codex_bridge status shows claimed tasks",
+        "task selection can skip active claims unless explicitly overridden"
       ]
     },
     {

--- a/docs/codex_worker_plan.md
+++ b/docs/codex_worker_plan.md
@@ -1,0 +1,151 @@
+# Codex Worker Integration Plan
+
+Этот план описывает, как добавить Magda режим работы через Codex: не как замену Jules, а как еще один coding-worker backend для задач разработки, ревью и улучшения проекта.
+
+## Идея
+
+Magda должна уметь формировать и сопровождать coding tasks для Codex:
+
+```text
+agent_tasks.json
+  -> Magda/Codex bridge selects task
+  -> renders focused prompt
+  -> Codex implements scoped change
+  -> tests/validation
+  -> PR
+  -> result compressed into lesson
+  -> task queue updated
+```
+
+Это повторяет полезные идеи Hermes: создать CLI, которым агент может пользоваться, сохранять workflows как skills, запускать long-horizon tasks, ревьюить PR и строить повторяемый improvement loop.
+
+## Official Codex Patterns To Reuse
+
+From official OpenAI Codex use-case docs:
+
+- Create a CLI Codex can use.
+- Save repeatable workflows as skills.
+- Follow a durable goal for long-running work.
+- Review GitHub pull requests.
+- Run code migrations in controlled checkpoints.
+- Add evals/tests to AI applications.
+- Use Codex for bug triage and verified operations.
+
+Magda should adapt these patterns through its own cognitive architecture.
+
+## Surfaces
+
+### 1. Repo Instructions: `AGENTS.md`
+
+`AGENTS.md` is the durable instruction layer for Codex/Jules inside the repository.
+
+It should explain:
+- task source priority;
+- validation commands;
+- risk boundaries;
+- files not to touch without explicit permission;
+- how to use the Codex bridge.
+
+### 2. Codex Bridge CLI
+
+Magda exposes a lightweight stdlib-only CLI:
+
+```bash
+python -m magda_agent.codex_bridge validate
+python -m magda_agent.codex_bridge status
+python -m magda_agent.codex_bridge next-task
+python -m magda_agent.codex_bridge render-prompt
+```
+
+This gives Codex a composable command surface without importing the full FastAPI/ChromaDB/Telegram stack.
+
+### 3. Codex Worker Skill
+
+Later, Magda should expose a controlled skill:
+
+```text
+codex_worker(task_id, mode="prompt" | "local" | "cloud")
+```
+
+Initial implementation should only render task specs. Running Codex or creating PRs should remain gated until policy and credentials are explicit.
+
+### 4. PR Review Worker
+
+Codex can act as a reviewer:
+
+```text
+PR diff
+  -> Codex review prompt
+  -> findings
+  -> risk score
+  -> missing tests
+  -> suggested follow-up tasks
+```
+
+This should feed the future `CriticAgent`.
+
+### 5. Workflow Skills
+
+Repeatable Codex workflows should become procedural memory:
+
+- "stabilize failing test";
+- "add a brain module";
+- "add command registry command";
+- "write doctor diagnostic";
+- "split a God Method step into processor".
+
+These should be stored as Magda procedure templates, not enabled as executable code automatically.
+
+## Safety Model
+
+Codex-worker tasks must obey the same policy gates as Jules:
+
+- one task id per PR;
+- allowed paths only;
+- no workflow/dependency/sandbox changes unless task allows them;
+- high/critical tasks require human review;
+- generated code is never auto-enabled as a skill;
+- PRs update `agent_tasks.json`.
+
+## First Implementation Slice
+
+Already included:
+
+- `AGENTS.md`
+- `magda_agent/codex_bridge.py`
+
+Next slices:
+
+1. Add focused tests for `codex_bridge`.
+2. Add `codex_worker` skill in prompt-only mode.
+3. Add `/codex next` command through future command registry.
+4. Add PR review prompt renderer.
+5. Add task claim/lock field to prevent multiple workers taking the same task.
+6. Add trajectory compression from Codex PRs into lessons.
+
+## Command Examples
+
+Get next task:
+
+```bash
+python -m magda_agent.codex_bridge next-task
+```
+
+Render prompt for the next task:
+
+```bash
+python -m magda_agent.codex_bridge render-prompt
+```
+
+Render prompt for a specific task:
+
+```bash
+python -m magda_agent.codex_bridge render-prompt --task-id planner-schema-validation
+```
+
+Check if the queue is running low:
+
+```bash
+python -m magda_agent.codex_bridge status
+```
+

--- a/docs/cognitive_architecture.md
+++ b/docs/cognitive_architecture.md
@@ -6,6 +6,8 @@
 
 Операционные правила для непрерывной работы Jules описаны отдельно: [jules_autonomous_loop.md](jules_autonomous_loop.md). Этот файл определяет, как агент выбирает задачи, пополняет очередь, реагирует на CI failures и не останавливается из-за нехватки явных backlog-пунктов.
 
+Работа через Codex описана в [codex_worker_plan.md](codex_worker_plan.md). Codex должен использовать `AGENTS.md` и `python -m magda_agent.codex_bridge` как легковесную поверхность для выбора задач, проверки manifest и рендера focused prompts.
+
 ## Базовая петля
 
 ```text

--- a/docs/jules_autonomous_loop.md
+++ b/docs/jules_autonomous_loop.md
@@ -35,12 +35,14 @@ Jules не должен спрашивать пользователя "что д
 Приоритет:
 
 1. `agent_tasks.json`
-2. CI failures
-3. `docs/cognitive_architecture.md`
-4. `docs/jules_autonomous_loop.md`
-5. `backlog.md`
-6. TODO/FIXME comments
-7. recurring errors from previous PRs
+2. `AGENTS.md`
+3. CI failures
+4. `docs/cognitive_architecture.md`
+5. `docs/jules_autonomous_loop.md`
+6. `docs/codex_worker_plan.md`
+7. `backlog.md`
+8. TODO/FIXME comments
+9. recurring errors from previous PRs
 
 Если явных задач нет, Jules создает пачку задач сам.
 

--- a/jules_next_task.yml
+++ b/jules_next_task.yml
@@ -23,7 +23,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Твоя единственная цель — автономное улучшение архитектуры Magda Agent.
-            1. Прочитай docs/cognitive_architecture.md и docs/jules_autonomous_loop.md, чтобы понять целевую когнитивную архитектуру, правила governance и автономную операционную модель.
+            1. Прочитай AGENTS.md, docs/cognitive_architecture.md, docs/jules_autonomous_loop.md и docs/codex_worker_plan.md, чтобы понять целевую когнитивную архитектуру, правила governance, автономную операционную модель и Codex worker surface.
             2. Открой agent_tasks.json в корне репозитория.
             3. Проверь replenishment_policy. Если задач со статусом "todo" нет или их меньше minimum_todo_tasks, сначала добавь новую пачку low/medium-risk задач из docs/cognitive_architecture.md, падающих тестов, TODO-комментариев и текущих архитектурных разрывов.
             4. Возьми первый пункт со статусом "todo".

--- a/magda_agent/codex_bridge.py
+++ b/magda_agent/codex_bridge.py
@@ -1,0 +1,174 @@
+"""Small CLI bridge that lets Codex/Jules work with Magda task manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MANIFEST = Path("agent_tasks.json")
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    """Load the agent task manifest from disk."""
+    with path.open("r", encoding="utf-8") as manifest_file:
+        data = json.load(manifest_file)
+    if not isinstance(data, dict):
+        raise ValueError("manifest root must be an object")
+    return data
+
+
+def iter_tasks(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return task objects from a manifest."""
+    tasks = manifest.get("tasks")
+    if not isinstance(tasks, list):
+        raise ValueError("manifest tasks must be a list")
+    return [task for task in tasks if isinstance(task, dict)]
+
+
+def todo_tasks(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return tasks with status todo."""
+    return [task for task in iter_tasks(manifest) if task.get("status") == "todo"]
+
+
+def next_task(manifest: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the next todo task in manifest order."""
+    tasks = todo_tasks(manifest)
+    return tasks[0] if tasks else None
+
+
+def task_by_id(manifest: dict[str, Any], task_id: str) -> dict[str, Any] | None:
+    """Find one task by id."""
+    for task in iter_tasks(manifest):
+        if task.get("id") == task_id:
+            return task
+    return None
+
+
+def queue_status(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Return summary information about the task queue."""
+    tasks = iter_tasks(manifest)
+    todos = todo_tasks(manifest)
+    policy = manifest.get("replenishment_policy") or {}
+    minimum = int(policy.get("minimum_todo_tasks", 0))
+    return {
+        "total_tasks": len(tasks),
+        "todo_tasks": len(todos),
+        "minimum_todo_tasks": minimum,
+        "needs_replenishment": len(todos) < minimum,
+        "next_task_id": todos[0].get("id") if todos else None,
+    }
+
+
+def render_prompt(task: dict[str, Any]) -> str:
+    """Render a focused prompt for Codex/Jules from one task object."""
+    allowed_paths = "\n".join(f"- {path}" for path in task.get("allowed_paths", []))
+    acceptance = "\n".join(f"- {item}" for item in task.get("acceptance", []))
+    return f"""You are working on Magda Agent.
+
+Read first:
+- AGENTS.md
+- docs/jules_autonomous_loop.md
+- docs/cognitive_architecture.md
+- docs/hermes_inspired_feature_plan.md
+- docs/codex_worker_plan.md
+
+Task id: {task.get("id")}
+Title: {task.get("title")}
+Area: {task.get("area")}
+Risk: {task.get("risk")}
+
+Description:
+{task.get("description")}
+
+Allowed paths:
+{allowed_paths}
+
+Acceptance criteria:
+{acceptance}
+
+Rules:
+- Keep the PR scoped to this task id.
+- Do not touch files outside allowed paths unless the task manifest is updated with a clear reason.
+- Update agent_tasks.json when the task is complete.
+- If you discover new work, add new todo tasks instead of widening this PR.
+"""
+
+
+def validate_manifest(path: Path) -> int:
+    """Run the repository manifest validator."""
+    try:
+        from scripts.validate_agent_tasks import load_manifest as load_for_validation
+        from scripts.validate_agent_tasks import validate_manifest as validate
+
+        warnings = validate(load_for_validation(path))
+    except Exception as exc:
+        print(f"validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"validation passed: {path}")
+    for warning in warnings:
+        print(f"warning: {warning}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST), help="Path to agent_tasks.json")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("validate", help="Validate the task manifest")
+    subparsers.add_parser("status", help="Print queue status as JSON")
+    subparsers.add_parser("next-task", help="Print the next todo task as JSON")
+
+    prompt_parser = subparsers.add_parser("render-prompt", help="Render a Codex prompt for a task")
+    prompt_parser.add_argument("--task-id", help="Task id to render. Defaults to the next todo task.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    manifest_path = Path(args.manifest)
+
+    if args.command == "validate":
+        return validate_manifest(manifest_path)
+
+    try:
+        manifest = load_manifest(manifest_path)
+    except Exception as exc:
+        print(f"failed to load manifest: {exc}", file=sys.stderr)
+        return 1
+
+    if args.command == "status":
+        print(json.dumps(queue_status(manifest), ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "next-task":
+        task = next_task(manifest)
+        if task is None:
+            print("no todo tasks found", file=sys.stderr)
+            return 2
+        print(json.dumps(task, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "render-prompt":
+        task = task_by_id(manifest, args.task_id) if args.task_id else next_task(manifest)
+        if task is None:
+            print("task not found", file=sys.stderr)
+            return 2
+        print(render_prompt(task))
+        return 0
+
+    parser.error(f"unknown command {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a Codex-friendly repository surface for Magda: AGENTS.md durable instructions, a stdlib-only magda_agent.codex_bridge CLI for manifest validation/task selection/prompt rendering, Codex worker plan docs, and follow-up tasks for prompt-only Codex skill, PR review renderer, and task claim locking.\n\nQuick checks run:\n- python -m magda_agent.codex_bridge validate\n- python -m magda_agent.codex_bridge status\n- python -m magda_agent.codex_bridge next-task\n- python -m magda_agent.codex_bridge render-prompt

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `magda_agent.codex_bridge` CLI for agent task queue management
> - Adds [magda_agent/codex_bridge.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/46/files#diff-e46909af37c21b2c74e8b8dd8852ebb34bbba6994171a08d5a6fbb71ad582efd) with four subcommands: `validate` (runs manifest validation), `status` (prints queue summary as JSON), `next-task` (returns the next todo task as JSON), and `render-prompt` (generates a focused prompt for a task by ID or next todo).
> - Adds new tasks and source entries to [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/46/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205), including a completed `codex-worker-plan-and-bridge` task and four new todo tasks.
> - Updates Jules workflow prompts in [.github/workflows/jules_next_task.yml](https://github.com/kazah4359-lgtm/Magda-agent/pull/46/files#diff-932aac44920d9f6d2cab7b4b995185f7c846ba3ed3bb1ece382b74a96cb49a36) to instruct the agent to read `AGENTS.md` and [docs/codex_worker_plan.md](https://github.com/kazah4359-lgtm/Magda-agent/pull/46/files#diff-7be731ff5471806c5376a01aad9539f6f2ddc8d27bd086838a43be9c989c0de1).
> - Adds [AGENTS.md](https://github.com/kazah4359-lgtm/Magda-agent/pull/46/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) as a repository guide for Codex/Jules with CLI examples, risk rules, and validation instructions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a665f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->