### PR TITLE
feat: Add list command to metrics CLI

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2345,7 +2345,7 @@
     },
     {
       "id": "longitudinal-quality-metrics-cli",
-      "status": "todo",
+      "status": "done",
       "area": "metrics",
       "risk": "low",
       "title": "Longitudinal Quality Metrics CLI",
@@ -2936,6 +2936,40 @@
       ],
       "acceptance": [
         "ACS checkpoints are enforced during tool execution."
+      ]
+    },
+    {
+      "id": "scheduled-operations-cron",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Scheduled operations cron-like tasks",
+      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement cron-like scheduled tasks that the agent can run autonomously.",
+      "allowed_paths": [
+        "magda_agent/operations/cron.py",
+        "tests/test_cron.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can schedule and execute background tasks autonomously",
+        "Tests verify task execution according to schedule"
+      ]
+    },
+    {
+      "id": "skill-marketplace-agentskills-compatibility",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Skill marketplace compatibility",
+      "description": "Inspired by trend: Skill marketplace — совместимость с agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
+      "allowed_paths": [
+        "magda_agent/integration/skill_marketplace.py",
+        "tests/test_skill_marketplace_integration.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can export skills to agentskills.io format",
+        "Tests verify successful export format"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Longitudinal Quality Metrics CLI
 * [x] FEATURE: Agent Skills MCP Export Enhancements (agent-skills-mcp-export)
 * [x] FEATURE: Multi-Channel Skills Sync (2026-06-XX)
 * [x] FEATURE: A2A Agent Cards Discovery (2026-06-05)

--- a/magda_agent/metacognition/metrics_cli.py
+++ b/magda_agent/metacognition/metrics_cli.py
@@ -26,6 +26,12 @@ def main() -> None:
     avg_parser.add_argument("--limit", type=int, help="Number of recent entries to average", default=10)
     avg_parser.add_argument("--db", type=str, help="Path to SQLite DB", default="./metrics_db.sqlite3")
 
+    # Subparser for listing metrics over time
+    list_parser = subparsers.add_parser("list", help="List recent metric values over time.")
+    list_parser.add_argument("metric_name", type=str, help="Name of the metric")
+    list_parser.add_argument("--limit", type=int, help="Number of recent entries to list", default=10)
+    list_parser.add_argument("--db", type=str, help="Path to SQLite DB", default="./metrics_db.sqlite3")
+
     args = parser.parse_args()
     tracker = QualityTracker(db_path=args.db)
 
@@ -45,6 +51,19 @@ def main() -> None:
             print(f"Average for {args.metric_name} (last {args.limit} entries): {avg}")
         else:
             print(f"No entries found for {args.metric_name}")
+
+    elif args.command == "list":
+        metrics = tracker.get_metrics(args.metric_name, args.limit)
+        if not metrics:
+            print(f"No entries found for {args.metric_name}")
+        else:
+            print(f"Recent metrics for {args.metric_name}:")
+            for m in metrics:
+                val = m.get("value")
+                ts = m.get("timestamp")
+                meta = {k: v for k, v in m.items() if k not in ("value", "timestamp")}
+                meta_str = f" | metadata: {json.dumps(meta)}" if meta else ""
+                print(f"[{ts}] {args.metric_name}: {val}{meta_str}")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,11 @@
 import pytest
+import sys
+import io
+import tempfile
+import os
+from unittest.mock import patch
 from magda_agent.metacognition.tracker import QualityTracker
+from magda_agent.metacognition.metrics_cli import main
 
 @pytest.fixture
 def quality_tracker():
@@ -51,3 +57,62 @@ def test_get_metrics_limit(quality_tracker):
 
     metrics = quality_tracker.get_metrics("pr_size", limit=5)
     assert len(metrics) <= 5
+
+
+
+
+
+
+def test_metrics_cli_list(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the list command from the CLI."""
+    # Setup test DB (we need to pass the same in-memory DB or temporary file)
+    # The CLI creates a new QualityTracker, so we'll use a temporary file instead of :memory:
+    # to avoid the DB disappearing between tracker instances.
+    import tempfile
+    import os
+
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        db_path = tmp.name
+
+    try:
+        # Create a tracker and log some entries
+        tracker = QualityTracker(db_path=db_path)
+        tracker.log_metric("test_metric", 10.5, {"info": "first"})
+        tracker.log_metric("test_metric", 20.0, {"info": "second"})
+
+        # Mock sys.argv to simulate running the CLI
+        test_args = ["metrics_cli.py", "list", "test_metric", "--db", db_path]
+        with patch.object(sys, 'argv', test_args):
+            main()
+
+        # Capture output
+        captured = capsys.readouterr()
+
+        # Verify the output contains the metrics
+        assert "Recent metrics for test_metric:" in captured.out
+        assert "10.5" in captured.out
+        assert "20.0" in captured.out
+        assert "first" in captured.out
+        assert "second" in captured.out
+    finally:
+        if os.path.exists(db_path):
+            os.remove(db_path)
+
+def test_metrics_cli_list_empty(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the list command from the CLI when no metrics exist."""
+    import tempfile
+    import os
+
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        db_path = tmp.name
+
+    try:
+        test_args = ["metrics_cli.py", "list", "non_existent_metric", "--db", db_path]
+        with patch.object(sys, 'argv', test_args):
+            main()
+
+        captured = capsys.readouterr()
+        assert "No entries found for non_existent_metric" in captured.out
+    finally:
+        if os.path.exists(db_path):
+            os.remove(db_path)


### PR DESCRIPTION
Implements the CLI list functionality for metrics and adds 2 new tasks to agent_tasks.json and backlog.md.

---
*PR created automatically by Jules for task [9931896412076210614](https://jules.google.com/task/9931896412076210614) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `list` subcommand to metrics CLI for displaying recent metric values
> Adds a `list` command to [metrics_cli.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/115/files#diff-f69c83051b4b244aef23fd7a157b02901083bf7d8915153bcc54046424ff5ad7) alongside the existing `log` and `average` commands. The command accepts a metric name, optional limit, and DB path, then prints timestamped entries with values and serialized metadata, or a "No entries found" message when the DB is empty. Two tests are added in [test_metrics.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/115/files#diff-c013839ae9f8d11da7ba9ed964de9d4b9ef733c1dd3d1a5487f32a5b2062e1cf) covering both the populated and empty cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc7e04f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->