### PR TITLE
Separate mutable agent state by user

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -279,7 +279,7 @@
     },
     {
       "id": "per-user-agent-state",
-      "status": "todo",
+      "status": "done",
       "area": "stabilization",
       "risk": "medium",
       "title": "Separate mutable agent state by user",

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -73,12 +73,12 @@ class Consciousness:
 
         # 1. Perception & Emotion Update (Initial reaction)
         # For simplicity, we just slightly increase arousal when receiving input
-        self.emotions.update(0.01, 0.05, 0.01)
+        self.emotions.update(0.01, 0.05, 0.01, user_id=user_id)
 
         if self.mirror_neurons:
             p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_input)
             if p_shift != 0.0 or a_shift != 0.0 or d_shift != 0.0:
-                self.emotions.update(p_shift, a_shift, d_shift)
+                self.emotions.update(p_shift, a_shift, d_shift, user_id=user_id)
 
         if self.hypothalamus:
             activity_level = 1.0
@@ -95,7 +95,7 @@ class Consciousness:
                     self.hypothalamus.energy,
                     self.hypothalamus.boredom
                 )
-                self.emotions.update(v_shift, a_shift, d_shift)
+                self.emotions.update(v_shift, a_shift, d_shift, user_id=user_id)
 
         # 2. Memory Retrieval
         relevant_memories = self.memory.retrieve_relevant(user_input, user_id=user_id)
@@ -165,14 +165,14 @@ class Consciousness:
                     plan_str += "\nNote: Plan execution was stopped early due to limits.\n"
 
         # 4. LLM Reasoning
-        emotion_summary = self.emotions.get_summary()
+        emotion_summary = self.emotions.get_summary(user_id=user_id)
         if self.hypothalamus:
             emotion_summary += f" | {self.hypothalamus.get_drives_summary()}"
 
         if self.pineal_gland:
             emotion_summary += f" | Time of day: {self.pineal_gland.get_time_context()}"
 
-        if self.attachment and user_id is not None:
+        if self.attachment:
             self.attachment.record_interaction(user_id)
             attachment_prompt = self.attachment.get_attachment_prompt(user_id)
             if attachment_prompt:
@@ -215,7 +215,7 @@ class Consciousness:
         self.memory.add_memory(
             content=memory_content,
             importance=0.5,
-            emotional_state=self.emotions.state,
+            emotional_state=self.emotions.get_state_history(user_id)[0],
             tags=["conversation"],
             user_id=user_id
         )
@@ -224,7 +224,7 @@ class Consciousness:
             self.long_term_memory.store(text=memory_content, metadata={"type": "conversation"}, user_id=user_id)
 
         # Gradual emotional decay after processing
-        self.emotions.decay()
+        self.emotions.decay(user_id=user_id)
 
         # 6. Metacognition (Self-Evaluation)
         if self.evaluator:

--- a/magda_agent/emotions/attachment.py
+++ b/magda_agent/emotions/attachment.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 class AttachmentModel:
     """
@@ -8,15 +8,27 @@ class AttachmentModel:
     def __init__(self) -> None:
         self.user_interactions: Dict[int, int] = {}
 
-    def record_interaction(self, user_id: int) -> None:
-        """Records an interaction with a user, increasing their interaction count."""
-        if user_id not in self.user_interactions:
-            self.user_interactions[user_id] = 0
-        self.user_interactions[user_id] += 1
+    def reset(self, user_id: Optional[int] = None) -> None:
+        """Resets the interaction count for a specific user (maps None to anonymous)."""
+        u_id = user_id if user_id is not None else -1
+        if u_id in self.user_interactions:
+            del self.user_interactions[u_id]
 
-    def get_level(self, user_id: int) -> str:
+    def reset_all(self) -> None:
+        """Clears interaction counts for all users completely."""
+        self.user_interactions.clear()
+
+    def record_interaction(self, user_id: Optional[int] = None) -> None:
+        """Records an interaction with a user, increasing their interaction count."""
+        u_id = user_id if user_id is not None else -1
+        if u_id not in self.user_interactions:
+            self.user_interactions[u_id] = 0
+        self.user_interactions[u_id] += 1
+
+    def get_level(self, user_id: Optional[int] = None) -> str:
         """Returns the attachment level for a given user based on their interactions."""
-        interactions = self.user_interactions.get(user_id, 0)
+        u_id = user_id if user_id is not None else -1
+        interactions = self.user_interactions.get(u_id, 0)
         if interactions <= 2:
             return "stranger"
         elif interactions <= 5:
@@ -26,7 +38,7 @@ class AttachmentModel:
         else:
             return "close_friend"
 
-    def get_attachment_prompt(self, user_id: int) -> str:
+    def get_attachment_prompt(self, user_id: Optional[int] = None) -> str:
         """Returns a string modifier for the system prompt based on attachment level."""
         level = self.get_level(user_id)
         if level == "stranger":

--- a/magda_agent/emotions/engine.py
+++ b/magda_agent/emotions/engine.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 @dataclass
 class PADState:
@@ -21,29 +21,55 @@ class EmotionalEngine:
     Allows for continuous emotional state representation and updates.
     """
     def __init__(self, decay_rate: float = 0.05, max_history_length: int = 100) -> None:
-        self.state = PADState()
         self.decay_rate = decay_rate
         self.max_history_length = max_history_length
-        self.history: List[PADState] = []
+        self._states: Dict[int, PADState] = {}
+        self._histories: Dict[int, List[PADState]] = {}
 
-    def update(self, p_delta: float, a_delta: float, d_delta: float) -> None:
+    def get_state_history(self, user_id: Optional[int]) -> Tuple[PADState, List[PADState]]:
+        u_id = user_id if user_id is not None else -1
+        if u_id not in self._states:
+            self._states[u_id] = PADState()
+            self._histories[u_id] = []
+        return self._states[u_id], self._histories[u_id]
+
+    @property
+    def state(self) -> PADState:
+        return self.get_state_history(None)[0]
+
+    @property
+    def history(self) -> List[PADState]:
+        return self.get_state_history(None)[1]
+
+    def update(self, p_delta: float, a_delta: float, d_delta: float, user_id: Optional[int] = None) -> None:
         """Update the emotional state with new stimuli."""
-        self.state.pleasure = self._clamp(self.state.pleasure + p_delta)
-        self.state.arousal = self._clamp(self.state.arousal + a_delta)
-        self.state.dominance = self._clamp(self.state.dominance + d_delta)
-        self.history.append(PADState(self.state.pleasure, self.state.arousal, self.state.dominance))
-        while len(self.history) > self.max_history_length:
-            self.history.pop(0)
+        state, history = self.get_state_history(user_id)
+        state.pleasure = self._clamp(state.pleasure + p_delta)
+        state.arousal = self._clamp(state.arousal + a_delta)
+        state.dominance = self._clamp(state.dominance + d_delta)
+        history.append(PADState(state.pleasure, state.arousal, state.dominance))
+        while len(history) > self.max_history_length:
+            history.pop(0)
 
-    def decay(self) -> None:
-        """Gradually return to neutral state (0,0,0)."""
-        self.state.pleasure *= (1 - self.decay_rate)
-        self.state.arousal *= (1 - self.decay_rate)
-        self.state.dominance *= (1 - self.decay_rate)
+    def decay(self, user_id: Optional[int] = None) -> None:
+        """Gradually return to neutral state (0,0,0) for one user or all if None."""
+        if user_id is None:
+            # None implies decaying all tracked states (for background jobs)
+            for u_id in list(self._states.keys()):
+                self._decay_single(u_id)
+        else:
+            self._decay_single(user_id)
 
-    def get_emotion_label(self) -> str:
+    def _decay_single(self, user_id: int) -> None:
+        state, _ = self.get_state_history(user_id)
+        state.pleasure *= (1 - self.decay_rate)
+        state.arousal *= (1 - self.decay_rate)
+        state.dominance *= (1 - self.decay_rate)
+
+    def get_emotion_label(self, user_id: Optional[int] = None) -> str:
         """Map PAD values to basic human emotion labels."""
-        p, a, d = self.state.pleasure, self.state.arousal, self.state.dominance
+        state, _ = self.get_state_history(user_id)
+        p, a, d = state.pleasure, state.arousal, state.dominance
 
         if p > 0.3:
             if a > 0.3:
@@ -68,6 +94,7 @@ class EmotionalEngine:
         """Clamp a value between min_val and max_val."""
         return max(min_val, min(max_val, value))
 
-    def get_summary(self) -> str:
+    def get_summary(self, user_id: Optional[int] = None) -> str:
         """Return a readable summary of the current emotional state."""
-        return f"Current Emotion: {self.get_emotion_label()} (P:{self.state.pleasure:.2f}, A:{self.state.arousal:.2f}, D:{self.state.dominance:.2f})"
+        state, _ = self.get_state_history(user_id)
+        return f"Current Emotion: {self.get_emotion_label(user_id)} (P:{state.pleasure:.2f}, A:{state.arousal:.2f}, D:{state.dominance:.2f})"

--- a/magda_agent/memory/storage.py
+++ b/magda_agent/memory/storage.py
@@ -23,13 +23,23 @@ class MemorySystem:
     Includes emotional coloring, importance-based decay, and ChromaDB vector search.
     """
     def __init__(self, short_term_limit: int = 10):
-        self.short_term: List[MemoryEntry] = []
-        self.long_term: List[MemoryEntry] = []
+        self._short_term_by_user: Dict[int, List[MemoryEntry]] = {}
+        self._long_term_by_user: Dict[int, List[MemoryEntry]] = {}
         self.short_term_limit = short_term_limit
 
         self.client = chromadb.EphemeralClient()
         self.collection = self.client.get_or_create_collection(name="working_memory")
         self._entries: Dict[str, MemoryEntry] = {}
+
+    @property
+    def short_term(self) -> List[MemoryEntry]:
+        """Flattened list of all short-term memories across all users."""
+        return [entry for user_list in self._short_term_by_user.values() for entry in user_list]
+
+    @property
+    def long_term(self) -> List[MemoryEntry]:
+        """Flattened list of all long-term memories across all users."""
+        return [entry for user_list in self._long_term_by_user.values() for entry in user_list]
 
     def add_memory(self, content: str, importance: float, emotional_state: PADState, tags: List[str] = None, user_id: int = None):
         """Add a new entry to short-term memory and index it in ChromaDB."""
@@ -41,14 +51,15 @@ class MemorySystem:
             tags=tags or [],
             user_id=user_id
         )
-        self.short_term.append(entry)
+
+        u_id = user_id if user_id is not None else -1
+        user_short_term = self._short_term_by_user.setdefault(u_id, [])
+        user_short_term.append(entry)
 
         entry_id_str = str(entry.id)
         self._entries[entry_id_str] = entry
 
-        meta = {"importance": importance}
-        if user_id is not None:
-            meta["user_id"] = user_id
+        meta = {"importance": importance, "user_id": u_id}
 
         try:
             self.collection.add(
@@ -60,28 +71,41 @@ class MemorySystem:
             logging.error(f"Failed to add memory to ChromaDB: {e}")
 
         # If short-term memory is full, consolidate
-        if len(self.short_term) > self.short_term_limit:
-            self.consolidate()
+        if len(user_short_term) > self.short_term_limit:
+            # Consolidate only this user's memory, pass u_id directly or wrap in logic
+            self._consolidate_user(u_id)
 
-    def consolidate(self):
+    def consolidate(self, user_id: Optional[int] = None):
         """
         Move important or emotionally significant memories to long-term storage.
         Less important memories in short-term are eventually discarded.
+        If user_id is None, it consolidates all tracked users.
         """
+        if user_id is None:
+            # None implies decaying all tracked states (for background jobs)
+            for u in list(self._short_term_by_user.keys()):
+                self._consolidate_user(u)
+        else:
+            self._consolidate_user(user_id)
+
+    def _consolidate_user(self, u_id: int):
+        user_short_term = self._short_term_by_user.setdefault(u_id, [])
+        user_long_term = self._long_term_by_user.setdefault(u_id, [])
+
         # Sort by importance and emotional intensity
-        self.short_term.sort(key=lambda x: x.importance + self._calc_emotional_intensity(x.emotional_state), reverse=True)
+        user_short_term.sort(key=lambda x: x.importance + self._calc_emotional_intensity(x.emotional_state), reverse=True)
 
         # Move the top memory to long-term
-        if self.short_term:
-            most_important = self.short_term.pop(0)
+        if user_short_term:
+            most_important = user_short_term.pop(0)
             if most_important.importance > 0.3: # Minimum threshold for long-term storage
-                self.long_term.append(most_important)
+                user_long_term.append(most_important)
             else:
                 self._remove_from_index(str(most_important.id))
 
         # Trim short-term memory
-        while len(self.short_term) > self.short_term_limit:
-            discarded = self.short_term.pop()
+        while len(user_short_term) > self.short_term_limit:
+            discarded = user_short_term.pop()
             self._remove_from_index(str(discarded.id))
 
     def _remove_from_index(self, entry_id_str: str) -> None:
@@ -102,12 +126,12 @@ class MemorySystem:
             if self.collection.count() == 0:
                 return []
 
+            u_id = user_id if user_id is not None else -1
             query_kwargs = {
                 "query_texts": [query],
-                "n_results": min(limit, self.collection.count())
+                "n_results": min(limit, self.collection.count()),
+                "where": {"user_id": u_id}
             }
-            if user_id is not None:
-                query_kwargs["where"] = {"user_id": user_id}
 
             results = self.collection.query(**query_kwargs)
 

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -86,6 +86,47 @@ async def test_consciousness_attachment_integration():
     call_args_2 = llm_mock.get_system_prompt.call_args[1]
     assert "Close Friend" in call_args_2["emotions"]
 
+def test_attachment_reset():
+    model = AttachmentModel()
+    user_id = 123
+    model.record_interaction(user_id)
+    model.record_interaction(user_id)
+    model.record_interaction(user_id)
+    assert model.get_level(user_id) == "acquaintance"
+
+    model.reset(user_id)
+    assert model.get_level(user_id) == "stranger"
+
+def test_attachment_anonymous_user():
+    model = AttachmentModel()
+    model.record_interaction(None)
+    model.record_interaction(None)
+    model.record_interaction(None)
+    assert model.get_level(None) == "acquaintance"
+
+    # Should not affect another user
+    assert model.get_level(123) == "stranger"
+
+def test_emotional_engine_user_context():
+    engine = EmotionalEngine()
+
+    # User 1 has positive experience
+    engine.update(0.5, 0.5, 0.5, user_id=1)
+
+    # User 2 has negative experience
+    engine.update(-0.5, -0.5, -0.5, user_id=2)
+
+    # Anonymous user has slightly positive
+    engine.update(0.1, 0.1, 0.1, user_id=None)
+
+    state1, _ = engine.get_state_history(1)
+    state2, _ = engine.get_state_history(2)
+    state_anon, _ = engine.get_state_history(None)
+
+    assert state1.pleasure > 0
+    assert state2.pleasure < 0
+    assert state_anon.pleasure > 0 and state_anon.pleasure < 0.2
+
 def test_emotional_engine_bounded_history() -> None:
     """Test that the emotional engine bounds the history length correctly when max_history_length is provided."""
     engine = EmotionalEngine(max_history_length=5)

--- a/tests/test_memory_user_context.py
+++ b/tests/test_memory_user_context.py
@@ -51,6 +51,17 @@ def test_memory_system_user_context(memory_system: MemorySystem) -> None:
     assert len(results_user2) == 1
     assert results_user2[0].content == "Hello from user 2"
 
+def test_memory_system_anonymous_user_context(memory_system: MemorySystem) -> None:
+    """Test that anonymous memory usage falls back to the default isolated context correctly."""
+    state = PADState(0.5, 0.5, 0.5)
+    memory_system.add_memory("Hello from anon", importance=0.8, emotional_state=state, user_id=None)
+    memory_system.add_memory("Hello from user 1", importance=0.8, emotional_state=state, user_id=1)
+
+    results_anon = memory_system.retrieve_relevant("Hello", user_id=None)
+
+    assert len(results_anon) == 1
+    assert results_anon[0].content == "Hello from anon"
+
 def test_habit_tracker_user_context(habit_tracker: HabitTracker) -> None:
     """Test that habit tracking isolates records correctly by user ID."""
     # Train user 1 habit


### PR DESCRIPTION
## Description
Separates mutable agent state (Emotions, Memory, Attachment) by user to prevent data from leaking across different users using the Magda agent.

## Implementation details
*   **EmotionalEngine**: Refactored `self.state` and `self.history` into `Dict[int, PADState]` tracking separate contexts per `user_id`. `decay()` supports passing `user_id=None` to decay all contexts simultaneously (e.g., for background subconscious jobs).
*   **AttachmentModel**: Refactored to map `user_id=None` to an anonymous user context (`-1`). Added `reset(user_id)` and `reset_all()` methods.
*   **MemorySystem**: Refactored short and long-term memory structures to be stored per `user_id`. Operations like `add_memory` and `retrieve_relevant` scope specifically to the user ID. Consolidate is backwards compatible via a parameter indicating "all" when none is specified.
*   **Consciousness core**: Updated all API hooks to pass the explicit `user_id`. Anonymous user conditions for attachment tracking were removed to allow tracking interactions for the default `-1` user context.
*   Tests added for anon user fallback, memory grouping isolation, and emotion contexts. Tasks manifest updated.

---
*PR created automatically by Jules for task [17165161363372029959](https://jules.google.com/task/17165161363372029959) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate mutable agent state by user in emotions, attachment, and memory
> - [`EmotionalEngine`](https://github.com/kazah4359-lgtm/Magda-agent/pull/54/files#diff-905d9204174127f87db6053cf0fd4ab85c9885f01efafdb7ed0f2786abeec19a) now tracks state and history per user via `_states` and `_histories` dicts keyed by user ID (None maps to -1 for anonymous); `update`, `decay`, `get_emotion_label`, and `get_summary` all accept a `user_id` parameter.
> - [`AttachmentModel`](https://github.com/kazah4359-lgtm/Magda-agent/pull/54/files#diff-56e77d2b37cba1570315a20898dd5e5b53c1d36dd106ffe2503a06fe88a18a32) tracks interactions per user (None → -1), and gains `reset(user_id)` and `reset_all()` methods.
> - [`MemorySystem`](https://github.com/kazah4359-lgtm/Magda-agent/pull/54/files#diff-b424973cadba3f7ba7408f34ddb96a0a289b8f8fc8a4df7641512737efa10581) stores short- and long-term memories in per-user maps; `retrieve_relevant` filters ChromaDB results by user ID so queries only return that user's entries.
> - The cognitive loop in [`consciousness/core.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/54/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) passes `user_id` through all emotion, attachment, and memory calls, including for anonymous users.
> - Behavioral Change: calling `EmotionalEngine.decay()` with no `user_id` now decays all tracked users instead of a single global state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4835860.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->