### PR TITLE
Implement Cross-Platform Channel Adapter Framework

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -1836,7 +1836,7 @@
     },
     {
       "id": "cross-platform-channel-adapter",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "low",
       "title": "Cross-Platform Channel Adapter Framework",
@@ -2644,6 +2644,40 @@
       "acceptance": [
         "Agent can discover and retrieve Agent Cards of peers",
         "Tests verify mock discovery and card parsing"
+      ]
+    },
+    {
+      "id": "mcpkernel-taint-tracking-db0c895d",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCPKernel Taint Tracking",
+      "description": "Inspired by MCPKernel trend: Implement taint tracking and sandboxed execution for external tool interactions.",
+      "allowed_paths": [
+        "magda_agent/safety/**",
+        "tests/test_mcpkernel*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tracking module intercepts tool inputs",
+        "Tests verify tainted inputs are blocked"
+      ]
+    },
+    {
+      "id": "assert-policy-evaluation-fbaa6aeb",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ASSERT Policy-Driven Evaluation",
+      "description": "Inspired by ASSERT Microsoft trend: Build a policy-driven evaluation framework to secure agentic workflows.",
+      "allowed_paths": [
+        "magda_agent/safety/**",
+        "tests/test_assert_eval*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ASSERT evaluator evaluates workflows against policies",
+        "Tests verify framework properly identifies violations"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -148,3 +148,5 @@
 
 * [x] MODULE: **Curiosity Drive** — `magda_agent/exploration/curiosity.py`. (2026-06-05)
   Proactively suggests exploration tasks when boredom is high.
+* [ ] FEATURE: MCPKernel Taint Tracking
+* [ ] FEATURE: ASSERT Policy-Driven Evaluation

--- a/magda_agent/channels/base.py
+++ b/magda_agent/channels/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict
 from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
 
-class BaseChannel(ABC):
+class ChannelAdapter(ABC):
     """Base class for all communication channels."""
 
     def __init__(self, channel_id: str, gateway: GatewayRouter):

--- a/magda_agent/channels/discord.py
+++ b/magda_agent/channels/discord.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict
-from magda_agent.channels.base import BaseChannel
+from magda_agent.channels.base import ChannelAdapter
 from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
 
-class DiscordChannel(BaseChannel):
+class DiscordAdapter(ChannelAdapter):
     """Adapter for Discord platform."""
 
     def __init__(self, gateway: GatewayRouter):

--- a/magda_agent/channels/rest.py
+++ b/magda_agent/channels/rest.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict
-from magda_agent.channels.base import BaseChannel
+from magda_agent.channels.base import ChannelAdapter
 from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
 
-class RestChannel(BaseChannel):
+class RestAdapter(ChannelAdapter):
     """Adapter for REST API."""
 
     def __init__(self, gateway: GatewayRouter):

--- a/magda_agent/channels/telegram.py
+++ b/magda_agent/channels/telegram.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict
-from magda_agent.channels.base import BaseChannel
+from magda_agent.channels.base import ChannelAdapter
 from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
 
-class TelegramChannel(BaseChannel):
+class TelegramAdapter(ChannelAdapter):
     """Adapter for Telegram platform."""
 
     def __init__(self, gateway: GatewayRouter):

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,0 +1,142 @@
+import pytest
+import asyncio
+from typing import Any, Dict
+from magda_agent.channels.base import ChannelAdapter
+from magda_agent.channels.discord import DiscordAdapter
+from magda_agent.channels.telegram import TelegramAdapter
+from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
+
+class MockChannel(ChannelAdapter):
+    """A mock channel adapter for testing purposes."""
+
+    def __init__(self, gateway: GatewayRouter) -> None:
+        """Initialize the mock channel.
+
+        Args:
+            gateway (GatewayRouter): The gateway router to register with.
+        """
+        super().__init__("mock", gateway)
+
+    async def receive(self, raw_data: Dict[str, Any]) -> Any:
+        """Process incoming mock data and route it.
+
+        Args:
+            raw_data (Dict[str, Any]): The incoming data.
+
+        Returns:
+            Any: The response from the gateway.
+        """
+        text: str = raw_data.get("text", "")
+        user_id: str = raw_data.get("user_id", "")
+        msg = UnifiedMessage(
+            channel=self.channel_id,
+            text=text,
+            user_id=user_id,
+            metadata={"raw": raw_data}
+        )
+        return await self.gateway.route_message(msg)
+
+    async def send(self, recipient_id: str, text: str, metadata: Dict[str, Any] = None) -> str:
+        """Mock sending a message.
+
+        Args:
+            recipient_id (str): The recipient's ID.
+            text (str): The message text.
+            metadata (Dict[str, Any], optional): Additional metadata.
+
+        Returns:
+            str: The mock sent message confirmation.
+        """
+        return f"Mock sent to {recipient_id}: {text}"
+
+@pytest.fixture
+def gateway() -> GatewayRouter:
+    """Fixture that provides a GatewayRouter with a mock message handler.
+
+    Returns:
+        GatewayRouter: The configured gateway.
+    """
+    router = GatewayRouter()
+
+    async def mock_handler(msg: UnifiedMessage) -> Dict[str, str]:
+        """Mock handler for testing routed messages.
+
+        Args:
+            msg (UnifiedMessage): The routed message.
+
+        Returns:
+            Dict[str, str]: Handled message details.
+        """
+        return {"handled_text": msg.text, "handled_user": msg.user_id, "channel": msg.channel}
+
+    router.set_message_handler(mock_handler)
+    return router
+
+@pytest.mark.asyncio
+async def test_channel_adapter_interface(gateway: GatewayRouter) -> None:
+    """Test that the ChannelAdapter interface behaves correctly.
+
+    Args:
+        gateway (GatewayRouter): The gateway fixture.
+    """
+    channel = MockChannel(gateway)
+    assert channel.channel_id == "mock"
+    assert gateway.get_channel("mock") is channel
+
+    response = await channel.receive({"text": "hello", "user_id": "123"})
+    assert response["handled_text"] == "hello"
+    assert response["handled_user"] == "123"
+    assert response["channel"] == "mock"
+
+    sent = await channel.send("123", "hi")
+    assert sent == "Mock sent to 123: hi"
+
+@pytest.mark.asyncio
+async def test_discord_adapter(gateway: GatewayRouter) -> None:
+    """Test the DiscordAdapter receive logic.
+
+    Args:
+        gateway (GatewayRouter): The gateway fixture.
+    """
+    adapter = DiscordAdapter(gateway)
+
+    class MockAuthor:
+        def __init__(self, author_id: str) -> None:
+            self.id = author_id
+
+    class MockDiscordMessage:
+        def __init__(self, content: str, author_id: str) -> None:
+            self.content = content
+            self.author = MockAuthor(author_id)
+
+    raw_msg = MockDiscordMessage("test discord", "d456")
+    response = await adapter.receive(raw_msg)
+
+    assert response["handled_text"] == "test discord"
+    assert response["handled_user"] == "d456"
+    assert response["channel"] == "discord"
+
+@pytest.mark.asyncio
+async def test_telegram_adapter(gateway: GatewayRouter) -> None:
+    """Test the TelegramAdapter receive logic.
+
+    Args:
+        gateway (GatewayRouter): The gateway fixture.
+    """
+    adapter = TelegramAdapter(gateway)
+
+    class MockUser:
+        def __init__(self, user_id: str) -> None:
+            self.id = user_id
+
+    class MockTelegramMessage:
+        def __init__(self, text: str, user_id: str) -> None:
+            self.text = text
+            self.from_user = MockUser(user_id)
+
+    raw_msg = MockTelegramMessage("test tg", "t789")
+    response = await adapter.receive(raw_msg)
+
+    assert response["handled_text"] == "test tg"
+    assert response["handled_user"] == "t789"
+    assert response["channel"] == "telegram"

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,9 +1,9 @@
 import pytest
 import asyncio
 from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
-from magda_agent.channels.telegram import TelegramChannel
-from magda_agent.channels.discord import DiscordChannel
-from magda_agent.channels.rest import RestChannel
+from magda_agent.channels.telegram import TelegramAdapter
+from magda_agent.channels.discord import DiscordAdapter
+from magda_agent.channels.rest import RestAdapter
 
 class MockAgentCore:
     def __init__(self):
@@ -19,7 +19,7 @@ async def test_telegram_channel_routing():
     agent = MockAgentCore()
     gateway.set_message_handler(agent.handle_message)
 
-    channel = TelegramChannel(gateway)
+    channel = TelegramAdapter(gateway)
 
     raw_telegram_msg = {"text": "Hello Telegram", "user_id": "123"}
     response = await channel.receive(raw_telegram_msg)
@@ -36,7 +36,7 @@ async def test_discord_channel_routing():
     agent = MockAgentCore()
     gateway.set_message_handler(agent.handle_message)
 
-    channel = DiscordChannel(gateway)
+    channel = DiscordAdapter(gateway)
 
     raw_discord_msg = {"content": "Hello Discord", "author_id": "456"}
     response = await channel.receive(raw_discord_msg)
@@ -53,7 +53,7 @@ async def test_rest_channel_routing():
     agent = MockAgentCore()
     gateway.set_message_handler(agent.handle_message)
 
-    channel = RestChannel(gateway)
+    channel = RestAdapter(gateway)
 
     raw_rest_msg = {"text": "Hello REST", "user_id": "789"}
     response = await channel.receive(raw_rest_msg)
@@ -67,9 +67,9 @@ async def test_rest_channel_routing():
 @pytest.mark.asyncio
 async def test_channel_sending():
     gateway = GatewayRouter()
-    tg = TelegramChannel(gateway)
-    dc = DiscordChannel(gateway)
-    rest = RestChannel(gateway)
+    tg = TelegramAdapter(gateway)
+    dc = DiscordAdapter(gateway)
+    rest = RestAdapter(gateway)
 
     assert "Telegram sent to 1: hi" == await tg.send("1", "hi")
     assert "Discord sent to 2: hello" == await dc.send("2", "hello")
@@ -82,7 +82,7 @@ async def test_channel_sending():
 @pytest.mark.asyncio
 async def test_missing_handler():
     gateway = GatewayRouter()
-    channel = TelegramChannel(gateway)
+    channel = TelegramAdapter(gateway)
     raw_telegram_msg = {"text": "Fail", "user_id": "1"}
 
     with pytest.raises(RuntimeError, match="No message handler registered with GatewayRouter"):


### PR DESCRIPTION
Implements the ChannelAdapter framework, tests, and updates agent_tasks.json and backlog.md

---
*PR created automatically by Jules for task [7802773548356830067](https://jules.google.com/task/7802773548356830067) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename channel classes to `ChannelAdapter` pattern across Discord, Telegram, and REST adapters
> - Renames `BaseChannel` to `ChannelAdapter` in [base.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/108/files#diff-e5fc2bd6359b9dbf36ee16e10c4cbdeb74aac8f6feca2363692c9c47a7bd858c) and updates all three channel implementations (`DiscordAdapter`, `TelegramAdapter`, `RestAdapter`) to match.
> - Adds tests in [test_channels.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/108/files#diff-f7dc3a55cae39d666601296500529b32e9fa77c7fc5d6c85853928d196db0d15) covering `ChannelAdapter` registration, `receive`/`send` routing, and per-adapter message field mapping for Discord and Telegram.
> - Updates [test_gateway.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/108/files#diff-4f0390209d7648ae2dbda296ebe43dc6e901a046b178a4e0aff1d78752ee65b7) to use the new adapter class names throughout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c6e83c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->