### PR TITLE
feat: Implement Salience Network

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -340,7 +340,7 @@
     },
     {
       "id": "salience-network",
-      "status": "todo",
+      "status": "done",
       "area": "cognition",
       "risk": "medium",
       "title": "Implement Salience Network",

--- a/magda_agent/attention/salience.py
+++ b/magda_agent/attention/salience.py
@@ -1,0 +1,83 @@
+"""
+Salience Network Module
+
+This module implements the Salience Network, responsible for determining the urgency
+and importance of events based on heuristics like urgency, test failures, and security risks.
+"""
+
+from typing import Tuple, Dict, Any
+
+
+class SalienceNetwork:
+    """
+    Evaluates events to determine their salience score.
+    Scores events based on multiple factors:
+    - urgency
+    - active task relevance
+    - CI/test signals
+    - uncertainty
+    - novelty
+    - security risk
+    """
+
+    def __init__(self):
+        pass
+
+    def score_event(self, event: Dict[str, Any]) -> Tuple[float, str]:
+        """
+        Scores an event and returns a salience score between 0.0 and 1.0,
+        along with an explanation string.
+
+        Args:
+            event: A dictionary representing the event. Expected keys might include:
+                   'content' (str), 'type' (str), 'is_ci_failure' (bool),
+                   'is_security_risk' (bool), 'urgency' (float).
+
+        Returns:
+            A tuple of (score, explanation).
+        """
+        score = 0.1  # Base salience for any event
+        reasons = ["base score 0.1"]
+
+        content = str(event.get("content", "")).lower()
+
+        # Check for noise or low-value input
+        if not content or len(content.strip()) < 2:
+            return 0.0, "noisy or empty input"
+
+        # Security risk
+        if event.get("is_security_risk", False) or "security" in content or "vulnerability" in content or "exploit" in content:
+            score += 0.8
+            reasons.append("security risk detected (+0.8)")
+
+        # CI failure
+        if event.get("is_ci_failure", False) or "ci failed" in content or "test failed" in content or "traceback" in content:
+            score += 0.6
+            reasons.append("CI/test failure detected (+0.6)")
+
+        # Urgency keywords
+        if "urgent" in content or "asap" in content or "emergency" in content:
+            score += 0.4
+            reasons.append("urgency keywords detected (+0.4)")
+
+        # Uncertainty
+        if event.get("uncertainty", 0.0) > 0.5:
+             score += 0.2
+             reasons.append("high uncertainty (+0.2)")
+
+        # Novelty
+        if event.get("novelty", 0.0) > 0.5:
+             score += 0.2
+             reasons.append("high novelty (+0.2)")
+
+        # Explicit urgency score
+        urgency = event.get("urgency", 0.0)
+        if urgency > 0:
+             score += urgency * 0.5
+             reasons.append(f"explicit urgency ({urgency} * 0.5 = +{urgency*0.5})")
+
+        # Clamp score between 0.0 and 1.0
+        final_score = max(0.0, min(1.0, score))
+        explanation = ", ".join(reasons)
+
+        return final_score, explanation

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -16,6 +16,7 @@ from magda_agent.emotions.insula import Insula
 from magda_agent.reflexes.brainstem import Brainstem
 from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
+from magda_agent.attention.salience import SalienceNetwork
 
 class Consciousness:
     """
@@ -39,7 +40,8 @@ class Consciousness:
         insula: Optional[Insula] = None,
         brainstem: Optional[Brainstem] = None,
         pineal_gland: Optional[PinealGland] = None,
-        mirror_neurons: Optional[MirrorNeurons] = None
+        mirror_neurons: Optional[MirrorNeurons] = None,
+        salience: Optional[SalienceNetwork] = None
     ):
         self.llm = llm
         self.emotions = emotions
@@ -57,9 +59,15 @@ class Consciousness:
         self.brainstem = brainstem
         self.pineal_gland = pineal_gland
         self.mirror_neurons = mirror_neurons
+        self.salience = salience
 
     async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
+
+        if self.salience:
+            event = {"content": user_input}
+            score, explanation = self.salience.score_event(event)
+            logging.info(f"Salience score: {score:.2f} ({explanation})")
 
         if self.thalamus and not self.thalamus.filter_input(user_input):
             return "Message ignored by Thalamus."

--- a/tests/test_salience.py
+++ b/tests/test_salience.py
@@ -1,0 +1,71 @@
+import pytest
+from magda_agent.attention.salience import SalienceNetwork
+
+
+def test_noisy_low_value_input():
+    salience_network = SalienceNetwork()
+
+    event_empty = {"content": ""}
+    score_empty, explain_empty = salience_network.score_event(event_empty)
+    assert score_empty == 0.0
+    assert "noisy or empty input" in explain_empty
+
+    event_whitespace = {"content": "   "}
+    score_whitespace, explain_whitespace = salience_network.score_event(event_whitespace)
+    assert score_whitespace == 0.0
+    assert "noisy or empty input" in explain_whitespace
+
+    event_short = {"content": "a"}
+    score_short, explain_short = salience_network.score_event(event_short)
+    assert score_short == 0.0
+    assert "noisy or empty input" in explain_short
+
+
+def test_failed_ci_event_receives_high_salience():
+    salience_network = SalienceNetwork()
+
+    event_ci_flag = {"content": "normal log", "is_ci_failure": True}
+    score_ci_flag, explain_ci_flag = salience_network.score_event(event_ci_flag)
+    assert score_ci_flag >= 0.7  # 0.1 base + 0.6 CI
+    assert "CI/test failure" in explain_ci_flag
+
+    event_ci_keyword = {"content": "the ci failed on master"}
+    score_ci_keyword, explain_ci_keyword = salience_network.score_event(event_ci_keyword)
+    assert score_ci_keyword >= 0.7
+    assert "CI/test failure" in explain_ci_keyword
+
+
+def test_security_risk_event_receives_high_salience():
+    salience_network = SalienceNetwork()
+
+    event_sec_flag = {"content": "normal log", "is_security_risk": True}
+    score_sec_flag, explain_sec_flag = salience_network.score_event(event_sec_flag)
+    assert score_sec_flag >= 0.9  # 0.1 base + 0.8 security
+    assert "security risk" in explain_sec_flag
+
+    event_sec_keyword = {"content": "found a vulnerability in dependency"}
+    score_sec_keyword, explain_sec_keyword = salience_network.score_event(event_sec_keyword)
+    assert score_sec_keyword >= 0.9
+    assert "security risk" in explain_sec_keyword
+
+
+def test_score_clamped_to_one():
+    salience_network = SalienceNetwork()
+
+    # Event with multiple high-salience triggers
+    event_max = {
+        "content": "urgent security vulnerability ci failed",
+        "is_security_risk": True,
+        "is_ci_failure": True
+    }
+    score_max, _ = salience_network.score_event(event_max)
+    assert score_max == 1.0
+
+
+def test_normal_input_salience():
+    salience_network = SalienceNetwork()
+
+    event_normal = {"content": "hello how are you"}
+    score_normal, explain_normal = salience_network.score_event(event_normal)
+    assert score_normal == 0.1
+    assert "base score" in explain_normal


### PR DESCRIPTION
This PR implements the Salience Network according to `docs/cognitive_architecture.md` and the `salience-network` task in `agent_tasks.json`.

Changes:
- Added `magda_agent/attention/salience.py` to compute a salience score from 0.0 to 1.0 based on urgency, CI signal, and security risks.
- Integrated `SalienceNetwork` into `Consciousness` to log scores of incoming user inputs without altering the public API.
- Added comprehensive unit tests in `tests/test_salience.py`.
- Updated `agent_tasks.json` to mark the task as `done`.

---
*PR created automatically by Jules for task [16578689892797297341](https://jules.google.com/task/16578689892797297341) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SalienceNetwork` to score events by security risk, CI failure, and urgency
> - Adds [`SalienceNetwork`](https://github.com/kazah4359-lgtm/Magda-agent/pull/56/files#diff-b63d79e1c27bd5babcc2da095fc1b28957d592bb4e7a85b8910ebcfd62b6eec5) with a `score_event` method that returns a `[0.0, 1.0]` score and human-readable explanation based on security keywords, CI/test failures, urgency signals, novelty, and uncertainty.
> - Integrates `SalienceNetwork` into [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/56/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) as an optional constructor parameter; when present, `process_input` logs the salience score and explanation before further processing.
> - Adds tests in [`tests/test_salience.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/56/files#diff-0f6cdd84e332b4e55c2db45b9bff68128d5a2486d7307eacf2175f18e34c46e3) covering noisy input, CI failure, security risk, combined trigger clamping, and normal base score.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1699c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->