### PR TITLE
feat: upgrade prefrontal cortex to output typed plans using pydantic

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -464,7 +464,7 @@
     },
     {
       "id": "planner-typed-plans",
-      "status": "todo",
+      "status": "done",
       "area": "cognition",
       "risk": "medium",
       "title": "Upgrade Prefrontal Cortex to output typed plans",
@@ -1008,6 +1008,67 @@
         "Retrieval boosts emotionally tagged memories",
         "Emotional similarity as retrieval factor",
         "Tests with emotionally tagged vs neutral memories"
+      ]
+    },
+    {
+      "id": "mcp-tools-export",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Export Skills as MCP-compatible Tools",
+      "description": "Implement a bridge to expose Magda's internal SkillRegistry as tools compliant with the Model Context Protocol (MCP). This enables seamless integration with other MCP-compatible clients and agents.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_export.py",
+        "magda_agent/skills/registry.py",
+        "tests/test_mcp_export*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be queried in MCP format",
+        "MCP tool schema validation passes",
+        "Tests verify tool metadata export matches MCP standard"
+      ]
+    },
+    {
+      "id": "agent-guardrails-policy-layer",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Implement Agent Guardrails Policy Layer",
+      "description": "Introduce a runtime governance layer that intercepts all tool calls with external effects before execution. Evaluates the action against a set of safety policies (e.g., read-only assertions). Inspired by MCPKernel and Microsoft ASSERT.",
+      "allowed_paths": [
+        "magda_agent/safety/guardrails.py",
+        "magda_agent/skills/executor.py",
+        "magda_agent/consciousness/core.py",
+        "tests/test_guardrails*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "All skill executions pass through the guardrails layer",
+        "Policy violations are blocked and logged",
+        "Safety evaluation runs before any state mutation",
+        "Tests mock policy violations and verify blocking behavior"
+      ]
+    },
+    {
+      "id": "context-engine-plugin-architecture",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Plugin Architecture",
+      "description": "Refactor Working Memory and Thalamus to support a Context Engine plugin interface with lifecycle hooks (pre_process, compress, post_process). Inspired by OpenClaw's context management.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine.py",
+        "magda_agent/memory/working.py",
+        "magda_agent/thalamus/router.py",
+        "tests/test_context_engine*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugins can register context compression hooks",
+        "Lifecycle events are dispatched during input processing",
+        "Context engine coordinates memory modules dynamically",
+        "Tests with mock plugins verify hook invocation"
       ]
     }
   ]

--- a/magda_agent/planning/planner.py
+++ b/magda_agent/planning/planner.py
@@ -1,9 +1,22 @@
 import json
 import logging
 from typing import List, Dict, Any, Optional
+from pydantic import BaseModel, Field, ValidationError
 from magda_agent.llm_client import LLMClient
 from magda_agent.skills.registry import SkillRegistry
 from magda_agent.learning.habits import HabitTracker
+
+class PlanStep(BaseModel):
+    description: str
+    skill: Optional[str] = None
+    skill_kwargs: Optional[Dict[str, Any]] = None
+
+class TypedPlan(BaseModel):
+    goal: str
+    constraints: List[str] = Field(default_factory=list)
+    risk: str
+    steps: List[PlanStep]
+    acceptance: List[str] = Field(default_factory=list)
 
 class Planner:
     """
@@ -18,6 +31,10 @@ class Planner:
         self.habit_tracker = habit_tracker
         self.current_plan: List[Dict[str, Any]] = []
         self.completed_steps: List[Dict[str, Any]] = []
+        self.current_goal: Optional[str] = None
+        self.current_constraints: List[str] = []
+        self.current_risk: Optional[str] = None
+        self.current_acceptance: List[str] = []
 
     async def generate_plan(self, user_input: str, user_id: int = None) -> List[Dict[str, Any]]:
         """
@@ -37,13 +54,16 @@ class Planner:
 
         system_prompt = (
             "You are the Prefrontal Cortex of an AI agent. Your job is to break down "
-            "the user's request into a logical sequence of steps. "
+            "the user's request into a logical sequence of steps.\n"
             "Available skills:\n"
             f"{skills_desc}\n"
-            "Return a JSON array of steps. Each step must be a JSON object with keys: "
-            "'description' (what to do), 'skill' (the name of the skill to use, or null if none), "
-            "and 'skill_kwargs' (a dictionary of arguments to pass to the skill, or null if no skill). "
-            "Only output the JSON array, nothing else."
+            "Return a JSON object with the following keys:\n"
+            "- 'goal': a string summarizing the objective\n"
+            "- 'constraints': an array of string constraints\n"
+            "- 'risk': a string indicating the risk level (e.g., low, medium, high)\n"
+            "- 'steps': an array of step objects. Each step must have 'description', 'skill' (or null), and 'skill_kwargs' (or null).\n"
+            "- 'acceptance': an array of string acceptance criteria\n"
+            "Only output the JSON object, nothing else."
         )
 
         if self.habit_tracker:
@@ -69,40 +89,40 @@ class Planner:
 
             response_text = response_text.strip()
 
-            plan = json.loads(response_text)
-            if not isinstance(plan, list):
-                logging.error("Plan generated is not a JSON list.")
-                self.current_plan = []
+            plan_dict = json.loads(response_text)
+            try:
+                typed_plan = TypedPlan(**plan_dict)
+            except ValidationError as ve:
+                logging.error(f"Plan validation failed: {ve}")
+                self.clear_pending_plan()
                 return []
 
-            for i, step in enumerate(plan):
-                if not isinstance(step, dict):
-                    logging.error(f"Step {i} in plan is not a JSON object.")
-                    self.current_plan = []
-                    return []
-                if "description" not in step or "skill" not in step or "skill_kwargs" not in step:
-                    logging.error(f"Step {i} in plan is missing required keys: 'description', 'skill', or 'skill_kwargs'.")
-                    self.current_plan = []
-                    return []
+            plan_steps = [step.model_dump() for step in typed_plan.steps]
+
+            for i, step in enumerate(plan_steps):
                 if step["skill"] is not None and not self.skills.has_skill(step["skill"]):
                     logging.error(f"Step {i} uses unknown skill: {step['skill']}.")
-                    self.current_plan = []
+                    self.clear_pending_plan()
                     return []
                 if step["skill_kwargs"] is not None and not isinstance(step["skill_kwargs"], dict):
                     logging.error(f"Step {i} 'skill_kwargs' must be a dictionary or null.")
-                    self.current_plan = []
+                    self.clear_pending_plan()
                     return []
 
-            self.current_plan = plan
+            self.current_plan = plan_steps
             self.completed_steps = []
-            return plan
+            self.current_goal = typed_plan.goal
+            self.current_constraints = typed_plan.constraints
+            self.current_risk = typed_plan.risk
+            self.current_acceptance = typed_plan.acceptance
+            return plan_steps
         except json.JSONDecodeError as e:
             logging.error(f"Failed to decode plan JSON: {e}")
-            self.current_plan = []
+            self.clear_pending_plan()
             return []
         except Exception as e:
             logging.error(f"Error during plan generation: {e}")
-            self.current_plan = []
+            self.clear_pending_plan()
             return []
 
     def get_current_plan(self) -> List[Dict[str, Any]]:
@@ -141,6 +161,12 @@ class Planner:
         if not self.current_plan and not self.completed_steps:
             return summary + "  No active plan."
 
+        if self.current_goal:
+            summary += f"  Goal: {self.current_goal}\n"
+            summary += f"  Risk: {self.current_risk}\n"
+            if self.current_constraints:
+                summary += f"  Constraints: {', '.join(self.current_constraints)}\n"
+
         if self.completed_steps:
             summary += "  Completed Steps:\n"
             for step in self.completed_steps:
@@ -158,4 +184,8 @@ class Planner:
         Clears the current pending plan steps.
         """
         self.current_plan = []
+        self.current_goal = None
+        self.current_constraints = []
+        self.current_risk = None
+        self.current_acceptance = []
         logging.info("Pending plan steps cleared.")

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -9,10 +9,16 @@ from magda_agent.skills.registry import SkillRegistry
 async def test_generate_plan_success():
     mock_llm = MagicMock(spec=LLMClient)
 
-    mock_plan = [
-        {"description": "Step 1", "skill": "search_internet", "skill_kwargs": {"query": "test query"}},
-        {"description": "Step 2", "skill": None, "skill_kwargs": None}
-    ]
+    mock_plan = {
+        "goal": "Do something complex",
+        "constraints": ["no new dependencies"],
+        "risk": "low",
+        "steps": [
+            {"description": "Step 1", "skill": "search_internet", "skill_kwargs": {"query": "test query"}},
+            {"description": "Step 2", "skill": None, "skill_kwargs": None}
+        ],
+        "acceptance": ["test passes"]
+    }
 
     mock_llm.chat_completion = AsyncMock(return_value=json.dumps(mock_plan))
 
@@ -27,6 +33,8 @@ async def test_generate_plan_success():
     assert result[0]["description"] == "Step 1"
     assert result[1]["skill"] is None
 
+    assert planner.current_goal == "Do something complex"
+    assert planner.current_risk == "low"
     assert len(planner.current_plan) == 2
     assert len(planner.completed_steps) == 0
 
@@ -49,8 +57,8 @@ async def test_generate_plan_validation_failures():
     """
     Tests that generate_plan correctly validates the LLM-generated plan output.
     It verifies that a plan is rejected and an empty list is returned if the plan
-    is not a list, contains invalid items, is missing keys, references an unknown skill,
-    or contains invalid skill arguments.
+    does not match the TypedPlan schema, contains invalid items, is missing keys,
+    references an unknown skill, or contains invalid skill arguments.
     """
     mock_llm = MagicMock(spec=LLMClient)
     mock_skills = MagicMock(spec=SkillRegistry)
@@ -58,29 +66,49 @@ async def test_generate_plan_validation_failures():
 
     planner = Planner(llm=mock_llm, skills=mock_skills)
 
-    # 1. Not a JSON list
+    # 1. Not a JSON object matching TypedPlan
     mock_llm.chat_completion = AsyncMock(return_value='{"step": 1}')
     result = await planner.generate_plan("test")
     assert result == []
 
-    # 2. Step is not a dict
-    mock_llm.chat_completion = AsyncMock(return_value='["step 1"]')
+    # 2. Step is not a valid PlanStep dict
+    mock_plan = {
+        "goal": "Test", "risk": "low", "steps": ["step 1"]
+    }
+    mock_llm.chat_completion = AsyncMock(return_value=json.dumps(mock_plan))
     result = await planner.generate_plan("test")
     assert result == []
 
-    # 3. Missing required keys
-    mock_llm.chat_completion = AsyncMock(return_value='[{"description": "desc"}]')
+    # 3. Missing required keys in TypedPlan (e.g., missing 'goal')
+    mock_plan = {
+        "risk": "low", "steps": [{"description": "desc"}]
+    }
+    mock_llm.chat_completion = AsyncMock(return_value=json.dumps(mock_plan))
     result = await planner.generate_plan("test")
     assert result == []
 
-    # 4. Unknown skill
-    mock_llm.chat_completion = AsyncMock(return_value='[{"description": "desc", "skill": "unknown", "skill_kwargs": {}}]')
+    # 4. Missing required keys in PlanStep
+    mock_plan = {
+        "goal": "Test", "risk": "low", "steps": [{"skill": "known"}]
+    }
+    mock_llm.chat_completion = AsyncMock(return_value=json.dumps(mock_plan))
     result = await planner.generate_plan("test")
     assert result == []
 
-    # 5. Invalid skill_kwargs
+    # 5. Unknown skill
+    mock_plan = {
+        "goal": "Test", "risk": "low", "steps": [{"description": "desc", "skill": "unknown"}]
+    }
+    mock_llm.chat_completion = AsyncMock(return_value=json.dumps(mock_plan))
+    result = await planner.generate_plan("test")
+    assert result == []
+
+    # 6. Invalid skill_kwargs
     mock_skills.has_skill.return_value = True
-    mock_llm.chat_completion = AsyncMock(return_value='[{"description": "desc", "skill": "known", "skill_kwargs": "not_a_dict"}]')
+    mock_plan = {
+        "goal": "Test", "risk": "low", "steps": [{"description": "desc", "skill": "known", "skill_kwargs": "not_a_dict"}]
+    }
+    mock_llm.chat_completion = AsyncMock(return_value=json.dumps(mock_plan))
     result = await planner.generate_plan("test")
     assert result == []
 
@@ -233,11 +261,17 @@ def test_get_state_summary():
     mock_skills = MagicMock(spec=SkillRegistry)
     planner = Planner(llm=mock_llm, skills=mock_skills)
 
+    planner.current_goal = "Find answers"
+    planner.current_risk = "low"
+    planner.current_constraints = ["fast"]
     planner.current_plan = [{"description": "Pending step", "skill": None}]
     planner.completed_steps = [{"description": "Done step", "skill": "search", "result": "Found it"}]
 
     summary = planner.get_state_summary()
 
+    assert "Goal: Find answers" in summary
+    assert "Risk: low" in summary
+    assert "Constraints: fast" in summary
     assert "Pending step" in summary
     assert "Done step" in summary
     assert "Found it" in summary


### PR DESCRIPTION
Upgrades the planner module to use Pydantic models for structured output generation.
Adds new properties for goal, constraints, risk, and acceptance criteria.
Updates agent_tasks.json by marking the task as done and adding 3 new trendy AI tasks.

---
*PR created automatically by Jules for task [11464362834887777546](https://jules.google.com/task/11464362834887777546) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade prefrontal cortex `Planner` to parse and validate typed plans using Pydantic
> - Introduces `PlanStep` and `TypedPlan` Pydantic models in [planner.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/66/files#diff-0dba6309dba5da62981c561d46f8b9e2e8128b6e7c999b43517c44d1e5735abb) to validate LLM-returned plan JSON against a typed schema before use.
> - Updates `Planner.generate_plan` to request a structured JSON object (with `goal`, `constraints`, `risk`, `steps`, `acceptance`) instead of a bare steps array, then validates the response via Pydantic.
> - Stores plan metadata (`current_goal`, `current_constraints`, `current_risk`, `current_acceptance`) on the `Planner` instance and surfaces them in `get_state_summary`.
> - `clear_pending_plan` now also resets all stored plan metadata fields.
> - Tests in [test_planner.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/66/files#diff-abc0e1a964f5d6e905e027363f1bc327f4aacbb16bf127c5ae502f612691be6b) are updated to cover the new format, metadata persistence, and multiple schema validation failure modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27b11c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->