### PR TITLE
Implement ContextEngine with plugin lifecycle hooks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -557,7 +557,7 @@
     },
     {
       "id": "context-engine-plugin",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine with plugin lifecycle hooks",

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -25,12 +25,18 @@ from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
 from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
+from magda_agent.context.engine import ContextEngine
+from magda_agent.context.default_plugin import DefaultContextPlugin
 
 logging.basicConfig(level=logging.INFO)
 
 llm_client = LLMClient()
 emotional_engine = EmotionalEngine()
-memory_system = MemorySystem()
+
+# Initialize ContextEngine with default plugin
+context_engine = ContextEngine(plugins=[DefaultContextPlugin(llm=llm_client)])
+
+memory_system = MemorySystem(llm=llm_client, context_engine=context_engine)
 procedural_memory = ProceduralMemory(persist_directory="./procedural_memory_db")
 skill_registry = initialize_skills()
 habit_tracker = HabitTracker()
@@ -62,7 +68,8 @@ consciousness = Consciousness(
     pineal_gland=pineal_gland,
     mirror_neurons=mirror_neurons,
     salience=salience_network,
-    global_workspace=global_workspace
+    global_workspace=global_workspace,
+    context_engine=context_engine
 )
 
 subconsciousness = Subconsciousness(

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -18,6 +18,7 @@ from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
 from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
+from magda_agent.context.engine import ContextEngine
 
 class Consciousness:
     """
@@ -43,7 +44,8 @@ class Consciousness:
         pineal_gland: Optional[PinealGland] = None,
         mirror_neurons: Optional[MirrorNeurons] = None,
         salience: Optional[SalienceNetwork] = None,
-        global_workspace: Optional[GlobalWorkspace] = None
+        global_workspace: Optional[GlobalWorkspace] = None,
+        context_engine: Optional[ContextEngine] = None
     ):
         self.llm = llm
         self.emotions = emotions
@@ -63,9 +65,14 @@ class Consciousness:
         self.mirror_neurons = mirror_neurons
         self.salience = salience
         self.global_workspace = global_workspace
+        self.context_engine = context_engine
 
     async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
+
+        # Use ContextEngine ingest hook if available
+        if self.context_engine:
+            user_input = await self.context_engine.ingest(user_input, {"user_id": user_id})
 
         if self.thalamus and not self.thalamus.filter_input(user_input):
             return "Message ignored by Thalamus."
@@ -135,7 +142,12 @@ class Consciousness:
 
         # 2. Memory Retrieval
         relevant_memories = self.memory.retrieve_relevant(user_input, user_id=user_id)
-        context_str = "\n".join([f"- {m.content}" for m in relevant_memories])
+
+        # Use ContextEngine assemble hook if available
+        if self.context_engine:
+            context_str = await self.context_engine.assemble(relevant_memories, {"user_id": user_id})
+        else:
+            context_str = "\n".join([f"- {m.content}" for m in relevant_memories])
 
         if self.long_term_memory:
             long_term_memories = self.long_term_memory.recall(user_input, user_id=user_id)

--- a/magda_agent/context/default_plugin.py
+++ b/magda_agent/context/default_plugin.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Any, Dict, List, Optional
+from magda_agent.context.plugin import ContextPlugin
+
+class DefaultContextPlugin(ContextPlugin):
+    """
+    Default plugin implementing Magda's current context behavior.
+    """
+    def __init__(self, llm: Optional[Any] = None):
+        self.llm = llm
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Standard context assembly from memory entries."""
+        return "\n".join([f"- {item.content}" for item in context_items if hasattr(item, 'content')])
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        Implements summarization logic when compacting.
+        Inspired by the existing MemorySystem/WorkingMemory logic.
+        """
+        # If the number of items is within limit, don't compact
+        limit = metadata.get("limit", 10)
+        if len(context_items) <= limit:
+            return context_items
+
+        if not self.llm:
+            logging.warning("No LLM available for compaction, dropping oldest item.")
+            return context_items[1:]
+
+        # Compact by summarizing the two oldest items
+        to_summarize = context_items[:2]
+        remaining = context_items[2:]
+
+        combined_text = "\n".join([f"- {e.content}" for e in to_summarize if hasattr(e, 'content')])
+        prompt = f"Please summarize the following short-term memory context into a single concise bullet point:\n{combined_text}"
+
+        try:
+            summary_content = await self.llm.chat_completion([
+                {"role": "system", "content": "You compress memory context. Return only the summary text."},
+                {"role": "user", "content": prompt}
+            ], temperature=0.3)
+
+            # Import here to avoid circular imports if any
+            from magda_agent.memory.working import MemoryEntry
+
+            # Use attributes from first entry
+            first = to_summarize[0]
+            avg_importance = sum(e.importance for e in to_summarize if hasattr(e, 'importance')) / len(to_summarize)
+
+            summary_entry = MemoryEntry(
+                content=summary_content.strip(),
+                importance=avg_importance,
+                emotional_state=getattr(first, 'emotional_state', None),
+                tags=getattr(first, 'tags', []),
+                user_id=getattr(first, 'user_id', None)
+            )
+            return [summary_entry] + remaining
+        except Exception as e:
+            logging.error(f"DefaultContextPlugin compaction failed: {e}")
+            return context_items[1:] # Fallback to dropping

--- a/magda_agent/context/engine.py
+++ b/magda_agent/context/engine.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Any, Dict, List, Optional
+from magda_agent.context.plugin import ContextPlugin
+
+class ContextEngine:
+    """
+    Orchestrates the lifecycle of context management via plugins.
+    """
+    def __init__(self, plugins: Optional[List[ContextPlugin]] = None):
+        self.plugins = plugins or []
+
+    async def bootstrap_all(self, config: Dict[str, Any]) -> None:
+        for plugin in self.plugins:
+            await plugin.bootstrap(config)
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        current_content = content
+        for plugin in self.plugins:
+            current_content = await plugin.ingest(current_content, metadata)
+        return current_content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        # For assemble, we might want one plugin to handle it or a chain.
+        # OpenClaw usually has one main assembly. Here we'll chain them.
+        assembled_context = ""
+        for plugin in self.plugins:
+            # Each plugin can augment or replace the context string
+            assembled_context = await plugin.assemble(context_items, metadata)
+        return assembled_context
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        current_items = context_items
+        for plugin in self.plugins:
+            current_items = await plugin.compact(current_items, metadata)
+        return current_items
+
+    def add_plugin(self, plugin: ContextPlugin):
+        self.plugins.append(plugin)

--- a/magda_agent/context/plugin.py
+++ b/magda_agent/context/plugin.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict, List, Optional
+
+class ContextPlugin:
+    """
+    Base class for Context Engine plugins.
+    Inspired by OpenClaw's architecture.
+    """
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration."""
+        pass
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Process incoming content before it is stored or used."""
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Assemble the context string from retrieved items for the LLM."""
+        return "\n".join([str(item) for item in context_items])
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact or summarize the context when limits are reached."""
+        return context_items

--- a/magda_agent/memory/storage.py
+++ b/magda_agent/memory/storage.py
@@ -8,6 +8,7 @@ from magda_agent.emotions.engine import PADState
 from magda_agent.memory.working import WorkingMemory, MemoryEntry
 from magda_agent.memory.episodic import EpisodicMemory
 from magda_agent.llm_client import LLMClient
+from magda_agent.context.engine import ContextEngine
 
 class MemorySystem:
     """
@@ -15,11 +16,12 @@ class MemorySystem:
     Includes emotional coloring and importance-based decay.
     Uses WorkingMemory for short-term and EpisodicMemory for long-term consolidation.
     """
-    def __init__(self, short_term_limit: int = 10, persist_directory: str = "./memory_db", llm: Optional[LLMClient] = None):
+    def __init__(self, short_term_limit: int = 10, persist_directory: str = "./memory_db", llm: Optional[LLMClient] = None, context_engine: Optional[ContextEngine] = None):
         self.short_term_limit = short_term_limit
-        self.working_memory = WorkingMemory(limit=short_term_limit)
+        self.working_memory = WorkingMemory(limit=short_term_limit, context_engine=context_engine)
         self.episodic_memory = EpisodicMemory(persist_directory=persist_directory)
         self.llm = llm
+        self.context_engine = context_engine
 
         # For backwards compatibility and testing
         self._long_term_by_user: Dict[int, List[MemoryEntry]] = {}
@@ -68,6 +70,7 @@ class MemorySystem:
             )
             return synthetic_entry
 
+        # Prefer ContextEngine.compact via working_memory.add, otherwise use local summarizer
         await self.working_memory.add(entry, summarizer=summarizer if self.llm else None)
         u_id = user_id if user_id is not None else -1
 

--- a/magda_agent/memory/working.py
+++ b/magda_agent/memory/working.py
@@ -1,6 +1,6 @@
 import time
 import logging
-from typing import List, Dict, Optional, Callable, Awaitable
+from typing import List, Dict, Optional, Callable, Awaitable, Any
 from magda_agent.emotions.engine import PADState
 
 class MemoryEntry:
@@ -19,8 +19,9 @@ class WorkingMemory:
     Working Memory stores bounded, short-term context for active tasks.
     It does not use persistent storage and does not use ChromaDB.
     """
-    def __init__(self, limit: int = 10):
+    def __init__(self, limit: int = 10, context_engine: Optional[Any] = None):
         self.limit = limit
+        self.context_engine = context_engine
         self._entries_by_user: Dict[int, List[MemoryEntry]] = {}
 
     async def add(self, entry: MemoryEntry, summarizer: Optional[Callable[[List['MemoryEntry']], Awaitable['MemoryEntry']]] = None) -> None:
@@ -31,7 +32,10 @@ class WorkingMemory:
 
         # Enforce bounded limit by removing oldest entries if exceeded
         while len(user_entries) > self.limit:
-            if summarizer:
+            if self.context_engine:
+                # Use ContextEngine compact lifecycle hook
+                user_entries = await self.context_engine.compact(user_entries, {"limit": self.limit, "user_id": u_id})
+            elif summarizer:
                 # Take oldest two entries to summarize, so we compress context and reduce length by 1
                 to_summarize = user_entries[:2]
                 user_entries = user_entries[2:]

--- a/tests/test_context_engine.py
+++ b/tests/test_context_engine.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.context.engine import ContextEngine
+from magda_agent.context.plugin import ContextPlugin
+from magda_agent.context.default_plugin import DefaultContextPlugin
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+class MockPlugin(ContextPlugin):
+    def __init__(self):
+        self.bootstrap_called = False
+        self.ingest_called = False
+        self.assemble_called = False
+        self.compact_called = False
+
+    async def bootstrap(self, config):
+        self.bootstrap_called = True
+
+    async def ingest(self, content, metadata):
+        self.ingest_called = True
+        return f"ingested_{content}"
+
+    async def assemble(self, context_items, metadata):
+        self.assemble_called = True
+        return "assembled_context"
+
+    async def compact(self, context_items, metadata):
+        self.compact_called = True
+        return context_items[:-1]
+
+@pytest.mark.asyncio
+async def test_context_engine_lifecycle():
+    mock_plugin = MockPlugin()
+    engine = ContextEngine(plugins=[mock_plugin])
+
+    # Test Bootstrap
+    await engine.bootstrap_all({"key": "value"})
+    assert mock_plugin.bootstrap_called
+
+    # Test Ingest
+    ingested = await engine.ingest("raw", {"user_id": 1})
+    assert mock_plugin.ingest_called
+    assert ingested == "ingested_raw"
+
+    # Test Assemble
+    assembled = await engine.assemble([], {"user_id": 1})
+    assert mock_plugin.assemble_called
+    assert assembled == "assembled_context"
+
+    # Test Compact
+    items = [1, 2, 3]
+    compacted = await engine.compact(items, {"limit": 2})
+    assert mock_plugin.compact_called
+    assert len(compacted) == 2
+
+@pytest.mark.asyncio
+async def test_default_plugin_assemble():
+    plugin = DefaultContextPlugin()
+    entry = MagicMock(spec=MemoryEntry)
+    entry.content = "hello"
+
+    assembled = await plugin.assemble([entry], {})
+    assert assembled == "- hello"
+
+@pytest.mark.asyncio
+async def test_default_plugin_compact_no_llm():
+    plugin = DefaultContextPlugin(llm=None)
+    entry1 = MagicMock(spec=MemoryEntry)
+    entry2 = MagicMock(spec=MemoryEntry)
+
+    # Limit is 1, we have 2 items
+    items = [entry1, entry2]
+    compacted = await plugin.compact(items, {"limit": 1})
+
+    # Should drop the first item
+    assert len(compacted) == 1
+    assert compacted[0] == entry2
+
+@pytest.mark.asyncio
+async def test_default_plugin_compact_with_llm():
+    llm = AsyncMock()
+    llm.chat_completion.return_value = "summary"
+    plugin = DefaultContextPlugin(llm=llm)
+
+    entry1 = MagicMock(spec=MemoryEntry)
+    entry1.content = "content1"
+    entry1.importance = 0.5
+    entry2 = MagicMock(spec=MemoryEntry)
+    entry2.content = "content2"
+    entry2.importance = 0.5
+
+    items = [entry1, entry2]
+    # Limit 1, items 2 -> compact
+    compacted = await plugin.compact(items, {"limit": 1})
+
+    assert len(compacted) == 1
+    assert compacted[0].content == "summary"
+    assert llm.chat_completion.called


### PR DESCRIPTION
Implemented a plugin-based Context Engine to manage the agent's context lifecycle. This includes hooks for ingesting raw input, assembling context for the LLM, and compacting/summarizing memory when limits are reached. The DefaultContextPlugin maintains existing behavior while providing a cleaner interface for future context strategies.

---
*PR created automatically by Jules for task [3759817986346771691](https://jules.google.com/task/3759817986346771691) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `ContextEngine` with plugin lifecycle hooks for input ingestion, context assembly, and working-memory compaction
> - Adds a `ContextEngine` class in [engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/72/files#diff-94cb4370f6df6e39f04f42977ae3e9071f231347fba4a272ad33f2708df2aa49) that orchestrates a pipeline of `ContextPlugin` instances via `bootstrap`, `ingest`, `assemble`, and `compact` hooks defined in [plugin.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/72/files#diff-8a22ed5a0976491aad2b9ecdb75b467d62747d620eee938b14de5f30dd81dcce).
> - Adds `DefaultContextPlugin` in [default_plugin.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/72/files#diff-09d91bd4ece1683ed8025c06b79591b4491e74c727471a14b2c0cf4c91d76df8) that assembles memories as bullet points and compacts working memory by LLM summarization or by dropping the oldest entry.
> - `Consciousness.process_input` in [core.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/72/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) now preprocesses user input and assembles retrieved memory context via `ContextEngine` when configured, falling back to a plain join otherwise.
> - `WorkingMemory.add` in [working.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/72/files#diff-4ab5abd1896168175de3841bbaf095efbcd7e928ea516fc7cf7234ae87467d9b) delegates compaction to `ContextEngine` when present, falling back to the prior summarizer-based approach.
> - Behavioral Change: memory compaction and context assembly are now plugin-driven when a `ContextEngine` is passed at construction; existing behavior is preserved via fallbacks when it is not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e65069.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->