### PR TITLE
feat: OpenAI-compatible LLM backend (Gemini) + long-running autonomous task executor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,15 @@
 BOT_TOKEN=<your-telegram-bot-token>
 ALLOWED_USER_IDS=123456789
 
-# OpenAI (consciousness / planner / reflection)
+# LLM backend (consciousness / planner / reflection)
+# Works with OpenAI or any OpenAI-compatible endpoint (e.g. self-hosted gemini-web2api).
 OPENAI_API_KEY=<your-openai-api-key>
+# Optional: point the agent at an OpenAI-compatible gateway instead of api.openai.com.
+# For gemini-web2api: OPENAI_BASE_URL=http://gemini-web2api:8081/v1
+# OPENAI_BASE_URL=
+# Optional: override the default model name (default: gpt-4o).
+# For gemini-web2api: OPENAI_MODEL=gemini-3.5-flash-thinking
+# OPENAI_MODEL=
 
 # Service URLs (Docker Compose defaults)
 CONSCIOUSNESS_API_URL=http://consciousness:8000

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -1,10 +1,11 @@
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from magda_agent.llm_client import LLMClient
 from magda_agent.safety.policy import PolicyLayer
@@ -22,6 +23,8 @@ from magda_agent.planning.planner import Planner
 from magda_agent.consciousness.core import Consciousness
 from magda_agent.subconsciousness.reflection import Subconsciousness
 from magda_agent.scheduler.cron import CronScheduler
+from magda_agent.autonomy.task_store import TaskStore, TaskStatus
+from magda_agent.autonomy.executor import AutonomousExecutor
 from magda_agent.memory.long_term import LongTermMemory
 from magda_agent.metacognition.evaluator import Evaluator
 from magda_agent.metacognition.confidence import ConfidenceCalibrator
@@ -112,6 +115,14 @@ consciousness = Consciousness(
 
 cron_scheduler = CronScheduler()
 
+task_store = TaskStore(path=os.getenv("AUTONOMY_TASKS_PATH", "./autonomy_tasks.json"))
+autonomous_executor = AutonomousExecutor(
+    store=task_store,
+    llm=llm_client,
+    skills=skill_registry,
+    step_timeout=float(os.getenv("AUTONOMY_STEP_TIMEOUT", "60")),
+)
+
 subconsciousness = Subconsciousness(
     llm=llm_client,
     emotions=emotional_engine,
@@ -126,10 +137,12 @@ async def lifespan(app: FastAPI):
     # Startup
     asyncio.create_task(subconsciousness.start())
     asyncio.create_task(cron_scheduler.start())
+    await autonomous_executor.start()
     yield
     # Shutdown
     await subconsciousness.stop()
     await cron_scheduler.stop()
+    await autonomous_executor.stop()
     memory_system.close()
 
 app = FastAPI(title="Magda Consciousness API", lifespan=lifespan)
@@ -166,3 +179,67 @@ class TraceResponse(BaseModel):
 @app.get("/trace", response_model=TraceResponse)
 async def get_trace():
     return TraceResponse(trace=thought_chain_tracer.get_trace())
+
+
+# --- Autonomous long-running tasks ---------------------------------------
+
+class CreateTaskRequest(BaseModel):
+    goal: str
+    user_id: Optional[int] = None
+    max_iterations: int = 20
+
+
+class TaskSummaryResponse(BaseModel):
+    task: Dict[str, Any]
+
+
+class TaskListResponse(BaseModel):
+    tasks: List[Dict[str, Any]]
+
+
+@app.post("/tasks", response_model=TaskSummaryResponse)
+async def create_task(req: CreateTaskRequest):
+    max_iters = max(1, min(req.max_iterations, 200))
+    task = await task_store.add_task(req.goal, user_id=req.user_id, max_iterations=max_iters)
+    return TaskSummaryResponse(task=task.summary())
+
+
+@app.get("/tasks", response_model=TaskListResponse)
+async def list_tasks(user_id: Optional[int] = None):
+    tasks = await task_store.list(user_id=user_id)
+    return TaskListResponse(tasks=[t.summary() for t in tasks])
+
+
+@app.get("/tasks/{task_id}")
+async def get_task(task_id: str, since: int = 0):
+    task = await task_store.get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    data = task.to_dict()
+    if since > 0:
+        data["progress"] = task.progress[since:]
+    return data
+
+
+@app.post("/tasks/{task_id}/cancel")
+async def cancel_task(task_id: str):
+    ok = await task_store.request_cancel(task_id)
+    if not ok:
+        raise HTTPException(status_code=409, detail="Task cannot be cancelled")
+    return {"status": "ok"}
+
+
+@app.post("/tasks/{task_id}/pause")
+async def pause_task(task_id: str):
+    ok = await task_store.request_pause(task_id)
+    if not ok:
+        raise HTTPException(status_code=409, detail="Task cannot be paused")
+    return {"status": "ok"}
+
+
+@app.post("/tasks/{task_id}/resume")
+async def resume_task(task_id: str):
+    ok = await task_store.resume(task_id)
+    if not ok:
+        raise HTTPException(status_code=409, detail="Task cannot be resumed")
+    return {"status": "ok"}

--- a/magda_agent/autonomy/__init__.py
+++ b/magda_agent/autonomy/__init__.py
@@ -1,0 +1,10 @@
+"""Long-running autonomous task execution.
+
+This package adds a persistent task queue and a background worker that can keep
+working a single goal over many planning/execution iterations (well beyond the
+short per-message turn handled by `Consciousness.process_input`).
+"""
+from magda_agent.autonomy.task_store import TaskRecord, TaskStore, TaskStatus
+from magda_agent.autonomy.executor import AutonomousExecutor
+
+__all__ = ["TaskRecord", "TaskStore", "TaskStatus", "AutonomousExecutor"]

--- a/magda_agent/autonomy/executor.py
+++ b/magda_agent/autonomy/executor.py
@@ -1,0 +1,227 @@
+"""Background worker that drives long-running autonomous tasks to completion.
+
+Unlike `Consciousness.process_input` (a single short turn, capped at a handful of
+steps), the executor keeps iterating on one goal: plan -> execute steps ->
+evaluate against the goal -> refine objective -> repeat, until the goal is met,
+the task is cancelled/paused, or a safety iteration budget is exhausted.
+"""
+import asyncio
+import json
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from magda_agent.autonomy.task_store import TaskStore, TaskStatus
+
+logger = logging.getLogger(__name__)
+
+
+def _default_planner_factory(llm: Any, skills: Any) -> Callable[[], Any]:
+    def factory() -> Any:
+        # Imported lazily so the executor module stays importable without the
+        # full cognitive/memory dependency stack (useful for tests).
+        from magda_agent.planning.planner import Planner
+
+        return Planner(llm=llm, skills=skills)
+
+    return factory
+
+
+class AutonomousExecutor:
+    def __init__(
+        self,
+        store: TaskStore,
+        llm: Any,
+        skills: Any,
+        *,
+        planner_factory: Optional[Callable[[], Any]] = None,
+        poll_interval: float = 2.0,
+        step_timeout: float = 60.0,
+        max_steps_per_iteration: int = 25,
+    ):
+        self.store = store
+        self.llm = llm
+        self.skills = skills
+        self.planner_factory = planner_factory or _default_planner_factory(llm, skills)
+        self.poll_interval = poll_interval
+        self.step_timeout = step_timeout
+        self.max_steps_per_iteration = max_steps_per_iteration
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info("AutonomousExecutor started.")
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("AutonomousExecutor stopped.")
+
+    async def _run_loop(self) -> None:
+        while self._running:
+            try:
+                task = await self.store.claim_next_queued()
+                if task is None:
+                    await asyncio.sleep(self.poll_interval)
+                    continue
+                await self._execute_task(task.id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # keep the worker alive across task failures
+                logger.exception("Executor loop error: %s", exc)
+                await asyncio.sleep(self.poll_interval)
+
+    async def _interrupted(self, task_id: str) -> Optional[str]:
+        """Returns a terminal status string if the task was cancelled/paused."""
+        current = await self.store.get(task_id)
+        if current is None:
+            return TaskStatus.CANCELLED
+        if current.status == TaskStatus.CANCELLING:
+            await self.store.update(task_id, status=TaskStatus.CANCELLED)
+            await self.store.append_progress(task_id, "Task cancelled.", event="cancelled")
+            return TaskStatus.CANCELLED
+        if current.status == TaskStatus.PAUSING:
+            await self.store.update(task_id, status=TaskStatus.PAUSED)
+            await self.store.append_progress(task_id, "Task paused.", event="paused")
+            return TaskStatus.PAUSED
+        return None
+
+    async def _execute_task(self, task_id: str) -> None:
+        task = await self.store.get(task_id)
+        if task is None:
+            return
+
+        await self.store.append_progress(task_id, f"Started working on goal: {task.goal}", event="started")
+        planner = self.planner_factory()
+        objective = task.goal
+        last_summary = ""
+
+        for iteration in range(1, task.max_iterations + 1):
+            if await self._interrupted(task_id):
+                return
+            await self.store.update(task_id, iterations=iteration)
+            await self.store.append_progress(task_id, f"Iteration {iteration}: planning '{objective}'", event="plan")
+
+            try:
+                steps = await planner.generate_plan(objective, user_id=task.user_id)
+            except Exception as exc:
+                logger.exception("Planning failed: %s", exc)
+                steps = []
+
+            if not steps:
+                await self.store.append_progress(task_id, "Planner returned no steps.", event="warn")
+            else:
+                last_summary = await self._execute_plan(task_id, planner)
+                if await self._interrupted(task_id):
+                    return
+
+            decision = await self._evaluate(task.goal, objective, last_summary)
+            await self.store.append_progress(
+                task_id, f"Self-check: {decision.get('summary', '')}", event="evaluate"
+            )
+
+            if decision.get("done"):
+                await self.store.update(task_id, status=TaskStatus.COMPLETED, result=decision.get("summary") or last_summary)
+                await self.store.append_progress(task_id, "Goal achieved.", event="completed")
+                return
+
+            next_objective = decision.get("next_objective")
+            if next_objective:
+                objective = next_objective
+
+        # Iteration budget exhausted without an explicit "done".
+        await self.store.update(
+            task_id,
+            status=TaskStatus.COMPLETED,
+            result=last_summary or "Reached max iterations without explicit completion.",
+        )
+        await self.store.append_progress(
+            task_id, f"Stopped after {task.max_iterations} iterations (budget reached).", event="completed"
+        )
+
+    async def _execute_plan(self, task_id: str, planner: Any) -> str:
+        """Execute the planner's current plan sequentially with no artificial cap."""
+        steps_executed = 0
+        while planner.get_current_plan() and steps_executed < self.max_steps_per_iteration:
+            if await self._interrupted(task_id):
+                break
+            steps_executed += 1
+            step = planner.get_current_plan()[0]
+            skill_name = step.get("skill")
+            kwargs = step.get("skill_kwargs") or {}
+            description = step.get("description", "")
+
+            if skill_name:
+                try:
+                    coro = asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
+                    result = await asyncio.wait_for(coro, timeout=self.step_timeout)
+                except asyncio.TimeoutError:
+                    result = f"Error: skill '{skill_name}' timed out after {self.step_timeout}s."
+                except Exception as exc:
+                    result = f"Error executing skill '{skill_name}': {exc}"
+            else:
+                result = "No skill required for this step."
+
+            planner.mark_step_completed(0, str(result))
+            await self.store.append_progress(
+                task_id, f"Step: {description} (skill={skill_name}) -> {str(result)[:400]}", event="step"
+            )
+
+        summary_lines = []
+        for i, step in enumerate(planner.completed_steps, start=1):
+            summary_lines.append(
+                f"{i}. {step.get('description')} (skill={step.get('skill')}) -> {step.get('result')}"
+            )
+        planner.clear_pending_plan()
+        return "\n".join(summary_lines)
+
+    async def _evaluate(self, goal: str, objective: str, results: str) -> Dict[str, Any]:
+        """Ask the LLM whether the goal is met; if not, what to do next."""
+        system = (
+            "You are the self-evaluation module of an autonomous agent. "
+            "Given the overall GOAL and the RESULTS of the latest work, decide whether the "
+            "goal is fully achieved. Respond ONLY with a JSON object: "
+            '{"done": boolean, "summary": string, "next_objective": string}. '
+            "'summary' briefly states current progress. If done is false, 'next_objective' "
+            "is the concrete next sub-goal to pursue. If done is true, 'next_objective' is empty."
+        )
+        user = f"GOAL:\n{goal}\n\nCURRENT OBJECTIVE:\n{objective}\n\nRESULTS SO FAR:\n{results or '(no results yet)'}"
+        try:
+            raw = await self.llm.chat_completion(
+                [{"role": "system", "content": system}, {"role": "user", "content": user}]
+            )
+        except Exception as exc:
+            logger.exception("Evaluation LLM call failed: %s", exc)
+            return {"done": False, "summary": f"Evaluation error: {exc}", "next_objective": objective}
+
+        return self._parse_decision(raw, objective)
+
+    @staticmethod
+    def _parse_decision(raw: str, objective: str) -> Dict[str, Any]:
+        text = (raw or "").strip()
+        if text.startswith("```json"):
+            text = text[7:]
+        if text.startswith("```"):
+            text = text[3:]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+        try:
+            data = json.loads(text)
+            return {
+                "done": bool(data.get("done", False)),
+                "summary": str(data.get("summary", "")),
+                "next_objective": str(data.get("next_objective", "") or ""),
+            }
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            # If the model didn't return JSON, be conservative and keep going.
+            return {"done": False, "summary": text[:300], "next_objective": objective}

--- a/magda_agent/autonomy/task_store.py
+++ b/magda_agent/autonomy/task_store.py
@@ -1,0 +1,185 @@
+"""Persistent, async-safe store for long-running autonomous tasks.
+
+Stdlib-only (json + asyncio) so it can run anywhere the agent runs without extra
+dependencies. State is persisted to a single JSON file and written atomically so
+in-flight tasks survive a process restart.
+"""
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+class TaskStatus:
+    QUEUED = "queued"
+    RUNNING = "running"
+    PAUSING = "pausing"
+    PAUSED = "paused"
+    CANCELLING = "cancelling"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+    ACTIVE = {QUEUED, RUNNING, PAUSING, CANCELLING}
+    TERMINAL = {CANCELLED, COMPLETED, FAILED}
+
+
+@dataclass
+class TaskRecord:
+    goal: str
+    user_id: Optional[int] = None
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    status: str = TaskStatus.QUEUED
+    max_iterations: int = 20
+    iterations: int = 0
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    result: Optional[str] = None
+    error: Optional[str] = None
+    progress: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def summary(self) -> Dict[str, Any]:
+        """A lightweight view without the (potentially large) progress log."""
+        data = asdict(self)
+        data["progress_count"] = len(self.progress)
+        data.pop("progress", None)
+        return data
+
+
+class TaskStore:
+    """JSON-file backed task store guarded by an asyncio lock."""
+
+    def __init__(self, path: str = "./autonomy_tasks.json"):
+        self.path = path
+        self._lock = asyncio.Lock()
+        self._tasks: Dict[str, TaskRecord] = {}
+        self._loaded = False
+
+    async def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        async with self._lock:
+            if self._loaded:
+                return
+            self._tasks = self._read_from_disk()
+            # Tasks that were mid-flight when the process died are requeued.
+            for task in self._tasks.values():
+                if task.status in (TaskStatus.RUNNING, TaskStatus.PAUSING, TaskStatus.CANCELLING):
+                    task.status = TaskStatus.QUEUED
+            self._loaded = True
+
+    def _read_from_disk(self) -> Dict[str, TaskRecord]:
+        if not os.path.exists(self.path):
+            return {}
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+            return {tid: TaskRecord(**rec) for tid, rec in raw.items()}
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            logging.error("Failed to load task store %s: %s", self.path, exc)
+            return {}
+
+    def _flush_locked(self) -> None:
+        """Persist current state atomically. Caller must hold the lock."""
+        tmp_path = f"{self.path}.tmp"
+        data = {tid: rec.to_dict() for tid, rec in self._tasks.items()}
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, self.path)
+
+    async def add_task(self, goal: str, user_id: Optional[int] = None, max_iterations: int = 20) -> TaskRecord:
+        await self._ensure_loaded()
+        async with self._lock:
+            task = TaskRecord(goal=goal, user_id=user_id, max_iterations=max_iterations)
+            self._tasks[task.id] = task
+            self._flush_locked()
+            return task
+
+    async def get(self, task_id: str) -> Optional[TaskRecord]:
+        await self._ensure_loaded()
+        async with self._lock:
+            return self._tasks.get(task_id)
+
+    async def list(self, user_id: Optional[int] = None) -> List[TaskRecord]:
+        await self._ensure_loaded()
+        async with self._lock:
+            tasks = list(self._tasks.values())
+        if user_id is not None:
+            tasks = [t for t in tasks if t.user_id == user_id]
+        return sorted(tasks, key=lambda t: t.created_at, reverse=True)
+
+    async def claim_next_queued(self) -> Optional[TaskRecord]:
+        """Atomically pick the oldest queued task and mark it running."""
+        await self._ensure_loaded()
+        async with self._lock:
+            queued = [t for t in self._tasks.values() if t.status == TaskStatus.QUEUED]
+            if not queued:
+                return None
+            task = min(queued, key=lambda t: t.created_at)
+            task.status = TaskStatus.RUNNING
+            task.updated_at = time.time()
+            self._flush_locked()
+            return task
+
+    async def update(self, task_id: str, **fields: Any) -> Optional[TaskRecord]:
+        await self._ensure_loaded()
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return None
+            for key, value in fields.items():
+                if hasattr(task, key):
+                    setattr(task, key, value)
+            task.updated_at = time.time()
+            self._flush_locked()
+            return task
+
+    async def append_progress(self, task_id: str, message: str, event: str = "info") -> None:
+        await self._ensure_loaded()
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                return
+            task.progress.append({"ts": time.time(), "event": event, "message": message})
+            task.updated_at = time.time()
+            self._flush_locked()
+
+    async def request_cancel(self, task_id: str) -> bool:
+        await self._ensure_loaded()
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None or task.status in TaskStatus.TERMINAL:
+                return False
+            task.status = TaskStatus.CANCELLING if task.status != TaskStatus.QUEUED else TaskStatus.CANCELLED
+            task.updated_at = time.time()
+            self._flush_locked()
+            return True
+
+    async def request_pause(self, task_id: str) -> bool:
+        await self._ensure_loaded()
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None or task.status not in (TaskStatus.RUNNING, TaskStatus.QUEUED):
+                return False
+            task.status = TaskStatus.PAUSING if task.status == TaskStatus.RUNNING else TaskStatus.PAUSED
+            task.updated_at = time.time()
+            self._flush_locked()
+            return True
+
+    async def resume(self, task_id: str) -> bool:
+        await self._ensure_loaded()
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None or task.status not in (TaskStatus.PAUSED, TaskStatus.PAUSING):
+                return False
+            task.status = TaskStatus.QUEUED
+            task.updated_at = time.time()
+            self._flush_locked()
+            return True

--- a/magda_agent/llm_client.py
+++ b/magda_agent/llm_client.py
@@ -12,13 +12,22 @@ class LLMClient:
     """
     Unified interface for interacting with Large Language Models (OpenAI API).
     """
-    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o"):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ):
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
-        self.model = model
+        self.model = model or os.getenv("OPENAI_MODEL", "gpt-4o")
+        self.base_url = base_url or os.getenv("OPENAI_BASE_URL")
         self.client = None
 
         if AsyncOpenAI and self.api_key:
-            self.client = AsyncOpenAI(api_key=self.api_key)
+            client_kwargs: Dict[str, Any] = {"api_key": self.api_key}
+            if self.base_url:
+                client_kwargs["base_url"] = self.base_url
+            self.client = AsyncOpenAI(**client_kwargs)
         else:
             if not AsyncOpenAI:
                 logging.warning("OpenAI library (Async) not installed.")

--- a/magda_agent/main.py
+++ b/magda_agent/main.py
@@ -205,7 +205,7 @@ async def voice_message_handler(message: Message) -> None:
             os.remove(local_ogg)
 
         # Send to Consciousness API
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=180.0) as client:
             payload = {"text": text}
             if message.from_user and message.from_user.id:
                 payload["user_id"] = message.from_user.id
@@ -242,7 +242,7 @@ async def main_message_handler(message: Message) -> None:
     await message.bot.send_chat_action(chat_id=message.chat.id, action="typing")
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=180.0) as client:
             payload = {"text": message.text}
             if message.from_user and message.from_user.id:
                 payload["user_id"] = message.from_user.id

--- a/magda_agent/main.py
+++ b/magda_agent/main.py
@@ -65,6 +65,123 @@ async def command_state_handler(message: Message) -> None:
         logging.error(f"Failed to get state: {e}")
         await message.answer("Error: Could not retrieve internal state from Consciousness API.")
 
+@dp.message(Command("task"))
+async def command_task_handler(message: Message) -> None:
+    """Enqueue a long-running autonomous task: /task <goal>."""
+    goal = (message.text or "").partition(" ")[2].strip()
+    if not goal:
+        await message.answer("Usage: <code>/task &lt;goal&gt;</code>\nExample: <code>/task research the top 3 Python web frameworks and summarize tradeoffs</code>")
+        return
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            payload = {"goal": goal}
+            if message.from_user and message.from_user.id:
+                payload["user_id"] = message.from_user.id
+            response = await client.post(f"{CONSCIOUSNESS_API_URL}/tasks", json=payload)
+            response.raise_for_status()
+            task = response.json().get("task", {})
+        await message.answer(
+            f"Task queued. id: <code>{task.get('id')}</code>\nI'll work on it in the background and post progress here.\n"
+            f"Use <code>/tasks</code> to list, <code>/cancel {task.get('id')}</code> to stop."
+        )
+    except Exception as e:
+        logging.error(f"Failed to create task: {e}")
+        await message.answer("Error: could not queue the task (Consciousness API unreachable).")
+
+
+@dp.message(Command("tasks"))
+async def command_tasks_handler(message: Message) -> None:
+    """List the caller's autonomous tasks."""
+    try:
+        params = {}
+        if message.from_user and message.from_user.id:
+            params["user_id"] = message.from_user.id
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(f"{CONSCIOUSNESS_API_URL}/tasks", params=params)
+            response.raise_for_status()
+            tasks = response.json().get("tasks", [])
+        if not tasks:
+            await message.answer("No tasks yet. Start one with <code>/task &lt;goal&gt;</code>.")
+            return
+        lines = ["<b>Your tasks:</b>"]
+        for t in tasks[:20]:
+            lines.append(
+                f"• <code>{t.get('id')}</code> [{t.get('status')}] "
+                f"iter {t.get('iterations')}/{t.get('max_iterations')} — {t.get('goal')[:60]}"
+            )
+        await message.answer("\n".join(lines))
+    except Exception as e:
+        logging.error(f"Failed to list tasks: {e}")
+        await message.answer("Error: could not list tasks.")
+
+
+async def _task_action(message: Message, action: str) -> None:
+    task_id = (message.text or "").partition(" ")[2].strip()
+    if not task_id:
+        await message.answer(f"Usage: <code>/{action} &lt;task_id&gt;</code>")
+        return
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(f"{CONSCIOUSNESS_API_URL}/tasks/{task_id}/{action}")
+        if response.status_code == 200:
+            await message.answer(f"Task <code>{task_id}</code>: {action} requested.")
+        elif response.status_code == 409:
+            await message.answer(f"Task <code>{task_id}</code> cannot be {action}d in its current state.")
+        else:
+            await message.answer(f"Task <code>{task_id}</code> not found.")
+    except Exception as e:
+        logging.error(f"Failed to {action} task: {e}")
+        await message.answer(f"Error: could not {action} the task.")
+
+
+@dp.message(Command("cancel"))
+async def command_cancel_handler(message: Message) -> None:
+    await _task_action(message, "cancel")
+
+
+@dp.message(Command("pause"))
+async def command_pause_handler(message: Message) -> None:
+    await _task_action(message, "pause")
+
+
+@dp.message(Command("resume"))
+async def command_resume_handler(message: Message) -> None:
+    await _task_action(message, "resume")
+
+
+async def task_progress_poller(bot: Bot, interval: float = 5.0) -> None:
+    """Polls the Consciousness API for new task progress and pushes it to users."""
+    delivered: Dict[str, int] = {}
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.get(f"{CONSCIOUSNESS_API_URL}/tasks")
+                resp.raise_for_status()
+                tasks = resp.json().get("tasks", [])
+                for t in tasks:
+                    task_id = t.get("id")
+                    user_id = t.get("user_id")
+                    if not task_id or not user_id:
+                        continue
+                    seen = delivered.get(task_id, 0)
+                    count = t.get("progress_count", 0)
+                    if count <= seen:
+                        continue
+                    detail = await client.get(f"{CONSCIOUSNESS_API_URL}/tasks/{task_id}", params={"since": seen})
+                    detail.raise_for_status()
+                    new_entries = detail.json().get("progress", [])
+                    for entry in new_entries:
+                        text = f"[{task_id}] {entry.get('event', 'info')}: {entry.get('message', '')}"
+                        try:
+                            await bot.send_message(chat_id=user_id, text=text[:4000])
+                        except Exception as send_err:
+                            logging.warning(f"Could not deliver progress to {user_id}: {send_err}")
+                    delivered[task_id] = count
+        except Exception as e:
+            logging.debug(f"Progress poller iteration failed: {e}")
+
+
 @dp.message(F.voice)
 async def voice_message_handler(message: Message) -> None:
     """Processes incoming voice messages."""
@@ -144,9 +261,15 @@ async def main_message_handler(message: Message) -> None:
 async def main() -> None:
     bot = Bot(token=BOT_TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
 
+    # Start background progress poller for long-running autonomous tasks.
+    poller = asyncio.create_task(task_progress_poller(bot))
+
     # Start Polling
     logging.info("Magda Agent is starting...")
-    await dp.start_polling(bot)
+    try:
+        await dp.start_polling(bot)
+    finally:
+        poller.cancel()
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)

--- a/tests/test_api_tasks.py
+++ b/tests/test_api_tasks.py
@@ -1,0 +1,73 @@
+"""HTTP-level tests for the autonomous task endpoints.
+
+The background executor is stopped so these tests exercise the queue/REST surface
+deterministically without running the (LLM-dependent) execution loop.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+import magda_agent.api as api_module
+from magda_agent.api import app
+from magda_agent.autonomy.task_store import TaskStore
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(monkeypatch, tmp_path):
+    store = TaskStore(path=str(tmp_path / "tasks.json"))
+    monkeypatch.setattr(api_module, "task_store", store)
+    # Prevent the real background worker from consuming/advancing tasks.
+    monkeypatch.setattr(api_module.autonomous_executor, "start", _noop)
+    monkeypatch.setattr(api_module.autonomous_executor, "stop", _noop)
+    monkeypatch.setattr(api_module.autonomous_executor, "store", store)
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+client = TestClient(app)
+
+
+def test_create_and_get_task():
+    resp = client.post("/tasks", json={"goal": "summarize the news", "user_id": 5})
+    assert resp.status_code == 200
+    task = resp.json()["task"]
+    assert task["status"] == "queued"
+    assert task["goal"] == "summarize the news"
+    task_id = task["id"]
+
+    detail = client.get(f"/tasks/{task_id}")
+    assert detail.status_code == 200
+    assert detail.json()["goal"] == "summarize the news"
+
+
+def test_list_tasks_filtered_by_user():
+    client.post("/tasks", json={"goal": "a", "user_id": 100})
+    client.post("/tasks", json={"goal": "b", "user_id": 200})
+    resp = client.get("/tasks", params={"user_id": 100})
+    assert resp.status_code == 200
+    tasks = resp.json()["tasks"]
+    assert all(t["user_id"] == 100 for t in tasks)
+    assert len(tasks) == 1
+
+
+def test_max_iterations_is_clamped():
+    resp = client.post("/tasks", json={"goal": "x", "max_iterations": 9999})
+    assert resp.json()["task"]["max_iterations"] == 200
+
+
+def test_cancel_queued_task():
+    task_id = client.post("/tasks", json={"goal": "cancel me"}).json()["task"]["id"]
+    resp = client.post(f"/tasks/{task_id}/cancel")
+    assert resp.status_code == 200
+    assert client.get(f"/tasks/{task_id}").json()["status"] == "cancelled"
+
+
+def test_get_missing_task_returns_404():
+    assert client.get("/tasks/doesnotexist").status_code == 404
+
+
+def test_resume_non_paused_task_conflicts():
+    task_id = client.post("/tasks", json={"goal": "x"}).json()["task"]["id"]
+    # A queued task cannot be resumed (it isn't paused).
+    assert client.post(f"/tasks/{task_id}/resume").status_code == 409

--- a/tests/test_autonomy_executor.py
+++ b/tests/test_autonomy_executor.py
@@ -1,0 +1,156 @@
+import json
+import os
+
+import pytest
+
+from magda_agent.autonomy.executor import AutonomousExecutor
+from magda_agent.autonomy.task_store import TaskStore, TaskStatus
+
+
+class FakePlanner:
+    """Minimal stand-in for magda_agent.planning.planner.Planner."""
+
+    def __init__(self, plans):
+        # plans: list of step-lists, one per generate_plan call
+        self._plans = list(plans)
+        self._current = []
+        self.completed_steps = []
+
+    async def generate_plan(self, objective, user_id=None):
+        steps = self._plans.pop(0) if self._plans else []
+        self._current = [dict(s) for s in steps]
+        self.completed_steps = []
+        return self._current
+
+    def get_current_plan(self):
+        return self._current
+
+    def mark_step_completed(self, index, result):
+        step = self._current.pop(index)
+        step["result"] = result
+        self.completed_steps.append(step)
+
+    def clear_pending_plan(self):
+        self._current = []
+
+
+class FakeSkills:
+    def __init__(self):
+        self.calls = []
+
+    def execute_skill(self, name, **kwargs):
+        self.calls.append((name, kwargs))
+        return f"ran {name}"
+
+
+class FakeLLM:
+    """Returns queued evaluation responses (JSON strings)."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def chat_completion(self, messages, temperature=0.7):
+        return self._responses.pop(0) if self._responses else json.dumps({"done": True, "summary": "fallback"})
+
+
+@pytest.fixture
+def store_path(tmp_path):
+    return os.path.join(str(tmp_path), "tasks.json")
+
+
+@pytest.mark.asyncio
+async def test_task_completes_when_evaluator_says_done(store_path):
+    store = TaskStore(path=store_path)
+    skills = FakeSkills()
+    llm = FakeLLM([json.dumps({"done": True, "summary": "all good", "next_objective": ""})])
+    planner = FakePlanner([[{"id": "s1", "description": "search", "skill": "internet_search", "skill_kwargs": {"query": "x"}}]])
+
+    executor = AutonomousExecutor(store, llm, skills, planner_factory=lambda: planner)
+    task = await store.add_task("find the answer", user_id=7)
+    await store.claim_next_queued()
+
+    await executor._execute_task(task.id)
+
+    result = await store.get(task.id)
+    assert result.status == TaskStatus.COMPLETED
+    assert result.result == "all good"
+    assert skills.calls == [("internet_search", {"query": "x"})]
+    events = [p["event"] for p in result.progress]
+    assert "started" in events and "step" in events and "completed" in events
+
+
+@pytest.mark.asyncio
+async def test_task_iterates_until_done(store_path):
+    store = TaskStore(path=store_path)
+    skills = FakeSkills()
+    # First eval: not done, refine objective. Second eval: done.
+    llm = FakeLLM([
+        json.dumps({"done": False, "summary": "step 1 done", "next_objective": "phase 2"}),
+        json.dumps({"done": True, "summary": "finished", "next_objective": ""}),
+    ])
+    planner = FakePlanner([
+        [{"id": "s1", "description": "phase1", "skill": "internet_search", "skill_kwargs": {}}],
+        [{"id": "s2", "description": "phase2", "skill": "internet_search", "skill_kwargs": {}}],
+    ])
+
+    executor = AutonomousExecutor(store, llm, skills, planner_factory=lambda: planner)
+    task = await store.add_task("multi-step goal")
+    await store.claim_next_queued()
+
+    await executor._execute_task(task.id)
+
+    result = await store.get(task.id)
+    assert result.status == TaskStatus.COMPLETED
+    assert result.iterations == 2
+    assert len(skills.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_max_iterations_budget_stops_task(store_path):
+    store = TaskStore(path=store_path)
+    skills = FakeSkills()
+    # Evaluator never says done.
+    llm = FakeLLM([json.dumps({"done": False, "summary": "still going", "next_objective": "again"})] * 10)
+    planner = FakePlanner([[{"id": "s", "description": "loop", "skill": "internet_search", "skill_kwargs": {}}]] * 10)
+
+    executor = AutonomousExecutor(store, llm, skills, planner_factory=lambda: planner)
+    task = await store.add_task("never ending", max_iterations=3)
+    await store.claim_next_queued()
+
+    await executor._execute_task(task.id)
+
+    result = await store.get(task.id)
+    assert result.status == TaskStatus.COMPLETED
+    assert result.iterations == 3
+
+
+@pytest.mark.asyncio
+async def test_cancellation_stops_before_completion(store_path):
+    store = TaskStore(path=store_path)
+    skills = FakeSkills()
+    llm = FakeLLM([json.dumps({"done": False, "summary": "wip", "next_objective": "more"})] * 5)
+    planner = FakePlanner([[{"id": "s", "description": "loop", "skill": "internet_search", "skill_kwargs": {}}]] * 5)
+
+    executor = AutonomousExecutor(store, llm, skills, planner_factory=lambda: planner)
+    task = await store.add_task("cancel me", max_iterations=5)
+    await store.claim_next_queued()
+    await store.request_cancel(task.id)  # cancel before execution starts iterating
+
+    await executor._execute_task(task.id)
+
+    result = await store.get(task.id)
+    assert result.status == TaskStatus.CANCELLED
+    assert skills.calls == []
+
+
+def test_parse_decision_handles_markdown_fences():
+    raw = "```json\n{\"done\": true, \"summary\": \"ok\", \"next_objective\": \"\"}\n```"
+    decision = AutonomousExecutor._parse_decision(raw, "obj")
+    assert decision["done"] is True
+    assert decision["summary"] == "ok"
+
+
+def test_parse_decision_non_json_is_conservative():
+    decision = AutonomousExecutor._parse_decision("I think we are not done yet", "current-obj")
+    assert decision["done"] is False
+    assert decision["next_objective"] == "current-obj"

--- a/tests/test_autonomy_task_store.py
+++ b/tests/test_autonomy_task_store.py
@@ -1,0 +1,90 @@
+import os
+
+import pytest
+
+from magda_agent.autonomy.task_store import TaskStore, TaskStatus
+
+
+@pytest.fixture
+def store_path(tmp_path):
+    return os.path.join(str(tmp_path), "tasks.json")
+
+
+@pytest.mark.asyncio
+async def test_add_and_get(store_path):
+    store = TaskStore(path=store_path)
+    task = await store.add_task("do a thing", user_id=42, max_iterations=5)
+    assert task.status == TaskStatus.QUEUED
+    fetched = await store.get(task.id)
+    assert fetched is not None
+    assert fetched.goal == "do a thing"
+    assert fetched.user_id == 42
+    assert fetched.max_iterations == 5
+
+
+@pytest.mark.asyncio
+async def test_claim_next_queued_is_fifo_and_marks_running(store_path):
+    store = TaskStore(path=store_path)
+    first = await store.add_task("first")
+    await store.add_task("second")
+    claimed = await store.claim_next_queued()
+    assert claimed.id == first.id
+    assert claimed.status == TaskStatus.RUNNING
+    # second claim returns the other queued task
+    claimed2 = await store.claim_next_queued()
+    assert claimed2.goal == "second"
+    # nothing left to claim
+    assert await store.claim_next_queued() is None
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_user(store_path):
+    store = TaskStore(path=store_path)
+    await store.add_task("a", user_id=1)
+    await store.add_task("b", user_id=2)
+    assert len(await store.list()) == 2
+    assert len(await store.list(user_id=1)) == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_goes_straight_to_cancelled(store_path):
+    store = TaskStore(path=store_path)
+    task = await store.add_task("x")
+    assert await store.request_cancel(task.id) is True
+    assert (await store.get(task.id)).status == TaskStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_sets_cancelling(store_path):
+    store = TaskStore(path=store_path)
+    task = await store.add_task("x")
+    await store.claim_next_queued()
+    assert await store.request_cancel(task.id) is True
+    assert (await store.get(task.id)).status == TaskStatus.CANCELLING
+
+
+@pytest.mark.asyncio
+async def test_pause_and_resume(store_path):
+    store = TaskStore(path=store_path)
+    task = await store.add_task("x")
+    await store.claim_next_queued()
+    assert await store.request_pause(task.id) is True
+    assert (await store.get(task.id)).status == TaskStatus.PAUSING
+    await store.update(task.id, status=TaskStatus.PAUSED)
+    assert await store.resume(task.id) is True
+    assert (await store.get(task.id)).status == TaskStatus.QUEUED
+
+
+@pytest.mark.asyncio
+async def test_persistence_and_requeue_of_running(store_path):
+    store = TaskStore(path=store_path)
+    task = await store.add_task("persist me")
+    await store.claim_next_queued()  # now RUNNING
+    await store.append_progress(task.id, "did something")
+
+    # New store instance reading the same file: running tasks become queued again.
+    store2 = TaskStore(path=store_path)
+    reloaded = await store2.get(task.id)
+    assert reloaded is not None
+    assert reloaded.status == TaskStatus.QUEUED
+    assert len(reloaded.progress) == 1

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,44 @@
+import os
+from unittest.mock import patch
+
+from magda_agent.llm_client import LLMClient
+
+
+def test_defaults_to_openai_without_base_url():
+    with patch.dict(os.environ, {}, clear=True):
+        client = LLMClient(api_key="sk-test")
+        assert client.model == "gpt-4o"
+        assert client.base_url is None
+
+
+def test_reads_base_url_and_model_from_env():
+    env = {
+        "OPENAI_API_KEY": "sk-test",
+        "OPENAI_BASE_URL": "http://gemini-web2api:8081/v1",
+        "OPENAI_MODEL": "gemini-3.5-flash-thinking",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        client = LLMClient()
+        assert client.base_url == "http://gemini-web2api:8081/v1"
+        assert client.model == "gemini-3.5-flash-thinking"
+
+
+def test_explicit_args_override_env():
+    env = {
+        "OPENAI_API_KEY": "sk-env",
+        "OPENAI_BASE_URL": "http://env-url/v1",
+        "OPENAI_MODEL": "env-model",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        client = LLMClient(api_key="sk-arg", model="arg-model", base_url="http://arg-url/v1")
+        assert client.api_key == "sk-arg"
+        assert client.model == "arg-model"
+        assert client.base_url == "http://arg-url/v1"
+
+
+def test_base_url_passed_to_async_client():
+    env = {"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "http://gemini-web2api:8081/v1"}
+    with patch.dict(os.environ, env, clear=True):
+        client = LLMClient()
+        # The underlying AsyncOpenAI client should carry the configured base_url.
+        assert str(client.client.base_url).rstrip("/") == "http://gemini-web2api:8081/v1"


### PR DESCRIPTION
## Summary
Enables the agent to run on any OpenAI-compatible backend (e.g. self-hosted `gemini-web2api`) and adds a real long-running autonomous task executor that works a single goal over many iterations instead of the short, 5-step-capped per-message turn.

## Changes
**1. Pluggable LLM backend** (`magda_agent/llm_client.py`)
- `LLMClient` now reads `OPENAI_BASE_URL` and `OPENAI_MODEL` (env or args); when `base_url` is set the `AsyncOpenAI` client is pointed there. Defaults unchanged (OpenAI, `gpt-4o`).
- `.env.example` documents the new vars (incl. gemini-web2api example).

**2. Long-running autonomous executor** (`magda_agent/autonomy/`)
- `TaskStore`: stdlib-only, async-safe, JSON-persisted task queue. Tasks survive restarts (in-flight `running` tasks are requeued on load). Atomic writes.
- `AutonomousExecutor`: background worker that drives one goal via a `plan -> execute steps -> self-evaluate -> refine` loop until the goal is met, cancelled, paused, or an iteration budget is reached. No artificial 5-step cap; per-skill timeout is configurable (`AUTONOMY_STEP_TIMEOUT`). A fresh `Planner` is created per task to avoid shared state.
- REST API (`magda_agent/api.py`): `POST /tasks`, `GET /tasks`, `GET /tasks/{id}` (with `?since=` for incremental progress), `POST /tasks/{id}/cancel|pause|resume`. Executor is started/stopped in the app lifespan.
- Telegram (`magda_agent/main.py`): `/task <goal>`, `/tasks`, `/cancel`, `/pause`, `/resume`, plus a background poller that streams task progress back to the requesting user. Services stay decoupled — the bot polls the API, so the consciousness service holds no Telegram credentials.

## Testing
- New tests: `tests/test_llm_client.py`, `tests/test_autonomy_task_store.py`, `tests/test_autonomy_executor.py`, `tests/test_api_tasks.py` (HTTP-level).
- Full suite green locally: **284 passed**.
- `python scripts/validate_agent_tasks.py agent_tasks.json` passes (manifest untouched).
- Verified live end-to-end on a VPS: gemini-web2api (self-hosted Gemini) + consciousness + bot via docker-compose; a submitted task planned, refined across iterations, executed a step, self-evaluated, and completed with a real Gemini-generated result.

## Notes
- No changes to `.github/workflows/**`, `requirements.txt`, or the repo's Docker files (per AGENTS.md risk rules). Slim deployment artifacts live only on the deploy host.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenAI-compatible LLM backend and long-running autonomous task executor
> - Adds `OPENAI_BASE_URL` and `OPENAI_MODEL` env var support to `LLMClient` so any OpenAI-compatible endpoint (e.g. Gemini) can be targeted without code changes.
> - Introduces a `TaskStore` ([task_store.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/99/files#diff-b5e1d393ed33625065e6ed36f15045478cecd9c5c6b16635bfa59045c6f329c1)) that persists tasks to a JSON file with FIFO claim, cancel/pause/resume, and automatic requeue of in-flight tasks on restart.
> - Adds `AutonomousExecutor` ([executor.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/99/files#diff-c2d2bb939c61e247056efccf6e83a9943714f6832cd50a1bbdce69eb866cf0eb)) that runs a background loop claiming queued tasks, executing planner+skill steps with timeouts, LLM-based completion evaluation, and cancel/pause interruption handling.
> - Exposes REST endpoints (`POST/GET /tasks`, `GET /tasks/{id}`, `POST /tasks/{id}/cancel|pause|resume`) in [api.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/99/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d); executor lifecycle is tied to the FastAPI lifespan.
> - Adds Telegram bot commands (`/task`, `/tasks`, `/cancel`, `/pause`, `/resume`) and a background progress poller in [main.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/99/files#diff-98ad95189b12dbce626f6a32364418145e82086c844111cab992c357c05ee834) that pushes incremental task updates to users; HTTP timeouts for `/process` calls are raised from 30s to 180s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67952a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->