### PR TITLE
Implement proactive notifications

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -873,7 +873,7 @@
     },
     {
       "id": "proactive-notifications",
-      "status": "todo",
+      "status": "done",
       "area": "operations",
       "risk": "low",
       "title": "Proactive notifications to user",
@@ -2054,6 +2054,61 @@
         "Subagents operate in their own git worktrees",
         "State is isolated and merges cleanly via explicit action",
         "Tests create dummy repos to verify isolation"
+      ]
+    },
+    {
+      "id": "a2a-agent-cards-discovery",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Agent Cards Discovery",
+      "description": "Inspired by the A2A trend: Implement an Agent Card discovery mechanism that broadcasts and discovers other available agents on the local network or given registry, enabling peer-to-peer delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery.py",
+        "tests/test_a2a_discovery*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can broadcast its own Agent Card",
+        "Agent can discover other agents' cards",
+        "Tests verify discovery using mock registry"
+      ]
+    },
+    {
+      "id": "planner-task-dependency-graphs",
+      "status": "todo",
+      "area": "planning",
+      "risk": "high",
+      "title": "Task Dependency Graphs in Planner",
+      "description": "Inspired by Claude Agent SDK: Refactor the Prefrontal Cortex (Planner) to support generating and managing execution plans as Directed Acyclic Graphs (DAGs) rather than linear steps, allowing sub-agents to run parallel steps.",
+      "allowed_paths": [
+        "magda_agent/planning/dag_planner.py",
+        "magda_agent/planning/planner.py",
+        "tests/test_dag_planner*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner can parse plans with dependencies",
+        "Independent steps can be identified for parallel execution",
+        "Tests verify DAG topological sorting and execution"
+      ]
+    },
+    {
+      "id": "skill-marketplace-export",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Skill Marketplace Export",
+      "description": "Inspired by agentskills.io trend: Implement a utility to package and export successfully created skills from ProceduralMemory into a standard format (JSON/YAML) that can be uploaded to a skill marketplace.",
+      "allowed_paths": [
+        "magda_agent/skills/exporter.py",
+        "tests/test_skill_exporter*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Procedural memory skills can be exported to standard JSON/YAML format",
+        "Export includes metadata, parameters, and code",
+        "Tests verify export format validity"
       ]
     }
   ]

--- a/magda_agent/gateway/router.py
+++ b/magda_agent/gateway/router.py
@@ -23,6 +23,11 @@ class GatewayRouter:
         """Register a channel with the gateway."""
         self._channels[channel_id] = channel
 
+    def get_channel(self, channel_id: str) -> Any:
+        """Retrieve a registered channel by its ID."""
+        return self._channels.get(channel_id)
+
+
     def set_message_handler(self, handler: Callable[[UnifiedMessage], Any]) -> None:
         """Set the main handler that processes unified messages."""
         self._message_handler = handler

--- a/magda_agent/notifications/__init__.py
+++ b/magda_agent/notifications/__init__.py
@@ -1,0 +1,3 @@
+from .manager import NotificationManager
+
+__all__ = ['NotificationManager']

--- a/magda_agent/notifications/manager.py
+++ b/magda_agent/notifications/manager.py
@@ -1,0 +1,57 @@
+from typing import Optional, Any
+import logging
+from magda_agent.gateway.router import GatewayRouter
+from magda_agent.user_model.model import UserModel
+
+class NotificationManager:
+    """
+    Manages proactive notifications sent from the agent to the user.
+    Respects user preferences like quiet hours and notification types.
+    """
+    def __init__(self, gateway: GatewayRouter, user_model: Optional[UserModel] = None):
+        self.gateway = gateway
+        self.user_model = user_model
+
+    async def send_notification(self, user_id: str, channel_id: str, text: str, notification_type: str = "general", urgency: str = "normal") -> bool:
+        """
+        Send a notification to a specific user on a specific channel.
+        Checks user preferences before sending.
+
+        Returns:
+            bool: True if the notification was sent, False if it was skipped due to preferences or error.
+        """
+        # Default behavior: send if no user model
+        if self.user_model:
+            try:
+                # Expecting user_id to be numeric for UserModel, but it's string in channels
+                uid = int(user_id) if user_id.isdigit() else 0
+                model_data = self.user_model.get_model(uid)
+                prefs = model_data.get("preferences", {})
+
+                # Check quiet hours constraint
+                # A simple check: if quiet_hours is True and urgency is not high/critical, skip
+                if prefs.get("quiet_hours", False) and urgency not in ["high", "critical"]:
+                    logging.info(f"Skipping notification for user {user_id} due to quiet hours.")
+                    return False
+
+                # Check ignored notification types
+                ignored_types = prefs.get("ignored_notifications", [])
+                if notification_type in ignored_types and urgency not in ["high", "critical"]:
+                    logging.info(f"Skipping notification for user {user_id} due to ignored type {notification_type}.")
+                    return False
+
+            except Exception as e:
+                logging.error(f"Error checking user preferences for notification: {e}")
+
+        # Route the message to the appropriate channel
+        channel = self.gateway.get_channel(channel_id)
+        if not channel:
+            logging.error(f"Cannot send notification: Channel {channel_id} not found.")
+            return False
+
+        try:
+            await channel.send(recipient_id=user_id, text=text, metadata={"notification_type": notification_type, "urgency": urgency})
+            return True
+        except Exception as e:
+            logging.error(f"Failed to send notification via {channel_id}: {e}")
+            return False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,88 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.notifications.manager import NotificationManager
+from magda_agent.gateway.router import GatewayRouter
+
+@pytest.mark.asyncio
+async def test_send_notification_no_user_model():
+    gateway = GatewayRouter()
+    channel = AsyncMock()
+    gateway.register_channel("telegram", channel)
+
+    manager = NotificationManager(gateway=gateway)
+
+    result = await manager.send_notification("123", "telegram", "Hello!")
+
+    assert result is True
+    channel.send.assert_awaited_once_with(recipient_id="123", text="Hello!", metadata={"notification_type": "general", "urgency": "normal"})
+
+@pytest.mark.asyncio
+async def test_send_notification_with_quiet_hours_blocked():
+    gateway = GatewayRouter()
+    channel = AsyncMock()
+    gateway.register_channel("telegram", channel)
+
+    user_model = MagicMock()
+    user_model.get_model.return_value = {
+        "preferences": {
+            "quiet_hours": True
+        }
+    }
+
+    manager = NotificationManager(gateway=gateway, user_model=user_model)
+
+    result = await manager.send_notification("123", "telegram", "Hello!")
+
+    assert result is False
+    channel.send.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_send_notification_with_quiet_hours_critical_urgency_allowed():
+    gateway = GatewayRouter()
+    channel = AsyncMock()
+    gateway.register_channel("telegram", channel)
+
+    user_model = MagicMock()
+    user_model.get_model.return_value = {
+        "preferences": {
+            "quiet_hours": True
+        }
+    }
+
+    manager = NotificationManager(gateway=gateway, user_model=user_model)
+
+    result = await manager.send_notification("123", "telegram", "Urgent alert!", urgency="critical")
+
+    assert result is True
+    channel.send.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_send_notification_ignored_type():
+    gateway = GatewayRouter()
+    channel = AsyncMock()
+    gateway.register_channel("telegram", channel)
+
+    user_model = MagicMock()
+    user_model.get_model.return_value = {
+        "preferences": {
+            "ignored_notifications": ["report"]
+        }
+    }
+
+    manager = NotificationManager(gateway=gateway, user_model=user_model)
+
+    result = await manager.send_notification("123", "telegram", "Daily report", notification_type="report")
+
+    assert result is False
+    channel.send.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_send_notification_invalid_channel():
+    gateway = GatewayRouter()
+
+    manager = NotificationManager(gateway=gateway)
+
+    result = await manager.send_notification("123", "unknown_channel", "Hello!")
+
+    assert result is False


### PR DESCRIPTION
Implements proactive notifications manager in `magda_agent/notifications/manager.py` that handles routing through `GatewayRouter` and respects user preferences (quiet hours, ignored notification types) via `UserModel`.

Adds `get_channel` method to `GatewayRouter`. Adds corresponding pytest tests using `AsyncMock` to verify notification sending, routing, and user preference filtering. Updates `agent_tasks.json` status to done and adds 3 new AI trend inspired tasks.

---
*PR created automatically by Jules for task [7521022452087877210](https://jules.google.com/task/7521022452087877210) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement proactive notifications via `NotificationManager`
> - Adds [`NotificationManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/89/files#diff-08a3b28d771f1fef30f45e54a5a5255e6d54810a12a44b632998af78dc03bf00) that sends notifications to users through registered gateway channels, with preference-aware gating (quiet hours, ignored notification types).
> - High and critical urgency notifications bypass user preferences and are always delivered.
> - Channel lookup uses a new `get_channel` method added to [`GatewayRouter`](https://github.com/kazah4359-lgtm/Magda-agent/pull/89/files#diff-4c387681c8e7518115a1c254f9155b22502cae18a45a1fe4ffaa22e779453fc4); sends fail gracefully if the channel is unregistered or the send raises.
> - Adds async pytest coverage in [`tests/test_notifications.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/89/files#diff-8a215c82f1e5fc3d3fba8597e5939cdb6fab0316ea2587d0dedbee138be84548) for preference gating, urgency overrides, and missing channels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 614a9b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->