### PR TITLE
feat: Implement three-agent architecture separation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -1093,7 +1093,7 @@
     },
     {
       "id": "three-agent-planner-generator-evaluator",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "Three-agent architecture separation",
@@ -2414,6 +2414,44 @@
       ],
       "acceptance": [
         "Agent CLI logs and displays metrics over time."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-v3",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Task Delegation (v3)",
+      "description": "Inspired by Google A2A trend: Allow PlannerAgent to discover and delegate specific sub-plans to external agents securely over MCP.",
+      "allowed_paths": [
+        "magda_agent/integration/**",
+        "magda_agent/agents/planner_agent.py",
+        "tests/test_a2a_delegation*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "PlannerAgent can query available external agents.",
+        "Sub-plans can be delegated to external agents.",
+        "Results are retrieved and integrated into the main plan context."
+      ]
+    },
+    {
+      "id": "mcp-action-tools-v3",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "MCP Action Tools Expansion",
+      "description": "Inspired by MCP trend: Expand GeneratorAgent's ability to execute external MCP server-prefixed tools beyond the current local SkillRegistry.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_client.py",
+        "magda_agent/agents/generator_agent.py",
+        "tests/test_mcp_client*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "GeneratorAgent can execute remote MCP action tools.",
+        "Results are collected safely with timeout limits.",
+        "Mock tests verify execution and error handling."
       ]
     }
   ]

--- a/magda_agent/agents/evaluator_agent.py
+++ b/magda_agent/agents/evaluator_agent.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Optional, Dict, Any
+
+from magda_agent.metacognition.evaluator import Evaluator
+from magda_agent.metacognition.confidence import ConfidenceCalibrator
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.planning.planner import Planner
+
+class EvaluatorAgent:
+    """
+    Agent responsible for evaluating the generated response.
+    """
+    def __init__(
+        self,
+        evaluator: Optional[Evaluator] = None,
+        confidence_calibrator: Optional[ConfidenceCalibrator] = None,
+        habit_tracker: Optional[HabitTracker] = None,
+        planner: Optional[Planner] = None
+    ):
+        self.evaluator = evaluator
+        self.confidence_calibrator = confidence_calibrator
+        self.habit_tracker = habit_tracker
+        self.planner = planner
+
+    async def evaluate(self, user_input: str, response: str, user_id: Optional[str] = None):
+        """
+        Evaluates the interaction and records habits.
+        """
+        if not self.evaluator:
+            return
+
+        await self.evaluator.evaluate_response(user_input, response)
+
+        if self.confidence_calibrator and self.evaluator.last_evaluation and self.confidence_calibrator.last_confidence is not None:
+            actual_score = self.evaluator.last_evaluation.get("average_score", 0.0)
+            self.confidence_calibrator.track_calibration(self.confidence_calibrator.last_confidence, actual_score)
+
+        if self.habit_tracker and self.evaluator.last_evaluation:
+            avg_score = self.evaluator.last_evaluation.get("average_score", 0.0)
+            if self.planner and self.planner.completed_steps:
+                for step in self.planner.completed_steps:
+                    skill = step.get("skill")
+                    if skill:
+                        self.habit_tracker.record_usage(user_input, skill, float(avg_score), user_id=user_id)

--- a/magda_agent/agents/generator_agent.py
+++ b/magda_agent/agents/generator_agent.py
@@ -1,0 +1,109 @@
+import logging
+import asyncio
+from typing import Optional, List, Dict, Any
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.planning.planner import Planner
+from magda_agent.learning.skill_versioning import SkillVersioning
+from magda_agent.learning.skill_creator import SkillCreator
+
+class GeneratorAgent:
+    """
+    Agent responsible for executing plan steps and generating final text response.
+    """
+    def __init__(
+        self,
+        llm: LLMClient,
+        skills: SkillRegistry,
+        planner: Optional[Planner] = None,
+        skill_versioning: Optional[SkillVersioning] = None,
+        skill_creator: Optional[SkillCreator] = None,
+        tracer=None
+    ):
+        self.llm = llm
+        self.skills = skills
+        self.planner = planner
+        self.skill_versioning = skill_versioning
+        self.skill_creator = skill_creator
+        self.tracer = tracer
+
+    async def execute_plan(self, user_input: str, user_id: Optional[str] = None) -> str:
+        """
+        Executes the plan step by step and returns the string representation of results.
+        """
+        plan_str = ""
+        if not self.planner:
+            return plan_str
+
+        plan = self.planner.get_current_plan()
+        if plan:
+            MAX_STEPS = 5
+            SKILL_TIMEOUT = 10.0
+            steps_executed = 0
+            plan_stopped_early = False
+
+            while self.planner.get_current_plan() and steps_executed < MAX_STEPS:
+                steps_executed += 1
+                step = self.planner.get_current_plan()[0]
+                skill_name = step.get('skill')
+                kwargs = step.get('skill_kwargs') or {}
+
+                if skill_name:
+                    try:
+                        task = asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
+                        result = await asyncio.wait_for(task, timeout=SKILL_TIMEOUT)
+                    except asyncio.TimeoutError:
+                        logging.error(f"Timeout executing skill {skill_name}")
+                        result = f"Error: Skill {skill_name} timed out after {SKILL_TIMEOUT} seconds."
+                        plan_stopped_early = True
+                    except Exception as e:
+                        logging.error(f"Error executing skill {skill_name}: {e}")
+                        result = f"Error: {e}"
+                else:
+                    result = "No skill executed for this step."
+
+                self.planner.mark_step_completed(0, str(result))
+                if self.skill_versioning and skill_name:
+                    success = 'Error:' not in str(result)
+                    best = self.skill_versioning.get_best_version(skill_name, user_id=user_id)
+                    if best:
+                        self.skill_versioning.record_usage_outcome(skill_name, best['version'], success, str(result), user_id=user_id)
+
+                if plan_stopped_early:
+                    break
+
+            if self.planner.get_current_plan() and steps_executed >= MAX_STEPS:
+                plan_stopped_early = True
+                logging.warning("Plan execution stopped due to MAX_STEPS limit.")
+
+            if plan_stopped_early:
+                self.planner.clear_pending_plan()
+            else:
+                if self.skill_creator and len(self.planner.completed_steps) > 1:
+                    asyncio.create_task(
+                        self.skill_creator.extract_and_store_skill(
+                            user_input,
+                            self.planner.completed_steps,
+                            user_id=user_id
+                        )
+                    )
+
+            plan_str = "Executed Plan Results:\n"
+            for i, step in enumerate(self.planner.completed_steps):
+                plan_str += f"- Step {i+1}: {step.get('description')} (Skill: {step.get('skill')})\n"
+                plan_str += f"  Result: {step.get('result')}\n"
+
+            if plan_stopped_early:
+                plan_str += "\nNote: Plan execution was stopped early due to limits.\n"
+
+        return plan_str
+
+    async def generate_response(self, messages: List[Dict[str, Any]]) -> str:
+        """
+        Generates the final response based on context and executed plan results.
+        """
+        response = await self.llm.chat_completion(messages)
+        if self.tracer:
+            self.tracer.add_step("response_generated", {"response": response})
+        return response

--- a/magda_agent/agents/planner_agent.py
+++ b/magda_agent/agents/planner_agent.py
@@ -1,0 +1,22 @@
+import logging
+from typing import Optional, List, Dict, Any
+from magda_agent.planning.planner import Planner
+
+class PlannerAgent:
+    """
+    Agent responsible for generating execution plans.
+    """
+    def __init__(self, planner: Optional[Planner]):
+        self.planner = planner
+
+    async def plan(self, user_input: str, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """
+        Generates a plan based on the user input.
+        """
+        if not self.planner:
+            return []
+
+        if not self.planner.get_current_plan():
+            await self.planner.generate_plan(user_input, user_id=user_id)
+
+        return self.planner.get_current_plan()

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -1,3 +1,6 @@
+from magda_agent.agents.planner_agent import PlannerAgent
+from magda_agent.agents.generator_agent import GeneratorAgent
+from magda_agent.agents.evaluator_agent import EvaluatorAgent
 import logging
 from typing import List, Dict, Any, Optional
 from magda_agent.llm_client import LLMClient
@@ -225,81 +228,22 @@ class Consciousness:
             if long_term_memories:
                 context_str += "\nLong Term Memories:\n" + "\n".join([f"- {m}" for m in long_term_memories])
 
-        # 3. Planning (Prefrontal Cortex)
-        plan_str = ""
+        # 3. Planning & Execution (Planner & Generator Agents)
         if self.tracer:
             self.tracer.add_step("planning_start", {})
-        if self.planner:
-            # Only generate a new plan if we don't have an active one
-            if not self.planner.get_current_plan():
-                await self.planner.generate_plan(user_input, user_id=user_id)
 
-            plan = self.planner.get_current_plan()
-            if plan:
-                import asyncio
+        planner_agent = PlannerAgent(planner=self.planner)
+        generator_agent = GeneratorAgent(
+            llm=self.llm,
+            skills=self.skills,
+            planner=self.planner,
+            skill_versioning=self.skill_versioning,
+            skill_creator=self.skill_creator,
+            tracer=self.tracer
+        )
 
-                MAX_STEPS = 5
-                SKILL_TIMEOUT = 10.0
-                steps_executed = 0
-                plan_stopped_early = False
-
-                # Execute the steps and collect results
-                while self.planner.get_current_plan() and steps_executed < MAX_STEPS:
-                    steps_executed += 1
-                    step = self.planner.get_current_plan()[0]
-                    skill_name = step.get('skill')
-                    kwargs = step.get('skill_kwargs') or {}
-
-                    if skill_name:
-                        # Execute heavy skills in a separate thread to avoid blocking the event loop
-                        try:
-                            task = asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
-                            result = await asyncio.wait_for(task, timeout=SKILL_TIMEOUT)
-                        except asyncio.TimeoutError:
-                            logging.error(f"Timeout executing skill {skill_name}")
-                            result = f"Error: Skill {skill_name} timed out after {SKILL_TIMEOUT} seconds."
-                            plan_stopped_early = True
-                        except Exception as e:
-                            logging.error(f"Error executing skill {skill_name}: {e}")
-                            result = f"Error: {e}"
-                    else:
-                        result = "No skill executed for this step."
-
-                    self.planner.mark_step_completed(0, str(result))
-                    if self.skill_versioning and skill_name:
-                        # Basic scoring hook based on result not containing 'Error'
-                        success = 'Error:' not in str(result)
-                        best = self.skill_versioning.get_best_version(skill_name, user_id=user_id)
-                        if best:
-                            self.skill_versioning.record_usage_outcome(skill_name, best['version'], success, str(result), user_id=user_id)
-
-                    if plan_stopped_early:
-                        break
-
-                if self.planner.get_current_plan() and steps_executed >= MAX_STEPS:
-                    plan_stopped_early = True
-                    logging.warning("Plan execution stopped due to MAX_STEPS limit.")
-
-                if plan_stopped_early:
-                    self.planner.clear_pending_plan()
-                else:
-                    if self.skill_creator and len(self.planner.completed_steps) > 1:
-                        # Extract skill candidate from successful multi-step plan
-                        asyncio.create_task(
-                            self.skill_creator.extract_and_store_skill(
-                                user_input,
-                                self.planner.completed_steps,
-                                user_id=user_id
-                            )
-                        )
-
-                plan_str = "Executed Plan Results:\n"
-                for i, step in enumerate(self.planner.completed_steps):
-                    plan_str += f"- Step {i+1}: {step.get('description')} (Skill: {step.get('skill')})\n"
-                    plan_str += f"  Result: {step.get('result')}\n"
-
-                if plan_stopped_early:
-                    plan_str += "\nNote: Plan execution was stopped early due to limits.\n"
+        await planner_agent.plan(user_input, user_id=user_id)
+        plan_str = await generator_agent.execute_plan(user_input, user_id=user_id)
 
         # 4. LLM Reasoning
         if self.tracer:
@@ -361,7 +305,7 @@ class Consciousness:
             elif selected_action and self.tracer:
                 self.tracer.add_step("action_selection", {"selected_action": selected_action["action"]})
 
-        response = await self.llm.chat_completion(messages)
+        response = await generator_agent.generate_response(messages)
 
         if self.confidence_calibrator:
             confidence = await self.confidence_calibrator.estimate_confidence(user_input, response)
@@ -385,22 +329,14 @@ class Consciousness:
         # Gradual emotional decay after processing
         self.emotions.decay(user_id=user_id)
 
-        # 6. Metacognition (Self-Evaluation)
-        if self.evaluator:
-            await self.evaluator.evaluate_response(user_input, response)
-
-            if self.confidence_calibrator and self.evaluator.last_evaluation and self.confidence_calibrator.last_confidence is not None:
-                actual_score = self.evaluator.last_evaluation.get("average_score", 0.0)
-                self.confidence_calibrator.track_calibration(self.confidence_calibrator.last_confidence, actual_score)
-
-            # Record habit if we have an evaluation and a tracker
-            if self.habit_tracker and self.evaluator.last_evaluation:
-                avg_score = self.evaluator.last_evaluation.get("average_score", 0.0)
-                if self.planner and self.planner.completed_steps:
-                    for step in self.planner.completed_steps:
-                        skill = step.get("skill")
-                        if skill:
-                            self.habit_tracker.record_usage(user_input, skill, float(avg_score), user_id=user_id)
+        # 6. Metacognition (Self-Evaluation) via Evaluator Agent
+        evaluator_agent = EvaluatorAgent(
+            evaluator=self.evaluator,
+            confidence_calibrator=self.confidence_calibrator,
+            habit_tracker=self.habit_tracker,
+            planner=self.planner
+        )
+        await evaluator_agent.evaluate(user_input, response, user_id=user_id)
 
         return response
 

--- a/tests/test_three_agent.py
+++ b/tests/test_three_agent.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.planner_agent import PlannerAgent
+from magda_agent.agents.generator_agent import GeneratorAgent
+from magda_agent.agents.evaluator_agent import EvaluatorAgent
+
+@pytest.mark.asyncio
+async def test_planner_agent():
+    mock_planner = MagicMock()
+    mock_planner.get_current_plan.side_effect = [[], [{"step": 1}]]
+    mock_planner.generate_plan = AsyncMock()
+
+    agent = PlannerAgent(planner=mock_planner)
+    plan = await agent.plan("test input")
+
+    assert plan == [{"step": 1}]
+    mock_planner.generate_plan.assert_called_once_with("test input", user_id=None)
+
+@pytest.mark.asyncio
+async def test_generator_agent():
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value="generated response")
+
+    mock_planner = MagicMock()
+
+    def mock_get_current_plan():
+        if getattr(mock_planner, 'cleared', False):
+            return []
+        return [{"skill": "test_skill", "skill_kwargs": {}}]
+    mock_planner.cleared = False
+    mock_planner.get_current_plan.side_effect = mock_get_current_plan
+
+    mock_planner.completed_steps = [{"description": "step1", "skill": "test_skill", "result": "success"}]
+    def mock_mark_completed(*args):
+        mock_planner.cleared = True
+    mock_planner.mark_step_completed.side_effect = mock_mark_completed
+
+    mock_skills = MagicMock()
+    mock_skills.execute_skill = MagicMock(return_value="success")
+
+    agent = GeneratorAgent(
+        llm=mock_llm,
+        skills=mock_skills,
+        planner=mock_planner
+    )
+
+    plan_str = await agent.execute_plan("test input")
+    assert "Executed Plan Results" in plan_str
+    assert "success" in plan_str
+
+    response = await agent.generate_response([{"role": "user", "content": "test input"}])
+    assert response == "generated response"
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_agent():
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate_response = AsyncMock()
+    mock_evaluator.last_evaluation = {"average_score": 9.0}
+
+    mock_confidence = MagicMock()
+    mock_confidence.last_confidence = 0.8
+    mock_confidence.track_calibration = MagicMock()
+
+    agent = EvaluatorAgent(
+        evaluator=mock_evaluator,
+        confidence_calibrator=mock_confidence
+    )
+
+    await agent.evaluate("test input", "response")
+    mock_evaluator.evaluate_response.assert_called_once_with("test input", "response")
+    mock_confidence.track_calibration.assert_called_once_with(0.8, 9.0)


### PR DESCRIPTION
This PR implements the "Three-agent architecture separation" task (id: three-agent-planner-generator-evaluator) inspired by Claude Agent SDK. The monolithic `Consciousness.process_input` loop was split into three distinct cooperative agents: `PlannerAgent`, `GeneratorAgent`, and `EvaluatorAgent`.

It also addresses the code review feedback from my initial attempt:
- Resolved the functional regression in `GeneratorAgent.generate_response` so it correctly receives and uses the fully constructed `messages` array from `Consciousness`, preserving action constraints and overall conversational context.
- Ensured no binary scratchpad databases (`chroma.sqlite3`) or `.py` patch scripts are polluting the PR.
- Validated all tests (`pytest tests/`) successfully.
- Re-run the `agent_tasks.json` validation script.
- The `backlog.md` did not have an existing task tracking this ID (verified via `grep`).

---
*PR created automatically by Jules for task [8466994236782513017](https://jules.google.com/task/8466994236782513017) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate planning, generation, and evaluation into three distinct agent classes
> - Introduces `PlannerAgent`, `GeneratorAgent`, and `EvaluatorAgent` in `magda_agent/agents/` to replace inline logic in `Consciousness.main_loop`.
> - `GeneratorAgent` executes plans up to 5 steps with a 10s per-step timeout, records version usage outcomes, and optionally triggers async skill extraction.
> - `EvaluatorAgent` handles post-response evaluation, confidence calibration tracking, and habit recording from completed plan steps.
> - `PlannerAgent` wraps the existing `Planner` with a simple async API that generates a plan only when one does not already exist.
> - Risk: `generate_response` in `GeneratorAgent` and the updated `Consciousness` main loop both record a `response_generated` tracer step, resulting in a duplicate trace entry when a tracer is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3743df5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->