### PR TITLE
Agent Skills MCP Export Enhancements

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2330,7 +2330,7 @@
     },
     {
       "id": "agent-skills-mcp-export",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Agent Skills MCP Export Enhancements",
@@ -2904,6 +2904,38 @@
       ],
       "acceptance": [
         "Memory state can be exported and accessed via MCP interface"
+      ]
+    },
+    {
+      "id": "a2a-protocol-integration-v4",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Agent-to-Agent (A2A) Protocol integration",
+      "description": "Inspired by A2A trend: integrate Agent discovery via Agent Cards and peer-to-peer task delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_protocol_integration.py",
+        "tests/test_a2a_protocol_integration.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can discover and connect to peers using A2A protocol."
+      ]
+    },
+    {
+      "id": "acs-runtime-safety-controls-v2",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS runtime safety controls",
+      "description": "Inspired by ACS trend: Implement 5 validation checkpoints for runtime safety controls.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_controls.py",
+        "tests/test_acs_controls.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS checkpoints are enforced during tool execution."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Agent Skills MCP Export Enhancements (agent-skills-mcp-export)
 * [x] FEATURE: Multi-Channel Skills Sync (2026-06-XX)
 * [x] FEATURE: A2A Agent Cards Discovery (2026-06-05)
 * [x] MODULE: **ASSERT Evaluator** — модуль magda_agent/metacognition/assert_evaluator.py.

--- a/magda_agent/skills/mcp_export.py
+++ b/magda_agent/skills/mcp_export.py
@@ -14,6 +14,9 @@ class MagdaMCPAdapter:
         """
         Extracts JSON schema parameters from the function signature.
         """
+        if hasattr(func, "__mcp_schema__"):
+            return getattr(func, "__mcp_schema__")
+
         sig = inspect.signature(func)
         properties = {}
         required = []
@@ -60,6 +63,36 @@ class MagdaMCPAdapter:
                 "inputSchema": schema
             })
         return tools
+
+    async def call_tool_async(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Invokes an async skill via the MCP protocol format.
+        """
+        if not self.registry.has_skill(name):
+            return {
+                "content": [{"type": "text", "text": f"Error: Tool '{name}' not found."}],
+                "isError": True
+            }
+
+        try:
+            result = self.registry.execute_skill(name, **arguments)
+            if inspect.isawaitable(result):
+                try:
+                    result = await result
+                except Exception as e:
+                    return {
+                        "content": [{"type": "text", "text": f"Error executing async tool {name}: {e}"}],
+                        "isError": True
+                    }
+            return {
+                "content": [{"type": "text", "text": str(result)}],
+                "isError": False
+            }
+        except Exception as e:
+            return {
+                "content": [{"type": "text", "text": f"Error executing tool {name}: {e}"}],
+                "isError": True
+            }
 
     def call_tool(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/tests/test_mcp_export.py
+++ b/tests/test_mcp_export.py
@@ -55,3 +55,59 @@ def test_call_tool_execution_error(adapter):
     # Let's adjust our test for that behavior.
     assert result["isError"] is False
     assert "Error executing skill" in result["content"][0]["text"]
+
+def dynamic_skill_with_schema(a: int) -> str:
+    """A dynamic skill with custom schema."""
+    return f"dynamic: {a}"
+
+dynamic_skill_with_schema.__mcp_schema__ = {
+    "type": "object",
+    "properties": {
+        "a": {"type": "integer"},
+        "b": {"type": "string"}
+    },
+    "required": ["a", "b"]
+}
+
+def test_dynamic_skill_schema(adapter):
+    adapter.registry.register_skill("dynamic_skill", dynamic_skill_with_schema, "Dynamic Test")
+    tools = adapter.list_tools()
+
+    dynamic_tool = next(t for t in tools if t["name"] == "dynamic_skill")
+    assert dynamic_tool["inputSchema"] == dynamic_skill_with_schema.__mcp_schema__
+
+import pytest
+
+async def async_sample_skill(a: int) -> str:
+    """An async sample skill for testing."""
+    return f"async: {a}"
+
+async def async_sample_skill_error(a: int) -> str:
+    """An async sample skill for testing."""
+    raise ValueError("async error")
+
+@pytest.fixture
+def async_adapter():
+    registry = SkillRegistry()
+    registry.register_skill("async_skill", async_sample_skill, "An async test skill")
+    registry.register_skill("async_skill_error", async_sample_skill_error, "An async test skill error")
+    return MagdaMCPAdapter(registry)
+
+@pytest.mark.asyncio
+async def test_call_tool_async_success(async_adapter):
+    result = await async_adapter.call_tool_async("async_skill", {"a": 42})
+    assert result["isError"] is False
+    assert result["content"][0]["type"] == "text"
+    assert result["content"][0]["text"] == "async: 42"
+
+@pytest.mark.asyncio
+async def test_call_tool_async_error(async_adapter):
+    result = await async_adapter.call_tool_async("async_skill_error", {"a": 42})
+    assert result["isError"] is True
+    assert "async error" in result["content"][0]["text"]
+
+@pytest.mark.asyncio
+async def test_call_tool_async_not_found(async_adapter):
+    result = await async_adapter.call_tool_async("missing_skill", {})
+    assert result["isError"] is True
+    assert "not found" in result["content"][0]["text"]


### PR DESCRIPTION
Implements MCP export for dynamic and async skills.

---
*PR created automatically by Jules for task [10810694881316786431](https://jules.google.com/task/10810694881316786431) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `call_tool_async` and `__mcp_schema__` support to `MagdaMCPAdapter`
> - Adds `call_tool_async` to [`MagdaMCPAdapter`](https://github.com/kazah4359-lgtm/Magda-agent/pull/114/files#diff-6c04862b977c757af22496c7b2a41250c52af66ab73ec44c12933fa3a337a508) to invoke skills asynchronously and return MCP-formatted responses, including error responses for missing tools and skill exceptions.
> - Adds support for a `__mcp_schema__` attribute on skill functions: when present, `_get_json_schema` returns it verbatim instead of introspecting the function signature.
> - Adds tests covering async success, async error propagation, tool-not-found handling, and custom schema passthrough.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f934ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->