### PR TITLE
feat: Implement ASSERT Policy-driven evaluation framework

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -1706,7 +1706,7 @@
     },
     {
       "id": "assert-policy-driven-evaluation",
-      "status": "todo",
+      "status": "done",
       "area": "metacognition",
       "risk": "low",
       "title": "ASSERT: Policy-driven evaluation framework",
@@ -2576,6 +2576,40 @@
         "Subagents can execute their assigned tasks in isolated contexts",
         "Orchestrator aggregates results from subagents successfully",
         "Tests mock subagent executions and verify parallelization"
+      ]
+    },
+    {
+      "id": "context-engine-plugin-architecture-v3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Plugin Architecture",
+      "description": "Inspired by trend #4 in docs/trends.md: Implement a plugin architecture for the Context Engine to manage context dynamically using lifecycle hooks.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine.py",
+        "tests/test_context_engine_plugins*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine supports plugin registration and lifecycle hooks",
+        "Tests verify plugin execution during context retrieval"
+      ]
+    },
+    {
+      "id": "scheduled-operations-cron-like-v2",
+      "status": "todo",
+      "area": "scheduler",
+      "risk": "low",
+      "title": "Scheduled operations for autonomous tasks",
+      "description": "Inspired by trend #7 in docs/trends.md: Implement cron-like scheduled tasks that run autonomously without user involvement.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron.py",
+        "tests/test_scheduler_cron*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler can register cron-like tasks",
+        "Tests verify task execution without user input"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] MODULE: **ASSERT Evaluator** — модуль magda_agent/metacognition/assert_evaluator.py.
 * [x] FEATURE: Multi-channel gateway (Telegram + Discord + API) (2026-06-05)
 * [x] MODULE: **User Model** — модуль `magda_agent/user_model/model.py`. (2026-06-05)
   Builds and maintains a persistent user model: preferences, communication style, expertise level, recurring topics.

--- a/magda_agent/metacognition/__init__.py
+++ b/magda_agent/metacognition/__init__.py
@@ -1,4 +1,5 @@
 from magda_agent.metacognition.evaluator import Evaluator
+from magda_agent.metacognition.assert_evaluator import AssertEvaluator
 from magda_agent.metacognition.confidence import ConfidenceCalibrator
 from magda_agent.metacognition.tracker import QualityTracker
 from magda_agent.metacognition.failure_patterns import FailurePatternTracker
@@ -6,4 +7,4 @@ from magda_agent.metacognition.failure_patterns import FailurePatternTracker
 # Global instance for tracking continuous improvement metrics
 quality_tracker = QualityTracker()
 
-__all__ = ["Evaluator", "QualityTracker", "quality_tracker", "FailurePatternTracker", "ConfidenceCalibrator"]
+__all__ = ["AssertEvaluator", "Evaluator", "QualityTracker", "quality_tracker", "FailurePatternTracker", "ConfidenceCalibrator"]

--- a/magda_agent/metacognition/assert_evaluator.py
+++ b/magda_agent/metacognition/assert_evaluator.py
@@ -1,0 +1,85 @@
+import json
+import logging
+from typing import Optional, Dict, Any, List
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.emotions.engine import PADState
+
+class AssertEvaluator:
+    """
+    Metacognition: Policy-driven Evaluation framework.
+    Evaluates the agent's responses conditionally based on satisfying explicit policy documents or rules.
+    """
+    def __init__(self, llm: LLMClient, memory: MemorySystem):
+        self.llm = llm
+        self.memory = memory
+        self.last_evaluation: Optional[Dict[str, Any]] = None
+
+    async def evaluate_response_with_policy(self, user_input: str, agent_response: str, policies: List[str]) -> Optional[Dict[str, Any]]:
+        """
+        Evaluates the generated response using the LLM based on explicit policy constraints and stores the result in memory.
+        """
+        formatted_policies = "\n".join([f"- {policy}" for policy in policies])
+        prompt = (
+            "Evaluate the following response given by an AI to a user's input.\n"
+            "Score the response from 1 to 10 based on how well it adheres to the following explicit policy constraints:\n"
+            f"{formatted_policies}\n\n"
+            "Consider criteria like usefulness, accuracy, completeness, and emotional adequacy, but strictly evaluate against the provided constraints.\n\n"
+            f"User input: {user_input}\n"
+            f"AI Response: {agent_response}\n\n"
+            "Respond ONLY with a JSON object in this format:\n"
+            "{\n"
+            '  "policy_adherence_score": 8.0,\n'
+            '  "violated_policies": ["Policy description if violated, else empty"],\n'
+            '  "feedback": "A short sentence explaining the score"\n'
+            "}"
+        )
+        messages = [{"role": "system", "content": prompt}]
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.llm.chat_completion(messages, temperature=0.1)
+                # Remove any markdown formatting (e.g. ```json)
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+
+                # Store in memory
+                content = f"Policy Evaluation of response to '{user_input[:20]}...': Score: {evaluation.get('policy_adherence_score')} - {evaluation.get('feedback')}"
+                await self.memory.add_memory(
+                    content=content,
+                    importance=0.7,
+                    emotional_state=PADState(0.0, 0.0, 0.0), # Neutral PAD state for evaluation
+                    tags=["evaluation", "metacognition", "policy"]
+                )
+
+                self.last_evaluation = evaluation
+                return evaluation
+            except json.JSONDecodeError as e:
+                logging.warning(f"JSON decoding error in evaluator attempt {attempt + 1}/{max_retries}: {e}. Retrying...")
+                if attempt == max_retries - 1:
+                    logging.error("Max retries reached for evaluate_response_with_policy JSON parsing.")
+                    return None
+            except Exception as e:
+                logging.error(f"Failed to evaluate response: {e}")
+                return None
+
+    def get_feedback_for_prompt(self) -> str:
+        """
+        Returns feedback to be included in the next system prompt if the previous evaluation was low.
+        """
+        if not self.last_evaluation:
+            return ""
+
+        score = self.last_evaluation.get("policy_adherence_score", 10.0)
+        if score < 8.0:
+            feedback = self.last_evaluation.get("feedback", "Improve policy adherence.")
+            violations = self.last_evaluation.get("violated_policies", [])
+            violation_text = f" Violated policies: {', '.join(violations)}." if violations else ""
+            return f"Note: Your previous response received a low policy adherence score ({score}/10).{violation_text} Feedback: {feedback}. Please ensure strict adherence to all stated policies."
+        return ""

--- a/tests/test_assert_evaluator.py
+++ b/tests/test_assert_evaluator.py
@@ -1,0 +1,128 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.metacognition.assert_evaluator import AssertEvaluator
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+
+@pytest.fixture
+def mock_llm_client():
+    mock = AsyncMock(spec=LLMClient)
+    # Default successful mock response
+    mock_json_response = '''
+    ```json
+    {
+      "policy_adherence_score": 9.0,
+      "violated_policies": [],
+      "feedback": "Complies well with the provided policies"
+    }
+    ```
+    '''
+    mock.chat_completion.return_value = mock_json_response
+    return mock
+
+@pytest.fixture
+def mock_memory_system():
+    mock = MagicMock(spec=MemorySystem)
+    mock.add_memory = AsyncMock()
+    return mock
+
+@pytest.fixture
+def evaluator(mock_llm_client, mock_memory_system):
+    return AssertEvaluator(llm=mock_llm_client, memory=mock_memory_system)
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_success(evaluator, mock_llm_client, mock_memory_system):
+    user_input = "Hello"
+    agent_response = "Hi there!"
+    policies = ["Be polite"]
+
+    result = await evaluator.evaluate_response_with_policy(user_input, agent_response, policies)
+
+    # Assert LLM was called
+    mock_llm_client.chat_completion.assert_called_once()
+
+    # Assert policies are in the prompt
+    call_args = mock_llm_client.chat_completion.call_args[0][0]
+    assert "- Be polite" in call_args[0]["content"]
+
+    # Assert memory was added
+    mock_memory_system.add_memory.assert_called_once()
+    mem_call_args = mock_memory_system.add_memory.call_args[1]
+    assert "Score: 9.0" in mem_call_args["content"]
+    assert mem_call_args["tags"] == ["evaluation", "metacognition", "policy"]
+
+    # Assert result
+    assert result is not None
+    assert result["policy_adherence_score"] == 9.0
+    assert result["feedback"] == "Complies well with the provided policies"
+
+    # Assert state updated
+    assert evaluator.last_evaluation == result
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_no_markdown(evaluator, mock_llm_client):
+    mock_json_response = '''{
+      "policy_adherence_score": 5.0,
+      "violated_policies": ["Do not use exclamation marks"],
+      "feedback": "Failed to adhere to policy"
+    }'''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    result = await evaluator.evaluate_response_with_policy("Test", "Response!", ["Do not use exclamation marks"])
+    assert result is not None
+    assert result["policy_adherence_score"] == 5.0
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_high_score(evaluator):
+    evaluator.last_evaluation = {"policy_adherence_score": 8.5, "feedback": "Great"}
+    feedback = evaluator.get_feedback_for_prompt()
+    assert feedback == "" # Should be empty for high scores
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_low_score(evaluator):
+    evaluator.last_evaluation = {"policy_adherence_score": 4.5, "violated_policies": ["No swearing"], "feedback": "Policy violation"}
+    feedback = evaluator.get_feedback_for_prompt()
+    assert "low policy adherence score (4.5/10)" in feedback
+    assert "Violated policies: No swearing" in feedback
+    assert "Policy violation" in feedback
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_no_evaluation(evaluator):
+    feedback = evaluator.get_feedback_for_prompt()
+    assert feedback == ""
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_exception(evaluator, mock_llm_client):
+    mock_llm_client.chat_completion.side_effect = Exception("API Error")
+    result = await evaluator.evaluate_response_with_policy("Test", "Response", [])
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_retry_success(evaluator, mock_llm_client):
+    # First response is invalid JSON, second response is valid JSON
+    invalid_json_response = "this is not valid json"
+    valid_json_response = '''{
+      "policy_adherence_score": 9.0,
+      "violated_policies": [],
+      "feedback": "Retry success"
+    }'''
+    mock_llm_client.chat_completion.side_effect = [invalid_json_response, valid_json_response]
+
+    result = await evaluator.evaluate_response_with_policy("Test", "Response", [])
+
+    assert result is not None
+    assert result["policy_adherence_score"] == 9.0
+    assert result["feedback"] == "Retry success"
+    assert mock_llm_client.chat_completion.call_count == 2
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_retry_failure(evaluator, mock_llm_client):
+    # Always return invalid JSON
+    invalid_json_response = "still not valid json"
+    mock_llm_client.chat_completion.side_effect = [invalid_json_response, invalid_json_response, invalid_json_response]
+
+    result = await evaluator.evaluate_response_with_policy("Test", "Response", [])
+
+    assert result is None
+    assert mock_llm_client.chat_completion.call_count == 3


### PR DESCRIPTION
This PR implements the ASSERT Policy-driven evaluation framework as described in `agent_tasks.json`.

Changes:
- Created `AssertEvaluator` inside `magda_agent/metacognition/assert_evaluator.py` which extends the evaluation capability to incorporate explicit policy constraints.
- Exported the module via `magda_agent/metacognition/__init__.py`.
- Wrote a complete test suite `tests/test_assert_evaluator.py` with mock LLM and memory components to verify policy inclusion and success/failure handling.
- Updated `agent_tasks.json` to mark the task as done and injected two new AI-trend inspired tasks (`context-engine-plugin-architecture-v3` and `scheduled-operations-cron-like-v2`).
- Kept `backlog.md` up to date.

All tests passed successfully, and `validate_agent_tasks.py` passes without errors.

---
*PR created automatically by Jules for task [15690313607173633588](https://jules.google.com/task/15690313607173633588) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AssertEvaluator` for policy-driven LLM response evaluation to metacognition module
> - Adds [`AssertEvaluator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/106/files#diff-d7e27d570e5c9093d30578790ffd85e37644ed7ad33c668ac14559333c71e761) to the metacognition package, which evaluates AI responses against explicit policy constraints by prompting the LLM for a JSON-formatted score and feedback.
> - On success, persists a summary memory entry tagged `["evaluation", "metacognition", "policy"]` with a neutral PAD state via `MemorySystem`.
> - `get_feedback_for_prompt` returns actionable feedback when the last evaluation score is below 8.0, listing violated policies; returns an empty string otherwise.
> - JSON parsing retries up to 3 times and strips optional markdown fences before parsing; returns `None` on total failure.
> - Exports `AssertEvaluator` from `magda_agent.metacognition` and adds a full async test suite covering success, retry, and failure paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17d19df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->