### PR TITLE
Implement Real-time Guardrail Fallback

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -1113,7 +1113,7 @@
     },
     {
       "id": "realtime-guardrail-fallback",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Realtime guardrail fallback",

--- a/magda_agent/agents/generator_agent.py
+++ b/magda_agent/agents/generator_agent.py
@@ -7,6 +7,7 @@ from magda_agent.skills.registry import SkillRegistry
 from magda_agent.planning.planner import Planner
 from magda_agent.learning.skill_versioning import SkillVersioning
 from magda_agent.learning.skill_creator import SkillCreator
+from magda_agent.safety.guardrails import RealtimeGuardrail, FallbackStrategy
 
 class GeneratorAgent:
     """
@@ -19,6 +20,7 @@ class GeneratorAgent:
         planner: Optional[Planner] = None,
         skill_versioning: Optional[SkillVersioning] = None,
         skill_creator: Optional[SkillCreator] = None,
+        guardrail: Optional[RealtimeGuardrail] = None,
         tracer=None
     ):
         self.llm = llm
@@ -26,6 +28,7 @@ class GeneratorAgent:
         self.planner = planner
         self.skill_versioning = skill_versioning
         self.skill_creator = skill_creator
+        self.guardrail = guardrail
         self.tracer = tracer
 
     async def execute_plan(self, user_input: str, user_id: Optional[str] = None) -> str:
@@ -50,6 +53,24 @@ class GeneratorAgent:
                 kwargs = step.get('skill_kwargs') or {}
 
                 if skill_name:
+                    # Real-time guardrail check before execution
+                    if self.guardrail:
+                        allowed, explanation, strategy = self.guardrail.check_action(skill_name, **kwargs)
+                        if not allowed:
+                            if strategy == FallbackStrategy.STOP_EXECUTION:
+                                result = f"Guardrail Fallback (STOP): {explanation}"
+                                plan_stopped_early = True
+                                logging.warning(f"Plan stopped by guardrail: {explanation}")
+                            elif strategy == FallbackStrategy.REQUEST_REVIEW:
+                                result = f"Guardrail Fallback (REVIEW REQUIRED): {explanation}"
+                                plan_stopped_early = True # Also stop for now until human intervention
+                                logging.warning(f"Plan paused for review by guardrail: {explanation}")
+                            else:
+                                result = f"Guardrail Denied: {explanation}"
+
+                            self.planner.mark_step_completed(0, str(result))
+                            break
+
                     try:
                         task = asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
                         result = await asyncio.wait_for(task, timeout=SKILL_TIMEOUT)

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -37,6 +37,7 @@ from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
 from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
+from magda_agent.safety.guardrails import RealtimeGuardrail
 from magda_agent.context.engine import ContextEngine
 from magda_agent.context.default_plugin import DefaultContextPlugin
 from magda_agent.tracing.tracer import ThoughtChainTracer
@@ -79,6 +80,7 @@ insula = Insula()
 pineal_gland = PinealGland()
 salience_network = SalienceNetwork()
 global_workspace = GlobalWorkspace(salience_network=salience_network)
+guardrail = RealtimeGuardrail(policy_layer=policy_layer)
 thought_chain_tracer = ThoughtChainTracer()
 
 consciousness = Consciousness(
@@ -104,6 +106,7 @@ consciousness = Consciousness(
     context_engine=context_engine,
     skill_creator=skill_creator,
     online_learner=online_learner,
+    guardrail=guardrail,
     tracer=thought_chain_tracer,
     style_adapter=style_adapter,
     user_model=user_model,

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -29,6 +29,7 @@ from magda_agent.attention.workspace import GlobalWorkspace
 from magda_agent.context.engine import ContextEngine
 from magda_agent.learning.skill_creator import SkillCreator
 from magda_agent.tracing.tracer import ThoughtChainTracer
+from magda_agent.safety.guardrails import RealtimeGuardrail
 
 class Consciousness:
     """
@@ -59,6 +60,7 @@ class Consciousness:
         context_engine: Optional[ContextEngine] = None,
         skill_creator: Optional[SkillCreator] = None,
         online_learner: Optional[OnlineLearner] = None,
+        guardrail: Optional[RealtimeGuardrail] = None,
         tracer: Optional[ThoughtChainTracer] = None,
         style_adapter: Optional[StyleAdapter] = None,
         user_model: Optional[UserModel] = None,
@@ -87,6 +89,7 @@ class Consciousness:
         self.context_engine = context_engine
         self.skill_creator = skill_creator
         self.online_learner = online_learner
+        self.guardrail = guardrail
         self.tracer = tracer
         self.skill_versioning = kwargs.get('skill_versioning', None)
         self.style_adapter = style_adapter
@@ -239,6 +242,7 @@ class Consciousness:
             planner=self.planner,
             skill_versioning=self.skill_versioning,
             skill_creator=self.skill_creator,
+            guardrail=self.guardrail,
             tracer=self.tracer
         )
 

--- a/magda_agent/safety/guardrails.py
+++ b/magda_agent/safety/guardrails.py
@@ -1,0 +1,37 @@
+import logging
+from enum import Enum
+from typing import Any, Tuple, Optional
+from magda_agent.safety.policy import PolicyLayer
+
+class FallbackStrategy(Enum):
+    STOP_EXECUTION = "stop_execution"
+    REQUEST_REVIEW = "request_review"
+    NONE = "none"
+
+class RealtimeGuardrail:
+    """
+    Realtime guardrails that trigger a safe fallback action immediately
+    when a policy violation is detected mid-execution.
+    """
+
+    def __init__(self, policy_layer: PolicyLayer, default_strategy: FallbackStrategy = FallbackStrategy.STOP_EXECUTION):
+        self.policy_layer = policy_layer
+        self.default_strategy = default_strategy
+
+    def check_action(self, tool_name: str, **kwargs: Any) -> Tuple[bool, str, FallbackStrategy]:
+        """
+        Checks an action against the policy and returns if it's allowed,
+        an explanation, and the fallback strategy to apply if denied.
+        """
+        allow, explanation = self.policy_layer.evaluate(tool_name, **kwargs)
+
+        if allow:
+            return True, explanation, FallbackStrategy.NONE
+
+        # Determine fallback strategy based on tool or context
+        # For now, use the default strategy
+        strategy = self.default_strategy
+
+        logging.warning(f"RealtimeGuardrail: Violation detected for '{tool_name}'. Strategy: {strategy.value}. Reason: {explanation}")
+
+        return False, explanation, strategy

--- a/tests/test_realtime_guardrail.py
+++ b/tests/test_realtime_guardrail.py
@@ -1,0 +1,118 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.agents.generator_agent import GeneratorAgent
+from magda_agent.safety.guardrails import RealtimeGuardrail, FallbackStrategy
+from magda_agent.safety.policy import PolicyLayer
+
+@pytest.mark.asyncio
+async def test_guardrail_allows_legit_action():
+    # Mock dependencies
+    llm = MagicMock()
+    skills = MagicMock()
+    planner = MagicMock()
+    policy = MagicMock(spec=PolicyLayer)
+
+    # Setup policy to allow
+    policy.evaluate.return_value = (True, "Allowed")
+
+    guardrail = RealtimeGuardrail(policy_layer=policy)
+    agent = GeneratorAgent(llm=llm, skills=skills, planner=planner, guardrail=guardrail)
+
+    # Setup planner with a simple step
+    planner.get_current_plan.return_value = [{"skill": "test_skill", "description": "test"}]
+
+    # Mock skill execution
+    skills.execute_skill.return_value = "Success"
+
+    # We need to mock mark_step_completed to avoid issues if it tries to pop from the list
+    # Actually, execute_plan uses self.planner.get_current_plan()[0] and then marks it completed.
+    # In the real Planner, mark_step_completed moves the step.
+
+    # Let's mock the planner more realistically for the loop
+    current_plan = [{"skill": "test_skill", "description": "test"}]
+    def mock_get_current_plan():
+        return current_plan
+
+    def mock_mark_completed(index, result):
+        nonlocal current_plan
+        step = current_plan.pop(index)
+        step['result'] = result
+        agent.planner.completed_steps.append(step)
+
+    planner.get_current_plan.side_effect = mock_get_current_plan
+    planner.mark_step_completed.side_effect = mock_mark_completed
+    planner.completed_steps = []
+
+    result = await agent.execute_plan("user input")
+
+    assert "Success" in result
+    assert "test_skill" in result
+    policy.evaluate.assert_called_with("test_skill")
+
+@pytest.mark.asyncio
+async def test_guardrail_stops_on_violation():
+    # Mock dependencies
+    llm = MagicMock()
+    skills = MagicMock()
+    planner = MagicMock()
+    policy = MagicMock(spec=PolicyLayer)
+
+    # Setup policy to DENY with STOP_EXECUTION
+    policy.evaluate.return_value = (False, "Policy Violation")
+
+    guardrail = RealtimeGuardrail(policy_layer=policy, default_strategy=FallbackStrategy.STOP_EXECUTION)
+    agent = GeneratorAgent(llm=llm, skills=skills, planner=planner, guardrail=guardrail)
+
+    # Setup planner
+    current_plan = [{"skill": "dangerous_skill", "description": "dangerous"}]
+    planner.get_current_plan.side_effect = lambda: current_plan
+    planner.completed_steps = []
+
+    def mock_mark_completed(index, result):
+        nonlocal current_plan
+        step = current_plan.pop(index)
+        step['result'] = result
+        agent.planner.completed_steps.append(step)
+
+    planner.mark_step_completed.side_effect = mock_mark_completed
+
+    result = await agent.execute_plan("user input")
+
+    assert "Guardrail Fallback (STOP): Policy Violation" in result
+    assert "dangerous_skill" in result
+    skills.execute_skill.assert_not_called()
+    planner.clear_pending_plan.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_guardrail_review_required():
+    # Mock dependencies
+    llm = MagicMock()
+    skills = MagicMock()
+    planner = MagicMock()
+    policy = MagicMock(spec=PolicyLayer)
+
+    # Setup policy to DENY with REQUEST_REVIEW
+    policy.evaluate.return_value = (False, "Review needed")
+
+    guardrail = RealtimeGuardrail(policy_layer=policy, default_strategy=FallbackStrategy.REQUEST_REVIEW)
+    agent = GeneratorAgent(llm=llm, skills=skills, planner=planner, guardrail=guardrail)
+
+    # Setup planner
+    current_plan = [{"skill": "sketchy_skill", "description": "sketchy"}]
+    planner.get_current_plan.side_effect = lambda: current_plan
+    planner.completed_steps = []
+
+    def mock_mark_completed(index, result):
+        nonlocal current_plan
+        step = current_plan.pop(index)
+        step['result'] = result
+        agent.planner.completed_steps.append(step)
+
+    planner.mark_step_completed.side_effect = mock_mark_completed
+
+    result = await agent.execute_plan("user input")
+
+    assert "Guardrail Fallback (REVIEW REQUIRED): Review needed" in result
+    skills.execute_skill.assert_not_called()
+    planner.clear_pending_plan.assert_called_once()


### PR DESCRIPTION
This PR implements a robust real-time guardrail system that ensures all agent actions are evaluated against safety policies immediately before execution. It allows for graceful fallback strategies like stopping the current plan or requesting a human review if a violation is detected mid-generation. The system is wired through the Consciousness microservice and verified with comprehensive unit tests.

---
*PR created automatically by Jules for task [1018497133354994058](https://jules.google.com/task/1018497133354994058) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add real-time guardrail checks to `GeneratorAgent` plan execution
> - Introduces `RealtimeGuardrail` in [`magda_agent/safety/guardrails.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/102/files#diff-fa5381fa98cdc402eb97f045f19e40ea13069daa025c155741cbd4797097b874) with a `FallbackStrategy` enum (`STOP_EXECUTION`, `REQUEST_REVIEW`, `NONE`) that wraps `PolicyLayer.evaluate` to determine if an action is allowed at runtime.
> - `GeneratorAgent.execute_plan` now calls `guardrail.check_action` before each skill; on denial, the step is marked complete with a guardrail message and the plan stops early based on the returned strategy.
> - `Consciousness` and the API entrypoint are updated to construct and propagate a `RealtimeGuardrail` instance into `GeneratorAgent` at startup.
> - Three async tests cover allowed actions, `STOP_EXECUTION` denials, and `REQUEST_REVIEW` denials, asserting skill skipping and `planner.clear_pending_plan` behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 923d0e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->