### PR TITLE
feat: structured consolidation for Subconsciousness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ venv.bak/
 .dockerignore
 memory_db/
 habits_db/
+procedural_memory_db/

--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -423,7 +423,7 @@
     },
     {
       "id": "subconscious-consolidation",
-      "status": "todo",
+      "status": "done",
       "area": "reflection",
       "risk": "medium",
       "title": "Upgrade Subconsciousness into structured consolidation",

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -10,6 +10,7 @@ from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import EmotionalEngine
 from magda_agent.emotions.attachment import AttachmentModel
 from magda_agent.memory.storage import MemorySystem
+from magda_agent.memory.procedural import ProceduralMemory
 from magda_agent.skills import initialize_skills
 from magda_agent.planning.planner import Planner
 from magda_agent.consciousness.core import Consciousness
@@ -30,6 +31,7 @@ logging.basicConfig(level=logging.INFO)
 llm_client = LLMClient()
 emotional_engine = EmotionalEngine()
 memory_system = MemorySystem()
+procedural_memory = ProceduralMemory(persist_directory="./procedural_memory_db")
 skill_registry = initialize_skills()
 habit_tracker = HabitTracker()
 planner = Planner(llm=llm_client, skills=skill_registry, habit_tracker=habit_tracker)
@@ -67,6 +69,7 @@ subconsciousness = Subconsciousness(
     llm=llm_client,
     emotions=emotional_engine,
     memory=memory_system,
+    procedural_memory=procedural_memory,
     interval=300
 )
 

--- a/magda_agent/subconsciousness/reflection.py
+++ b/magda_agent/subconsciousness/reflection.py
@@ -5,6 +5,7 @@ from typing import List
 from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import EmotionalEngine
 from magda_agent.memory.storage import MemorySystem
+from magda_agent.memory.procedural import ProceduralMemory
 
 class Subconsciousness:
     """
@@ -16,11 +17,13 @@ class Subconsciousness:
         llm: LLMClient,
         emotions: EmotionalEngine,
         memory: MemorySystem,
+        procedural_memory: ProceduralMemory = None,
         interval: int = 60  # Reflection interval in seconds
     ):
         self.llm = llm
         self.emotions = emotions
         self.memory = memory
+        self.procedural_memory = procedural_memory
         self.interval = interval
         self.is_running = False
         self._stop_event = asyncio.Event()
@@ -63,13 +66,17 @@ class Subconsciousness:
         Recent events:
         {memories_text}
 
-        Based on these events, perform a brief self-reflection.
+        Based on these events, perform a structured self-reflection.
         How are you doing? Are you fulfilling your goals as an AGI?
-        Suggest a minor adjustment to your emotional state (Pleasure, Arousal, Dominance) as a result of this reflection.
+        Identify any reusable lessons or anti-patterns. Are there tasks you should propose?
+        Suggest a minor adjustment to your emotional state (Pleasure, Arousal, Dominance).
 
         You MUST respond ONLY with a valid JSON object in the exact format below, with no additional text:
         {{
-            "reflection": "Your textual self-reflection here",
+            "summary": "Your textual self-reflection and summary here",
+            "lessons": ["lesson 1", "lesson 2"],
+            "anti_patterns": ["anti-pattern 1", "anti-pattern 2"],
+            "proposed_tasks": ["proposed task 1", "proposed task 2"],
             "pad_adjustment": {{
                 "p": 0.0,
                 "a": 0.0,
@@ -84,6 +91,9 @@ class Subconsciousness:
         logging.info(f"Raw reflection response: {raw_response}")
 
         reflection_text = "Parsed reflection failed."
+        lessons = []
+        anti_patterns = []
+        proposed_tasks = []
         p_adj, a_adj, d_adj = 0.02, -0.01, 0.05  # Defaults
 
         try:
@@ -97,7 +107,10 @@ class Subconsciousness:
                 cleaned_response = cleaned_response[:-3]
 
             parsed_data = json.loads(cleaned_response.strip())
-            reflection_text = parsed_data.get("reflection", "No reflection text provided.")
+            reflection_text = parsed_data.get("summary", "No reflection text provided.")
+            lessons = parsed_data.get("lessons", [])
+            anti_patterns = parsed_data.get("anti_patterns", [])
+            proposed_tasks = parsed_data.get("proposed_tasks", [])
             pad_adj = parsed_data.get("pad_adjustment", {})
             p_adj = float(pad_adj.get("p", 0.0))
             a_adj = float(pad_adj.get("a", 0.0))
@@ -114,3 +127,12 @@ class Subconsciousness:
             emotional_state=self.emotions.state,
             tags=["reflection", "internal"]
         )
+
+        if self.procedural_memory:
+            for lesson in lessons:
+                self.procedural_memory.store_procedure(name="lesson", procedure=lesson)
+            for ap in anti_patterns:
+                self.procedural_memory.store_procedure(name="anti_pattern", procedure=ap)
+
+        for task in proposed_tasks:
+            logging.info(f"Subconscious proposed task: {task}")

--- a/tests/test_subconsciousness.py
+++ b/tests/test_subconsciousness.py
@@ -4,6 +4,7 @@ from magda_agent.subconsciousness.reflection import Subconsciousness
 from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import EmotionalEngine
 from magda_agent.memory.storage import MemorySystem, MemoryEntry
+from magda_agent.memory.procedural import ProceduralMemory
 
 @pytest.fixture
 def mock_llm_client():
@@ -11,7 +12,10 @@ def mock_llm_client():
     mock.chat_completion.return_value = """
     ```json
     {
-        "reflection": "I am doing well and growing.",
+        "summary": "I am doing well and growing.",
+        "lessons": ["Mock LLM responses."],
+        "anti_patterns": ["Hardcoding secrets."],
+        "proposed_tasks": ["Add new mock."],
         "pad_adjustment": {
             "p": 0.1,
             "a": -0.05,
@@ -35,11 +39,17 @@ def mock_memory_system():
     return mock
 
 @pytest.fixture
-def subconsciousness(mock_llm_client, mock_emotions, mock_memory_system):
+def mock_procedural_memory():
+    mock = MagicMock(spec=ProceduralMemory)
+    return mock
+
+@pytest.fixture
+def subconsciousness(mock_llm_client, mock_emotions, mock_memory_system, mock_procedural_memory):
     return Subconsciousness(
         llm=mock_llm_client,
         emotions=mock_emotions,
         memory=mock_memory_system,
+        procedural_memory=mock_procedural_memory,
         interval=10
     )
 
@@ -50,7 +60,7 @@ async def test_subconsciousness_instantiation(subconsciousness):
     assert hasattr(subconsciousness, "_stop_event")
 
 @pytest.mark.asyncio
-async def test_subconsciousness_reflect(subconsciousness, mock_llm_client, mock_emotions, mock_memory_system):
+async def test_subconsciousness_reflect(subconsciousness, mock_llm_client, mock_emotions, mock_memory_system, mock_procedural_memory):
     await subconsciousness.reflect()
 
     # Verify memory consolidation was called
@@ -68,6 +78,11 @@ async def test_subconsciousness_reflect(subconsciousness, mock_llm_client, mock_
     assert "Subconscious reflection: I am doing well and growing." in call_args["content"]
     assert call_args["tags"] == ["reflection", "internal"]
     assert call_args["importance"] == 0.4
+
+    # Verify procedural memory was called
+    assert mock_procedural_memory.store_procedure.call_count == 2
+    mock_procedural_memory.store_procedure.assert_any_call(name="lesson", procedure="Mock LLM responses.")
+    mock_procedural_memory.store_procedure.assert_any_call(name="anti_pattern", procedure="Hardcoding secrets.")
 
 @pytest.mark.asyncio
 async def test_subconsciousness_reflect_no_short_term(subconsciousness, mock_llm_client, mock_memory_system):


### PR DESCRIPTION
Upgrade `Subconsciousness` module to use a structured consolidation format (extracting lessons, anti-patterns, and proposed tasks) and integrate these findings with `ProceduralMemory`.

---
*PR created automatically by Jules for task [4507503282863588403](https://jules.google.com/task/4507503282863588403) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured JSON reflection output and procedural memory storage to `Subconsciousness`
> - `Subconsciousness.reflect` now requests a structured JSON response from the LLM containing `summary`, `lessons`, `anti_patterns`, `proposed_tasks`, and `pad_adjustment` fields, replacing the previous flat `reflection` field.
> - Lessons and anti-patterns extracted from each reflection are persisted to a `ProceduralMemory` instance (stored under `./procedural_memory_db`); proposed tasks are logged via `logging.info`.
> - `ProceduralMemory` is wired in at startup in [api.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/61/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d) and passed as an optional parameter to `Subconsciousness.__init__`, keeping existing callers without it working unchanged.
> - Behavioral Change: any code parsing the reflection output now receives `summary` instead of `reflection` as the top-level text key.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 36928be. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->