### PR TITLE
stabilization: Make Subconsciousness stop promptly

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -302,7 +302,7 @@
     },
     {
       "id": "subconscious-graceful-stop",
-      "status": "todo",
+      "status": "done",
       "area": "stabilization",
       "risk": "low",
       "title": "Make Subconsciousness stop promptly",

--- a/magda_agent/subconsciousness/reflection.py
+++ b/magda_agent/subconsciousness/reflection.py
@@ -23,17 +23,22 @@ class Subconsciousness:
         self.memory = memory
         self.interval = interval
         self.is_running = False
+        self._stop_event = asyncio.Event()
 
     async def start(self):
         """Start the background reflection loop."""
         self.is_running = True
+        self._stop_event.clear()
         logging.info("Subconsciousness reflection loop started.")
         while self.is_running:
-            await asyncio.sleep(self.interval)
-            await self.reflect()
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self.interval)
+            except asyncio.TimeoutError:
+                await self.reflect()
 
     async def stop(self):
         self.is_running = False
+        self._stop_event.set()
         logging.info("Subconsciousness reflection loop stopped.")
 
     async def reflect(self):

--- a/tests/test_subconsciousness.py
+++ b/tests/test_subconsciousness.py
@@ -47,6 +47,7 @@ def subconsciousness(mock_llm_client, mock_emotions, mock_memory_system):
 async def test_subconsciousness_instantiation(subconsciousness):
     assert subconsciousness.interval == 10
     assert subconsciousness.is_running is False
+    assert hasattr(subconsciousness, "_stop_event")
 
 @pytest.mark.asyncio
 async def test_subconsciousness_reflect(subconsciousness, mock_llm_client, mock_emotions, mock_memory_system):
@@ -80,3 +81,27 @@ async def test_subconsciousness_reflect_no_short_term(subconsciousness, mock_llm
 
     # Verify LLM was NOT called
     mock_llm_client.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_subconsciousness_stop_promptly(subconsciousness):
+    import asyncio
+
+    # Run start() as a background task
+    task = asyncio.create_task(subconsciousness.start())
+
+    # Yield control to let the task start and reach the wait_for
+    await asyncio.sleep(0)
+
+    assert subconsciousness.is_running is True
+
+    # Call stop
+    await subconsciousness.stop()
+
+    # The task should complete quickly without waiting the full interval (10s)
+    # wait_for will throw TimeoutError if it doesn't complete within 1s
+    try:
+        await asyncio.wait_for(task, timeout=1.0)
+    except asyncio.TimeoutError:
+        pytest.fail("Subconsciousness.start() did not stop promptly.")
+
+    assert subconsciousness.is_running is False


### PR DESCRIPTION
This PR implements the `subconscious-graceful-stop` task.

**Changes:**
- Initialized an `asyncio.Event` (`_stop_event`) inside `Subconsciousness.__init__`.
- Updated `start` to clear the event and use `asyncio.wait_for` instead of `asyncio.sleep`. If the interval times out, `reflect()` is called.
- Updated `stop` to set `_stop_event`, prompting the sleep to instantly interrupt.
- Updated `test_subconsciousness.py` unit tests to ensure `stop` accurately interrupts `start`.
- Marked `subconscious-graceful-stop` as done in `agent_tasks.json`.

Tested with:
```bash
python scripts/validate_agent_tasks.py agent_tasks.json
export PYTHONPATH=$(pwd) && python3 -m pytest tests/
```

---
*PR created automatically by Jules for task [1404263709590737401](https://jules.google.com/task/1404263709590737401) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `Subconsciousness` reflection loop stop promptly using an asyncio stop event
> Replaces the fixed `asyncio.sleep(self.interval)` in the reflection loop with `asyncio.wait_for(self._stop_event.wait(), timeout=self.interval)`, so `stop()` can interrupt the wait immediately instead of blocking until the interval elapses. `reflect()` is called on `TimeoutError`, preserving existing behavior. A new test verifies the loop terminates within 1 second after `stop()` is called.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0dcaa13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->