### PR TITLE
feat(safety): Validate LLM-generated plans before execution

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -259,7 +259,7 @@
     },
     {
       "id": "planner-schema-validation",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Validate LLM-generated plans before execution",

--- a/magda_agent/planning/planner.py
+++ b/magda_agent/planning/planner.py
@@ -70,14 +70,32 @@ class Planner:
             response_text = response_text.strip()
 
             plan = json.loads(response_text)
-            if isinstance(plan, list):
-                self.current_plan = plan
-                self.completed_steps = []
-                return plan
-            else:
+            if not isinstance(plan, list):
                 logging.error("Plan generated is not a JSON list.")
                 self.current_plan = []
                 return []
+
+            for i, step in enumerate(plan):
+                if not isinstance(step, dict):
+                    logging.error(f"Step {i} in plan is not a JSON object.")
+                    self.current_plan = []
+                    return []
+                if "description" not in step or "skill" not in step or "skill_kwargs" not in step:
+                    logging.error(f"Step {i} in plan is missing required keys: 'description', 'skill', or 'skill_kwargs'.")
+                    self.current_plan = []
+                    return []
+                if step["skill"] is not None and not self.skills.has_skill(step["skill"]):
+                    logging.error(f"Step {i} uses unknown skill: {step['skill']}.")
+                    self.current_plan = []
+                    return []
+                if step["skill_kwargs"] is not None and not isinstance(step["skill_kwargs"], dict):
+                    logging.error(f"Step {i} 'skill_kwargs' must be a dictionary or null.")
+                    self.current_plan = []
+                    return []
+
+            self.current_plan = plan
+            self.completed_steps = []
+            return plan
         except json.JSONDecodeError as e:
             logging.error(f"Failed to decode plan JSON: {e}")
             self.current_plan = []

--- a/magda_agent/skills/registry.py
+++ b/magda_agent/skills/registry.py
@@ -14,6 +14,18 @@ class SkillRegistry:
         self.descriptions[name] = description
         logging.info(f"Skill registered: {name}")
 
+    def has_skill(self, name: str) -> bool:
+        """
+        Checks whether a skill with the given name is registered.
+
+        Args:
+            name (str): The name of the skill to check.
+
+        Returns:
+            bool: True if the skill exists, False otherwise.
+        """
+        return name in self.skills
+
     def execute_skill(self, name: str, **kwargs) -> Any:
         if name not in self.skills:
             return f"Error: Skill '{name}' not found."

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -44,6 +44,46 @@ async def test_generate_plan_invalid_json():
     assert result == []
     assert len(planner.current_plan) == 0
 
+@pytest.mark.asyncio
+async def test_generate_plan_validation_failures():
+    """
+    Tests that generate_plan correctly validates the LLM-generated plan output.
+    It verifies that a plan is rejected and an empty list is returned if the plan
+    is not a list, contains invalid items, is missing keys, references an unknown skill,
+    or contains invalid skill arguments.
+    """
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_skills = MagicMock(spec=SkillRegistry)
+    mock_skills.has_skill.return_value = False
+
+    planner = Planner(llm=mock_llm, skills=mock_skills)
+
+    # 1. Not a JSON list
+    mock_llm.chat_completion = AsyncMock(return_value='{"step": 1}')
+    result = await planner.generate_plan("test")
+    assert result == []
+
+    # 2. Step is not a dict
+    mock_llm.chat_completion = AsyncMock(return_value='["step 1"]')
+    result = await planner.generate_plan("test")
+    assert result == []
+
+    # 3. Missing required keys
+    mock_llm.chat_completion = AsyncMock(return_value='[{"description": "desc"}]')
+    result = await planner.generate_plan("test")
+    assert result == []
+
+    # 4. Unknown skill
+    mock_llm.chat_completion = AsyncMock(return_value='[{"description": "desc", "skill": "unknown", "skill_kwargs": {}}]')
+    result = await planner.generate_plan("test")
+    assert result == []
+
+    # 5. Invalid skill_kwargs
+    mock_skills.has_skill.return_value = True
+    mock_llm.chat_completion = AsyncMock(return_value='[{"description": "desc", "skill": "known", "skill_kwargs": "not_a_dict"}]')
+    result = await planner.generate_plan("test")
+    assert result == []
+
 def test_mark_step_completed():
     mock_llm = MagicMock(spec=LLMClient)
     mock_skills = MagicMock(spec=SkillRegistry)


### PR DESCRIPTION
Implement safety boundaries on LLM plan execution by validating the structure and skill references of generated plans.

This fulfills the `planner-schema-validation` task from `agent_tasks.json`.

---
*PR created automatically by Jules for task [16405625151853317062](https://jules.google.com/task/16405625151853317062) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate LLM-generated plans before execution in `Planner.generate_plan`
> - `Planner.generate_plan` in [planner.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/53/files#diff-0dba6309dba5da62981c561d46f8b9e2e8128b6e7c999b43517c44d1e5735abb) now validates the parsed plan before storing it: rejects non-list plans, non-dict steps, steps missing `description`/`skill`/`skill_kwargs` keys, unknown skill references, and non-dict `skill_kwargs` values.
> - `SkillRegistry` gains a `has_skill(name)` method in [registry.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/53/files#diff-86e5584dfd92efbf66a1e0600c1ab5a5e678bc67b8a389d2501997611f7f2ffa) used by the planner to verify skill references.
> - On any validation failure, `generate_plan` clears `current_plan` and returns `[]`.
> - New async tests in [test_planner.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/53/files#diff-abc0e1a964f5d6e905e027363f1bc327f4aacbb16bf127c5ae502f612691be6b) cover all five failure cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b5a62d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->