### PR TITLE
Implement Confidence Calibration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -933,7 +933,7 @@
     },
     {
       "id": "confidence-calibration",
-      "status": "todo",
+      "status": "done",
       "area": "metacognition",
       "risk": "low",
       "title": "Confidence calibration for responses",
@@ -2220,6 +2220,40 @@
         "Plugins can register lifecycle hooks",
         "Hooks can compress short-term context",
         "Tests verify plugins alter the context payload appropriately"
+      ]
+    },
+    {
+      "id": "openclaw-rl-interactions",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Interactive Learning",
+      "description": "Implement online reinforcement learning from user interactions, inspired by OpenClaw.",
+      "allowed_paths": [
+        "magda_agent/learning/interactive_rl.py",
+        "tests/test_interactive_rl*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "User interactions feed into RL loop",
+        "RL loop updates preferences"
+      ]
+    },
+    {
+      "id": "acs-runtime-safety",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Runtime Safety Controls",
+      "description": "Implement 5 validation checkpoints for runtime safety, inspired by ACS.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_controls.py",
+        "tests/test_acs_controls*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Checkpoints validate agent actions",
+        "Violations block actions"
       ]
     }
   ]

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -7,6 +7,7 @@ from magda_agent.skills.registry import SkillRegistry
 from magda_agent.planning.planner import Planner
 from magda_agent.memory.long_term import LongTermMemory
 from magda_agent.metacognition.evaluator import Evaluator
+from magda_agent.metacognition.confidence import ConfidenceCalibrator
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.emotions.attachment import AttachmentModel
 from magda_agent.thalamus.router import Thalamus
@@ -40,6 +41,7 @@ class Consciousness:
         planner: Optional[Planner] = None,
         long_term_memory: Optional[LongTermMemory] = None,
         evaluator: Optional[Evaluator] = None,
+        confidence_calibrator: Optional[ConfidenceCalibrator] = None,
         habit_tracker: Optional[HabitTracker] = None,
         attachment: Optional[AttachmentModel] = None,
         thalamus: Optional[Thalamus] = None,
@@ -66,6 +68,7 @@ class Consciousness:
         self.planner = planner
         self.long_term_memory = long_term_memory
         self.evaluator = evaluator
+        self.confidence_calibrator = confidence_calibrator
         self.habit_tracker = habit_tracker
         self.attachment = attachment
         self.thalamus = thalamus
@@ -359,6 +362,10 @@ class Consciousness:
                 self.tracer.add_step("action_selection", {"selected_action": selected_action["action"]})
 
         response = await self.llm.chat_completion(messages)
+
+        if self.confidence_calibrator:
+            confidence = await self.confidence_calibrator.estimate_confidence(user_input, response)
+            response = self.confidence_calibrator.add_caveat_if_needed(response, confidence)
         if self.tracer:
             self.tracer.add_step("response_generated", {"response": response})
 
@@ -381,6 +388,10 @@ class Consciousness:
         # 6. Metacognition (Self-Evaluation)
         if self.evaluator:
             await self.evaluator.evaluate_response(user_input, response)
+
+            if self.confidence_calibrator and self.evaluator.last_evaluation and self.confidence_calibrator.last_confidence is not None:
+                actual_score = self.evaluator.last_evaluation.get("average_score", 0.0)
+                self.confidence_calibrator.track_calibration(self.confidence_calibrator.last_confidence, actual_score)
 
             # Record habit if we have an evaluation and a tracker
             if self.habit_tracker and self.evaluator.last_evaluation:

--- a/magda_agent/metacognition/__init__.py
+++ b/magda_agent/metacognition/__init__.py
@@ -1,8 +1,9 @@
 from magda_agent.metacognition.evaluator import Evaluator
+from magda_agent.metacognition.confidence import ConfidenceCalibrator
 from magda_agent.metacognition.tracker import QualityTracker
 from magda_agent.metacognition.failure_patterns import FailurePatternTracker
 
 # Global instance for tracking continuous improvement metrics
 quality_tracker = QualityTracker()
 
-__all__ = ["Evaluator", "QualityTracker", "quality_tracker", "FailurePatternTracker"]
+__all__ = ["Evaluator", "QualityTracker", "quality_tracker", "FailurePatternTracker", "ConfidenceCalibrator"]

--- a/magda_agent/metacognition/confidence.py
+++ b/magda_agent/metacognition/confidence.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Optional
+from magda_agent.llm_client import LLMClient
+from magda_agent.metacognition.tracker import QualityTracker
+
+class ConfidenceCalibrator:
+    """
+    Estimates confidence in the agent's responses and tracks calibration accuracy.
+    """
+    def __init__(self, llm: LLMClient, tracker: QualityTracker) -> None:
+        self.llm = llm
+        self.tracker = tracker
+        self.last_confidence: Optional[float] = None
+
+    async def estimate_confidence(self, user_input: str, response: str) -> float:
+        """
+        Estimates confidence score between 0.0 and 1.0 based on user input and agent response.
+        """
+        prompt = (
+            "Evaluate your confidence in the following response to the user's input.\n"
+            "Return a single float value between 0.0 and 1.0 representing your confidence.\n"
+            "High confidence (e.g., 0.9) means you are certain of the facts and logic.\n"
+            "Low confidence (e.g., 0.3) means you are guessing or lack information.\n\n"
+            f"User input: {user_input}\n"
+            f"Response: {response}\n\n"
+            "Respond ONLY with a number between 0.0 and 1.0."
+        )
+        messages = [{"role": "system", "content": prompt}]
+        try:
+            result_text = await self.llm.chat_completion(messages, temperature=0.1)
+            score = float(result_text.strip())
+            score = max(0.0, min(1.0, score))
+            self.last_confidence = score
+            return score
+        except Exception as e:
+            logging.error(f"Failed to estimate confidence: {e}")
+            self.last_confidence = 0.5
+            return 0.5
+
+    def add_caveat_if_needed(self, response: str, confidence: float, threshold: float = 0.6) -> str:
+        """
+        Appends a caveat if confidence is below the threshold.
+        """
+        if confidence < threshold:
+            caveat = "\n\n*(Note: I am not completely confident in this answer, please verify the details.)*"
+            return response + caveat
+        return response
+
+    def track_calibration(self, confidence: float, actual_score: float) -> None:
+        """
+        Tracks the difference between predicted confidence (0-1) and actual score (0-10) scaled to (0-1).
+        """
+        actual_scaled = actual_score / 10.0
+        calibration_error = abs(confidence - actual_scaled)
+        self.tracker.log_metric(
+            "calibration_error",
+            calibration_error,
+            metadata={"confidence": confidence, "actual_score": actual_score}
+        )

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.metacognition.confidence import ConfidenceCalibrator
+from magda_agent.llm_client import LLMClient
+from magda_agent.metacognition.tracker import QualityTracker
+
+@pytest.fixture
+def mock_llm():
+    llm = AsyncMock(spec=LLMClient)
+    llm.chat_completion.return_value = "0.9"
+    return llm
+
+@pytest.fixture
+def mock_tracker():
+    tracker = MagicMock(spec=QualityTracker)
+    return tracker
+
+@pytest.fixture
+def calibrator(mock_llm, mock_tracker):
+    return ConfidenceCalibrator(llm=mock_llm, tracker=mock_tracker)
+
+@pytest.mark.asyncio
+async def test_estimate_confidence_high(calibrator, mock_llm):
+    score = await calibrator.estimate_confidence("Hello", "Hi there!")
+    assert score == 0.9
+    assert calibrator.last_confidence == 0.9
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_estimate_confidence_low(calibrator, mock_llm):
+    mock_llm.chat_completion.return_value = "0.3"
+    score = await calibrator.estimate_confidence("Explain quantum gravity", "I think it is magic.")
+    assert score == 0.3
+    assert calibrator.last_confidence == 0.3
+
+@pytest.mark.asyncio
+async def test_estimate_confidence_exception(calibrator, mock_llm):
+    mock_llm.chat_completion.side_effect = Exception("API Error")
+    score = await calibrator.estimate_confidence("Hello", "Hi there!")
+    assert score == 0.5
+    assert calibrator.last_confidence == 0.5
+
+def test_add_caveat_high_confidence(calibrator):
+    response = calibrator.add_caveat_if_needed("Direct answer.", 0.9)
+    assert "Direct answer." == response
+    assert "verify the details" not in response
+
+def test_add_caveat_low_confidence(calibrator):
+    response = calibrator.add_caveat_if_needed("Guess answer.", 0.4)
+    assert "Guess answer." in response
+    assert "verify the details" in response
+
+def test_track_calibration(calibrator, mock_tracker):
+    # Predicted confidence: 0.8
+    # Actual score: 6.0 (scaled to 0.6)
+    # Error: |0.8 - 0.6| = 0.2
+    calibrator.track_calibration(0.8, 6.0)
+    mock_tracker.log_metric.assert_called_once()
+
+    args, kwargs = mock_tracker.log_metric.call_args
+    assert args[0] == "calibration_error"
+    assert pytest.approx(args[1]) == 0.2
+    assert kwargs["metadata"]["confidence"] == 0.8
+    assert kwargs["metadata"]["actual_score"] == 6.0


### PR DESCRIPTION
This PR adds a `ConfidenceCalibrator` inside the `magda_agent/metacognition/confidence.py` module, which prompts the LLM to estimate a confidence score for its own response. If confidence is low, a caveat is appended. Calibration accuracy is logged via `QualityTracker.log_metric`. Unit tests are provided, the tasks file is successfully updated and new Trend-inspired tasks are added.

---
*PR created automatically by Jules for task [3936156212221821390](https://jules.google.com/task/3936156212221821390) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement confidence calibration in the agent's response pipeline
> - Adds a new `ConfidenceCalibrator` class in [`confidence.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/92/files#diff-68859f0c146edac54a87ca46940687596999d0bb6752e2a1ce717fdba52f08df) that uses an LLM prompt to produce a numeric confidence score (0.0–1.0) for each response.
> - Integrates `ConfidenceCalibrator` into [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/92/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a): after each response is generated, confidence is estimated and a low-confidence caveat is appended if the score falls below a threshold.
> - After evaluation, `track_calibration` logs a `calibration_error` metric by comparing the predicted confidence to the evaluator's average score.
> - Exports `ConfidenceCalibrator` from the `magda_agent.metacognition` package.
> - Risk: if confidence estimation fails, the score silently defaults to 0.5, which may mask errors and suppress or incorrectly add caveats.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cca4ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->