### PR TITLE
Implement online learning from user feedback

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -615,7 +615,7 @@
     },
     {
       "id": "online-learning-from-feedback",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from user replies (next-state signal)",
@@ -1384,6 +1384,57 @@
         "Main agent can delegate a sub-task to a specialized workflow",
         "Sub-agent runs in an isolated context and returns structured results",
         "Tests verify delegation and result aggregation"
+      ]
+    },
+    {
+      "id": "agent-teams-isolation-v2",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Implement Agent Teams Isolation",
+      "description": "Inspired by Claude Agent SDK. Implement Agent Teams for subagents using git worktrees. This will create new paths.",
+      "allowed_paths": [
+        "magda_agent/teams/**",
+        "tests/test_teams*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agents can be spawned in isolated worktrees",
+        "Tests verify isolation"
+      ]
+    },
+    {
+      "id": "mcp-tools-export-v2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tools Export",
+      "description": "Inspired by MCP. Implement MCP Server adapter to export skills. This will create new paths.",
+      "allowed_paths": [
+        "magda_agent/mcp/**",
+        "tests/test_mcp*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP tools can be exposed",
+        "Tests mock client"
+      ]
+    },
+    {
+      "id": "agent-guardrails-policy-layer-v2",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Implement ACS Guardrails",
+      "description": "Inspired by ACS. Implement Agent Control Specification policy layer. This will create new paths.",
+      "allowed_paths": [
+        "magda_agent/safety/acs.py",
+        "tests/test_acs*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tools intercepted",
+        "Tests mock calls"
       ]
     }
   ]

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -16,6 +16,7 @@ from magda_agent.emotions.insula import Insula
 from magda_agent.reflexes.brainstem import Brainstem
 from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
+from magda_agent.learning.online import OnlineLearner
 from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
 from magda_agent.context.engine import ContextEngine
@@ -47,7 +48,8 @@ class Consciousness:
         salience: Optional[SalienceNetwork] = None,
         global_workspace: Optional[GlobalWorkspace] = None,
         context_engine: Optional[ContextEngine] = None,
-        skill_creator: Optional[SkillCreator] = None
+        skill_creator: Optional[SkillCreator] = None,
+        online_learner: Optional[OnlineLearner] = None
     ):
         self.llm = llm
         self.emotions = emotions
@@ -69,6 +71,7 @@ class Consciousness:
         self.global_workspace = global_workspace
         self.context_engine = context_engine
         self.skill_creator = skill_creator
+        self.online_learner = online_learner
 
     async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
@@ -76,6 +79,11 @@ class Consciousness:
         # Use ContextEngine ingest hook if available
         if self.context_engine:
             user_input = await self.context_engine.ingest(user_input, {"user_id": user_id})
+
+        if self.online_learner:
+            # For simplicity, we use the planner's last state or a generic string as the action context
+            last_context = self.planner.get_state_summary() if getattr(self, 'planner', None) else "Recent action context"
+            await self.online_learner.process_feedback(user_input, last_context, user_id)
 
         if self.thalamus and not self.thalamus.filter_input(user_input):
             return "Message ignored by Thalamus."

--- a/magda_agent/learning/online.py
+++ b/magda_agent/learning/online.py
@@ -1,0 +1,54 @@
+import logging
+from typing import Optional
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+from magda_agent.emotions.engine import PADState
+
+class OnlineLearner:
+    """
+    Online learning from user replies (next-state signal).
+    Treats each user reply as a next-state signal. Positive signals reinforce approach,
+    negative signals trigger reflection and adjustment.
+    """
+    def __init__(
+        self,
+        habit_tracker: HabitTracker,
+        memory: MemorySystem,
+        mirror_neurons: MirrorNeurons
+    ) -> None:
+        self.habit_tracker = habit_tracker
+        self.memory = memory
+        self.mirror_neurons = mirror_neurons
+
+    async def process_feedback(self, user_reply: str, last_action_context: str, user_id: Optional[int] = None) -> None:
+        """
+        Analyzes the user's reply to an action, and reinforces or penalizes the habit.
+
+        Args:
+            user_reply (str): The text of the user's reply.
+            last_action_context (str): The context of the action that was taken.
+            user_id (Optional[int]): The user's ID.
+        """
+        if not user_reply or not last_action_context:
+            return
+
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_reply)
+
+        if p_shift > 0.0:
+            # Positive signal, reinforce the habit
+            # Note: "online_learned_skill" is a placeholder for the actual skill used
+            # For this simple heuristic, we just assume the last action was successful.
+            self.habit_tracker.record_usage(last_action_context, "online_learned_skill", 10.0, user_id=user_id)
+            logging.info(f"Online learning: Positive signal received (p_shift={p_shift:.2f}). Reinforced habit.")
+        elif p_shift < 0.0:
+            # Negative signal, trigger reflection
+            content = f"Negative feedback received for action context '{last_action_context}'. User said: '{user_reply}'"
+            await self.memory.add_memory(
+                content=content,
+                importance=0.8,
+                emotional_state=PADState(p_shift, a_shift, d_shift),
+                tags=["reflection", "online_learning", "negative_feedback"],
+                user_id=user_id
+            )
+            logging.info(f"Online learning: Negative signal received (p_shift={p_shift:.2f}). Stored reflection.")

--- a/tests/test_online_learning.py
+++ b/tests/test_online_learning.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.learning.online import OnlineLearner
+from magda_agent.emotions.engine import PADState
+
+@pytest.mark.asyncio
+async def test_online_learner_positive_feedback():
+    habit_tracker = MagicMock()
+    memory = MagicMock()
+    mirror_neurons = MagicMock()
+    # Empathize returns positive shift
+    mirror_neurons.empathize.return_value = (0.2, 0.1, 0.0)
+
+    learner = OnlineLearner(habit_tracker, memory, mirror_neurons)
+    await learner.process_feedback("Thanks, that was great!", "Some context", user_id=42)
+
+    # Should reinforce habit
+    habit_tracker.record_usage.assert_called_once_with("Some context", "online_learned_skill", 10.0, user_id=42)
+    # Should not add a negative reflection memory
+    memory.add_memory.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_online_learner_negative_feedback():
+    habit_tracker = MagicMock()
+    memory = MagicMock()
+    memory.add_memory = AsyncMock()
+    mirror_neurons = MagicMock()
+    # Empathize returns negative shift
+    mirror_neurons.empathize.return_value = (-0.3, 0.2, 0.1)
+
+    learner = OnlineLearner(habit_tracker, memory, mirror_neurons)
+    await learner.process_feedback("This is completely wrong and useless.", "Some bad context", user_id=42)
+
+    # Should not reinforce habit
+    habit_tracker.record_usage.assert_not_called()
+    # Should add a reflection memory
+    memory.add_memory.assert_called_once()
+
+    call_kwargs = memory.add_memory.call_args.kwargs
+    assert "Negative feedback received" in call_kwargs["content"]
+    assert "Some bad context" in call_kwargs["content"]
+    assert "reflection" in call_kwargs["tags"]
+    assert call_kwargs["user_id"] == 42


### PR DESCRIPTION
Implements `OnlineLearner` in `magda_agent/learning/online.py` and integrates it into `Consciousness.process_input` to learn from user feedback. Marks the corresponding task in `agent_tasks.json` as done and adds 3 new AI trend tasks.

---
*PR created automatically by Jules for task [1333027923611906686](https://jules.google.com/task/1333027923611906686) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement online learning from user feedback in `Consciousness.process_input`
> - Adds [online.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/76/files#diff-58e64acde017d7d909c2b66acda4743138b0f816a5d3bb7efc89ca7ca4dc270a) with a new `OnlineLearner` class that uses `MirrorNeurons.empathize` to derive PAD affect shifts from user replies, reinforcing habits via `HabitTracker.record_usage` on positive affect and storing reflective memories via `MemorySystem.add_memory` on negative affect.
> - Hooks `OnlineLearner.process_feedback` into [core.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/76/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) `Consciousness.process_input`, triggered after context ingestion when an `OnlineLearner` instance is provided.
> - Adds unit tests in [test_online_learning.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/76/files#diff-20541e7886bb9554abab931210f54d17198adefff9bb53af96a125f2823b0289) covering positive and negative feedback paths with mocked dependencies.
> - Behavioral Change: when `OnlineLearner` is provided, every call to `process_input` now triggers an async empathy inference and potential habit/memory write before thalamic filtering.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b541ef0. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->