### PR TITLE
feat: Add context summarization to Working Memory

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -483,7 +483,7 @@
     },
     {
       "id": "working-memory-summarization",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Add context summarization to Working Memory limit",
@@ -1069,6 +1069,64 @@
         "Lifecycle events are dispatched during input processing",
         "Context engine coordinates memory modules dynamically",
         "Tests with mock plugins verify hook invocation"
+      ]
+    },
+    {
+      "id": "agent-teams-isolation",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Agent Teams: multi-agent with git worktree isolation",
+      "description": "Inspired by Claude Agent SDK: implement isolated git worktrees for sub-agents to avoid stepping on each other's toes during parallel task execution.",
+      "allowed_paths": [
+        "magda_agent/agents/**",
+        "magda_agent/workspace/**",
+        "tests/test_agent_teams*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agents can check out code into isolated worktrees",
+        "Changes from sub-agents do not leak into the main repository state until merged",
+        "Tests verify isolation and concurrent execution"
+      ]
+    },
+    {
+      "id": "three-agent-planner-generator-evaluator",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Three-agent architecture separation",
+      "description": "Inspired by Claude Agent SDK: separate the monolithic Consciousness loop into three distinct cooperative agents: Planner, Generator, Evaluator. This increases modularity and focus.",
+      "allowed_paths": [
+        "magda_agent/consciousness/**",
+        "magda_agent/agents/**",
+        "tests/test_three_agent*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner creates the plan",
+        "Generator executes the plan steps and generates code/text",
+        "Evaluator reviews the outcome against the acceptance criteria",
+        "Tests verify the handoff between the three roles"
+      ]
+    },
+    {
+      "id": "realtime-guardrail-fallback",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Realtime guardrail fallback",
+      "description": "Inspired by OpenAI Agents SDK: implement real-time guardrails that trigger a safe fallback action (e.g. asking for human review or stopping execution) immediately when a policy violation is detected mid-generation.",
+      "allowed_paths": [
+        "magda_agent/safety/**",
+        "magda_agent/action/**",
+        "tests/test_realtime_guardrail*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Guardrail triggers correctly on simulated policy violation during execution",
+        "System falls back to a safe state without crashing",
+        "Tests verify the fallback path is executed"
       ]
     }
   ]

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -248,7 +248,7 @@ class Consciousness:
 
         # 5. Post-processing & Memory Storage
         memory_content = f"User said: {user_input} | I replied: {response}"
-        self.memory.add_memory(
+        await self.memory.add_memory(
             content=memory_content,
             importance=0.5,
             emotional_state=self.emotions.get_state_history(user_id)[0],

--- a/magda_agent/memory/storage.py
+++ b/magda_agent/memory/storage.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Optional
 from magda_agent.emotions.engine import PADState
 from magda_agent.memory.working import WorkingMemory, MemoryEntry
 from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.llm_client import LLMClient
 
 class MemorySystem:
     """
@@ -14,10 +15,11 @@ class MemorySystem:
     Includes emotional coloring and importance-based decay.
     Uses WorkingMemory for short-term and EpisodicMemory for long-term consolidation.
     """
-    def __init__(self, short_term_limit: int = 10, persist_directory: str = "./memory_db"):
+    def __init__(self, short_term_limit: int = 10, persist_directory: str = "./memory_db", llm: Optional[LLMClient] = None):
         self.short_term_limit = short_term_limit
         self.working_memory = WorkingMemory(limit=short_term_limit)
         self.episodic_memory = EpisodicMemory(persist_directory=persist_directory)
+        self.llm = llm
 
         # For backwards compatibility and testing
         self._long_term_by_user: Dict[int, List[MemoryEntry]] = {}
@@ -32,7 +34,7 @@ class MemorySystem:
         """Flattened list of all long-term memories across all users."""
         return [entry for user_list in self._long_term_by_user.values() for entry in user_list]
 
-    def add_memory(self, content: str, importance: float, emotional_state: PADState, tags: List[str] = None, user_id: int = None):
+    async def add_memory(self, content: str, importance: float, emotional_state: PADState, tags: List[str] = None, user_id: int = None):
         """Add a new entry to short-term working memory."""
         entry = MemoryEntry(
             content=content,
@@ -42,7 +44,31 @@ class MemorySystem:
             user_id=user_id
         )
 
-        self.working_memory.add(entry)
+        async def summarizer(entries: List[MemoryEntry]) -> MemoryEntry:
+            if not self.llm:
+                raise Exception("No LLM client available for summarization.")
+
+            combined_text = "\n".join([f"- {e.content}" for e in entries])
+            prompt = f"Please summarize the following short-term memory context into a single concise bullet point:\n{combined_text}"
+
+            summary_content = await self.llm.chat_completion([
+                {"role": "system", "content": "You compress memory context. Return only the summary text."},
+                {"role": "user", "content": prompt}
+            ], temperature=0.3)
+
+            # Combine attributes from the oldest entry for simplicity, or average them
+            avg_importance = sum(e.importance for e in entries) / len(entries)
+            # Create a synthetic memory entry for the summarized text
+            synthetic_entry = MemoryEntry(
+                content=summary_content.strip(),
+                importance=avg_importance,
+                emotional_state=entries[0].emotional_state,
+                tags=entries[0].tags,
+                user_id=entries[0].user_id
+            )
+            return synthetic_entry
+
+        await self.working_memory.add(entry, summarizer=summarizer if self.llm else None)
         u_id = user_id if user_id is not None else -1
 
         user_short_term = self.working_memory.get_entries(u_id)

--- a/magda_agent/memory/working.py
+++ b/magda_agent/memory/working.py
@@ -1,6 +1,6 @@
 import time
 import logging
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Callable, Awaitable
 from magda_agent.emotions.engine import PADState
 
 class MemoryEntry:
@@ -23,7 +23,7 @@ class WorkingMemory:
         self.limit = limit
         self._entries_by_user: Dict[int, List[MemoryEntry]] = {}
 
-    def add(self, entry: MemoryEntry) -> None:
+    async def add(self, entry: MemoryEntry, summarizer: Optional[Callable[[List['MemoryEntry']], Awaitable['MemoryEntry']]] = None) -> None:
         """Add a memory entry to the active working memory."""
         u_id = entry.user_id if entry.user_id is not None else -1
         user_entries = self._entries_by_user.setdefault(u_id, [])
@@ -31,7 +31,23 @@ class WorkingMemory:
 
         # Enforce bounded limit by removing oldest entries if exceeded
         while len(user_entries) > self.limit:
-            user_entries.pop(0)
+            if summarizer:
+                # Take oldest two entries to summarize, so we compress context and reduce length by 1
+                to_summarize = user_entries[:2]
+                user_entries = user_entries[2:]
+
+                try:
+                    summary_entry = await summarizer(to_summarize)
+                    # Insert summary at the beginning
+                    user_entries.insert(0, summary_entry)
+                except Exception as e:
+                    logging.error(f"Summarizer failed, falling back to drop: {e}")
+                    # Revert to plain dropping if summarizer fails, to ensure limit is enforced
+                    user_entries.insert(0, to_summarize[1]) # Keep the 2nd oldest if 1 is dropped, so len reduces by 1
+            else:
+                user_entries.pop(0)
+
+        self._entries_by_user[u_id] = user_entries
 
     def get_entries(self, user_id: Optional[int] = None) -> List[MemoryEntry]:
         """Get the current working memory entries for a user."""

--- a/magda_agent/metacognition/evaluator.py
+++ b/magda_agent/metacognition/evaluator.py
@@ -55,7 +55,7 @@ class Evaluator:
 
                 # Store in memory
                 content = f"Evaluation of response to '{user_input[:20]}...': Avg Score: {evaluation.get('average_score')} - {evaluation.get('feedback')}"
-                self.memory.add_memory(
+                await self.memory.add_memory(
                     content=content,
                     importance=0.6,
                     emotional_state=PADState(0.0, 0.0, 0.0), # Neutral PAD state for evaluation

--- a/magda_agent/subconsciousness/reflection.py
+++ b/magda_agent/subconsciousness/reflection.py
@@ -121,7 +121,7 @@ class Subconsciousness:
         # 3. Apply emotional "reward" or "punishment" based on reflection
         self.emotions.update(p_adj, a_adj, d_adj)
 
-        self.memory.add_memory(
+        await self.memory.add_memory(
             content=f"Subconscious reflection: {reflection_text}",
             importance=0.4,
             emotional_state=self.emotions.state,

--- a/tests/test_brainstem.py
+++ b/tests/test_brainstem.py
@@ -62,6 +62,7 @@ async def test_brainstem_integration_no_reflex():
     mock_llm.chat_completion = AsyncMock(return_value="mock response")
     mock_emotions = MagicMock()
     mock_memory = MagicMock()
+    mock_memory.add_memory = AsyncMock()
     mock_skills = MagicMock()
 
     brainstem = Brainstem()

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -26,7 +26,9 @@ def mock_llm_client():
 
 @pytest.fixture
 def mock_memory_system():
-    return MagicMock(spec=MemorySystem)
+    mock = MagicMock(spec=MemorySystem)
+    mock.add_memory = AsyncMock()
+    return mock
 
 @pytest.fixture
 def evaluator(mock_llm_client, mock_memory_system):

--- a/tests/test_memory_user_context.py
+++ b/tests/test_memory_user_context.py
@@ -36,11 +36,12 @@ def test_long_term_memory_user_context(long_term_memory: LongTermMemory) -> None
     # Assuming 'recall' without user_id returns results globally (or based on similarity)
     # the returned result will be the top match, but we know it's storing them separately.
 
-def test_memory_system_user_context(memory_system: MemorySystem) -> None:
+@pytest.mark.asyncio
+async def test_memory_system_user_context(memory_system: MemorySystem) -> None:
     """Test that the short/long-term memory system isolates records correctly by user ID."""
     state = PADState(0.5, 0.5, 0.5)
-    memory_system.add_memory("Hello from user 1", importance=0.8, emotional_state=state, user_id=1)
-    memory_system.add_memory("Hello from user 2", importance=0.8, emotional_state=state, user_id=2)
+    await memory_system.add_memory("Hello from user 1", importance=0.8, emotional_state=state, user_id=1)
+    await memory_system.add_memory("Hello from user 2", importance=0.8, emotional_state=state, user_id=2)
 
     results_user1 = memory_system.retrieve_relevant("Hello", user_id=1)
     results_user2 = memory_system.retrieve_relevant("Hello", user_id=2)
@@ -51,11 +52,12 @@ def test_memory_system_user_context(memory_system: MemorySystem) -> None:
     assert len(results_user2) == 1
     assert results_user2[0].content == "Hello from user 2"
 
-def test_memory_system_anonymous_user_context(memory_system: MemorySystem) -> None:
+@pytest.mark.asyncio
+async def test_memory_system_anonymous_user_context(memory_system: MemorySystem) -> None:
     """Test that anonymous memory usage falls back to the default isolated context correctly."""
     state = PADState(0.5, 0.5, 0.5)
-    memory_system.add_memory("Hello from anon", importance=0.8, emotional_state=state, user_id=None)
-    memory_system.add_memory("Hello from user 1", importance=0.8, emotional_state=state, user_id=1)
+    await memory_system.add_memory("Hello from anon", importance=0.8, emotional_state=state, user_id=None)
+    await memory_system.add_memory("Hello from user 1", importance=0.8, emotional_state=state, user_id=1)
 
     results_anon = memory_system.retrieve_relevant("Hello", user_id=None)
 
@@ -75,14 +77,15 @@ def test_habit_tracker_user_context(habit_tracker: HabitTracker) -> None:
     assert habit_tracker.suggest_strategy("do the task", user_id=1) == "skill_A"
     assert habit_tracker.suggest_strategy("do the task", user_id=2) == "skill_B"
 
-def test_memory_system_retrieval(memory_system: MemorySystem) -> None:
+@pytest.mark.asyncio
+async def test_memory_system_retrieval(memory_system: MemorySystem) -> None:
     """Test that the memory system retrieves records using basic keyword search from WorkingMemory."""
     state = PADState(0.5, 0.5, 0.5)
 
     # Store some contextually distinct memories
-    memory_system.add_memory("The quick brown fox jumps over the lazy dog", importance=0.8, emotional_state=state, user_id=1)
-    memory_system.add_memory("I love eating apples and bananas", importance=0.6, emotional_state=state, user_id=1)
-    memory_system.add_memory("Docker is a containerization technology", importance=0.9, emotional_state=state, user_id=1)
+    await memory_system.add_memory("The quick brown fox jumps over the lazy dog", importance=0.8, emotional_state=state, user_id=1)
+    await memory_system.add_memory("I love eating apples and bananas", importance=0.6, emotional_state=state, user_id=1)
+    await memory_system.add_memory("Docker is a containerization technology", importance=0.9, emotional_state=state, user_id=1)
 
     # Search for an animal keyword
     results = memory_system.retrieve_relevant("fox", limit=1, user_id=1)

--- a/tests/test_memory_working.py
+++ b/tests/test_memory_working.py
@@ -1,8 +1,10 @@
 import pytest
+import asyncio
 from magda_agent.memory.working import WorkingMemory, MemoryEntry
 from magda_agent.emotions.engine import PADState
 
-def test_working_memory_add_and_get():
+@pytest.mark.asyncio
+async def test_working_memory_add_and_get():
     wm = WorkingMemory(limit=2)
     state = PADState(0, 0, 0)
 
@@ -10,32 +12,34 @@ def test_working_memory_add_and_get():
     e2 = MemoryEntry("Second", 0.6, state, user_id=1)
     e3 = MemoryEntry("Third", 0.7, state, user_id=1)
 
-    wm.add(e1)
+    await wm.add(e1)
     assert len(wm.get_entries(user_id=1)) == 1
 
-    wm.add(e2)
+    await wm.add(e2)
     assert len(wm.get_entries(user_id=1)) == 2
 
     # Should evict e1
-    wm.add(e3)
+    await wm.add(e3)
     entries = wm.get_entries(user_id=1)
     assert len(entries) == 2
     assert entries[0].content == "Second"
     assert entries[1].content == "Third"
 
-def test_working_memory_user_isolation():
+@pytest.mark.asyncio
+async def test_working_memory_user_isolation():
     wm = WorkingMemory(limit=5)
     state = PADState(0, 0, 0)
 
-    wm.add(MemoryEntry("User 1", 0.5, state, user_id=1))
-    wm.add(MemoryEntry("User 2", 0.5, state, user_id=2))
-    wm.add(MemoryEntry("Anon", 0.5, state, user_id=None))
+    await wm.add(MemoryEntry("User 1", 0.5, state, user_id=1))
+    await wm.add(MemoryEntry("User 2", 0.5, state, user_id=2))
+    await wm.add(MemoryEntry("Anon", 0.5, state, user_id=None))
 
     assert len(wm.get_entries(user_id=1)) == 1
     assert len(wm.get_entries(user_id=2)) == 1
     assert len(wm.get_entries(user_id=None)) == 1
 
-def test_working_memory_remove_and_clear():
+@pytest.mark.asyncio
+async def test_working_memory_remove_and_clear():
     wm = WorkingMemory(limit=5)
     state = PADState(0, 0, 0)
 
@@ -46,8 +50,8 @@ def test_working_memory_remove_and_clear():
     e2 = MemoryEntry("B", 0.5, state, user_id=1)
     e2.id = 2
 
-    wm.add(e1)
-    wm.add(e2)
+    await wm.add(e1)
+    await wm.add(e2)
 
     wm.remove(e1.id, user_id=1)
     assert len(wm.get_entries(user_id=1)) == 1
@@ -55,3 +59,27 @@ def test_working_memory_remove_and_clear():
 
     wm.clear(user_id=1)
     assert len(wm.get_entries(user_id=1)) == 0
+
+@pytest.mark.asyncio
+async def test_working_memory_summarizer():
+    wm = WorkingMemory(limit=2)
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("Message 1", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Message 2", 0.6, state, user_id=1)
+    e3 = MemoryEntry("Message 3", 0.7, state, user_id=1)
+
+    async def mock_summarizer(entries):
+        assert len(entries) == 2
+        content = "Summary of: " + " and ".join([e.content for e in entries])
+        return MemoryEntry(content, 0.55, state, user_id=1)
+
+    await wm.add(e1)
+    await wm.add(e2)
+    # This add will exceed the limit (len will be 3), triggering summarizer on e1 and e2
+    await wm.add(e3, summarizer=mock_summarizer)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 2
+    assert entries[0].content == "Summary of: Message 1 and Message 2"
+    assert entries[1].content == "Message 3"

--- a/tests/test_subconsciousness.py
+++ b/tests/test_subconsciousness.py
@@ -35,6 +35,7 @@ def mock_emotions():
 @pytest.fixture
 def mock_memory_system():
     mock = MagicMock(spec=MemorySystem)
+    mock.add_memory = AsyncMock()
     mock.short_term = [MemoryEntry(content="Test content 1", importance=0.5, emotional_state=MagicMock())]
     return mock
 


### PR DESCRIPTION
Implementation of the `working-memory-summarization` task from `agent_tasks.json`:
- `WorkingMemory.add` made async to await the `summarizer` callable.
- `MemorySystem` now accepts `LLMClient` on init and passes an async `summarizer` function to `working_memory.add`.
- The summarizer creates a synthetic `MemoryEntry` summarizing dropped events, reducing truncation loss.
- Updated calls in `Consciousness.process_input`, `Subconsciousness.reflect`, and `Evaluator.evaluate_response` to await the memory addition.
- `agent_tasks.json` marked `done` and updated with 3 new "todo" tasks based on `docs/trends.md`.
- All tests updated for async and `AsyncMock`.

---
*PR created automatically by Jules for task [16990034447931613050](https://jules.google.com/task/16990034447931613050) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LLM-based context summarization to `WorkingMemory` on capacity overflow
> - `WorkingMemory.add` in [working.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/68/files#diff-4ab5abd1896168175de3841bbaf095efbcd7e928ea516fc7cf7234ae87467d9b) is now async and accepts an optional async summarizer callback; when capacity is exceeded and a summarizer is provided, the two oldest entries are compressed into a single synthetic entry rather than evicted.
> - `MemorySystem` in [storage.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/68/files#diff-b424973cadba3f7ba7408f34ddb96a0a289b8f8fc8a4df7641512737efa10581) accepts an optional `LLMClient` and wires a summarizer to `WorkingMemory.add` when one is present, using the LLM to produce the compressed entry.
> - All callers of `add_memory` (`Consciousness`, `Evaluator`, `Subconsciousness`) are updated to `await` the now-async method.
> - Tests in [test_memory_working.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/68/files#diff-1e8f7551147ecd85dc13bcec2c906e78281fe505deaa07c36fb128ce420ab02f) and [test_memory_user_context.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/68/files#diff-43866608bcc9e5495cb3769ae0e5879c09a7cebf5c273702f125bc4a1f402fd3) are converted to async and a new test covers the summarization path.
> - Behavioral Change: when an LLM client is supplied, memory consolidation now mutates entry content via summarization instead of simple oldest-first eviction; summarizer failures fall back to dropping one entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 38bc7c9. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->