### PR TITLE
feat: semantic memory conflict detection

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -754,7 +754,7 @@
     },
     {
       "id": "conflict-detection-memory",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "low",
       "title": "Detect contradictions between memories",
@@ -1757,6 +1757,43 @@
         "Evaluator accepts a list of policy constraints",
         "LLM evaluates outputs conditionally based on satisfying these constraints",
         "Tests mock the LLM to verify constraint-driven scoring"
+      ]
+    },
+    {
+      "id": "openclaw-rl-online-learning",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Online Reinforcement Learning",
+      "description": "Inspired by OpenClaw trend: Implement an online reinforcement learning mechanism using MirrorNeurons PAD shifts from user replies to train agent simply by talking. Extract implicit feedback as next-state signals.",
+      "allowed_paths": [
+        "magda_agent/learning/online.py",
+        "tests/test_online_learning*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent adjusts policies based on conversation PAD shifts.",
+        "Tests verify that positive feedback reinforces recent habits.",
+        "Tests verify that negative feedback triggers reflection."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-expansion",
+      "status": "todo",
+      "area": "scheduler",
+      "risk": "low",
+      "title": "Hermes-inspired Cron Scheduler Expansion",
+      "description": "Inspired by Hermes Agent trend: Expand CronScheduler to support daily reports, nightly backups, and persistent scheduled tasks configurable by user.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron.py",
+        "magda_agent/scheduler/reports.py",
+        "tests/test_scheduler_expansion*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Users can schedule daily reports.",
+        "Scheduler persists tasks across reboots.",
+        "Tests verify job triggers and serialization."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -110,6 +110,7 @@
 ---
 
 ## 🔍 Обнаружено (добавляется агентом автоматически)
+* [x] MODULE: **Conflict Detection Memory** — `magda_agent/memory/semantic.py` и `magda_agent/subconsciousness/reflection.py`. Subconsciousness detects when new information contradicts existing semantic memory and flags conflicts for resolution.
 * [x] IMPROVEMENT: Добавить механизм выполнения шагов плана и сбора результатов внутри `Consciousness.process_input`. Сейчас планер интегрирован только для генерации и учета в контексте LLM, но сами функции Skills не вызываются автоматически. (2026-06-03)
 * [x] BUG/IMPROVEMENT: В `Evaluator.evaluate_response` можно добавить логику retry на случай, если LLM возвращает невалидный JSON, вместо того, чтобы сразу падать с ошибкой парсинга. (2026-06-04)
 * [x] IMPROVEMENT: В модуле `Cerebellum` (`HabitTracker`) сейчас используется точное совпадение текста запроса. Можно улучшить, добавив семантический поиск (через эмбеддинги и ChromaDB) для нечеткого совпадения намерений пользователя. (2026-06-04)

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -11,6 +11,7 @@ from magda_agent.emotions.engine import EmotionalEngine
 from magda_agent.emotions.attachment import AttachmentModel
 from magda_agent.memory.storage import MemorySystem
 from magda_agent.memory.procedural import ProceduralMemory
+from magda_agent.memory.semantic import SemanticMemory
 from magda_agent.learning.skill_creator import SkillCreator
 from magda_agent.skills import initialize_skills
 from magda_agent.planning.planner import Planner
@@ -41,6 +42,7 @@ context_engine = ContextEngine(plugins=[DefaultContextPlugin(llm=llm_client)])
 
 memory_system = MemorySystem(llm=llm_client, context_engine=context_engine)
 procedural_memory = ProceduralMemory(persist_directory="./procedural_memory_db")
+semantic_memory = SemanticMemory(persist_directory="./semantic_memory_db")
 skill_creator = SkillCreator(procedural_memory=procedural_memory, llm=llm_client)
 skill_registry = initialize_skills()
 habit_tracker = HabitTracker()
@@ -86,6 +88,7 @@ subconsciousness = Subconsciousness(
     emotions=emotional_engine,
     memory=memory_system,
     procedural_memory=procedural_memory,
+    semantic_memory=semantic_memory,
     interval=300
 )
 

--- a/magda_agent/memory/semantic.py
+++ b/magda_agent/memory/semantic.py
@@ -62,3 +62,42 @@ class SemanticMemory:
         except Exception as e:
             logging.error(f"Failed to recall semantic facts: {e}")
             return []
+
+    def search_facts(self, query: str, top_k: int = 5, user_id: int = None) -> list[dict]:
+        """
+        Search facts returning dictionaries with id, text and metadata.
+        """
+        try:
+            query_kwargs = {
+                "query_texts": [query],
+                "n_results": top_k
+            }
+            if user_id is not None:
+                query_kwargs["where"] = {"user_id": user_id}
+
+            results = self.collection.query(**query_kwargs)
+            facts = []
+            if results and results.get("documents") and len(results["documents"]) > 0:
+                docs = results["documents"][0]
+                ids = results["ids"][0]
+                metas = results["metadatas"][0] if results.get("metadatas") and results["metadatas"][0] else [{}] * len(docs)
+                for i in range(len(docs)):
+                    facts.append({
+                        "id": ids[i],
+                        "text": docs[i],
+                        "metadata": metas[i] if metas[i] is not None else {}
+                    })
+            return facts
+        except Exception as e:
+            logging.error(f"Failed to search semantic facts: {e}")
+            return []
+
+    def delete_fact(self, memory_id: str) -> None:
+        """
+        Delete a fact from semantic memory by ID.
+        """
+        try:
+            self.collection.delete(ids=[memory_id])
+            logging.debug(f"Deleted semantic fact with ID: {memory_id}")
+        except Exception as e:
+            logging.error(f"Failed to delete semantic fact: {e}")

--- a/magda_agent/subconsciousness/reflection.py
+++ b/magda_agent/subconsciousness/reflection.py
@@ -6,6 +6,7 @@ from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import EmotionalEngine
 from magda_agent.memory.storage import MemorySystem
 from magda_agent.memory.procedural import ProceduralMemory
+from magda_agent.memory.semantic import SemanticMemory
 
 class Subconsciousness:
     """
@@ -18,12 +19,14 @@ class Subconsciousness:
         emotions: EmotionalEngine,
         memory: MemorySystem,
         procedural_memory: ProceduralMemory = None,
+        semantic_memory: SemanticMemory = None,
         interval: int = 60  # Reflection interval in seconds
     ):
         self.llm = llm
         self.emotions = emotions
         self.memory = memory
         self.procedural_memory = procedural_memory
+        self.semantic_memory = semantic_memory
         self.interval = interval
         self.is_running = False
         self._stop_event = asyncio.Event()
@@ -77,6 +80,7 @@ class Subconsciousness:
             "lessons": ["lesson 1", "lesson 2"],
             "anti_patterns": ["anti-pattern 1", "anti-pattern 2"],
             "proposed_tasks": ["proposed task 1", "proposed task 2"],
+            "new_facts": ["fact 1", "fact 2"],
             "pad_adjustment": {{
                 "p": 0.0,
                 "a": 0.0,
@@ -94,6 +98,7 @@ class Subconsciousness:
         lessons = []
         anti_patterns = []
         proposed_tasks = []
+        new_facts = []
         p_adj, a_adj, d_adj = 0.02, -0.01, 0.05  # Defaults
 
         try:
@@ -111,6 +116,7 @@ class Subconsciousness:
             lessons = parsed_data.get("lessons", [])
             anti_patterns = parsed_data.get("anti_patterns", [])
             proposed_tasks = parsed_data.get("proposed_tasks", [])
+            new_facts = parsed_data.get("new_facts", [])
             pad_adj = parsed_data.get("pad_adjustment", {})
             p_adj = float(pad_adj.get("p", 0.0))
             a_adj = float(pad_adj.get("a", 0.0))
@@ -133,6 +139,57 @@ class Subconsciousness:
                 self.procedural_memory.store_procedure(name="lesson", procedure=lesson)
             for ap in anti_patterns:
                 self.procedural_memory.store_procedure(name="anti_pattern", procedure=ap)
+
+
+        if self.semantic_memory:
+            for fact in new_facts:
+                existing = self.semantic_memory.search_facts(fact, top_k=3)
+                if not existing:
+                    self.semantic_memory.store_fact(fact)
+                    continue
+
+                # Check for conflicts
+                existing_texts = "\n".join([f"ID: {e['id']} | Fact: {e['text']}" for e in existing])
+                conflict_prompt = f"""
+                New fact: '{fact}'
+                Existing facts:
+                {existing_texts}
+
+                Does the new fact contradict any existing facts?
+                Output ONLY a JSON object:
+                {{
+                    "conflict": true/false,
+                    "conflicting_id": "ID of the conflicting fact or null",
+                    "strategy": "newer_wins", // or "keep_old", "merge"
+                    "resolved_fact": "The final fact to store if newer_wins or merge"
+                }}
+                """
+                conflict_res = await self.llm.chat_completion([
+                    {"role": "system", "content": "You detect semantic memory contradictions. Output ONLY JSON."},
+                    {"role": "user", "content": conflict_prompt}
+                ])
+                try:
+                    c_resp = conflict_res.strip()
+                    if c_resp.startswith("```json"): c_resp = c_resp[7:]
+                    if c_resp.startswith("```"): c_resp = c_resp[3:]
+                    if c_resp.endswith("```"): c_resp = c_resp[:-3]
+                    c_data = json.loads(c_resp.strip())
+
+                    if c_data.get("conflict"):
+                        logging.warning(f"Memory conflict detected! New: {fact}")
+                        c_id = c_data.get("conflicting_id")
+                        strategy = c_data.get("strategy")
+                        resolved = c_data.get("resolved_fact")
+
+                        if strategy in ["newer_wins", "merge"]:
+                            if c_id:
+                                self.semantic_memory.delete_fact(c_id)
+                            self.semantic_memory.store_fact(resolved)
+                    else:
+                        self.semantic_memory.store_fact(fact)
+                except Exception as e:
+                    logging.error(f"Failed to process conflict resolution: {e}")
+                    self.semantic_memory.store_fact(fact) # Fallback
 
         for task in proposed_tasks:
             logging.info(f"Subconscious proposed task: {task}")

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -1,0 +1,71 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.subconsciousness.reflection import Subconsciousness
+from magda_agent.emotions.engine import EmotionalEngine
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.memory.semantic import SemanticMemory
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.working import MemoryEntry
+
+@pytest.fixture
+def mock_semantic_memory():
+    sm = MagicMock(spec=SemanticMemory)
+    # Simulate an existing fact
+    sm.search_facts.return_value = [{"id": "123", "text": "The sky is blue", "metadata": {}}]
+    return sm
+
+@pytest.fixture
+def mock_memory_system():
+    ms = MagicMock(spec=MemorySystem)
+    ms.short_term = [MemoryEntry(content="Someone told me the sky is red.", importance=0.8, emotional_state=None)]
+    return ms
+
+@pytest.fixture
+def mock_llm_conflict():
+    llm = MagicMock(spec=LLMClient)
+
+    # Needs to return 2 things: the reflection response, then the conflict response.
+    # We will use side_effect
+    async def mock_chat_completion(messages, **kwargs):
+        if "detect semantic memory contradictions" in messages[0]["content"]:
+            return json.dumps({
+                "conflict": True,
+                "conflicting_id": "123",
+                "strategy": "newer_wins",
+                "resolved_fact": "The sky is red"
+            })
+        else:
+            return json.dumps({
+                "summary": "Reflection summary",
+                "lessons": [],
+                "anti_patterns": [],
+                "proposed_tasks": [],
+                "new_facts": ["The sky is red"],
+                "pad_adjustment": {"p": 0.0, "a": 0.0, "d": 0.0}
+            })
+
+    llm.chat_completion = AsyncMock(side_effect=mock_chat_completion)
+    return llm
+
+@pytest.mark.asyncio
+async def test_subconsciousness_conflict_detection(mock_llm_conflict, mock_memory_system, mock_semantic_memory):
+    emotions = EmotionalEngine()
+
+    subconsciousness = Subconsciousness(
+        llm=mock_llm_conflict,
+        emotions=emotions,
+        memory=mock_memory_system,
+        semantic_memory=mock_semantic_memory,
+        interval=1
+    )
+
+    await subconsciousness.reflect()
+
+    # Check that search_facts was called with the new fact
+    mock_semantic_memory.search_facts.assert_called_with("The sky is red", top_k=3)
+
+    # Check that the conflict resolution deleted the old fact and stored the new one
+    mock_semantic_memory.delete_fact.assert_called_with("123")
+    mock_semantic_memory.store_fact.assert_called_with("The sky is red")


### PR DESCRIPTION
Implemented autonomous detection of semantic memory conflicts within the Subconsciousness module. When the subconscious process reflects on short-term memory and extracts new facts, it queries the SemanticMemory vector database for potential matches. If matches are found, it asks the LLM to identify contradictions and recommend a resolution strategy (newer wins, merge, etc.). The old fact is deleted and the new fact is stored seamlessly.

Also generated 2 new AI-trend-inspired tasks and added them to `agent_tasks.json`.

---
*PR created automatically by Jules for task [4704059475884050079](https://jules.google.com/task/4704059475884050079) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add semantic memory conflict detection to `Subconsciousness.reflect`
> - `Subconsciousness.reflect` now extracts LLM-suggested `new_facts`, searches existing semantic memory for contradictions, and applies an LLM-provided resolution strategy (`newer_wins`, `keep_old`, or `merge`) before storing facts.
> - Adds `SemanticMemory.search_facts` and `SemanticMemory.delete_fact` methods to support querying and removing facts by ID from the vector store.
> - Wires a persistent `SemanticMemory` instance (stored at `./semantic_memory_db`) into `Subconsciousness` in [api.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/83/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d).
> - A new async test in [tests/test_conflict.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/83/files#diff-640c919476734a845bcdf0f19bd2fef66e1b5c2c11ed26811146c398d2543353) verifies the search, delete, and store flow under a mocked contradiction scenario.
> - Risk: conflict resolution makes two additional LLM calls per new fact during every reflection cycle, which may increase latency and token usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 270c69e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->