### PR TITLE
Implement curiosity driven exploration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -774,7 +774,7 @@
     },
     {
       "id": "curiosity-driven-exploration",
-      "status": "todo",
+      "status": "done",
       "area": "drives",
       "risk": "low",
       "title": "Curiosity drive: explore when bored",
@@ -1794,6 +1794,63 @@
         "Users can schedule daily reports.",
         "Scheduler persists tasks across reboots.",
         "Tests verify job triggers and serialization."
+      ]
+    },
+    {
+      "id": "mcp-skill-export",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Export Skills as MCP Tools",
+      "description": "Implement a Model Context Protocol (MCP) compatible server interface to expose the agent's internal skills to external clients, aligning with the industry standard for agent-to-tool communication.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_server.py",
+        "magda_agent/skills/__init__.py",
+        "tests/test_mcp_server.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP server can list available skills",
+        "MCP server can execute skills via JSON-RPC",
+        "Unit tests verify MCP message format compliance"
+      ]
+    },
+    {
+      "id": "online-rl-feedback",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL from User Feedback",
+      "description": "Implement online reinforcement learning (OpenClaw-RL pattern) where explicit positive/negative user replies (e.g., 'thanks', 'bad response') are used as next-state signals to adjust tool selection weights in the Basal Ganglia.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl.py",
+        "magda_agent/action/selector.py",
+        "tests/test_online_rl.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "User feedback modifies action weights",
+        "Weights are persisted across sessions",
+        "Tests mock feedback and verify weight changes"
+      ]
+    },
+    {
+      "id": "agent-guard-policy",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Agent Guard Policy Layer",
+      "description": "Implement an ACS-inspired Agent Guard policy layer that intercepts every tool call with an external effect to run an explicit allow/deny evaluation before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/agent_guard.py",
+        "magda_agent/consciousness/core.py",
+        "tests/test_agent_guard.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "All external tool calls pass through Agent Guard",
+        "Guard can block calls based on policy rules",
+        "Blocked calls return an explanatory error to the agent"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -144,3 +144,6 @@
 * [ ] SKILL: **Image Generator (Генерация изображений)** — модуль `magda_agent/skills/image_gen.py`. Создание изображений по текстовому описанию (интеграция с DALL-E или Stable Diffusion).
 * [ ] SKILL: **Smart Home Control (Умный дом)** — модуль `magda_agent/skills/smart_home.py`. Интеграция с системами умного дома (Home Assistant, MQTT) для управления устройствами.
 * [ ] SKILL: **Crypto Prices (Курсы криптовалют)** — модуль `magda_agent/skills/crypto.py`. Получение актуальных курсов криптовалют с бирж (Binance, CoinMarketCap).
+
+* [x] MODULE: **Curiosity Drive** — `magda_agent/exploration/curiosity.py`. (2026-06-05)
+  Proactively suggests exploration tasks when boredom is high.

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -11,6 +11,7 @@ from magda_agent.learning.habits import HabitTracker
 from magda_agent.emotions.attachment import AttachmentModel
 from magda_agent.thalamus.router import Thalamus
 from magda_agent.action.selector import BasalGanglia
+from magda_agent.exploration.curiosity import CuriosityExplorer
 from magda_agent.drives.hypothalamus import Hypothalamus
 from magda_agent.emotions.insula import Insula
 from magda_agent.reflexes.brainstem import Brainstem
@@ -64,6 +65,7 @@ class Consciousness:
         self.attachment = attachment
         self.thalamus = thalamus
         self.basal_ganglia = basal_ganglia
+        self.curiosity_explorer = CuriosityExplorer()
         self.hypothalamus = hypothalamus
         self.insula = insula
         self.brainstem = brainstem
@@ -142,6 +144,18 @@ class Consciousness:
             p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_input)
             if p_shift != 0.0 or a_shift != 0.0 or d_shift != 0.0:
                 self.emotions.update(p_shift, a_shift, d_shift, user_id=user_id)
+
+                # Curiosity-driven exploration
+        if self.hypothalamus and self.curiosity_explorer:
+            if self.curiosity_explorer.should_explore(self.hypothalamus.boredom):
+                exploration_tasks = self.curiosity_explorer.explore()
+                # If we have a global workspace, we could post these tasks there.
+                # For now, we'll log them and potentially add them to the system prompt if needed.
+                logging.info(f"Curiosity triggered. Proposed tasks: {exploration_tasks}")
+
+                # We decrease boredom slightly just to show we acted on it
+                if len(exploration_tasks) > 0:
+                     self.hypothalamus.update(1.0)
 
         if self.hypothalamus:
             activity_level = 1.0

--- a/magda_agent/exploration/curiosity.py
+++ b/magda_agent/exploration/curiosity.py
@@ -1,0 +1,52 @@
+from typing import List, Dict, Any
+
+class CuriosityExplorer:
+    """
+    Curiosity Explorer module.
+    Responsible for proactively suggesting read-only exploration actions
+    when the agent's boredom level reaches a certain threshold.
+    """
+
+    def __init__(self, boredom_threshold: float = 0.8) -> None:
+        """
+        Initializes the CuriosityExplorer.
+
+        Args:
+            boredom_threshold (float): The minimum boredom level (0.0 to 1.0)
+                required to trigger an exploration suggestion.
+        """
+        self.boredom_threshold = boredom_threshold
+
+    def should_explore(self, boredom: float) -> bool:
+        """
+        Determines whether exploration should be triggered based on current boredom.
+
+        Args:
+            boredom (float): The current boredom level of the agent.
+
+        Returns:
+            bool: True if boredom is at or above the threshold, False otherwise.
+        """
+        return boredom >= self.boredom_threshold
+
+    def explore(self, workspace_context: Dict[str, Any] | None = None) -> List[str]:
+        """
+        Generates a list of safe, read-only exploration actions.
+        These are proposed to the workspace when no other user tasks are pending.
+
+        Args:
+            workspace_context (Dict[str, Any] | None): Optional context from the global
+                workspace to guide exploration. Currently unused but reserved for future.
+
+        Returns:
+            List[str]: A list of actionable string descriptions of tasks to explore.
+        """
+        if workspace_context is None:
+            workspace_context = {}
+
+        return [
+            "Propose code review on recent PRs",
+            "Read newly updated documentation",
+            "Analyze current system architecture for missing components",
+            "Check recent failing tests for patterns"
+        ]

--- a/tests/test_curiosity.py
+++ b/tests/test_curiosity.py
@@ -1,0 +1,46 @@
+import pytest
+from magda_agent.exploration.curiosity import CuriosityExplorer
+
+def test_curiosity_initialization():
+    """Test that CuriosityExplorer initializes with default and custom thresholds."""
+    explorer_default = CuriosityExplorer()
+    assert explorer_default.boredom_threshold == 0.8
+
+    explorer_custom = CuriosityExplorer(boredom_threshold=0.5)
+    assert explorer_custom.boredom_threshold == 0.5
+
+def test_should_explore():
+    """Test the should_explore boundary conditions."""
+    explorer = CuriosityExplorer(boredom_threshold=0.8)
+
+    # Below threshold
+    assert not explorer.should_explore(0.79)
+    assert not explorer.should_explore(0.0)
+
+    # At threshold
+    assert explorer.should_explore(0.8)
+
+    # Above threshold
+    assert explorer.should_explore(0.9)
+    assert explorer.should_explore(1.0)
+
+def test_explore_returns_safe_actions():
+    """Test that explore returns a list of read-only string tasks."""
+    explorer = CuriosityExplorer()
+    actions = explorer.explore()
+
+    assert isinstance(actions, list)
+    assert len(actions) > 0
+    assert all(isinstance(action, str) for action in actions)
+
+    # Ensure some known safe keywords are present
+    combined_actions = " ".join(actions).lower()
+    assert "read" in combined_actions or "analyze" in combined_actions or "check" in combined_actions
+
+def test_explore_with_mock_context():
+    """Test explore with a mock context object."""
+    explorer = CuriosityExplorer()
+    mock_context = {"active_files": ["main.py"]}
+
+    actions = explorer.explore(workspace_context=mock_context)
+    assert len(actions) > 0


### PR DESCRIPTION
Implement curiosity driven exploration

- Add CuriosityExplorer module
- Integrate with Consciousness core to suggest actions when bored
- Create tests for module
- Add 3 new tasks to agent_tasks.json

---
*PR created automatically by Jules for task [9778744701630124240](https://jules.google.com/task/9778744701630124240) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement curiosity-driven exploration in the agent cognitive loop
> - Adds [curiosity.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/84/files#diff-135e4e948da61eab6fc046534ef7ca1af5f6528b34e6c9c3d56a45a4d0d6066f) with a `CuriosityExplorer` class that triggers read-only exploration task suggestions when `boredom >= threshold` (default 0.8).
> - Integrates `CuriosityExplorer` into [consciousness/core.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/84/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a): after each message cycle, if boredom threshold is met, `explore()` is called, tasks are logged, and `hypothalamus.update(1.0)` resets boredom.
> - Adds unit tests in [tests/test_curiosity.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/84/files#diff-e6ae043db623a30d726fb6d2924e0791f231d9caf6aeba1cb0e38a6ed09a1054) covering threshold defaults, boundary behavior, and explore output properties.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b327d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->