### PR TITLE
Add Codex worker skill in prompt-only mode

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -133,7 +133,7 @@
     },
     {
       "id": "codex-worker-skill-prompt-only",
-      "status": "todo",
+      "status": "done",
       "area": "codex",
       "risk": "medium",
       "title": "Add Codex worker skill in prompt-only mode",

--- a/docs/codex_worker_plan.md
+++ b/docs/codex_worker_plan.md
@@ -117,7 +117,7 @@ Already included:
 Next slices:
 
 1. Add focused tests for `codex_bridge`.
-2. Add `codex_worker` skill in prompt-only mode.
+2. [x] Add `codex_worker` skill in prompt-only mode.
 3. Add `/codex next` command through future command registry.
 4. Add PR review prompt renderer.
 5. Add task claim/lock field to prevent multiple workers taking the same task.

--- a/magda_agent/skills/__init__.py
+++ b/magda_agent/skills/__init__.py
@@ -3,6 +3,7 @@ from magda_agent.skills.registry import SkillRegistry
 from magda_agent.skills.system_execute_code import execute as code_executor
 from magda_agent.skills.internet_search import search_internet
 from magda_agent.skills.omnichannel import send_message as omnichannel_send
+from magda_agent.skills.codex_worker import codex_worker
 
 def initialize_skills() -> SkillRegistry:
     registry = SkillRegistry()
@@ -26,6 +27,13 @@ def initialize_skills() -> SkillRegistry:
         name="omnichannel_send",
         func=omnichannel_send,
         description="Sends a message to a recipient on a specified platform (telegram, whatsapp, email). Input: 'platform', 'recipient', 'message' strings."
+    )
+
+    # Register Codex Worker Skill
+    registry.register_skill(
+        name="codex_worker",
+        func=codex_worker,
+        description="Generates a Codex-ready task prompt from the project's task manifest. This is a low side-effect prompt-only capability. Input: optional 'task_id' string."
     )
 
     return registry

--- a/magda_agent/skills/codex_worker.py
+++ b/magda_agent/skills/codex_worker.py
@@ -1,0 +1,38 @@
+"""
+Codex worker skill module.
+
+Exposes a safe skill that renders a Codex-ready task prompt without
+launching external Codex processes or creating PRs.
+"""
+
+from typing import Optional
+from magda_agent.codex_bridge import load_manifest, next_task, task_by_id, render_prompt
+
+
+def codex_worker(task_id: Optional[str] = None) -> str:
+    """
+    Renders a Codex-ready task prompt for a given task ID or the next todo task.
+    This is a low side-effect prompt-only capability that does not execute shell commands
+    or network calls.
+
+    Args:
+        task_id: Optional string ID of the task. If not provided, the next todo task is used.
+
+    Returns:
+        The rendered prompt text, or an error message if the task is not found or manifest cannot be loaded.
+    """
+    try:
+        manifest = load_manifest()
+    except Exception as exc:
+        return f"Error loading task manifest: {exc}"
+
+    if task_id:
+        task = task_by_id(manifest, task_id)
+        if not task:
+            return f"Task with ID '{task_id}' not found."
+    else:
+        task = next_task(manifest)
+        if not task:
+            return "No 'todo' tasks found in the manifest."
+
+    return render_prompt(task)

--- a/tests/test_codex_worker.py
+++ b/tests/test_codex_worker.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import patch
+
+from magda_agent.skills.codex_worker import codex_worker
+
+
+@pytest.fixture
+def mock_manifest():
+    return {
+        "tasks": [
+            {
+                "id": "task-1",
+                "status": "done",
+                "title": "Task 1",
+                "area": "core",
+                "risk": "low",
+                "description": "Done task",
+                "allowed_paths": [],
+                "acceptance": []
+            },
+            {
+                "id": "task-2",
+                "status": "todo",
+                "title": "Task 2",
+                "area": "api",
+                "risk": "low",
+                "description": "Todo task 2",
+                "allowed_paths": ["path/to/file"],
+                "acceptance": ["check 1"]
+            },
+            {
+                "id": "task-3",
+                "status": "todo",
+                "title": "Task 3",
+                "area": "cli",
+                "risk": "medium",
+                "description": "Todo task 3",
+                "allowed_paths": [],
+                "acceptance": []
+            }
+        ]
+    }
+
+
+@patch("magda_agent.skills.codex_worker.load_manifest")
+def test_codex_worker_no_task_id(mock_load_manifest, mock_manifest):
+    mock_load_manifest.return_value = mock_manifest
+
+    prompt = codex_worker()
+
+    # Should get task-2 since it's the first todo task
+    assert "Task id: task-2" in prompt
+    assert "Title: Task 2" in prompt
+    assert "- path/to/file" in prompt
+
+
+@patch("magda_agent.skills.codex_worker.load_manifest")
+def test_codex_worker_with_task_id(mock_load_manifest, mock_manifest):
+    mock_load_manifest.return_value = mock_manifest
+
+    prompt = codex_worker("task-3")
+
+    assert "Task id: task-3" in prompt
+    assert "Title: Task 3" in prompt
+    assert "Area: cli" in prompt
+
+
+@patch("magda_agent.skills.codex_worker.load_manifest")
+def test_codex_worker_task_not_found(mock_load_manifest, mock_manifest):
+    mock_load_manifest.return_value = mock_manifest
+
+    prompt = codex_worker("nonexistent-task")
+
+    assert prompt == "Task with ID 'nonexistent-task' not found."
+
+
+@patch("magda_agent.skills.codex_worker.load_manifest")
+def test_codex_worker_no_todo_tasks(mock_load_manifest):
+    mock_load_manifest.return_value = {
+        "tasks": [
+            {
+                "id": "task-1",
+                "status": "done"
+            }
+        ]
+    }
+
+    prompt = codex_worker()
+
+    assert prompt == "No 'todo' tasks found in the manifest."
+
+
+@patch("magda_agent.skills.codex_worker.load_manifest")
+def test_codex_worker_manifest_load_error(mock_load_manifest):
+    mock_load_manifest.side_effect = Exception("File not found")
+
+    prompt = codex_worker()
+
+    assert "Error loading task manifest: File not found" in prompt


### PR DESCRIPTION
This PR implements the `codex-worker-skill-prompt-only` task:

- Creates `magda_agent/skills/codex_worker.py` to generate Codex prompts from `agent_tasks.json`.
- Exposes `codex_worker` as a prompt-only skill (no external processes/calls) via `magda_agent/skills/__init__.py`.
- Includes full unit tests in `tests/test_codex_worker.py`.
- Updates `agent_tasks.json` status to `done` and checks off the backlog item in `docs/codex_worker_plan.md`.
- All tests and validations pass.

---
*PR created automatically by Jules for task [4785788429363108455](https://jules.google.com/task/4785788429363108455) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `codex_worker` skill to generate Codex-ready task prompts in prompt-only mode
> - Adds a new [`codex_worker.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/49/files#diff-f3d2abda6b3bcf1dce97de7d3ebfef21156dd1c0243df7abe85a4673f23e89cb) skill that loads the task manifest and returns a rendered prompt for a specified task ID or the next `todo` task.
> - Registers the skill in [`skills/__init__.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/49/files#diff-bfa99a5f255fc1d222418cb8c21dfa1cce609468589a12c95c937cd2b77bd315) under the name `"codex_worker"` with an optional `task_id` parameter.
> - Returns clear error messages for manifest load failures, missing task IDs, and absence of `todo` tasks.
> - Covers the new skill with five unit tests in [`tests/test_codex_worker.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/49/files#diff-c7dad5cd90e1bff819155fb1d2bfc49b8d2de9493972c665bf98ef8d46c90a1a) patching `load_manifest`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e6dadd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->