### PR TITLE
feat(cognition): introduce global workspace

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -361,7 +361,7 @@
     },
     {
       "id": "global-workspace",
-      "status": "todo",
+      "status": "done",
       "area": "cognition",
       "risk": "medium",
       "title": "Introduce Global Workspace",
@@ -379,6 +379,23 @@
         "suppressed candidates remain inspectable",
         "existing /process API behavior remains compatible",
         "planner still receives the focused user input"
+      ]
+    },
+    {
+      "id": "procedural-memory",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Implement Procedural Memory",
+      "description": "Implement a Procedural Memory module to store reusable successful procedures.",
+      "allowed_paths": [
+        "magda_agent/memory/**",
+        "tests/test_memory*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Procedural memory stores reusable successful methods",
+        "Existing user_id filtering remains supported"
       ]
     },
     {

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -22,6 +22,8 @@ from magda_agent.drives.hypothalamus import Hypothalamus
 from magda_agent.emotions.insula import Insula
 from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
+from magda_agent.attention.salience import SalienceNetwork
+from magda_agent.attention.workspace import GlobalWorkspace
 
 logging.basicConfig(level=logging.INFO)
 
@@ -39,6 +41,8 @@ hypothalamus = Hypothalamus()
 insula = Insula()
 pineal_gland = PinealGland()
 mirror_neurons = MirrorNeurons()
+salience_network = SalienceNetwork()
+global_workspace = GlobalWorkspace(salience_network=salience_network)
 
 consciousness = Consciousness(
     llm=llm_client,
@@ -54,7 +58,9 @@ consciousness = Consciousness(
     hypothalamus=hypothalamus,
     insula=insula,
     pineal_gland=pineal_gland,
-    mirror_neurons=mirror_neurons
+    mirror_neurons=mirror_neurons,
+    salience=salience_network,
+    global_workspace=global_workspace
 )
 
 subconsciousness = Subconsciousness(

--- a/magda_agent/attention/workspace.py
+++ b/magda_agent/attention/workspace.py
@@ -1,0 +1,80 @@
+"""
+Global Workspace Module
+
+This module implements the Global Workspace, a central cognitive loop
+component where multiple candidate events compete for focus based on
+their salience score before memory retrieval, planning, and action selection.
+"""
+
+from typing import Dict, Any, List, Optional
+from magda_agent.attention.salience import SalienceNetwork
+
+
+class GlobalWorkspace:
+    """
+    Manages candidate events and selects the focal event based on salience.
+    """
+
+    def __init__(self, salience_network: SalienceNetwork):
+        self.salience_network = salience_network
+        self.candidates: List[Dict[str, Any]] = []
+        self.suppressed_candidates: List[Dict[str, Any]] = []
+
+    def add_candidate(self, event: Dict[str, Any]) -> None:
+        """
+        Adds a new candidate event to the workspace.
+
+        Args:
+            event: A dictionary representing the event.
+        """
+        self.candidates.append(event)
+
+    def select_focus(self) -> Optional[Dict[str, Any]]:
+        """
+        Scores all candidates using the SalienceNetwork and selects the one
+        with the highest score to be the focal event.
+        The remaining candidates are moved to suppressed_candidates.
+
+        Returns:
+            The focused event dictionary, or None if there are no candidates.
+        """
+        if not self.candidates:
+            return None
+
+        scored_candidates = []
+        for event in self.candidates:
+            score, explanation = self.salience_network.score_event(event)
+            # Annotate event with score and explanation
+            event["_salience_score"] = score
+            event["_salience_explanation"] = explanation
+            scored_candidates.append((score, event))
+
+        # Sort candidates by score descending
+        scored_candidates.sort(key=lambda x: x[0], reverse=True)
+
+        # Select the highest scoring candidate
+        focus_event = scored_candidates[0][1]
+
+        # Move the rest to suppressed candidates
+        self.suppressed_candidates = [event for _, event in scored_candidates[1:]]
+
+        # Clear candidates for the next cycle
+        self.candidates = []
+
+        return focus_event
+
+    def get_suppressed_candidates(self) -> List[Dict[str, Any]]:
+        """
+        Returns the list of suppressed candidate events from the last focus selection.
+
+        Returns:
+            A list of event dictionaries.
+        """
+        return self.suppressed_candidates
+
+    def clear(self) -> None:
+        """
+        Clears all candidates and suppressed candidates.
+        """
+        self.candidates = []
+        self.suppressed_candidates = []

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -17,6 +17,7 @@ from magda_agent.reflexes.brainstem import Brainstem
 from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
 from magda_agent.attention.salience import SalienceNetwork
+from magda_agent.attention.workspace import GlobalWorkspace
 
 class Consciousness:
     """
@@ -41,7 +42,8 @@ class Consciousness:
         brainstem: Optional[Brainstem] = None,
         pineal_gland: Optional[PinealGland] = None,
         mirror_neurons: Optional[MirrorNeurons] = None,
-        salience: Optional[SalienceNetwork] = None
+        salience: Optional[SalienceNetwork] = None,
+        global_workspace: Optional[GlobalWorkspace] = None
     ):
         self.llm = llm
         self.emotions = emotions
@@ -60,17 +62,43 @@ class Consciousness:
         self.pineal_gland = pineal_gland
         self.mirror_neurons = mirror_neurons
         self.salience = salience
+        self.global_workspace = global_workspace
 
     async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
 
-        if self.salience:
+        if self.thalamus and not self.thalamus.filter_input(user_input):
+            return "Message ignored by Thalamus."
+
+        focus_content = user_input
+        if self.global_workspace:
+            # 0. Global Workspace selection
+            # Clear previous candidates
+            self.global_workspace.clear()
+
+            # Add user input as candidate
+            main_event = {"type": "user_input", "content": user_input, "urgency": 0.5}
+            self.global_workspace.add_candidate(main_event)
+
+            # If we had other sub-systems adding events, they would do so here.
+            # E.g. self.global_workspace.add_candidate(boredom_event)
+
+            focused_event = self.global_workspace.select_focus()
+
+            if focused_event:
+                focus_content = str(focused_event.get("content", focus_content))
+                score = focused_event.get("_salience_score", 0.0)
+                explanation = focused_event.get("_salience_explanation", "")
+                logging.info(f"Workspace focused on event '{focused_event.get('type')}' with Salience: {score:.2f} ({explanation})")
+
+            # Only user_input is supported for full processing in the current API,
+            # but using focus_content ensures workspace output is piped in.
+            user_input = focus_content
+        elif self.salience:
+            # Fallback if no workspace but salience exists
             event = {"content": user_input}
             score, explanation = self.salience.score_event(event)
             logging.info(f"Salience score: {score:.2f} ({explanation})")
-
-        if self.thalamus and not self.thalamus.filter_input(user_input):
-            return "Message ignored by Thalamus."
 
         # 0. Brainstem Autonomic Reflexes
         if self.brainstem:

--- a/tests/test_global_workspace.py
+++ b/tests/test_global_workspace.py
@@ -1,0 +1,74 @@
+import pytest
+from magda_agent.attention.workspace import GlobalWorkspace
+from magda_agent.attention.salience import SalienceNetwork
+
+
+class MockSalienceNetwork(SalienceNetwork):
+    def score_event(self, event):
+        # Allow testing by providing a fixed score in the event
+        score = event.get("mock_score", 0.1)
+        explanation = "mock explanation"
+        return score, explanation
+
+
+def test_global_workspace_selects_highest_salience():
+    salience_network = MockSalienceNetwork()
+    workspace = GlobalWorkspace(salience_network=salience_network)
+
+    event1 = {"id": 1, "mock_score": 0.2}
+    event2 = {"id": 2, "mock_score": 0.9}
+    event3 = {"id": 3, "mock_score": 0.5}
+
+    workspace.add_candidate(event1)
+    workspace.add_candidate(event2)
+    workspace.add_candidate(event3)
+
+    focused = workspace.select_focus()
+
+    assert focused is not None
+    assert focused["id"] == 2
+    assert focused["_salience_score"] == 0.9
+
+
+def test_global_workspace_stores_suppressed_candidates():
+    salience_network = MockSalienceNetwork()
+    workspace = GlobalWorkspace(salience_network=salience_network)
+
+    event1 = {"id": 1, "mock_score": 0.8}
+    event2 = {"id": 2, "mock_score": 0.4}
+    event3 = {"id": 3, "mock_score": 0.6}
+
+    workspace.add_candidate(event1)
+    workspace.add_candidate(event2)
+    workspace.add_candidate(event3)
+
+    focused = workspace.select_focus()
+
+    assert focused is not None
+    assert focused["id"] == 1
+
+    suppressed = workspace.get_suppressed_candidates()
+    assert len(suppressed) == 2
+    suppressed_ids = [e["id"] for e in suppressed]
+    assert 2 in suppressed_ids
+    assert 3 in suppressed_ids
+
+
+def test_global_workspace_handles_empty_candidates():
+    salience_network = MockSalienceNetwork()
+    workspace = GlobalWorkspace(salience_network=salience_network)
+
+    focused = workspace.select_focus()
+    assert focused is None
+    assert len(workspace.get_suppressed_candidates()) == 0
+
+
+def test_global_workspace_clear():
+    salience_network = MockSalienceNetwork()
+    workspace = GlobalWorkspace(salience_network=salience_network)
+
+    workspace.add_candidate({"id": 1, "mock_score": 0.5})
+    workspace.clear()
+
+    focused = workspace.select_focus()
+    assert focused is None


### PR DESCRIPTION
Implemented the `GlobalWorkspace` module as specified in `agent_tasks.json`.

Changes:
- Created `magda_agent/attention/workspace.py` with a `GlobalWorkspace` class.
- Re-routed `Consciousness.process_input` (`magda_agent/consciousness/core.py`) to pipe input through the GlobalWorkspace.
- Instantiated `GlobalWorkspace` in `magda_agent/api.py`.
- Wrote full unit test coverage via `tests/test_global_workspace.py`.
- Ran full test suite to ensure no regressions.
- Validated `agent_tasks.json` with the new changes and created a new generic task to satisfy minimum todo task rules for replenishment.

---
*PR created automatically by Jules for task [10709282721198082551](https://jules.google.com/task/10709282721198082551) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce `GlobalWorkspace` into the cognitive loop for salience-based focus selection
> - Adds a new [`GlobalWorkspace`](https://github.com/kazah4359-lgtm/Magda-agent/pull/57/files#diff-f39fec33826ae55a3dfc3117e81bb1a12976302c3012af6b2e870c798b40b43b) class that collects candidate events, scores them via `SalienceNetwork`, selects the highest-salience event as focus, and retains suppressed candidates for inspection.
> - Wires `GlobalWorkspace` and `SalienceNetwork` into [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/57/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a): on each `process_input` call, the workspace selects the focal event and its content replaces `user_input` for downstream processing.
> - Reorders the cognitive loop in `Consciousness.process_input` so the `Thalamus` filter runs first and returns immediately on rejection, before any salience scoring occurs.
> - Behavioral Change: when a `GlobalWorkspace` is provided, `user_input` is replaced by the focused event's content rather than the raw input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85b75f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->