### PR TITLE
feat(reflection): add longitudinal quality metrics tracker for Jules loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ venv.bak/
 memory_db/
 habits_db/
 procedural_memory_db/
+metrics_db/
+metrics_db.sqlite3

--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -444,7 +444,7 @@
     },
     {
       "id": "quality-metrics-tracking",
-      "status": "todo",
+      "status": "done",
       "area": "reflection",
       "risk": "medium",
       "title": "Add longitudinal quality metrics for Jules loop",

--- a/magda_agent/metacognition/__init__.py
+++ b/magda_agent/metacognition/__init__.py
@@ -1,0 +1,7 @@
+from magda_agent.metacognition.evaluator import Evaluator
+from magda_agent.metacognition.tracker import QualityTracker
+
+# Global instance for tracking continuous improvement metrics
+quality_tracker = QualityTracker()
+
+__all__ = ["Evaluator", "QualityTracker", "quality_tracker"]

--- a/magda_agent/metacognition/metrics_cli.py
+++ b/magda_agent/metacognition/metrics_cli.py
@@ -1,0 +1,50 @@
+import argparse
+import sys
+import json
+from magda_agent.metacognition.tracker import QualityTracker
+
+def main() -> None:
+    """
+    CLI integration point for the Jules autonomous loop.
+    Allows bash scripts (e.g., CI/CD pipelines or local automated tasks) to
+    log continuous improvement metrics easily.
+    """
+    parser = argparse.ArgumentParser(description="Log and retrieve quality metrics for the Jules loop.")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Subparser for logging
+    log_parser = subparsers.add_parser("log", help="Log a new metric value.")
+    log_parser.add_argument("metric_name", type=str, help="Name of the metric (e.g., test_pass_rate)")
+    log_parser.add_argument("value", type=float, help="Value of the metric")
+    log_parser.add_argument("--metadata", type=str, help="Optional JSON string with metadata", default="{}")
+    log_parser.add_argument("--db", type=str, help="Path to SQLite DB", default="./metrics_db.sqlite3")
+
+    # Subparser for getting averages
+    avg_parser = subparsers.add_parser("average", help="Calculate average for a metric.")
+    avg_parser.add_argument("metric_name", type=str, help="Name of the metric")
+    avg_parser.add_argument("--limit", type=int, help="Number of recent entries to average", default=10)
+    avg_parser.add_argument("--db", type=str, help="Path to SQLite DB", default="./metrics_db.sqlite3")
+
+    args = parser.parse_args()
+    tracker = QualityTracker(db_path=args.db)
+
+    if args.command == "log":
+        try:
+            metadata = json.loads(args.metadata)
+        except json.JSONDecodeError:
+            print("Error: Metadata must be a valid JSON string.", file=sys.stderr)
+            sys.exit(1)
+
+        tracker.log_metric(args.metric_name, args.value, metadata)
+        print(f"Successfully logged {args.metric_name}: {args.value}")
+
+    elif args.command == "average":
+        avg = tracker.calculate_average(args.metric_name, args.limit)
+        if avg is not None:
+            print(f"Average for {args.metric_name} (last {args.limit} entries): {avg}")
+        else:
+            print(f"No entries found for {args.metric_name}")
+
+if __name__ == "__main__":
+    main()

--- a/magda_agent/metacognition/tracker.py
+++ b/magda_agent/metacognition/tracker.py
@@ -1,0 +1,127 @@
+import sqlite3
+import json
+import logging
+from typing import Optional, Dict, Any, List
+
+class QualityTracker:
+    """
+    QualityTracker logs continuous improvement metrics like test pass rates and PR sizes.
+    It stores these metrics persistently in a SQLite database so that Subconsciousness can read them for reflection.
+    """
+    def __init__(self, db_path: str = "./metrics_db.sqlite3") -> None:
+        """
+        Initialize the QualityTracker with a SQLite database.
+
+        Args:
+            db_path (str): Path to store the DB, or ':memory:' for an ephemeral database.
+        """
+        self.db_path = db_path
+        # If it's an in-memory DB, we must keep the connection open to retain data
+        self._memory_conn = sqlite3.connect(':memory:') if self.db_path == ':memory:' else None
+        self._init_db()
+        logging.info(f"Initialized QualityTracker with database: {db_path}")
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Returns a connection to the database."""
+        if self._memory_conn:
+            return self._memory_conn
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self) -> None:
+        """Initializes the database schema."""
+        conn = self._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS metrics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    metric_name TEXT NOT NULL,
+                    value REAL NOT NULL,
+                    metadata TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+            conn.commit()
+        finally:
+            if not self._memory_conn:
+                conn.close()
+
+    def log_metric(self, metric_name: str, value: float, metadata: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Logs a specific metric value.
+
+        Args:
+            metric_name (str): The name of the metric (e.g., 'test_pass_rate', 'pr_size').
+            value (float): The recorded value for the metric.
+            metadata (Optional[Dict[str, Any]]): Additional context/metadata for the metric.
+        """
+        try:
+            meta_json = json.dumps(metadata) if metadata else None
+            conn = self._get_connection()
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    'INSERT INTO metrics (metric_name, value, metadata) VALUES (?, ?, ?)',
+                    (metric_name, value, meta_json)
+                )
+                conn.commit()
+            finally:
+                if not self._memory_conn:
+                    conn.close()
+            logging.debug(f"Logged metric '{metric_name}': {value}")
+        except Exception as e:
+            logging.error(f"Failed to log metric '{metric_name}': {e}")
+
+    def get_metrics(self, metric_name: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """
+        Retrieves recent entries for a specific metric.
+
+        Args:
+            metric_name (str): The name of the metric to retrieve.
+            limit (int): The maximum number of entries to return.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries containing metric metadata.
+        """
+        try:
+            conn = self._get_connection()
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    'SELECT value, metadata, timestamp FROM metrics WHERE metric_name = ? ORDER BY timestamp DESC LIMIT ?',
+                    (metric_name, limit)
+                )
+                rows = cursor.fetchall()
+            finally:
+                if not self._memory_conn:
+                    conn.close()
+
+            results = []
+            for row in rows:
+                value, meta_json, timestamp = row
+                meta = json.loads(meta_json) if meta_json else {}
+                meta['value'] = value
+                meta['timestamp'] = timestamp
+                results.append(meta)
+            return results
+        except Exception as e:
+            logging.error(f"Failed to retrieve metrics for '{metric_name}': {e}")
+            return []
+
+    def calculate_average(self, metric_name: str, limit: int = 10) -> Optional[float]:
+        """
+        Calculates the average value for a specific metric over recent entries.
+
+        Args:
+            metric_name (str): The name of the metric.
+            limit (int): The number of recent entries to consider.
+
+        Returns:
+            Optional[float]: The average value, or None if no entries exist.
+        """
+        metrics = self.get_metrics(metric_name, limit=limit)
+        if not metrics:
+            return None
+
+        total = sum(float(m.get("value", 0.0)) for m in metrics)
+        return total / len(metrics)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,53 @@
+import pytest
+from magda_agent.metacognition.tracker import QualityTracker
+
+@pytest.fixture
+def quality_tracker():
+    """Provides a QualityTracker instance using an ephemeral SQLite database for testing."""
+    return QualityTracker(db_path=":memory:")
+
+def test_log_and_get_metrics(quality_tracker):
+    """Test that metrics can be logged and correctly retrieved."""
+    # Log some test metrics
+    quality_tracker.log_metric("test_pass_rate", 95.5, {"commit": "abc1234"})
+    quality_tracker.log_metric("test_pass_rate", 98.0, {"commit": "def5678"})
+    quality_tracker.log_metric("pr_size", 120.0, {"commit": "abc1234"})
+
+    # Retrieve metrics for test_pass_rate
+    pass_rate_metrics = quality_tracker.get_metrics("test_pass_rate")
+
+    assert len(pass_rate_metrics) == 2
+
+    # Values should be present in the returned metadata
+    values = [m["value"] for m in pass_rate_metrics]
+    assert 95.5 in values
+    assert 98.0 in values
+
+    # Retrieve metrics for pr_size
+    pr_size_metrics = quality_tracker.get_metrics("pr_size")
+    assert len(pr_size_metrics) == 1
+    assert pr_size_metrics[0]["value"] == 120.0
+
+def test_calculate_average(quality_tracker):
+    """Test the calculation of average metric values."""
+    # Log multiple values for a metric
+    quality_tracker.log_metric("test_pass_rate", 90.0)
+    quality_tracker.log_metric("test_pass_rate", 100.0)
+    quality_tracker.log_metric("test_pass_rate", 80.0)
+
+    # Calculate average
+    avg = quality_tracker.calculate_average("test_pass_rate")
+    assert avg == 90.0
+
+def test_calculate_average_empty(quality_tracker):
+    """Test calculating average when no metrics exist."""
+    avg = quality_tracker.calculate_average("non_existent_metric")
+    assert avg is None
+
+def test_get_metrics_limit(quality_tracker):
+    """Test that get_metrics respects the limit parameter."""
+    for i in range(15):
+        quality_tracker.log_metric("pr_size", float(i))
+
+    metrics = quality_tracker.get_metrics("pr_size", limit=5)
+    assert len(metrics) <= 5


### PR DESCRIPTION
This PR implements the `quality-metrics-tracking` task to track continuous improvement metrics for the Jules autonomous loop.\n\nChanges include:\n- `QualityTracker` class using SQLite for persistent, efficient storage without embedding overhead.\n- Unit tests using an ephemeral (`:memory:`) SQLite connection.\n- A CLI endpoint (`metrics_cli.py`) for bash scripts to log metrics easily.\n- Updates to `.gitignore` to prevent local binary sqlite artifacts from being committed.\n- Status update in `agent_tasks.json`.

---
*PR created automatically by Jules for task [16808091229775600593](https://jules.google.com/task/16808091229775600593) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add longitudinal quality metrics tracker with SQLite persistence for Jules loop reflection
> - Introduces `QualityTracker` in [`magda_agent/metacognition/tracker.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/63/files#diff-8548c6673c5fbad7637212e30860f095082d4ed6b0407ae237b6d5b621cfd31d) with a SQLite-backed API to log metrics, retrieve recent entries, and compute rolling averages.
> - Adds a CLI in [`magda_agent/metacognition/metrics_cli.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/63/files#diff-f69c83051b4b244aef23fd7a157b02901083bf7d8915153bcc54046424ff5ad7) with `log` and `average` subcommands for interacting with the metrics database.
> - Exports a pre-instantiated `quality_tracker` singleton from the `magda_agent.metacognition` package.
> - Adds pytest coverage for log/retrieve, average calculation, empty metric handling, and limit enforcement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e6bea7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->