### PR TITLE
feat: Bound EmotionalEngine history length

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -110,7 +110,7 @@
     },
     {
       "id": "bounded-emotional-history",
-      "status": "todo",
+      "status": "done",
       "area": "stabilization",
       "risk": "low",
       "title": "Bound EmotionalEngine history",

--- a/magda_agent/emotions/engine.py
+++ b/magda_agent/emotions/engine.py
@@ -20,19 +20,22 @@ class EmotionalEngine:
     Mathematical Emotional Engine based on the PAD model.
     Allows for continuous emotional state representation and updates.
     """
-    def __init__(self, decay_rate: float = 0.05):
+    def __init__(self, decay_rate: float = 0.05, max_history_length: int = 100) -> None:
         self.state = PADState()
         self.decay_rate = decay_rate
+        self.max_history_length = max_history_length
         self.history: List[PADState] = []
 
-    def update(self, p_delta: float, a_delta: float, d_delta: float):
+    def update(self, p_delta: float, a_delta: float, d_delta: float) -> None:
         """Update the emotional state with new stimuli."""
         self.state.pleasure = self._clamp(self.state.pleasure + p_delta)
         self.state.arousal = self._clamp(self.state.arousal + a_delta)
         self.state.dominance = self._clamp(self.state.dominance + d_delta)
         self.history.append(PADState(self.state.pleasure, self.state.arousal, self.state.dominance))
+        while len(self.history) > self.max_history_length:
+            self.history.pop(0)
 
-    def decay(self):
+    def decay(self) -> None:
         """Gradually return to neutral state (0,0,0)."""
         self.state.pleasure *= (1 - self.decay_rate)
         self.state.arousal *= (1 - self.decay_rate)
@@ -62,7 +65,9 @@ class EmotionalEngine:
             return "Neutral"
 
     def _clamp(self, value: float, min_val: float = -1.0, max_val: float = 1.0) -> float:
+        """Clamp a value between min_val and max_val."""
         return max(min_val, min(max_val, value))
 
     def get_summary(self) -> str:
+        """Return a readable summary of the current emotional state."""
         return f"Current Emotion: {self.get_emotion_label()} (P:{self.state.pleasure:.2f}, A:{self.state.arousal:.2f}, D:{self.state.dominance:.2f})"

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -85,3 +85,30 @@ async def test_consciousness_attachment_integration():
     assert attachment.user_interactions[user_id] == 10
     call_args_2 = llm_mock.get_system_prompt.call_args[1]
     assert "Close Friend" in call_args_2["emotions"]
+
+def test_emotional_engine_bounded_history() -> None:
+    """Test that the emotional engine bounds the history length correctly when max_history_length is provided."""
+    engine = EmotionalEngine(max_history_length=5)
+
+    # Add 10 updates
+    for i in range(10):
+        engine.update(0.1, 0.05, -0.05)
+
+    # The length of the history should be capped at 5
+    assert len(engine.history) == 5
+
+    # The values in history should reflect the most recent updates
+    # The last update was the 10th one, so the history should have the values
+    # corresponding to the state after the 6th, 7th, 8th, 9th, and 10th updates.
+    # We can check that the history is not empty and is bounded.
+    assert len(engine.history) <= engine.max_history_length
+
+def test_emotional_engine_default_bounded_history() -> None:
+    """Test that the emotional engine defaults to bounding the history length to 100."""
+    engine = EmotionalEngine()
+
+    # Default is 100
+    for i in range(150):
+        engine.update(0.01, 0.01, 0.01)
+
+    assert len(engine.history) == 100


### PR DESCRIPTION
Updates EmotionalEngine to bound the list of history to a given `max_history_length` defaulting to 100, effectively mitigating indefinite list growth over long running sessions. Also ensures full type hints and docstrings exist across engine methods and its test functions.

Closes task `bounded-emotional-history` in `agent_tasks.json`.

---
*PR created automatically by Jules for task [10507672957214041400](https://jules.google.com/task/10507672957214041400) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound `EmotionalEngine` history length with a configurable `max_history_length`
> Adds a `max_history_length` parameter (default 100) to [`EmotionalEngine.__init__`](https://github.com/kazah4359-lgtm/Magda-agent/pull/47/files#diff-905d9204174127f87db6053cf0fd4ab85c9885f01efafdb7ed0f2786abeec19a). On each call to `update`, the oldest entries are discarded once the history list exceeds this limit. Two tests cover the custom-length cap and the default 100-entry cap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cba8fa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->