### PR TITLE
feat: Implement thought chain visualization for debugging

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -734,7 +734,7 @@
     },
     {
       "id": "thought-chain-visualization",
-      "status": "todo",
+      "status": "done",
       "area": "metacognition",
       "risk": "low",
       "title": "Thought chain visualization for debugging",
@@ -1703,6 +1703,60 @@
         "Every tool call produces an audit trail entry.",
         "Audit trail logs include risk level and policy outcome.",
         "Tests verify audit logging during mock tool calls."
+      ]
+    },
+    {
+      "id": "agent-guard-runtime-governance",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Agent Guard: Runtime Governance Layer",
+      "description": "Inspired by the Agent Guard and Prempti trend (June 2026), implement a runtime governance layer between the agent and external actions, effectively wrapping the Policy layer into a formalized execution checkpoint.",
+      "allowed_paths": [
+        "magda_agent/safety/agent_guard.py",
+        "tests/test_agent_guard*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A new AgentGuard class evaluates external tool actions",
+        "It acts as a middleware wrapping existing risk/policy checks",
+        "Tests verify tool calls are appropriately gated by AgentGuard"
+      ]
+    },
+    {
+      "id": "mcp-kernel-sandboxed-execution",
+      "status": "todo",
+      "area": "security",
+      "risk": "high",
+      "title": "MCPKernel: Taint Tracking and Sandboxed Execution",
+      "description": "Inspired by the MCPKernel trend (June 2026), implement an isolated execution environment for code blocks using strict taint tracking to prevent side-channel leaks during execution.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_kernel.py",
+        "tests/test_mcp_kernel*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCPKernel runs dynamically generated code securely",
+        "Code containing unsafe calls (network, uncontrolled FS) is blocked",
+        "Tests mock tainted executions to verify blocking"
+      ]
+    },
+    {
+      "id": "assert-policy-driven-evaluation",
+      "status": "todo",
+      "area": "metacognition",
+      "risk": "low",
+      "title": "ASSERT: Policy-driven evaluation framework",
+      "description": "Inspired by Microsoft's ASSERT framework trend (June 2026), augment the Metacognition Evaluator to automatically score outputs based on explicitly defined policy documents or rules, rather than just raw heuristic scores.",
+      "allowed_paths": [
+        "magda_agent/metacognition/assert_evaluator.py",
+        "tests/test_assert_evaluator*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator accepts a list of policy constraints",
+        "LLM evaluates outputs conditionally based on satisfying these constraints",
+        "Tests mock the LLM to verify constraint-driven scoring"
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -29,6 +29,7 @@ from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
 from magda_agent.context.engine import ContextEngine
 from magda_agent.context.default_plugin import DefaultContextPlugin
+from magda_agent.tracing.tracer import ThoughtChainTracer
 
 logging.basicConfig(level=logging.INFO)
 
@@ -54,6 +55,7 @@ pineal_gland = PinealGland()
 mirror_neurons = MirrorNeurons()
 salience_network = SalienceNetwork()
 global_workspace = GlobalWorkspace(salience_network=salience_network)
+thought_chain_tracer = ThoughtChainTracer()
 
 consciousness = Consciousness(
     llm=llm_client,
@@ -73,7 +75,8 @@ consciousness = Consciousness(
     salience=salience_network,
     global_workspace=global_workspace,
     context_engine=context_engine,
-    skill_creator=skill_creator
+    skill_creator=skill_creator,
+    tracer=thought_chain_tracer
 )
 
 cron_scheduler = CronScheduler()
@@ -124,3 +127,10 @@ class HealthResponse(BaseModel):
 @app.get("/health", response_model=HealthResponse)
 async def healthcheck():
     return HealthResponse(status="ok")
+
+class TraceResponse(BaseModel):
+    trace: list
+
+@app.get("/trace", response_model=TraceResponse)
+async def get_trace():
+    return TraceResponse(trace=thought_chain_tracer.get_trace())

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -21,6 +21,7 @@ from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
 from magda_agent.context.engine import ContextEngine
 from magda_agent.learning.skill_creator import SkillCreator
+from magda_agent.tracing.tracer import ThoughtChainTracer
 
 class Consciousness:
     """
@@ -49,7 +50,8 @@ class Consciousness:
         global_workspace: Optional[GlobalWorkspace] = None,
         context_engine: Optional[ContextEngine] = None,
         skill_creator: Optional[SkillCreator] = None,
-        online_learner: Optional[OnlineLearner] = None
+        online_learner: Optional[OnlineLearner] = None,
+        tracer: Optional[ThoughtChainTracer] = None
     ):
         self.llm = llm
         self.emotions = emotions
@@ -72,9 +74,12 @@ class Consciousness:
         self.context_engine = context_engine
         self.skill_creator = skill_creator
         self.online_learner = online_learner
+        self.tracer = tracer
 
     async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
+        if self.tracer:
+            self.tracer.add_step("input_received", {"user_input": user_input, "user_id": user_id})
 
         # Use ContextEngine ingest hook if available
         if self.context_engine:
@@ -108,6 +113,8 @@ class Consciousness:
                 score = focused_event.get("_salience_score", 0.0)
                 explanation = focused_event.get("_salience_explanation", "")
                 logging.info(f"Workspace focused on event '{focused_event.get('type')}' with Salience: {score:.2f} ({explanation})")
+                if self.tracer:
+                    self.tracer.add_step("global_workspace_focus", {"event_type": focused_event.get('type'), "salience": score, "explanation": explanation})
 
             # Only user_input is supported for full processing in the current API,
             # but using focus_content ensures workspace output is piped in.
@@ -117,6 +124,8 @@ class Consciousness:
             event = {"content": user_input}
             score, explanation = self.salience.score_event(event)
             logging.info(f"Salience score: {score:.2f} ({explanation})")
+            if self.tracer:
+                self.tracer.add_step("salience_scoring", {"salience": score, "explanation": explanation})
 
         # 0. Brainstem Autonomic Reflexes
         if self.brainstem:
@@ -153,6 +162,8 @@ class Consciousness:
 
         # 2. Memory Retrieval
         relevant_memories = self.memory.retrieve_relevant(user_input, user_id=user_id)
+        if self.tracer:
+            self.tracer.add_step("memory_retrieval", {"retrieved_count": len(relevant_memories)})
 
         # Use ContextEngine assemble hook if available
         if self.context_engine:
@@ -174,6 +185,8 @@ class Consciousness:
 
         # 3. Planning (Prefrontal Cortex)
         plan_str = ""
+        if self.tracer:
+            self.tracer.add_step("planning_start", {})
         if self.planner:
             # Only generate a new plan if we don't have an active one
             if not self.planner.get_current_plan():
@@ -241,6 +254,8 @@ class Consciousness:
                     plan_str += "\nNote: Plan execution was stopped early due to limits.\n"
 
         # 4. LLM Reasoning
+        if self.tracer:
+            self.tracer.add_step("llm_reasoning_start", {"plan_str": plan_str})
         emotion_summary = self.emotions.get_summary(user_id=user_id)
         if self.hypothalamus:
             emotion_summary += f" | {self.hypothalamus.get_drives_summary()}"
@@ -282,9 +297,15 @@ class Consciousness:
             ]
             selected_action = self.basal_ganglia.select_action(possible_actions)
             if selected_action and selected_action["action"] == "ignore":
+                if self.tracer:
+                    self.tracer.add_step("action_selection", {"selected_action": "ignore"})
                 return "Message ignored by Basal Ganglia."
+            elif selected_action and self.tracer:
+                self.tracer.add_step("action_selection", {"selected_action": selected_action["action"]})
 
         response = await self.llm.chat_completion(messages)
+        if self.tracer:
+            self.tracer.add_step("response_generated", {"response": response})
 
         # 5. Post-processing & Memory Storage
         memory_content = f"User said: {user_input} | I replied: {response}"

--- a/magda_agent/tracing/tracer.py
+++ b/magda_agent/tracing/tracer.py
@@ -1,0 +1,34 @@
+import time
+from typing import List, Dict, Any
+
+class ThoughtChainTracer:
+    """
+    Traces the internal reasoning steps of the cognitive architecture.
+    """
+    def __init__(self):
+        self.trace: List[Dict[str, Any]] = []
+
+    def add_step(self, step_name: str, data: Any = None) -> None:
+        """
+        Records a single cognitive step.
+        """
+        entry = {
+            "timestamp": time.time(),
+            "step": step_name
+        }
+        if data is not None:
+            entry["data"] = data
+
+        self.trace.append(entry)
+
+    def get_trace(self) -> List[Dict[str, Any]]:
+        """
+        Returns the full current trace.
+        """
+        return self.trace
+
+    def clear(self) -> None:
+        """
+        Clears the current trace.
+        """
+        self.trace.clear()

--- a/patch_api.py
+++ b/patch_api.py
@@ -1,0 +1,34 @@
+with open("magda_agent/api.py", "r") as f:
+    content = f.read()
+
+# Add import
+content = content.replace(
+    "from magda_agent.context.default_plugin import DefaultContextPlugin",
+    "from magda_agent.context.default_plugin import DefaultContextPlugin\nfrom magda_agent.tracing.tracer import ThoughtChainTracer"
+)
+
+# Instantiate tracer
+content = content.replace(
+    "global_workspace = GlobalWorkspace(salience_network=salience_network)",
+    "global_workspace = GlobalWorkspace(salience_network=salience_network)\nthought_chain_tracer = ThoughtChainTracer()"
+)
+
+# Pass tracer to Consciousness
+content = content.replace(
+    "    skill_creator=skill_creator\n)",
+    "    skill_creator=skill_creator,\n    tracer=thought_chain_tracer\n)"
+)
+
+# Add route
+route_str = """
+class TraceResponse(BaseModel):
+    trace: list
+
+@app.get("/trace", response_model=TraceResponse)
+async def get_trace():
+    return TraceResponse(trace=thought_chain_tracer.get_trace())
+"""
+content = content + route_str
+
+with open("magda_agent/api.py", "w") as f:
+    f.write(content)

--- a/patch_consciousness.py
+++ b/patch_consciousness.py
@@ -1,0 +1,73 @@
+import re
+
+with open("magda_agent/consciousness/core.py", "r") as f:
+    content = f.read()
+
+# Add import
+content = content.replace(
+    "from magda_agent.context.engine import ContextEngine\nfrom magda_agent.learning.skill_creator import SkillCreator",
+    "from magda_agent.context.engine import ContextEngine\nfrom magda_agent.learning.skill_creator import SkillCreator\nfrom magda_agent.tracing.tracer import ThoughtChainTracer"
+)
+
+# Add __init__ argument
+content = content.replace(
+    "        skill_creator: Optional[SkillCreator] = None,\n        online_learner: Optional[OnlineLearner] = None\n    ):",
+    "        skill_creator: Optional[SkillCreator] = None,\n        online_learner: Optional[OnlineLearner] = None,\n        tracer: Optional[ThoughtChainTracer] = None\n    ):"
+)
+content = content.replace(
+    "        self.online_learner = online_learner\n",
+    "        self.online_learner = online_learner\n        self.tracer = tracer\n"
+)
+
+# Add tracing to process_input
+# Start of process_input
+content = content.replace(
+    "        logging.info(f\"Consciousness processing: {user_input}\")",
+    "        logging.info(f\"Consciousness processing: {user_input}\")\n        if self.tracer:\n            self.tracer.add_step(\"input_received\", {\"user_input\": user_input, \"user_id\": user_id})"
+)
+
+# After Global Workspace focus
+content = content.replace(
+    "                logging.info(f\"Workspace focused on event '{focused_event.get('type')}' with Salience: {score:.2f} ({explanation})\")",
+    "                logging.info(f\"Workspace focused on event '{focused_event.get('type')}' with Salience: {score:.2f} ({explanation})\")\n                if self.tracer:\n                    self.tracer.add_step(\"global_workspace_focus\", {\"event_type\": focused_event.get('type'), \"salience\": score, \"explanation\": explanation})"
+)
+
+# After Salience fallback focus
+content = content.replace(
+    "            logging.info(f\"Salience score: {score:.2f} ({explanation})\")",
+    "            logging.info(f\"Salience score: {score:.2f} ({explanation})\")\n            if self.tracer:\n                self.tracer.add_step(\"salience_scoring\", {\"salience\": score, \"explanation\": explanation})"
+)
+
+# Before Memory Retrieval, after emotion update
+content = content.replace(
+    "        # 2. Memory Retrieval\n        relevant_memories = self.memory.retrieve_relevant(user_input, user_id=user_id)",
+    "        # 2. Memory Retrieval\n        relevant_memories = self.memory.retrieve_relevant(user_input, user_id=user_id)\n        if self.tracer:\n            self.tracer.add_step(\"memory_retrieval\", {\"retrieved_count\": len(relevant_memories)})"
+)
+
+# Planning Step
+content = content.replace(
+    "        # 3. Planning (Prefrontal Cortex)\n        plan_str = \"\"",
+    "        # 3. Planning (Prefrontal Cortex)\n        plan_str = \"\"\n        if self.tracer:\n            self.tracer.add_step(\"planning_start\", {})"
+)
+
+# LLM Reasoning start
+content = content.replace(
+    "        # 4. LLM Reasoning\n        emotion_summary = self.emotions.get_summary(user_id=user_id)",
+    "        # 4. LLM Reasoning\n        if self.tracer:\n            self.tracer.add_step(\"llm_reasoning_start\", {\"plan_str\": plan_str})\n        emotion_summary = self.emotions.get_summary(user_id=user_id)"
+)
+
+# Before basal ganglia return (ignore)
+content = content.replace(
+    "            if selected_action and selected_action[\"action\"] == \"ignore\":\n                return \"Message ignored by Basal Ganglia.\"",
+    "            if selected_action and selected_action[\"action\"] == \"ignore\":\n                if self.tracer:\n                    self.tracer.add_step(\"action_selection\", {\"selected_action\": \"ignore\"})\n                return \"Message ignored by Basal Ganglia.\"\n            elif selected_action and self.tracer:\n                self.tracer.add_step(\"action_selection\", {\"selected_action\": selected_action[\"action\"]})"
+)
+
+# After response is generated
+content = content.replace(
+    "        response = await self.llm.chat_completion(messages)",
+    "        response = await self.llm.chat_completion(messages)\n        if self.tracer:\n            self.tracer.add_step(\"response_generated\", {\"response\": response})"
+)
+
+
+with open("magda_agent/consciousness/core.py", "w") as f:
+    f.write(content)

--- a/patch_tasks.py
+++ b/patch_tasks.py
@@ -1,0 +1,72 @@
+import json
+
+with open("agent_tasks.json", "r") as f:
+    data = json.load(f)
+
+# Update thought-chain-visualization
+for task in data["tasks"]:
+    if task["id"] == "thought-chain-visualization":
+        task["status"] = "done"
+
+new_tasks = [
+    {
+      "id": "agent-guard-runtime-governance",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Agent Guard: Runtime Governance Layer",
+      "description": "Inspired by the Agent Guard and Prempti trend (June 2026), implement a runtime governance layer between the agent and external actions, effectively wrapping the Policy layer into a formalized execution checkpoint.",
+      "allowed_paths": [
+        "magda_agent/safety/agent_guard.py",
+        "tests/test_agent_guard*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A new AgentGuard class evaluates external tool actions",
+        "It acts as a middleware wrapping existing risk/policy checks",
+        "Tests verify tool calls are appropriately gated by AgentGuard"
+      ]
+    },
+    {
+      "id": "mcp-kernel-sandboxed-execution",
+      "status": "todo",
+      "area": "security",
+      "risk": "high",
+      "title": "MCPKernel: Taint Tracking and Sandboxed Execution",
+      "description": "Inspired by the MCPKernel trend (June 2026), implement an isolated execution environment for code blocks using strict taint tracking to prevent side-channel leaks during execution.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_kernel.py",
+        "tests/test_mcp_kernel*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCPKernel runs dynamically generated code securely",
+        "Code containing unsafe calls (network, uncontrolled FS) is blocked",
+        "Tests mock tainted executions to verify blocking"
+      ]
+    },
+    {
+      "id": "assert-policy-driven-evaluation",
+      "status": "todo",
+      "area": "metacognition",
+      "risk": "low",
+      "title": "ASSERT: Policy-driven evaluation framework",
+      "description": "Inspired by Microsoft's ASSERT framework trend (June 2026), augment the Metacognition Evaluator to automatically score outputs based on explicitly defined policy documents or rules, rather than just raw heuristic scores.",
+      "allowed_paths": [
+        "magda_agent/metacognition/assert_evaluator.py",
+        "tests/test_assert_evaluator*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator accepts a list of policy constraints",
+        "LLM evaluates outputs conditionally based on satisfying these constraints",
+        "Tests mock the LLM to verify constraint-driven scoring"
+      ]
+    }
+]
+
+data["tasks"].extend(new_tasks)
+
+with open("agent_tasks.json", "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write("\n")

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,21 @@
+import pytest
+from magda_agent.tracing.tracer import ThoughtChainTracer
+
+def test_tracer_add_step():
+    tracer = ThoughtChainTracer()
+    assert len(tracer.get_trace()) == 0
+
+    tracer.add_step("memory_retrieval", {"count": 3})
+    trace = tracer.get_trace()
+    assert len(trace) == 1
+    assert trace[0]["step"] == "memory_retrieval"
+    assert trace[0]["data"]["count"] == 3
+    assert "timestamp" in trace[0]
+
+def test_tracer_clear():
+    tracer = ThoughtChainTracer()
+    tracer.add_step("test")
+    assert len(tracer.get_trace()) == 1
+
+    tracer.clear()
+    assert len(tracer.get_trace()) == 0


### PR DESCRIPTION
Implements thought chain visualization for debugging.

1. **Tracer implementation**: Added `ThoughtChainTracer` class to `magda_agent/tracing/tracer.py` to record cognitive steps with timestamps.
2. **Integration in Consciousness core**: Patched `magda_agent/consciousness/core.py` to optionally accept the tracer and record steps (input, workspace focus, salience, memory, planning, reasoning, action, response).
3. **API endpoint**: Modified `magda_agent/api.py` to instantiate the tracer and expose `/trace` which returns the trace array as structured JSON.
4. **Tests**: Added `tests/test_tracing.py` to verify step recording and trace clearing.
5. **Task management**: Marked task `thought-chain-visualization` as complete in `agent_tasks.json` and generated 3 new AI trend tasks.

---
*PR created automatically by Jules for task [14044082746253534935](https://jules.google.com/task/14044082746253534935) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thought chain visualization with a `ThoughtChainTracer` and `GET /trace` endpoint
> - Adds a new `ThoughtChainTracer` class in [tracer.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/82/files#diff-547b188517ee6e902003b232fa6db10214fb55584dd9387c6ab667e53d489660) that records timestamped cognitive steps in memory, with `add_step`, `get_trace`, and `clear` methods.
> - Wires the tracer into `Consciousness.__init__` and inserts `tracer.add_step` hooks at key stages of `process_input` (input receipt, workspace focus, memory retrieval, planning, LLM reasoning, action selection, and response generation).
> - Exposes the trace via a new `GET /trace` endpoint in [api.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/82/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d) returning a `TraceResponse` payload.
> - Includes patch scripts ([patch_api.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/82/files#diff-6ceded6106dc7ba18d0f330549dd0930478eea9406425c1fa7f249259ca8b374), [patch_consciousness.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/82/files#diff-821349b37cc9bc6d34101feed1305de8c7fe54260b7c05ca2032b272fccb2f7f)) that apply the changes via string replacement, suggesting these may have been used to generate the final file edits.
> - Behavioral Change: `Consciousness.process_input` now has a side effect of writing to an in-memory trace list when a tracer is provided; the trace is not persisted across restarts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ae966e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->