### PR TITLE
feat: implement A2A Agent Card for discovery

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -539,7 +539,7 @@
     },
     {
       "id": "a2a-agent-card",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "Implement A2A Agent Card for discovery",
@@ -1239,6 +1239,60 @@
         "Guardrails implement the 5 ACS checkpoints",
         "Tool calls are intercepted and validated",
         "Tests verify policy enforcement"
+      ]
+    },
+    {
+      "id": "a2a-peer-delegation",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Peer Delegation Support",
+      "description": "Inspired by the A2A standard trend: Enable Magda to discover other A2A-compliant agents using their Agent Cards and delegate sub-tasks peer-to-peer asynchronously.",
+      "allowed_paths": [
+        "magda_agent/a2a/**",
+        "tests/test_a2a_delegation*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can read remote Agent Cards",
+        "Agent can delegate tasks based on remote capabilities",
+        "Tests verify A2A protocol messaging for delegation"
+      ]
+    },
+    {
+      "id": "skill-marketplace-integration",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Skill Marketplace Integration",
+      "description": "Inspired by the agentskills.io standard (Hermes trend): Implement a mechanism for Magda to discover and dynamically load external skills conforming to the open skill marketplace specification.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace.py",
+        "tests/test_skill_marketplace*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can query a skill marketplace endpoint",
+        "Agent can parse standard agentskills.io definitions",
+        "Tests verify integration with a mock marketplace"
+      ]
+    },
+    {
+      "id": "canvas-live-visualization",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Canvas Live Visualization",
+      "description": "Inspired by the OpenClaw trend: Implement a local WebSocket server that streams Magda's internal cognitive state (current plan, active memory, emotional state) for live visualization in a Canvas UI.",
+      "allowed_paths": [
+        "magda_agent/visualization/**",
+        "tests/test_visualization*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket server broadcasts state updates",
+        "State stream is read-only and does not block the main Consciousness loop",
+        "Tests mock WebSocket connections"
       ]
     }
   ]

--- a/magda_agent/a2a/agent_card.py
+++ b/magda_agent/a2a/agent_card.py
@@ -1,0 +1,48 @@
+import json
+from typing import Dict, Any, List
+from magda_agent.skills.registry import SkillRegistry
+
+def generate_agent_card(registry: SkillRegistry, endpoint: str) -> Dict[str, Any]:
+    """
+    Generates an A2A Agent Card describing Magda's capabilities, modalities, and endpoint.
+
+    Args:
+        registry (SkillRegistry): The initialized skill registry containing Magda's skills.
+        endpoint (str): The URL or identifier of the agent's communication endpoint.
+
+    Returns:
+        Dict[str, Any]: A dictionary representing the A2A Agent Card JSON schema.
+    """
+    capabilities: List[Dict[str, str]] = []
+
+    for name, desc in registry.descriptions.items():
+        capabilities.append({
+            "name": name,
+            "description": desc
+        })
+
+    card = {
+        "agent_name": "Magda",
+        "description": "A sophisticated multi-modal agent with long-term memory, emotional intelligence, and dynamic skill execution capabilities.",
+        "endpoint": endpoint,
+        "supported_modalities": ["text", "voice", "image"],
+        "capabilities": capabilities,
+        "version": "1.0.0",
+        "protocol": "A2A"
+    }
+
+    return card
+
+def generate_agent_card_json(registry: SkillRegistry, endpoint: str) -> str:
+    """
+    Generates an A2A Agent Card as a JSON formatted string.
+
+    Args:
+        registry (SkillRegistry): The initialized skill registry containing Magda's skills.
+        endpoint (str): The URL or identifier of the agent's communication endpoint.
+
+    Returns:
+        str: A JSON string representing the A2A Agent Card.
+    """
+    card = generate_agent_card(registry, endpoint)
+    return json.dumps(card, indent=2, ensure_ascii=False)

--- a/tests/test_a2a_agent_card.py
+++ b/tests/test_a2a_agent_card.py
@@ -1,0 +1,49 @@
+import json
+import pytest
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.a2a.agent_card import generate_agent_card, generate_agent_card_json
+
+def mock_skill_func():
+    pass
+
+@pytest.fixture
+def mock_registry() -> SkillRegistry:
+    registry = SkillRegistry()
+    registry.register_skill("search", mock_skill_func, "Searches the internet for information.")
+    registry.register_skill("weather", mock_skill_func, "Gets current weather for a location.")
+    return registry
+
+def test_generate_agent_card(mock_registry: SkillRegistry):
+    endpoint = "https://magda.example.com/api/v1/a2a"
+    card = generate_agent_card(mock_registry, endpoint)
+
+    assert card["agent_name"] == "Magda"
+    assert card["endpoint"] == endpoint
+    assert "text" in card["supported_modalities"]
+    assert "protocol" in card
+    assert card["protocol"] == "A2A"
+
+    capabilities = card["capabilities"]
+    assert len(capabilities) == 2
+
+    # Check capabilities
+    search_cap = next((cap for cap in capabilities if cap["name"] == "search"), None)
+    assert search_cap is not None
+    assert search_cap["description"] == "Searches the internet for information."
+
+    weather_cap = next((cap for cap in capabilities if cap["name"] == "weather"), None)
+    assert weather_cap is not None
+    assert weather_cap["description"] == "Gets current weather for a location."
+
+def test_generate_agent_card_json(mock_registry: SkillRegistry):
+    endpoint = "tcp://192.168.1.10:5050"
+    card_json = generate_agent_card_json(mock_registry, endpoint)
+
+    # Parse back to dict
+    card = json.loads(card_json)
+
+    assert card["agent_name"] == "Magda"
+    assert card["endpoint"] == endpoint
+    assert card["capabilities"][0]["name"] == "search"
+    assert card["capabilities"][1]["name"] == "weather"
+    assert card["version"] == "1.0.0"


### PR DESCRIPTION
This PR implements the `a2a-agent-card` task from `agent_tasks.json`.

It introduces `generate_agent_card` and `generate_agent_card_json` in `magda_agent/a2a/agent_card.py`, which build an A2A-compliant Agent Card based on Magda's current SkillRegistry capabilities, supported modalities, and endpoint. Comprehensive pytest unit tests are added, using mocks for the registry to avoid side-effects.

In addition, 3 new trend-inspired tasks have been appended to `agent_tasks.json` as requested. All schemas are validated and tests pass.

---
*PR created automatically by Jules for task [1360530936338879642](https://jules.google.com/task/1360530936338879642) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A Agent Card generation for agent discovery
> Adds a new `magda_agent.a2a` package with [`agent_card.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/71/files#diff-beb25fe3508cf07704191b4dabb18fb175c836449a103a86ee5fbd0370d58bf2) providing two functions: `generate_agent_card` returns a dict representing an A2A Agent Card populated from a `SkillRegistry`, and `generate_agent_card_json` returns the same card as a formatted JSON string. The card includes fixed fields (agent name, description, version, supported modalities) alongside dynamic capabilities derived from registered skill descriptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aa0b5a2. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->