### PR TITLE
feat: implement policy layer for action execution

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -654,7 +654,7 @@
     },
     {
       "id": "policy-layer-tool-calls",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Policy layer for all tool/action execution",
@@ -1489,6 +1489,60 @@
         "System analyzes past interactions to propose new skills",
         "Proposed skills are persisted and can be refined",
         "Tests mock interactions and verify skill creation"
+      ]
+    },
+    {
+      "id": "context-engine-compression-v2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine selective retrieval and compression",
+      "description": "Inspired by MemGPT/Letta pattern and OpenClaw trend: Implement advanced selective retrieval and context compression to handle long dialogues and maintain virtual context window constraints.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine.py",
+        "tests/test_context_engine_compression*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ContextEngine compresses old context beyond token limits",
+        "Selective retrieval fetches highly relevant episodic memories",
+        "Tests mock LLM for compression and verify token bounds"
+      ]
+    },
+    {
+      "id": "online-rl-from-feedback-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL from user feedback",
+      "description": "Inspired by OpenClaw-RL trend: Enhance the OnlineLearner module to automatically update agent preferences and strategy embeddings directly from explicit or implicit user feedback (e.g., negative pad shifts).",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl.py",
+        "tests/test_online_rl*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent parses user feedback for reward signals",
+        "Strategy weights or preferences are adjusted online",
+        "Tests verify preference shift after feedback"
+      ]
+    },
+    {
+      "id": "mcp-action-tools-v2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP action tools support",
+      "description": "Inspired by MCP trend where action tools grew to 65%: Implement a robust interface in MCP compatibility layer to not just export read-only skills, but full state-mutating action tools protected by policy layer.",
+      "allowed_paths": [
+        "magda_agent/mcp/action_tools.py",
+        "tests/test_mcp_action_tools*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Action tools can be registered and invoked via MCP",
+        "All action tool calls must route through the Policy layer",
+        "Tests verify invocation and policy gating"
       ]
     }
   ]

--- a/magda_agent/action/selector.py
+++ b/magda_agent/action/selector.py
@@ -7,27 +7,47 @@ class BasalGanglia:
     based on their assigned priorities.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, policy_layer: Optional[Any] = None) -> None:
         """
         Initializes the Basal Ganglia module.
+
+        Args:
+            policy_layer (Optional[Any]): The policy layer to evaluate actions.
         """
-        pass
+        self.policy_layer = policy_layer
 
     def select_action(self, actions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """
-        Selects the action with the highest priority from the provided list.
+        Selects the action with the highest priority from the provided list,
+        filtering out those denied by the policy layer.
 
         Args:
             actions (List[Dict[str, Any]]): A list of dictionaries representing possible actions.
-                                            Each action should have a 'priority' key (int or float).
+                                            Each action should have a 'priority' key (int or float),
+                                            and an 'action' key (str) representing the tool name.
 
         Returns:
-            Optional[Dict[str, Any]]: The selected action, or None if the list is empty.
+            Optional[Dict[str, Any]]: The selected action, or None if the list is empty or all actions are denied.
         """
         if not actions:
             return None
 
-        # Sort actions by priority in descending order and return the first one
-        # If 'priority' is missing, default to 0
-        selected = max(actions, key=lambda a: a.get('priority', 0))
-        return selected
+        # Sort actions by priority in descending order
+        sorted_actions = sorted(actions, key=lambda a: a.get('priority', 0), reverse=True)
+
+        for action_dict in sorted_actions:
+            action_name = action_dict.get("action")
+
+            # If there's a policy layer and an action name, evaluate it
+            if self.policy_layer and action_name:
+                # Extract kwargs if any (assuming they are stored in 'kwargs' key, or pass entire dict except 'priority'/'action')
+                kwargs = action_dict.get("kwargs", {})
+                allow, explanation = self.policy_layer.evaluate(action_name, **kwargs)
+
+                if not allow:
+                    # Keep looking for the next best action
+                    continue
+
+            return action_dict
+
+        return None

--- a/magda_agent/safety/policy.py
+++ b/magda_agent/safety/policy.py
@@ -1,0 +1,69 @@
+import logging
+from typing import Tuple, Dict, Any, List
+
+class PolicyLayer:
+    """
+    Policy Layer for all tool/action execution.
+    Evaluates every action with an external effect before execution.
+    Logs an audit trail of all allowed and denied actions.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the Policy Layer.
+        """
+        self.audit_trail: List[Dict[str, Any]] = []
+
+    def evaluate(self, tool_name: str, **kwargs: Any) -> Tuple[bool, str]:
+        """
+        Evaluates a tool call against the safety policy.
+
+        Args:
+            tool_name (str): The name of the tool or action.
+            **kwargs: The arguments passed to the tool.
+
+        Returns:
+            Tuple[bool, str]: A tuple containing a boolean indicating whether the action is allowed,
+                              and an LLM-friendly explanation string.
+        """
+        allow = True
+        explanation = f"Action '{tool_name}' is allowed."
+
+        # Example policy rules
+        if tool_name == "system_execute_code":
+            # Check for sensitive paths
+            code = kwargs.get("code", "")
+            if ".env" in code or "secrets" in code:
+                allow = False
+                explanation = "Action denied: 'system_execute_code' cannot access sensitive paths like '.env' or 'secrets'."
+        elif tool_name == "send_message":
+            # Check for spam or blocked recipients
+            recipient = kwargs.get("recipient", "")
+            if recipient == "blocked_user":
+                allow = False
+                explanation = "Action denied: Cannot send message to a blocked recipient."
+
+        # Audit trail
+        audit_entry = {
+            "tool_name": tool_name,
+            "kwargs": kwargs,
+            "allowed": allow,
+            "explanation": explanation
+        }
+        self.audit_trail.append(audit_entry)
+
+        if allow:
+            logging.info(f"PolicyLayer: ALLOW - {tool_name} with args {kwargs}")
+        else:
+            logging.warning(f"PolicyLayer: DENY - {tool_name} with args {kwargs}. Reason: {explanation}")
+
+        return allow, explanation
+
+    def get_audit_trail(self) -> List[Dict[str, Any]]:
+        """
+        Retrieves the audit trail of all evaluated actions.
+
+        Returns:
+            List[Dict[str, Any]]: The list of audit entries.
+        """
+        return self.audit_trail

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,67 @@
+import pytest
+from magda_agent.safety.policy import PolicyLayer
+from magda_agent.action.selector import BasalGanglia
+
+def test_policy_layer_allow() -> None:
+    """Test that a safe tool is allowed by the policy layer."""
+    policy = PolicyLayer()
+    allow, explanation = policy.evaluate("safe_tool", arg1="value")
+    assert allow is True
+    assert "allowed" in explanation.lower()
+
+    trail = policy.get_audit_trail()
+    assert len(trail) == 1
+    assert trail[0]["tool_name"] == "safe_tool"
+    assert trail[0]["kwargs"] == {"arg1": "value"}
+    assert trail[0]["allowed"] is True
+
+def test_policy_layer_deny_system_execute_code() -> None:
+    """Test that system_execute_code is denied when trying to access sensitive paths."""
+    policy = PolicyLayer()
+    # Mocking a code execution that touches .env
+    allow, explanation = policy.evaluate("system_execute_code", code="cat .env")
+    assert allow is False
+    assert "denied" in explanation.lower()
+
+    trail = policy.get_audit_trail()
+    assert len(trail) == 1
+    assert trail[0]["tool_name"] == "system_execute_code"
+    assert trail[0]["allowed"] is False
+
+def test_policy_layer_deny_send_message() -> None:
+    """Test that sending a message to a blocked user is denied."""
+    policy = PolicyLayer()
+    allow, explanation = policy.evaluate("send_message", recipient="blocked_user", message="hello")
+    assert allow is False
+    assert "denied" in explanation.lower()
+
+def test_basal_ganglia_with_policy() -> None:
+    """Test that BasalGanglia filters out denied actions and selects the next best allowed action."""
+    policy = PolicyLayer()
+    bg = BasalGanglia(policy_layer=policy)
+
+    actions = [
+        {"action": "system_execute_code", "priority": 10, "kwargs": {"code": "cat .env"}}, # Should be denied
+        {"action": "safe_tool", "priority": 5, "kwargs": {"param": "value"}},              # Should be allowed
+        {"action": "another_safe_tool", "priority": 1, "kwargs": {}}                       # Allowed but lower priority
+    ]
+
+    selected = bg.select_action(actions)
+
+    # The highest priority is denied, so it should select the second highest
+    assert selected is not None
+    assert selected["action"] == "safe_tool"
+    assert selected["priority"] == 5
+
+def test_basal_ganglia_all_denied() -> None:
+    """Test that BasalGanglia returns None if all actions are denied by the policy layer."""
+    policy = PolicyLayer()
+    bg = BasalGanglia(policy_layer=policy)
+
+    actions = [
+        {"action": "system_execute_code", "priority": 10, "kwargs": {"code": "cat secrets/keys"}},
+        {"action": "send_message", "priority": 5, "kwargs": {"recipient": "blocked_user"}}
+    ]
+
+    selected = bg.select_action(actions)
+    assert selected is None


### PR DESCRIPTION
This PR implements the Policy Layer (`magda_agent/safety/policy.py`) to intercept and evaluate every external tool/action execution request before execution. 
- Integrated the policy layer into the `BasalGanglia` action selector (`magda_agent/action/selector.py`) so that denied actions are filtered out and the next best allowed action is selected.
- Added comprehensive pytest test coverage (`tests/test_policy.py`) with type hints and docstrings.
- Updated `agent_tasks.json` to mark the `policy-layer-tool-calls` task as done.
- Appended 3 new tasks to `agent_tasks.json` based on modern AI agent trends.

---
*PR created automatically by Jules for task [3971676119605123026](https://jules.google.com/task/3971676119605123026) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PolicyLayer` to filter action execution in `BasalGanglia.select_action`
> - Introduces [`magda_agent/safety/policy.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/78/files#diff-21e196972ada89b3f130ec7359fff3d360b20820d0f3df501cf08341d588f71a) with a `PolicyLayer` class that evaluates allow/deny decisions for named actions and records an in-memory audit trail.
> - `BasalGanglia.select_action` in [`magda_agent/action/selector.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/78/files#diff-30288e7ff74577ecc1d46fb819252f4b40b46533dd67465efc8ada18d1237bae) now accepts an optional `policy_layer` and iterates candidates by priority, skipping denied actions and returning the first allowed one.
> - Built-in rules deny `system_execute_code` when kwargs reference `.env` or `secrets`, and deny `send_message` to `blocked_user`.
> - Behavioral Change: `select_action` may now return a lower-priority action than before, or `None` if all candidates are denied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8742ad8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->