### PR TITLE
Add Skill Marketplace Export

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2058,7 +2058,7 @@
     },
     {
       "id": "skill-marketplace-export",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Skill Marketplace Export",
@@ -2678,6 +2678,42 @@
       "acceptance": [
         "ASSERT evaluator evaluates workflows against policies",
         "Tests verify framework properly identifies violations"
+      ]
+    },
+    {
+      "id": "agent-teams-git-worktree-isolation",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Agent Teams Git Worktree Isolation",
+      "description": "Inspired by Claude Agent SDK Agent Teams trend: Implement multi-agent workflows with git worktree isolation to allow subagents to operate concurrently without file conflicts.",
+      "allowed_paths": [
+        "magda_agent/agents/team_isolation.py",
+        "tests/test_team_isolation*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents spawn in isolated git worktrees",
+        "Concurrent tasks do not clash on filesystem",
+        "Tests verify isolation and cleanup"
+      ]
+    },
+    {
+      "id": "online-rl-feedback-integration",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL Feedback Integration",
+      "description": "Inspired by OpenClaw-RL trend: integrate online reinforcement learning from user feedback (next-state signals) directly into agent's habits.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl.py",
+        "tests/test_online_rl*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent collects explicit and implicit feedback signals",
+        "Feedback signals adjust habit weights dynamically",
+        "Tests verify weight shifts based on simulated feedback"
       ]
     }
   ]

--- a/magda_agent/skills/exporter.py
+++ b/magda_agent/skills/exporter.py
@@ -1,0 +1,47 @@
+import json
+import logging
+from typing import Optional
+import yaml
+from magda_agent.memory.procedural import ProceduralMemory
+
+class SkillExporter:
+    """
+    Utility to package and export successfully created skills from ProceduralMemory
+    into a standard format (JSON/YAML) for a skill marketplace.
+    """
+    def __init__(self, procedural_memory: ProceduralMemory) -> None:
+        self.procedural_memory = procedural_memory
+
+    def export_skill(self, name: str, export_format: str = "json", user_id: Optional[int] = None) -> str:
+        """
+        Exports a skill from ProceduralMemory into JSON or YAML format.
+        """
+        try:
+            results = self.procedural_memory.get_procedure_versions(name=name, user_id=user_id)
+            if not results or not results.get("documents"):
+                raise ValueError(f"Skill '{name}' not found in procedural memory.")
+
+            # Assume we export the most recent/first match
+            document = results["documents"][0]
+            metadata = results["metadatas"][0] if results.get("metadatas") else {}
+
+            if "Procedure: " not in document:
+                raise ValueError("Skill document does not contain a procedure block.")
+
+            code = document.split("Procedure: ")[-1].strip()
+
+            export_data = {
+                "metadata": metadata,
+                "parameters": {},  # Future expansion
+                "code": code
+            }
+
+            if export_format.lower() == "json":
+                return json.dumps(export_data, indent=2)
+            elif export_format.lower() == "yaml":
+                return yaml.dump(export_data, default_flow_style=False)
+            else:
+                raise ValueError(f"Unsupported format: {export_format}")
+        except Exception as e:
+            logging.error(f"Failed to export skill '{name}': {e}")
+            raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ sentencepiece
 datasets<3.0.0
 croniter
 websockets==12.0
+PyYAML

--- a/tests/test_skill_exporter.py
+++ b/tests/test_skill_exporter.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.skills.exporter import SkillExporter
+from magda_agent.memory.procedural import ProceduralMemory
+import json
+import yaml
+
+def test_export_skill_json():
+    mock_memory = MagicMock(spec=ProceduralMemory)
+    mock_memory.get_procedure_versions.return_value = {
+        "documents": ["Procedure Name: test_skill\nProcedure: def my_func():\n    return 'hello'"],
+        "metadatas": [{"name": "test_skill", "user_id": 1}]
+    }
+
+    exporter = SkillExporter(mock_memory)
+    result_json = exporter.export_skill("test_skill", export_format="json", user_id=1)
+
+    data = json.loads(result_json)
+    assert data["metadata"]["name"] == "test_skill"
+    assert data["metadata"]["user_id"] == 1
+    assert data["code"] == "def my_func():\n    return 'hello'"
+
+def test_export_skill_yaml():
+    mock_memory = MagicMock(spec=ProceduralMemory)
+    mock_memory.get_procedure_versions.return_value = {
+        "documents": ["Procedure Name: test_skill\nProcedure: def my_func():\n    return 'hello'"],
+        "metadatas": [{"name": "test_skill", "user_id": 1}]
+    }
+
+    exporter = SkillExporter(mock_memory)
+    result_yaml = exporter.export_skill("test_skill", export_format="yaml", user_id=1)
+
+    data = yaml.safe_load(result_yaml)
+    assert data["metadata"]["name"] == "test_skill"
+    assert data["metadata"]["user_id"] == 1
+    assert data["code"] == "def my_func():\n    return 'hello'"
+
+def test_export_skill_not_found():
+    mock_memory = MagicMock(spec=ProceduralMemory)
+    mock_memory.get_procedure_versions.return_value = {}
+
+    exporter = SkillExporter(mock_memory)
+    with pytest.raises(ValueError, match="not found in procedural memory"):
+        exporter.export_skill("missing_skill")
+
+def test_export_skill_invalid_format():
+    mock_memory = MagicMock(spec=ProceduralMemory)
+    mock_memory.get_procedure_versions.return_value = {
+        "documents": ["Procedure Name: test_skill\nProcedure: def my_func():\n    return 'hello'"],
+        "metadatas": [{"name": "test_skill"}]
+    }
+
+    exporter = SkillExporter(mock_memory)
+    with pytest.raises(ValueError, match="Unsupported format"):
+        exporter.export_skill("test_skill", export_format="xml")


### PR DESCRIPTION
This implements the SkillExporter module for packaging and exporting skills from ProceduralMemory into standard JSON/YAML formats. It fulfills the `skill-marketplace-export` task, marks it as complete, and appends two new "todo" tasks inspired by recent agent trends (Agent Teams Git Worktree Isolation, Online RL Feedback Integration).
PyYAML was added to requirements.txt to support YAML export. Tests use mocked ProceduralMemory objects to ensure correct functioning and robust formatting conversions without making real database calls.

---
*PR created automatically by Jules for task [4127325410299425225](https://jules.google.com/task/4127325410299425225) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SkillExporter` class to export skills from `ProceduralMemory` to JSON or YAML
> - Adds [exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/109/files#diff-716d70d74edad26927ae3265bded8accdc234c6ca39b9ab36f04a22df8c62ee2) with a `SkillExporter` class that fetches the latest procedure version from `ProceduralMemory`, extracts the code block after a `Procedure: ` marker, and serializes it with metadata to JSON or YAML.
> - Raises `ValueError` for missing skills, documents lacking a `Procedure: ` block, or unsupported formats.
> - Adds `PyYAML` to [requirements.txt](https://github.com/kazah4359-lgtm/Magda-agent/pull/109/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552) to support YAML serialization.
> - Tests in [tests/test_skill_exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/109/files#diff-aff53176970f7103d6a7dafb103cec104c54b5750b99a91a076efcc2bd1b0d40) cover JSON export, YAML export, missing skill, and unsupported format using a mocked `ProceduralMemory`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c1b590.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->