### PR TITLE
feat: tag memories with emotional context

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -993,7 +993,7 @@
     },
     {
       "id": "emotional-memory-tagging",
-      "status": "todo",
+      "status": "done",
       "area": "emotions",
       "risk": "low",
       "title": "Tag memories with emotional context",

--- a/magda_agent/memory/episodic.py
+++ b/magda_agent/memory/episodic.py
@@ -1,3 +1,4 @@
+import math
 import chromadb
 import uuid
 import logging
@@ -69,7 +70,11 @@ class EpisodicMemory:
                 where["decayed"] = False
 
             if where:
-                results = self.collection.get(where=where, limit=limit)
+                if len(where) > 1:
+                    where_list = [{k: v} for k, v in where.items()]
+                    results = self.collection.get(where={"$and": where_list}, limit=limit)
+                else:
+                    results = self.collection.get(where=where, limit=limit)
             else:
                 results = self.collection.get(limit=limit)
 
@@ -93,7 +98,7 @@ class EpisodicMemory:
         try:
             query_kwargs = {
                 "query_texts": [query],
-                "n_results": top_k
+                "n_results": top_k * 2
             }
             where_clause = {"decayed": False}
             if user_id is not None:
@@ -107,7 +112,24 @@ class EpisodicMemory:
 
             results = self.collection.query(**query_kwargs)
             if results and results.get("documents") and len(results["documents"]) > 0:
-                return results["documents"][0]
+                docs = results["documents"][0]
+                dists = results["distances"][0] if "distances" in results and results["distances"] else [0.0] * len(docs)
+                metas = results["metadatas"][0] if "metadatas" in results and results["metadatas"] else [{}] * len(docs)
+
+                scored_docs = []
+                for doc, dist, meta in zip(docs, dists, metas):
+                    meta = meta or {}
+                    pad_p = float(meta.get("pad_p", 0.0))
+                    pad_a = float(meta.get("pad_a", 0.0))
+                    pad_d = float(meta.get("pad_d", 0.0))
+
+                    intensity = math.sqrt(pad_p**2 + pad_a**2 + pad_d**2)
+                    adjusted_score = dist - (intensity * 1.0)
+                    scored_docs.append((adjusted_score, doc))
+
+                scored_docs.sort(key=lambda x: x[0])
+
+                return [doc for score, doc in scored_docs[:top_k]]
             return []
         except Exception as e:
             logging.error(f"Failed to recall episodic events: {e}")

--- a/magda_agent/memory/storage.py
+++ b/magda_agent/memory/storage.py
@@ -118,7 +118,13 @@ class MemorySystem:
             if most_important.importance > 0.3: # Minimum threshold for long-term storage
                 user_long_term.append(most_important)
                 # Store in episodic memory for true long-term retrieval
-                meta = {"importance": most_important.importance, "tags": ",".join(most_important.tags)}
+                meta = {
+                    "importance": most_important.importance,
+                    "tags": ",".join(most_important.tags),
+                    "pad_p": most_important.emotional_state.pleasure,
+                    "pad_a": most_important.emotional_state.arousal,
+                    "pad_d": most_important.emotional_state.dominance
+                }
                 self.episodic_memory.store_event(
                     text=most_important.content,
                     metadata=meta,

--- a/tests/test_emotional_memory.py
+++ b/tests/test_emotional_memory.py
@@ -1,0 +1,49 @@
+import pytest
+from magda_agent.memory.episodic import EpisodicMemory
+
+def test_emotional_memory_tagging_and_boosting():
+    # Use ephemeral client for testing
+    memory = EpisodicMemory(persist_directory=":memory:")
+
+    # Generate unique collection for this test to avoid state sharing
+    import uuid
+    col_name = f"episodic_{uuid.uuid4().hex}"
+    memory.collection = memory.client.create_collection(col_name)
+
+    # Add a neutral memory
+    memory.store_event(
+        text="I walked in the park.",
+        metadata={"user_id": 1, "pad_p": 0.0, "pad_a": 0.0, "pad_d": 0.0},
+        user_id=1
+    )
+
+    # Add an emotionally charged memory with very similar text
+    memory.store_event(
+        text="I walked in the park and was terrified by a bear.",
+        metadata={"user_id": 1, "pad_p": -0.8, "pad_a": 0.9, "pad_d": -0.5},
+        user_id=1
+    )
+
+    # Search for "walked in the park"
+    results = memory.recall_events("I walked in the park", top_k=1, user_id=1)
+
+    # The emotionally charged memory should be boosted and come out on top
+    # despite the neutral memory being a closer match to "walked in the park" text-wise.
+    assert len(results) == 1
+    assert "bear" in results[0]
+
+def test_store_event_with_metadata():
+    memory = EpisodicMemory(persist_directory=":memory:")
+    import uuid
+    col_name = f"episodic_{uuid.uuid4().hex}"
+    memory.collection = memory.client.create_collection(col_name)
+
+    memory.store_event(
+        text="A test event",
+        metadata={"pad_p": 1.0, "pad_a": 1.0, "pad_d": 1.0},
+        user_id=2
+    )
+
+    all_events = memory.get_all_events(user_id=2)
+    assert len(all_events) == 1
+    assert all_events[0]["metadata"]["pad_p"] == 1.0


### PR DESCRIPTION
Implemented emotional tagging for episodic memories. 
- Updated `MemorySystem._consolidate_user` to attach PAD state to metadata when writing to `EpisodicMemory`.
- Updated `EpisodicMemory.recall_events` to retrieve `top_k * 2` documents and boost distances dynamically based on emotional intensity before sorting.
- Added `tests/test_emotional_memory.py` to test metadata persistence and score boosting.
- Verified there are no side effects using `chromadb.EphemeralClient` and dynamic collections for isolated tests.

---
*PR created automatically by Jules for task [1982340400471127967](https://jules.google.com/task/1982340400471127967) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tag episodic memories with emotional context using PAD metadata to boost recall of intense memories
> - Stores PAD (Pleasure-Arousal-Dominance) components (`pad_p`, `pad_a`, `pad_d`) in episodic memory metadata when promoting short-term memories to long-term in [storage.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/95/files#diff-b424973cadba3f7ba7408f34ddb96a0a289b8f8fc8a4df7641512737efa10581).
> - Re-ranks recall results in `EpisodicMemory.recall_events` by computing emotional intensity as `sqrt(p²+a²+d²)` and subtracting it from ChromaDB distance scores, so emotionally intense memories rank higher.
> - Doubles the initial candidate pool (`top_k*2`) before re-ranking, then returns the top `top_k` results.
> - Fixes a ChromaDB query bug in `get_all_events` where combining `user_id` and `decayed` filters via a multi-key dict was invalid; now uses an `$and` array of single-key conditions.
> - Adds tests in [test_emotional_memory.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/95/files#diff-6a1c9c26ceb750bf2f894d2304c878275adafd9f948e8d58e32706c342ca8995) covering PAD-boosted recall ranking and round-trip PAD metadata storage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df6648f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->