### PR TITLE
feat(memory): Implement ProceduralMemory module with ChromaDB

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -383,7 +383,7 @@
     },
     {
       "id": "procedural-memory",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Implement Procedural Memory",
@@ -440,6 +440,24 @@
         "lessons are stored separately from raw conversation",
         "recurring failures can create proposed tasks",
         "LLM calls remain mocked in tests"
+      ]
+    },
+    {
+      "id": "quality-metrics-tracking",
+      "status": "todo",
+      "area": "reflection",
+      "risk": "medium",
+      "title": "Add longitudinal quality metrics for Jules loop",
+      "description": "Implement a tracker to measure continuous improvement metrics like test pass rate and PR size, storing them for reflection.",
+      "allowed_paths": [
+        "magda_agent/metacognition/**",
+        "tests/test_metrics.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tracker module logs pass rates and PR stats",
+        "Metrics are stored in a persistent store",
+        "Subconsciousness can read metrics"
       ]
     }
   ]

--- a/magda_agent/memory/procedural.py
+++ b/magda_agent/memory/procedural.py
@@ -1,0 +1,63 @@
+import chromadb
+import uuid
+import logging
+
+class ProceduralMemory:
+    """
+    Procedural memory stores reusable successful methods and procedures.
+    Uses ChromaDB for vector-based semantic retrieval of procedures.
+    """
+    def __init__(self, persist_directory: str = "./procedural_memory_db") -> None:
+        """Initialize ProceduralMemory with an ephemeral or persistent ChromaDB client."""
+        if persist_directory == ":memory:":
+            self.client = chromadb.EphemeralClient()
+            logging.info("Initialized ProceduralMemory with EphemeralClient")
+        else:
+            self.client = chromadb.PersistentClient(path=persist_directory)
+            logging.info(f"Initialized ProceduralMemory with persistent directory: {persist_directory}")
+        self.collection = self.client.get_or_create_collection(name="procedural_memory")
+
+    def store_procedure(self, name: str, procedure: str, metadata: dict = None, user_id: int = None) -> None:
+        """
+        Store a procedural memory (e.g., a method or steps) with optional metadata.
+        """
+        try:
+            memory_id = str(uuid.uuid4())
+
+            meta = metadata.copy() if metadata else {}
+            meta["name"] = name
+            if user_id is not None:
+                meta["user_id"] = user_id
+
+            # The content being embedded is the name and the procedure for better semantic matching
+            content = f"Procedure Name: {name}\nProcedure: {procedure}"
+
+            self.collection.add(
+                documents=[content],
+                metadatas=[meta],
+                ids=[memory_id]
+            )
+            logging.debug(f"Stored procedure: {name}")
+        except Exception as e:
+            logging.error(f"Failed to store procedure: {e}")
+
+    def recall_procedure(self, query: str, top_k: int = 5, user_id: int = None) -> list[str]:
+        """
+        Recall relevant procedures based on semantic similarity to the query.
+        Returns the procedural documents that match.
+        """
+        try:
+            query_kwargs = {
+                "query_texts": [query],
+                "n_results": top_k
+            }
+            if user_id is not None:
+                query_kwargs["where"] = {"user_id": user_id}
+
+            results = self.collection.query(**query_kwargs)
+            if results and results.get("documents") and len(results["documents"]) > 0:
+                return results["documents"][0]
+            return []
+        except Exception as e:
+            logging.error(f"Failed to recall procedures: {e}")
+            return []

--- a/tests/test_memory_procedural.py
+++ b/tests/test_memory_procedural.py
@@ -1,0 +1,51 @@
+import pytest
+from magda_agent.memory.procedural import ProceduralMemory
+
+@pytest.fixture
+def procedural_memory(tmp_path):
+    """
+    Fixture to provide an ephemeral ProceduralMemory instance for testing.
+    We use ':memory:' to avoid persisting test data to disk.
+    """
+    return ProceduralMemory(persist_directory=":memory:")
+
+def test_store_and_recall_procedure(procedural_memory: ProceduralMemory) -> None:
+    """Test that procedures can be stored and recalled."""
+    procedural_memory.store_procedure("test_proc", "Do this, then do that", user_id=1)
+
+    # We expect some match if we query something similar
+    results = procedural_memory.recall_procedure("How to test proc?", user_id=1)
+
+    assert len(results) > 0
+    assert "Procedure Name: test_proc" in results[0]
+    assert "Do this, then do that" in results[0]
+
+def test_procedural_memory_user_context(procedural_memory: ProceduralMemory) -> None:
+    """Test that procedural memory isolates records correctly by user ID."""
+    procedural_memory.store_procedure("user1_proc", "User 1 secret procedure", user_id=1)
+    procedural_memory.store_procedure("user2_proc", "User 2 secret procedure", user_id=2)
+
+    results_user1 = procedural_memory.recall_procedure("secret procedure", user_id=1)
+    results_user2 = procedural_memory.recall_procedure("secret procedure", user_id=2)
+    results_all = procedural_memory.recall_procedure("secret procedure", user_id=None)
+
+    # Check user 1's recall
+    assert any("user1_proc" in r for r in results_user1)
+    assert not any("user2_proc" in r for r in results_user1)
+
+    # Check user 2's recall
+    assert any("user2_proc" in r for r in results_user2)
+    assert not any("user1_proc" in r for r in results_user2)
+
+    # Calling recall without user_id might return both, depending on Chromadb matching,
+    # but at the very least it shouldn't fail and should return something.
+    assert len(results_all) > 0
+
+def test_store_procedure_with_metadata(procedural_memory: ProceduralMemory) -> None:
+    """Test storing procedure with additional metadata."""
+    metadata = {"category": "system", "version": "1.0"}
+    procedural_memory.store_procedure("meta_proc", "Steps with metadata", metadata=metadata, user_id=1)
+
+    results = procedural_memory.recall_procedure("meta_proc", user_id=1)
+    assert len(results) > 0
+    assert "meta_proc" in results[0]


### PR DESCRIPTION
Implements the `procedural-memory` task, utilizing ChromaDB to store and semantically retrieve procedures, correctly factoring `user_id` context. Also replenishes a task in the queue to respect the minimum pool threshold.

---
*PR created automatically by Jules for task [419592887633642650](https://jules.google.com/task/419592887633642650) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ProceduralMemory` module with ChromaDB-backed semantic storage and retrieval
> - Introduces [procedural.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/58/files#diff-85a49588b323e14c8a6fc7e16784e7b36dcda58b5300e34b3516585bf83090a3) with a `ProceduralMemory` class that stores and retrieves procedures using ChromaDB vector search.
> - Supports both ephemeral (`:memory:`) and persistent modes, with optional per-user scoping via `user_id` metadata filtering.
> - Procedures are stored as semantically rich documents combining name and content, assigned a UUID, and queryable by natural language.
> - Test coverage in [tests/test_memory_procedural.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/58/files#diff-3f73dec4033b82a895288a4624a97f0d2f43bda68c65d1ed86fdd2e47685bcba) validates store/recall, user isolation, and extra metadata handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8023d68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->