### PR TITLE
Implement Failure Pattern Tracker

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -814,7 +814,7 @@
     },
     {
       "id": "failure-pattern-detection",
-      "status": "todo",
+      "status": "done",
       "area": "metacognition",
       "risk": "low",
       "title": "Detect recurring failure patterns",
@@ -1887,6 +1887,60 @@
         "Abstract ChannelAdapter interface exists",
         "A mock or Discord-specific implementation is provided",
         "Messages are successfully routed through the UnifiedMessage pipeline"
+      ]
+    },
+    {
+      "id": "a2a-task-delegation",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Task Delegation Protocol",
+      "description": "Inspired by A2A Protocol trend (June 2026). Implement an Agent-to-Agent communication module enabling Magda to delegate complex tasks to other specialized agents on the network.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a.py",
+        "tests/test_a2a_delegation*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A delegation client is implemented.",
+        "Can send and receive task payloads.",
+        "Tests verify successful delegation mocking the external agent."
+      ]
+    },
+    {
+      "id": "context-compression-selective-retrieval",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Compression & Selective Retrieval",
+      "description": "Inspired by MemGPT/Letta pattern. Implement a context engine hook that aggressively compresses old working memory and uses selective retrieval from episodic memory to keep context window small.",
+      "allowed_paths": [
+        "magda_agent/memory/compression.py",
+        "tests/test_compression*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Working memory size is continuously monitored.",
+        "Compression hook automatically runs when threshold is reached.",
+        "Tests verify context is shrunk correctly."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-subagent",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "MCP Subagent for Action Tools",
+      "description": "Inspired by the Hermes subagent trend. Spawn an isolated sub-agent specifically dedicated to executing complex MCP action tools, ensuring its state and context are completely separate from the main process.",
+      "allowed_paths": [
+        "magda_agent/teams/mcp_subagent.py",
+        "tests/test_mcp_subagent*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent can be spawned explicitly for MCP tools.",
+        "Execution context does not bleed into main agent.",
+        "Tests verify isolated execution."
       ]
     }
   ]

--- a/magda_agent/metacognition/__init__.py
+++ b/magda_agent/metacognition/__init__.py
@@ -1,7 +1,8 @@
 from magda_agent.metacognition.evaluator import Evaluator
 from magda_agent.metacognition.tracker import QualityTracker
+from magda_agent.metacognition.failure_patterns import FailurePatternTracker
 
 # Global instance for tracking continuous improvement metrics
 quality_tracker = QualityTracker()
 
-__all__ = ["Evaluator", "QualityTracker", "quality_tracker"]
+__all__ = ["Evaluator", "QualityTracker", "quality_tracker", "FailurePatternTracker"]

--- a/magda_agent/metacognition/failure_patterns.py
+++ b/magda_agent/metacognition/failure_patterns.py
@@ -1,0 +1,135 @@
+import json
+import logging
+import sqlite3
+import datetime
+from typing import Optional, Dict, Any, List
+
+from magda_agent.llm_client import LLMClient
+
+class FailurePatternTracker:
+    """
+    Tracks failures (test failures, user corrections, plan abandonment).
+    Detects recurring patterns and generates preventive rules.
+    """
+    def __init__(self, llm: LLMClient, db_path: str = ":memory:"):
+        """
+        Initializes the failure tracker.
+
+        Args:
+            llm: LLMClient instance to generate preventive rules.
+            db_path: Path to SQLite DB. Uses in-memory by default.
+        """
+        self.llm = llm
+        self.db_path = db_path
+        self._conn = sqlite3.connect(self.db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the sqlite schema."""
+        cursor = self._conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS failures (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                category TEXT,
+                detail TEXT
+            )
+        ''')
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS preventive_rules (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT,
+                rule TEXT,
+                timestamp TEXT
+            )
+        ''')
+        self._conn.commit()
+
+    def log_failure(self, category: str, detail: str) -> None:
+        """
+        Logs a failure event.
+
+        Args:
+            category: The category of the failure.
+            detail: Detailed description of the failure.
+        """
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'INSERT INTO failures (timestamp, category, detail) VALUES (?, ?, ?)',
+            (datetime.datetime.now().isoformat(), category, detail)
+        )
+        self._conn.commit()
+
+    def _get_failures_by_category(self, category: str) -> List[str]:
+        """Gets failure details for a category."""
+        cursor = self._conn.cursor()
+        cursor.execute('SELECT detail FROM failures WHERE category = ? ORDER BY timestamp DESC LIMIT 10', (category,))
+        rows = cursor.fetchall()
+        return [row[0] for row in rows]
+
+    async def detect_recurring_patterns(self, threshold: int = 2) -> List[Dict[str, Any]]:
+        """
+        Detects if a failure category repeats more than `threshold` times
+        and generates preventive rules.
+
+        Args:
+            threshold: Number of occurrences to trigger pattern detection.
+
+        Returns:
+            List of generated preventive rules with their category.
+        """
+        cursor = self._conn.cursor()
+        cursor.execute(
+            'SELECT category, COUNT(*) as count FROM failures GROUP BY category HAVING count > ?',
+            (threshold,)
+        )
+        recurring = cursor.fetchall()
+
+        results = []
+        for row in recurring:
+            category = row[0]
+            # Check if we already generated a rule recently to prevent spamming
+            cursor.execute('SELECT id FROM preventive_rules WHERE category = ?', (category,))
+            if cursor.fetchone():
+                continue
+
+            failures = self._get_failures_by_category(category)
+            rule = await self._generate_preventive_rule(category, failures)
+            if rule:
+                cursor.execute(
+                    'INSERT INTO preventive_rules (category, rule, timestamp) VALUES (?, ?, ?)',
+                    (category, rule, datetime.datetime.now().isoformat())
+                )
+                self._conn.commit()
+                results.append({"category": category, "rule": rule})
+
+        return results
+
+    async def _generate_preventive_rule(self, category: str, failures: List[str]) -> Optional[str]:
+        """
+        Calls the LLM to generate a preventive rule for the recurring failures.
+        """
+        failure_text = "\n".join(f"- {f}" for f in failures)
+        prompt = (
+            f"The following failures occurred repeatedly in the '{category}' category:\n"
+            f"{failure_text}\n\n"
+            "Analyze these failures and provide a single concise, actionable preventive rule "
+            "to avoid this in the future."
+        )
+        messages = [{"role": "system", "content": prompt}]
+
+        try:
+            rule_text = await self.llm.chat_completion(messages, temperature=0.1)
+            return rule_text.strip()
+        except Exception as e:
+            logging.error(f"Failed to generate preventive rule for category '{category}': {e}")
+            return None
+
+    def get_preventive_rules(self) -> List[str]:
+        """
+        Retrieves all active preventive rules.
+        """
+        cursor = self._conn.cursor()
+        cursor.execute('SELECT rule FROM preventive_rules ORDER BY timestamp DESC')
+        rows = cursor.fetchall()
+        return [row[0] for row in rows]

--- a/tests/test_failure_patterns.py
+++ b/tests/test_failure_patterns.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.metacognition.failure_patterns import FailurePatternTracker
+
+@pytest.fixture
+def mock_llm():
+    llm = MagicMock()
+    llm.chat_completion = AsyncMock(return_value="Always double check variables before referencing them.")
+    return llm
+
+@pytest.fixture
+def tracker(mock_llm):
+    # Use memory database
+    return FailurePatternTracker(llm=mock_llm, db_path=":memory:")
+
+def test_log_failure_and_get_by_category(tracker):
+    tracker.log_failure("pytest", "AssertionError in test_foo")
+    tracker.log_failure("pytest", "ModuleNotFoundError in test_bar")
+    tracker.log_failure("lint", "E501 line too long")
+
+    failures = tracker._get_failures_by_category("pytest")
+    assert len(failures) == 2
+    assert "AssertionError in test_foo" in failures
+    assert "ModuleNotFoundError in test_bar" in failures
+
+    lint_failures = tracker._get_failures_by_category("lint")
+    assert len(lint_failures) == 1
+    assert lint_failures[0] == "E501 line too long"
+
+@pytest.mark.asyncio
+async def test_detect_recurring_patterns(tracker, mock_llm):
+    # Log 3 failures in 'pytest' (threshold is 2)
+    tracker.log_failure("pytest", "Error 1")
+    tracker.log_failure("pytest", "Error 2")
+    tracker.log_failure("pytest", "Error 3")
+
+    # Log 2 failures in 'lint' (won't trigger pattern detection)
+    tracker.log_failure("lint", "Error A")
+    tracker.log_failure("lint", "Error B")
+
+    results = await tracker.detect_recurring_patterns(threshold=2)
+
+    assert len(results) == 1
+    assert results[0]["category"] == "pytest"
+    assert results[0]["rule"] == "Always double check variables before referencing them."
+
+    mock_llm.chat_completion.assert_called_once()
+
+    rules = tracker.get_preventive_rules()
+    assert len(rules) == 1
+    assert rules[0] == "Always double check variables before referencing them."
+
+@pytest.mark.asyncio
+async def test_detect_recurring_patterns_no_duplicate_rules(tracker, mock_llm):
+    tracker.log_failure("pytest", "Error 1")
+    tracker.log_failure("pytest", "Error 2")
+    tracker.log_failure("pytest", "Error 3")
+
+    results1 = await tracker.detect_recurring_patterns(threshold=2)
+    assert len(results1) == 1
+
+    # Call again immediately, should not generate another rule for the same category
+    results2 = await tracker.detect_recurring_patterns(threshold=2)
+    assert len(results2) == 0
+
+    # LLM should have only been called once
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Implement Failure Pattern Tracker
- Added FailurePatternTracker in magda_agent/metacognition/failure_patterns.py
- Updated agent_tasks.json and backlog.md
- Added pytest unit tests using mocked LLM
- Integrated export into magda_agent/metacognition/__init__.py

---
*PR created automatically by Jules for task [17727673422218690270](https://jules.google.com/task/17727673422218690270) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `FailurePatternTracker` for SQLite-backed failure logging and LLM-generated preventive rules
> - Adds [`failure_patterns.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/86/files#diff-777bf670abe46413102febcbcbf7ae645a54d8b0a699cb476f639462e26ee508) with `FailurePatternTracker`, which persists failure events to SQLite and asynchronously generates preventive rules via `LLMClient` when a failure category exceeds a configurable occurrence threshold.
> - Rules are stored in the DB and deduplicated — categories with an existing rule are skipped on subsequent detection runs.
> - Exports `FailurePatternTracker` from the `magda_agent.metacognition` package.
> - Tests in [`tests/test_failure_patterns.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/86/files#diff-c6ca6533ef719f0d015a0269c474408fb5b163e96d800ec9186ddc66421b426e) cover logging, pattern detection, rule persistence, and deduplication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6038aa1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->