### PR TITLE
feat: implement cross-session conversation continuity

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -674,7 +674,7 @@
     },
     {
       "id": "conversation-continuity",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "low",
       "title": "Cross-session conversation continuity",
@@ -1543,6 +1543,60 @@
         "Action tools can be registered and invoked via MCP",
         "All action tool calls must route through the Policy layer",
         "Tests verify invocation and policy gating"
+      ]
+    },
+    {
+      "id": "task-dependency-graph",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Task System with Dependency Graphs",
+      "description": "Inspired by Claude Agent SDK trend: Implement a task system in the Planner module that supports dependency graphs, allowing complex multi-step tasks to be resolved sequentially or in parallel based on prerequisite requirements.",
+      "allowed_paths": [
+        "magda_agent/planning/dependency_graph.py",
+        "tests/test_dependency_graph*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner can parse dependency relationships between tasks.",
+        "Independent tasks can be executed concurrently.",
+        "Tests verify dependency resolution logic."
+      ]
+    },
+    {
+      "id": "p2p-agent-discovery",
+      "status": "todo",
+      "area": "integration",
+      "risk": "low",
+      "title": "P2P Agent Discovery via A2A Protocol",
+      "description": "Inspired by A2A Protocol trend: Enhance the A2A integration by implementing peer-to-peer agent discovery where Magda broadcasts its Agent Card capabilities over a local network or designated channel.",
+      "allowed_paths": [
+        "magda_agent/a2a/discovery.py",
+        "tests/test_a2a_discovery*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Magda can broadcast its Agent Card.",
+        "Magda can receive and registry other agents' cards.",
+        "Tests mock network broadcasts to verify discovery."
+      ]
+    },
+    {
+      "id": "longitudinal-quality-metrics",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Longitudinal Quality Metrics Tracking",
+      "description": "Inspired by Self-Improvement Loops trend: Implement SQLite-based longitudinal tracking of agent success rates, post-merge smoke tests, and SWE-bench performance to monitor continuous improvement.",
+      "allowed_paths": [
+        "magda_agent/operations/metrics_tracker.py",
+        "tests/test_metrics_tracker*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Metrics are stored in a local SQLite database.",
+        "Tracker provides aggregated quality scores.",
+        "Tests verify insertion and aggregation without ChomaDB overhead."
       ]
     }
   ]

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -160,6 +160,13 @@ class Consciousness:
         else:
             context_str = "\n".join([f"- {m.content}" for m in relevant_memories])
 
+        # Cross-session continuity: Check if this is a new session (no active working memory)
+        working_memory_entries = self.memory.working_memory.get_entries(user_id=user_id)
+        if len(working_memory_entries) == 0:
+            past_episodes = self.memory.episodic_memory.recall_events(user_input, top_k=3, user_id=user_id)
+            if past_episodes:
+                context_str += "\n\nPast Relevant Episodes:\n" + "\n".join([f"- {ep}" for ep in past_episodes])
+
         if self.long_term_memory:
             long_term_memories = self.long_term_memory.recall(user_input, user_id=user_id)
             if long_term_memories:

--- a/tests/test_continuity.py
+++ b/tests/test_continuity.py
@@ -1,0 +1,89 @@
+import pytest
+import sys
+from unittest.mock import MagicMock, AsyncMock
+
+# Mock transformers to prevent CI issues
+sys.modules['transformers'] = MagicMock()
+
+from magda_agent.consciousness.core import Consciousness
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.emotions.engine import EmotionalEngine
+from magda_agent.llm_client import LLMClient
+from magda_agent.context.engine import ContextEngine
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.fixture
+def mock_llm() -> MagicMock:
+    """Provides a mock LLMClient instance."""
+    llm = MagicMock(spec=LLMClient)
+    llm.get_system_prompt.return_value = "System prompt"
+    llm.chat_completion = AsyncMock(return_value="LLM Response")
+    return llm
+
+@pytest.fixture
+def setup_consciousness(mock_llm: MagicMock, tmp_path: str) -> tuple[Consciousness, MemorySystem]:
+    """Sets up a Consciousness instance with a mocked LLM and fresh MemorySystem."""
+    persist_dir = str(tmp_path / "test_episodic_db")
+    memory_system = MemorySystem(persist_directory=persist_dir, llm=mock_llm, short_term_limit=5)
+    emotions = EmotionalEngine()
+    skills = SkillRegistry()
+
+    consciousness = Consciousness(
+        llm=mock_llm,
+        emotions=emotions,
+        memory=memory_system,
+        skills=skills
+    )
+    return consciousness, memory_system
+
+@pytest.mark.asyncio
+async def test_cross_session_continuity(setup_consciousness: tuple[Consciousness, MemorySystem]) -> None:
+    """Verifies that past episodic memories are retrieved when starting a new session."""
+    consciousness, memory_system = setup_consciousness
+    user_id = 999
+
+    # 1. Store a past episodic memory directly (simulating a previous session)
+    memory_system.episodic_memory.store_event("My favorite color is blue.", user_id=user_id)
+
+    # 2. Process input in a "new session" (working memory is empty)
+    user_input = "What is my favorite color?"
+
+    # Run the core process_input
+    response = await consciousness.process_input(user_input, user_id=user_id)
+
+    # Verify that the llm was called with the episodic memory context
+    system_prompt_calls = consciousness.llm.get_system_prompt.call_args_list
+    assert len(system_prompt_calls) > 0
+
+    # We look for the "Past Relevant Episodes" in the context parameter passed to get_system_prompt
+    context_str = system_prompt_calls[0].kwargs.get('context', '')
+
+    assert "Past Relevant Episodes:" in context_str
+    assert "blue" in context_str
+
+@pytest.mark.asyncio
+async def test_continuity_ignored_when_active_session(setup_consciousness: tuple[Consciousness, MemorySystem]) -> None:
+    """Verifies that episodic continuity is not triggered if the session is already active."""
+    consciousness, memory_system = setup_consciousness
+    user_id = 888
+
+    # 1. Store a past episodic memory directly (simulating a previous session)
+    memory_system.episodic_memory.store_event("My favorite color is red.", user_id=user_id)
+
+    # 2. Simulate an active session by populating working memory
+    from magda_agent.memory.working import MemoryEntry
+    from magda_agent.emotions.engine import PADState
+
+    # Add memory through the official async way to properly handle the list limit/summarization
+    await memory_system.add_memory("Hello", 0.5, PADState(0,0,0), ["tag"], user_id=user_id)
+
+    # 3. Process input
+    user_input = "What is my favorite color?"
+    response = await consciousness.process_input(user_input, user_id=user_id)
+
+    # Verify that the episodic memory was NOT included because working memory wasn't empty
+    system_prompt_calls = consciousness.llm.get_system_prompt.call_args_list
+    context_str = system_prompt_calls[1].kwargs.get('context', '') if len(system_prompt_calls) > 1 else system_prompt_calls[0].kwargs.get('context', '')
+
+    assert "Past Relevant Episodes:" not in context_str
+    assert "red" not in context_str


### PR DESCRIPTION
Implemented the first 'todo' task in `agent_tasks.json`: **Cross-session conversation continuity**.

Changes include:
- Modifying `Consciousness.process_input` to retrieve recent events from `EpisodicMemory` if the active session `WorkingMemory` is empty.
- Mock-based tests verifying the cross-session retrieval logic without triggering actual LLM API calls.
- Completing the task in `agent_tasks.json` and satisfying the constraint of generating 3 new tasks based on current AI trends in `docs/trends.md`.
- Adhered strictly to code quality guidelines, including type hints and docstrings for all functions.

---
*PR created automatically by Jules for task [4969896540081422732](https://jules.google.com/task/4969896540081422732) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-session conversation continuity by injecting episodic memory into new session context
> - In [`consciousness/core.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/79/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a), `Consciousness.process_input` now checks if working memory is empty for the user and, if so, fetches up to 3 past episodic events and appends them under a `Past Relevant Episodes:` section in the LLM context string.
> - When working memory is non-empty (active session), episodic context is skipped, leaving existing behavior unchanged.
> - Two new tests in [`tests/test_continuity.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/79/files#diff-f187161a79766f141fb9207a98bd6df25c71c773e428dc000f55fa9277124bab) cover both the injection and suppression paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a45861.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->