### PR TITLE
Add max steps and skill timeouts to plan execution

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -238,7 +238,7 @@
     },
     {
       "id": "planner-execution-limits",
-      "status": "todo",
+      "status": "done",
       "area": "stabilization",
       "risk": "medium",
       "title": "Add max steps and timeouts to plan execution",

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -116,8 +116,15 @@ class Consciousness:
             plan = self.planner.get_current_plan()
             if plan:
                 import asyncio
+
+                MAX_STEPS = 5
+                SKILL_TIMEOUT = 10.0
+                steps_executed = 0
+                plan_stopped_early = False
+
                 # Execute the steps and collect results
-                while self.planner.get_current_plan():
+                while self.planner.get_current_plan() and steps_executed < MAX_STEPS:
+                    steps_executed += 1
                     step = self.planner.get_current_plan()[0]
                     skill_name = step.get('skill')
                     kwargs = step.get('skill_kwargs') or {}
@@ -125,7 +132,12 @@ class Consciousness:
                     if skill_name:
                         # Execute heavy skills in a separate thread to avoid blocking the event loop
                         try:
-                            result = await asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
+                            task = asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
+                            result = await asyncio.wait_for(task, timeout=SKILL_TIMEOUT)
+                        except asyncio.TimeoutError:
+                            logging.error(f"Timeout executing skill {skill_name}")
+                            result = f"Error: Skill {skill_name} timed out after {SKILL_TIMEOUT} seconds."
+                            plan_stopped_early = True
                         except Exception as e:
                             logging.error(f"Error executing skill {skill_name}: {e}")
                             result = f"Error: {e}"
@@ -134,10 +146,23 @@ class Consciousness:
 
                     self.planner.mark_step_completed(0, str(result))
 
+                    if plan_stopped_early:
+                        break
+
+                if self.planner.get_current_plan() and steps_executed >= MAX_STEPS:
+                    plan_stopped_early = True
+                    logging.warning("Plan execution stopped due to MAX_STEPS limit.")
+
+                if plan_stopped_early:
+                    self.planner.clear_pending_plan()
+
                 plan_str = "Executed Plan Results:\n"
                 for i, step in enumerate(self.planner.completed_steps):
                     plan_str += f"- Step {i+1}: {step.get('description')} (Skill: {step.get('skill')})\n"
                     plan_str += f"  Result: {step.get('result')}\n"
+
+                if plan_stopped_early:
+                    plan_str += "\nNote: Plan execution was stopped early due to limits.\n"
 
         # 4. LLM Reasoning
         emotion_summary = self.emotions.get_summary()

--- a/magda_agent/planning/planner.py
+++ b/magda_agent/planning/planner.py
@@ -134,3 +134,10 @@ class Planner:
                 summary += f"    - {step.get('description')} (Skill: {step.get('skill')})\n"
 
         return summary
+
+    def clear_pending_plan(self) -> None:
+        """
+        Clears the current pending plan steps.
+        """
+        self.current_plan = []
+        logging.info("Pending plan steps cleared.")

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -111,6 +111,83 @@ async def test_consciousness_executes_plan():
     assert real_planner.completed_steps[0]["result"] == "Mocked search result for testing"
     assert real_planner.completed_steps[1]["result"] == "No skill executed for this step."
 
+@pytest.mark.asyncio
+async def test_consciousness_plan_max_steps():
+    from magda_agent.consciousness.core import Consciousness
+    from magda_agent.emotions.engine import EmotionalEngine
+    from magda_agent.memory.storage import MemorySystem
+
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.get_system_prompt.return_value = "System prompt"
+    mock_llm.chat_completion = AsyncMock(return_value="Final LLM Response")
+
+    mock_skills = MagicMock(spec=SkillRegistry)
+    mock_skills.execute_skill.return_value = "Mocked result"
+    mock_skills.get_skills_summary.return_value = "Available Skills..."
+
+    real_planner = Planner(llm=mock_llm, skills=mock_skills)
+    real_planner.generate_plan = AsyncMock()
+
+    # set up a plan with 6 steps
+    real_planner.current_plan = [{"description": f"Step {i}", "skill": None, "skill_kwargs": None} for i in range(6)]
+
+    emotions = EmotionalEngine()
+    memory = MemorySystem()
+
+    consciousness = Consciousness(
+        llm=mock_llm,
+        emotions=emotions,
+        memory=memory,
+        skills=mock_skills,
+        planner=real_planner
+    )
+
+    await consciousness.process_input("Help me test max steps")
+
+    # verify only 5 steps were completed
+    assert len(real_planner.completed_steps) == 5
+    assert len(real_planner.current_plan) == 0
+
+@pytest.mark.asyncio
+async def test_consciousness_plan_timeout():
+    from magda_agent.consciousness.core import Consciousness
+    from magda_agent.emotions.engine import EmotionalEngine
+    from magda_agent.memory.storage import MemorySystem
+    import asyncio
+    from unittest.mock import patch
+
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.get_system_prompt.return_value = "System prompt"
+    mock_llm.chat_completion = AsyncMock(return_value="Final LLM Response")
+
+    mock_skills = MagicMock(spec=SkillRegistry)
+    mock_skills.get_skills_summary.return_value = "Available Skills..."
+
+    real_planner = Planner(llm=mock_llm, skills=mock_skills)
+    real_planner.generate_plan = AsyncMock()
+
+    # set up a plan with 1 skill step
+    real_planner.current_plan = [{"description": "Step 1", "skill": "slow_skill", "skill_kwargs": None}]
+
+    emotions = EmotionalEngine()
+    memory = MemorySystem()
+
+    consciousness = Consciousness(
+        llm=mock_llm,
+        emotions=emotions,
+        memory=memory,
+        skills=mock_skills,
+        planner=real_planner
+    )
+
+    with patch('asyncio.wait_for', side_effect=asyncio.TimeoutError):
+        await consciousness.process_input("Help me test timeout")
+
+    # verify 1 step completed with timeout error, and pending plan is cleared
+    assert len(real_planner.completed_steps) == 1
+    assert "timed out after" in real_planner.completed_steps[0]["result"]
+    assert len(real_planner.current_plan) == 0
+
 def test_get_state_summary():
     mock_llm = MagicMock(spec=LLMClient)
     mock_skills = MagicMock(spec=SkillRegistry)


### PR DESCRIPTION
This PR addresses the `planner-execution-limits` task in `agent_tasks.json`.

**Changes:**
- Added `MAX_STEPS` and `SKILL_TIMEOUT` limits to the plan execution loop in `Consciousness.process_input`.
- Wrapped skill execution with `asyncio.wait_for` to safely timeout runaway synchronous tasks.
- Added a `clear_pending_plan` method to `Planner` to cleanly abort subsequent steps when a limit is hit.
- Added tests in `test_planner.py` to verify both the max step abort logic and the skill timeout abort logic.
- Updated task manifest `agent_tasks.json` with the task status set to "done".

All tests and validation scripts pass locally.

---
*PR created automatically by Jules for task [13417256126479451629](https://jules.google.com/task/13417256126479451629) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add max steps and skill timeouts to plan execution in `Consciousness.process_input`
> - Caps plan execution at 5 steps (`MAX_STEPS`) per `process_input` call; any remaining steps are cleared via a new `Planner.clear_pending_plan()` method.
> - Wraps each skill execution in `asyncio.wait_for` with a 10-second timeout (`SKILL_TIMEOUT`); on timeout, records an error string in the result and sets `plan_stopped_early`.
> - When execution stops early (either reason), appends a note to the plan results string.
> - Adds tests covering both the step-cap and timeout paths in [tests/test_planner.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/52/files#diff-abc0e1a964f5d6e905e027363f1bc327f4aacbb16bf127c5ae502f612691be6b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ca5be1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->