### PR TITLE
feat: implement MCP Action Tools Expansion (mcp-action-tools-v3)

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2380,7 +2380,7 @@
     },
     {
       "id": "mcp-action-tools-v3",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "low",
       "title": "MCP Action Tools Expansion",
@@ -3008,6 +3008,60 @@
         "A2A requests require authentication tokens.",
         "A2A task delegations and discoveries are logged in the audit trail.",
         "Unauthorized A2A requests are rejected."
+      ]
+    },
+    {
+      "id": "context-engine-plugin-arch",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine plugin architecture",
+      "description": "Inspired by trend 'Context Engine — plugin-архитектура для управления контекстом': Implement a plugin interface with lifecycle hooks for managing working memory context.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine.py",
+        "tests/test_context_engine*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine supports plugins",
+        "Plugins can hook into lifecycle events",
+        "Tests verify plugin execution"
+      ]
+    },
+    {
+      "id": "agent-teams-sub-agents",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Agent Teams sub-agents spawning",
+      "description": "Inspired by trend 'Agent Teams — порождение sub-agents для параллельных задач': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
+      "allowed_paths": [
+        "magda_agent/agents/teams.py",
+        "tests/test_agent_teams*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Manager can spawn sub-agents",
+        "Sub-agents execute tasks in parallel",
+        "Tests verify parallel execution and result gathering"
+      ]
+    },
+    {
+      "id": "cross-platform-reach-channels",
+      "status": "todo",
+      "area": "gateway",
+      "risk": "low",
+      "title": "Cross-platform reach across channels",
+      "description": "Inspired by trend 'Cross-platform reach — один агент, много каналов': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
+      "allowed_paths": [
+        "magda_agent/gateway/channels.py",
+        "tests/test_gateway_channels*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Gateway supports additional mocked channels",
+        "UnifiedMessage format remains consistent",
+        "Tests verify message routing from new channels"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: MCP Action Tools Expansion (mcp-action-tools-v3)
 * [x] FEATURE: A2A Task Delegation (v3)
 * [x] FEATURE: Longitudinal Quality Metrics CLI
 * [x] FEATURE: Agent Skills MCP Export Enhancements (agent-skills-mcp-export)

--- a/magda_agent/agents/generator_agent.py
+++ b/magda_agent/agents/generator_agent.py
@@ -8,6 +8,8 @@ from magda_agent.planning.planner import Planner
 from magda_agent.learning.skill_versioning import SkillVersioning
 from magda_agent.learning.skill_creator import SkillCreator
 from magda_agent.safety.guardrails import RealtimeGuardrail, FallbackStrategy
+from magda_agent.skills.mcp_client import MCPClient
+
 
 class GeneratorAgent:
     """
@@ -21,6 +23,7 @@ class GeneratorAgent:
         skill_versioning: Optional[SkillVersioning] = None,
         skill_creator: Optional[SkillCreator] = None,
         guardrail: Optional[RealtimeGuardrail] = None,
+        mcp_client: Optional[MCPClient] = None,
         tracer=None
     ):
         self.llm = llm
@@ -29,6 +32,7 @@ class GeneratorAgent:
         self.skill_versioning = skill_versioning
         self.skill_creator = skill_creator
         self.guardrail = guardrail
+        self.mcp_client = mcp_client
         self.tracer = tracer
 
     async def execute_plan(self, user_input: str, user_id: Optional[str] = None) -> str:
@@ -45,10 +49,11 @@ class GeneratorAgent:
             SKILL_TIMEOUT = 10.0
             steps_executed = 0
             plan_stopped_early = False
+            current_plan = self.planner.get_current_plan()
 
-            while self.planner.get_current_plan() and steps_executed < MAX_STEPS:
+            while current_plan and steps_executed < MAX_STEPS:
                 steps_executed += 1
-                step = self.planner.get_current_plan()[0]
+                step = current_plan[0]
                 skill_name = step.get('skill')
                 kwargs = step.get('skill_kwargs') or {}
 
@@ -72,7 +77,10 @@ class GeneratorAgent:
                             break
 
                     try:
-                        task = asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
+                        if hasattr(self, 'mcp_client') and self.mcp_client and self.mcp_client.has_tool(skill_name):
+                            task = asyncio.create_task(self.mcp_client.execute_tool(skill_name, **kwargs))
+                        else:
+                            task = asyncio.to_thread(self.skills.execute_skill, skill_name, **kwargs)
                         result = await asyncio.wait_for(task, timeout=SKILL_TIMEOUT)
                     except asyncio.TimeoutError:
                         logging.error(f"Timeout executing skill {skill_name}")
@@ -93,8 +101,9 @@ class GeneratorAgent:
 
                 if plan_stopped_early:
                     break
+                current_plan = self.planner.get_current_plan()
 
-            if self.planner.get_current_plan() and steps_executed >= MAX_STEPS:
+            if current_plan and steps_executed >= MAX_STEPS:
                 plan_stopped_early = True
                 logging.warning("Plan execution stopped due to MAX_STEPS limit.")
 

--- a/magda_agent/skills/mcp_client.py
+++ b/magda_agent/skills/mcp_client.py
@@ -1,0 +1,59 @@
+import httpx
+import json
+import uuid
+from typing import Any, Dict
+import asyncio
+import logging
+
+class MCPClient:
+    """
+    A client to execute remote MCP server-prefixed tools.
+    """
+    def __init__(self, timeout: float = 10.0):
+        self.timeout = timeout
+        self.registered_tools: Dict[str, Any] = {}
+
+    def register_remote_tool(self, tool_name: str, connection_info: Any) -> None:
+        """Register a remote MCP tool."""
+        self.registered_tools[tool_name] = connection_info
+        logging.info(f"Registered remote MCP tool: {tool_name}")
+
+    def has_tool(self, name: str) -> bool:
+        """Check if a remote tool is registered."""
+        return name in self.registered_tools
+
+    async def execute_tool(self, name: str, **kwargs) -> Any:
+        """
+        Execute a remote MCP tool using JSON-RPC over HTTP.
+        """
+        if not self.has_tool(name):
+            return f"Error: Remote MCP skill '{name}' not found."
+
+        connection_info = self.registered_tools[name]
+        url = connection_info.get("url")
+        if not url:
+            return f"Error: Remote MCP skill '{name}' has no URL configured."
+
+
+
+
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": name,
+            "params": kwargs,
+            "id": str(uuid.uuid4())
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(url, json=payload)
+                response.raise_for_status()
+                data = response.json()
+
+                if "error" in data:
+                    return f"Error from remote MCP server: {data['error']}"
+                return data.get("result", "No result returned.")
+        except Exception as e:
+            logging.error(f"Failed to execute remote MCP tool {name} at {url}: {e}")
+            return f"Error executing remote MCP tool {name}: {e}"

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,109 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from magda_agent.skills.mcp_client import MCPClient
+from magda_agent.agents.generator_agent import GeneratorAgent
+from magda_agent.planning.planner import Planner
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_mcp_client_registration_and_execution():
+    client = MCPClient(timeout=1.0)
+    client.register_remote_tool("test_mcp.search", {"url": "mock"})
+
+    assert client.has_tool("test_mcp.search") is True
+    assert client.has_tool("local.skill") is False
+
+    with patch("httpx.AsyncClient.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"jsonrpc": "2.0", "result": "Mocked MCP Response", "id": "123"}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = await client.execute_tool("test_mcp.search", q="magda")
+        assert result == "Mocked MCP Response"
+        mock_post.assert_called_once()
+
+    error_result = await client.execute_tool("unknown.tool")
+    assert "Error: Remote MCP skill" in error_result
+
+@pytest.mark.asyncio
+async def test_generator_agent_with_mcp_client():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_skills = MagicMock(spec=SkillRegistry)
+
+    mock_planner = MagicMock(spec=Planner)
+
+    # Needs to return something on the first check of while loop, then []
+    mock_planner.get_current_plan.side_effect = [
+        [{"skill": "test_mcp.run", "skill_kwargs": {"data": "123"}, "description": "test_step"}],
+        [{"skill": "test_mcp.run", "skill_kwargs": {"data": "123"}, "description": "test_step"}],
+        []
+    ]
+
+    mock_planner.completed_steps = []
+    def mock_mark_completed(idx, result_str):
+        mock_planner.completed_steps.append({"skill": "test_mcp.run", "result": result_str, "description": "test_step"})
+
+    mock_planner.mark_step_completed.side_effect = mock_mark_completed
+
+    mcp_client = MCPClient()
+    mcp_client.register_remote_tool("test_mcp.run", {"url": "mock"})
+
+    agent = GeneratorAgent(
+        llm=mock_llm,
+        skills=mock_skills,
+        planner=mock_planner,
+    )
+    agent.mcp_client = mcp_client
+
+    with patch("httpx.AsyncClient.post") as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"jsonrpc": "2.0", "result": "Executed remote MCP tool test_mcp.run", "id": "123"}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = await agent.execute_plan("test input")
+        assert "Executed remote MCP tool test_mcp.run" in result
+
+@pytest.mark.asyncio
+async def test_generator_agent_mcp_timeout():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_skills = MagicMock(spec=SkillRegistry)
+    mock_planner = MagicMock(spec=Planner)
+
+    mock_planner.get_current_plan.side_effect = [
+        [{"skill": "slow_mcp.tool", "skill_kwargs": {}, "description": "slow_step"}],
+        [{"skill": "slow_mcp.tool", "skill_kwargs": {}, "description": "slow_step"}],
+        []
+    ]
+
+    mock_planner.completed_steps = []
+    def mock_mark_completed(idx, result_str):
+        mock_planner.completed_steps.append({"skill": "slow_mcp.tool", "result": result_str, "description": "slow_step"})
+
+    mock_planner.mark_step_completed.side_effect = mock_mark_completed
+
+    mcp_client = MCPClient()
+    mcp_client.register_remote_tool("slow_mcp.tool", {})
+
+    async def slow_execute(*args, **kwargs):
+        await asyncio.sleep(2.0)
+        return "too late"
+
+    mcp_client.execute_tool = AsyncMock(side_effect=slow_execute)
+
+    agent = GeneratorAgent(
+        llm=mock_llm,
+        skills=mock_skills,
+        planner=mock_planner,
+    )
+    agent.mcp_client = mcp_client
+
+    with patch("magda_agent.agents.generator_agent.asyncio.wait_for") as mock_wait:
+        mock_wait.side_effect = asyncio.TimeoutError()
+        result = await agent.execute_plan("test input")
+
+    assert "timed out" in result


### PR DESCRIPTION
This PR implements the `mcp-action-tools-v3` task from the backlog.

- Implemented `MCPClient` in `magda_agent/skills/mcp_client.py` which executes remote MCP tools using JSON-RPC over HTTP.
- Updated `GeneratorAgent` to route skill execution through the `MCPClient` if the tool is registered remotely.
- Added full test coverage for the client and the agent integration, including error and timeout handling.
- Appended 3 new AI-trend-inspired tasks to `agent_tasks.json` based on current trends.
- Updated `backlog.md` to reflect the completed task.

---
*PR created automatically by Jules for task [13646992263936721448](https://jules.google.com/task/13646992263936721448) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP remote tool execution to `GeneratorAgent` via new `MCPClient`
> - Adds [mcp_client.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/118/files#diff-51b17fedb8fcad1bfb0e8c545691ed95635f5a952c5d7d2c74114beedea020c3) with a new `MCPClient` class that registers remote tools and executes them over HTTP JSON-RPC using `httpx.AsyncClient`.
> - Updates [`GeneratorAgent`](https://github.com/kazah4359-lgtm/Magda-agent/pull/118/files#diff-dd973f617719839744f22c006462345f236826001bb3f8dc28948dbe173ee173) to accept an optional `MCPClient`; during `execute_plan`, if the current step's skill matches a registered remote tool, it is dispatched to `MCPClient.execute_tool` instead of the local `SkillRegistry`.
> - Adds tests covering registration, remote execution, `GeneratorAgent` integration, and timeout behavior.
> - Risk: remote tool calls introduce network dependency and latency; failures return formatted error strings rather than raising exceptions, which may silently degrade plan execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b852ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->