### PR TITLE
feat(learning): implement task recovery lessons mechanism

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -501,7 +501,7 @@
     },
     {
       "id": "task-recovery-lesson",
-      "status": "todo",
+      "status": "done",
       "area": "reflection",
       "risk": "medium",
       "title": "Introduce Task Recovery Lessons",
@@ -1127,6 +1127,64 @@
         "Guardrail triggers correctly on simulated policy violation during execution",
         "System falls back to a safe state without crashing",
         "Tests verify the fallback path is executed"
+      ]
+    },
+    {
+      "id": "agent-teams-subagents",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Implement Agent Teams and Subagent Spawning",
+      "description": "Inspired by Claude Agent SDK: implement sub-agents for parallel tasks with isolated Git worktrees and context compression to avoid context window explosion.",
+      "allowed_paths": [
+        "magda_agent/agents/**",
+        "magda_agent/workspace/**",
+        "tests/test_subagents*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Main agent can spawn sub-agents for specific tasks",
+        "Sub-agents run in isolated workspaces",
+        "Sub-agent results are compressed and returned to the main agent",
+        "Tests verify sub-agent creation and isolation"
+      ]
+    },
+    {
+      "id": "mcp-tools-exporter",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Implement MCP Server for Skills Export",
+      "description": "Inspired by the Model Context Protocol (MCP) trend: build an MCP server adapter to export Magda's internal SkillRegistry as MCP-compatible tools.",
+      "allowed_paths": [
+        "magda_agent/mcp/**",
+        "magda_agent/skills/registry.py",
+        "tests/test_mcp*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP server wrapper correctly exposes available skills",
+        "Tool schemas map internal parameters to MCP JSON schema correctly",
+        "Tests verify a simulated MCP client can query and execute skills"
+      ]
+    },
+    {
+      "id": "online-rl-from-feedback",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL from User Feedback",
+      "description": "Inspired by OpenClaw-RL: implement online reinforcement learning from next-state signals (e.g., user replies after tool outputs) rather than just periodic reflection.",
+      "allowed_paths": [
+        "magda_agent/learning/online.py",
+        "magda_agent/consciousness/core.py",
+        "tests/test_online_rl*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent analyzes immediate user response (positive/negative signal)",
+        "Strong signals immediately reinforce or penalize procedural/habit memory",
+        "Tests verify that user corrections influence future skill suggestions"
       ]
     }
   ]

--- a/magda_agent/learning/lessons.py
+++ b/magda_agent/learning/lessons.py
@@ -1,0 +1,87 @@
+import logging
+from typing import List, Optional
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.procedural import ProceduralMemory
+
+
+class TaskRecoveryLessons:
+    """
+    Mechanism to convert PR failures and execution errors into reusable 'lessons'
+    in Procedural Memory, minimizing repeated identical mistakes.
+    """
+
+    def __init__(self, procedural_memory: ProceduralMemory, llm: LLMClient) -> None:
+        """
+        Initializes the TaskRecoveryLessons module.
+
+        Args:
+            procedural_memory (ProceduralMemory): The procedural memory storage.
+            llm (LLMClient): The LLM client to summarize failures into lessons.
+        """
+        self.procedural_memory = procedural_memory
+        self.llm = llm
+
+    async def generate_and_store_lesson(
+        self,
+        task_description: str,
+        failure_reason: str,
+        user_id: Optional[int] = None
+    ) -> None:
+        """
+        Summarizes the task and failure into a concise lesson using the LLM,
+        and stores it in Procedural Memory.
+
+        Args:
+            task_description (str): A description of the task that failed.
+            failure_reason (str): The details or logs of the failure.
+            user_id (int, optional): The ID of the user.
+        """
+        prompt = f"""
+        Analyze the following task failure and generate a concise, reusable lesson or anti-pattern.
+        The lesson should describe what went wrong and what should be done differently next time.
+        Keep it under 3 sentences.
+
+        Task Description:
+        {task_description}
+
+        Failure Reason:
+        {failure_reason}
+
+        Lesson:
+        """
+
+        try:
+            response = await self.llm.chat_completion(
+                [{"role": "user", "content": prompt}]
+            )
+            lesson_text = response.strip()
+
+            if lesson_text:
+                self.procedural_memory.store_procedure(
+                    "recovery_lesson",
+                    lesson_text,
+                    user_id=user_id
+                )
+                logging.info(f"Stored recovery lesson for task: {task_description[:30]}...")
+            else:
+                logging.warning("LLM generated an empty lesson.")
+        except Exception as e:
+            logging.error(f"Failed to generate and store lesson: {e}")
+
+    def retrieve_relevant_lessons(
+        self,
+        task_description: str,
+        user_id: Optional[int] = None
+    ) -> List[str]:
+        """
+        Recalls relevant past lessons based on a new task description.
+
+        Args:
+            task_description (str): The description of the new task.
+            user_id (int, optional): The ID of the user.
+
+        Returns:
+            List[str]: A list of relevant procedural lessons.
+        """
+        return self.procedural_memory.recall_procedure(task_description, user_id=user_id)

--- a/tests/test_learning/test_lessons.py
+++ b/tests/test_learning/test_lessons.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.learning.lessons import TaskRecoveryLessons
+from magda_agent.memory.procedural import ProceduralMemory
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def procedural_memory():
+    # Use ephemeral client for testing to prevent persisting data to disk
+    return ProceduralMemory(persist_directory=":memory:")
+
+@pytest.fixture
+def mock_llm():
+    llm = MagicMock(spec=LLMClient)
+    llm.chat_completion = AsyncMock(return_value="Always ensure dependencies are installed before running tests.")
+    return llm
+
+@pytest.fixture
+def task_recovery_lessons(procedural_memory, mock_llm):
+    return TaskRecoveryLessons(procedural_memory=procedural_memory, llm=mock_llm)
+
+@pytest.mark.asyncio
+async def test_generate_and_store_lesson(task_recovery_lessons, mock_llm, procedural_memory):
+    task_desc = "Run unit tests for the learning module"
+    failure_reason = "ModuleNotFoundError: No module named pytest"
+    user_id = 42
+
+    await task_recovery_lessons.generate_and_store_lesson(task_desc, failure_reason, user_id=user_id)
+
+    # Verify LLM was called to generate the lesson
+    mock_llm.chat_completion.assert_called_once()
+
+    # Retrieve to verify it was stored
+    results = task_recovery_lessons.retrieve_relevant_lessons(task_desc, user_id=user_id)
+
+    assert len(results) > 0
+    # Our mock LLM returns "Always ensure dependencies are installed before running tests."
+    assert "Always ensure dependencies are installed before running tests." in results[0]
+
+@pytest.mark.asyncio
+async def test_retrieve_relevant_lessons_no_results(task_recovery_lessons):
+    # Should be empty for a new query
+    results = task_recovery_lessons.retrieve_relevant_lessons("Some completely unrelated task", user_id=1)
+    assert len(results) == 0
+
+@pytest.mark.asyncio
+async def test_generate_empty_lesson(task_recovery_lessons, mock_llm, procedural_memory):
+    # If the LLM returns an empty string, it shouldn't store anything
+    mock_llm.chat_completion = AsyncMock(return_value="")
+
+    # Use a unique user_id to ensure isolation from other tests
+    await task_recovery_lessons.generate_and_store_lesson("unique_empty_task", "failure", user_id=999)
+
+    results = task_recovery_lessons.retrieve_relevant_lessons("unique_empty_task", user_id=999)
+    assert len(results) == 0


### PR DESCRIPTION
Implement Task Recovery Lessons mechanism

This PR implements the first `todo` task from `agent_tasks.json`: **Introduce Task Recovery Lessons** (`task-recovery-lesson`).

**Changes:**
1.  **TaskRecoveryLessons:** Added `magda_agent/learning/lessons.py` containing a new `TaskRecoveryLessons` class. This class uses `ProceduralMemory` to store semantic lessons and `LLMClient` to summarize failures into concise statements.
2.  **Tests:** Added `tests/test_learning/test_lessons.py`. The tests use an ephemeral ChromaDB client (`:memory:`) and `AsyncMock` to prevent real LLM API calls, verifying the correctness of generating, storing, and retrieving lessons.
3.  **Manifest Update:** Updated `agent_tasks.json` to mark the task as `"done"`.
4.  **Trend Replenishment:** Appended 3 new tasks to `agent_tasks.json` based on current trends read from `docs/trends.md`:
    *   **Agent Teams and Subagent Spawning** (Architecture, High Risk)
    *   **MCP Server for Skills Export** (Integration, Medium Risk)
    *   **Online RL from User Feedback** (Learning, Medium Risk)
5. **Cleaned up:** Deleted scratchpad scripts used during development. All 172 tests are passing locally.

---
*PR created automatically by Jules for task [9702386014883749569](https://jules.google.com/task/9702386014883749569) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TaskRecoveryLessons` class to generate and store lessons from task failures
> - Adds [`TaskRecoveryLessons`](https://github.com/kazah4359-lgtm/Magda-agent/pull/69/files#diff-0dd1d32e69dbf601c81b666f94743dbc17547302a0d5b4f49b19f8e05f918015) which uses an LLM to convert a task description and failure reason into a concise lesson, then persists it to `ProceduralMemory` under the key `recovery_lesson`.
> - Lessons are only stored if the LLM returns a non-empty response; empty responses log a warning and skip storage.
> - A `retrieve_relevant_lessons` method delegates to `ProceduralMemory.recall_procedure` to fetch previously stored lessons by task description and optional user ID.
> - Adds async tests in [`tests/test_learning/test_lessons.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/69/files#diff-b08c57b3f8ed4570a19098a8b9b9d2947a21e48c08e4ce21ead13633dba87720) covering lesson generation, empty-lesson guard, and retrieval with no results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 206ace3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->