### PR TITLE
feat: Agent Teams via Git Worktree Isolation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2417,7 +2417,7 @@
     },
     {
       "id": "agent-teams-claude-sdk",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams via Git Worktree Isolation",

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Agent Teams via Git Worktree Isolation (agent-teams-claude-sdk)
 - [x] openclaw-rl-interactive-learning-v3: OpenClaw-RL Interactive Learning
 * [x] FEATURE: MCP Action Tools Expansion (mcp-action-tools-v3)
 * [x] FEATURE: A2A Task Delegation (v3)

--- a/magda_agent/agents/sub_agent.py
+++ b/magda_agent/agents/sub_agent.py
@@ -1,18 +1,21 @@
 import logging
 from typing import Optional
 from magda_agent.llm_client import LLMClient
+from magda_agent.isolation.git_worktree import GitWorktreeManager
 
 class SubAgent:
     """
     SubAgent for executing isolated tasks in a separate context.
     Inspired by Claude Agent Teams and Hermes sub-agents.
     """
-    def __init__(self, llm: LLMClient, system_prompt: Optional[str] = None):
+    def __init__(self, llm: LLMClient, system_prompt: Optional[str] = None, use_isolation: bool = False):
         """
         Initializes the SubAgent.
         """
         self.llm = llm
         self.system_prompt = system_prompt or "You are an isolated Sub-Agent executing a specific task."
+        self.use_isolation = use_isolation
+        self.worktree_manager = GitWorktreeManager() if use_isolation else None
 
     async def execute(self, task: str, context: str) -> str:
         """
@@ -20,7 +23,19 @@ class SubAgent:
         """
         logging.info(f"SubAgent starting task: {task[:50]}...")
 
-        full_context = f"Parent Context:\n{context}\n\nAssigned Task:\n{task}"
+        worktree_path = None
+        current_context = context
+
+        if self.use_isolation and self.worktree_manager:
+            try:
+                worktree_path = await self.worktree_manager.create_worktree_async()
+                current_context += f"\n\nIsolated Git Worktree Path: {worktree_path}"
+                logging.info(f"SubAgent operating in isolated worktree: {worktree_path}")
+            except Exception as e:
+                logging.error(f"Failed to create isolated worktree: {e}")
+                return f"Error: Failed to create isolated worktree - {e}"
+
+        full_context = f"Parent Context:\n{current_context}\n\nAssigned Task:\n{task}"
         messages = [
             {"role": "system", "content": self.system_prompt},
             {"role": "user", "content": full_context}
@@ -33,3 +48,9 @@ class SubAgent:
         except Exception as e:
             logging.error(f"Error executing SubAgent task: {e}")
             return f"Error executing SubAgent task: {e}"
+        finally:
+            if worktree_path and self.worktree_manager:
+                try:
+                    await self.worktree_manager.remove_worktree_async(worktree_path)
+                except Exception as cleanup_error:
+                    logging.error(f"Failed to cleanup worktree {worktree_path}: {cleanup_error}")

--- a/magda_agent/isolation/git_worktree.py
+++ b/magda_agent/isolation/git_worktree.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from typing import Optional
+
+class GitWorktreeManager:
+    """
+    Manages isolated Git worktrees for SubAgents.
+    Ensures parallel tasks run in separate file system contexts.
+    """
+    def __init__(self, base_dir: str = "/tmp/magda_worktrees"):
+        self.base_dir = base_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+
+    async def create_worktree_async(self, branch_name: Optional[str] = None) -> str:
+        """
+        Creates a new git worktree. If branch_name is not provided,
+        a detached worktree is created based on the current HEAD.
+        Returns the path to the newly created worktree.
+        """
+        worktree_id = str(uuid.uuid4())[:8]
+        worktree_path = os.path.join(self.base_dir, f"worktree_{worktree_id}")
+
+        if branch_name:
+            cmd = ["git", "worktree", "add", "-b", branch_name, worktree_path, "HEAD"]
+        else:
+            cmd = ["git", "worktree", "add", "-d", worktree_path, "HEAD"]
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                logging.error(f"Failed to create git worktree: {stderr.decode()}")
+                raise RuntimeError(f"Git worktree creation failed: {stderr.decode()}")
+
+            logging.info(f"Created git worktree at {worktree_path}")
+            return worktree_path
+        except Exception as e:
+            logging.error(f"Error executing git worktree add: {e}")
+            raise
+
+    async def remove_worktree_async(self, worktree_path: str) -> None:
+        """
+        Removes a git worktree and deletes its directory.
+        """
+        cmd = ["git", "worktree", "remove", "--force", worktree_path]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                logging.error(f"Failed to remove git worktree: {stderr.decode()}")
+                # Fallback to manual deletion if git worktree remove fails
+                if os.path.exists(worktree_path):
+                    shutil.rmtree(worktree_path)
+            else:
+                 logging.info(f"Removed git worktree at {worktree_path}")
+        except Exception as e:
+            logging.error(f"Error executing git worktree remove: {e}")
+            if os.path.exists(worktree_path):
+                shutil.rmtree(worktree_path)

--- a/tests/test_agent_teams_isolation.py
+++ b/tests/test_agent_teams_isolation.py
@@ -1,0 +1,109 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.llm_client import LLMClient
+from magda_agent.isolation.git_worktree import GitWorktreeManager
+
+@pytest.mark.asyncio
+async def test_sub_agent_with_isolation_success():
+    """Tests SubAgent successfully uses and cleans up an isolated git worktree."""
+    llm_mock = MagicMock(spec=LLMClient)
+    llm_mock.chat_completion = AsyncMock(return_value="Task completed in isolation.")
+
+    with patch('magda_agent.isolation.git_worktree.GitWorktreeManager.create_worktree_async', new_callable=AsyncMock) as mock_create, \
+         patch('magda_agent.isolation.git_worktree.GitWorktreeManager.remove_worktree_async', new_callable=AsyncMock) as mock_remove:
+
+        mock_create.return_value = "/tmp/magda_worktrees/worktree_mock123"
+
+        sub_agent = SubAgent(llm=llm_mock, use_isolation=True)
+        result = await sub_agent.execute(task="Test task", context="Base context")
+
+        assert result == "Task completed in isolation."
+
+        # Verify worktree creation
+        mock_create.assert_awaited_once()
+
+        # Verify context injection
+        llm_mock.chat_completion.assert_awaited_once()
+        call_args = llm_mock.chat_completion.call_args[0][0]
+        user_message = call_args[1]["content"]
+        assert "Base context" in user_message
+        assert "/tmp/magda_worktrees/worktree_mock123" in user_message
+        assert "Test task" in user_message
+
+        # Verify cleanup
+        mock_remove.assert_awaited_once_with("/tmp/magda_worktrees/worktree_mock123")
+
+@pytest.mark.asyncio
+async def test_sub_agent_with_isolation_llm_failure():
+    """Tests SubAgent cleans up worktree even if LLM execution fails."""
+    llm_mock = MagicMock(spec=LLMClient)
+    llm_mock.chat_completion = AsyncMock(side_effect=Exception("LLM API Error"))
+
+    with patch('magda_agent.isolation.git_worktree.GitWorktreeManager.create_worktree_async', new_callable=AsyncMock) as mock_create, \
+         patch('magda_agent.isolation.git_worktree.GitWorktreeManager.remove_worktree_async', new_callable=AsyncMock) as mock_remove:
+
+        mock_create.return_value = "/tmp/magda_worktrees/worktree_mock456"
+
+        sub_agent = SubAgent(llm=llm_mock, use_isolation=True)
+        result = await sub_agent.execute(task="Test task", context="Base context")
+
+        assert "Error executing SubAgent task: LLM API Error" in result
+
+        mock_create.assert_awaited_once()
+        llm_mock.chat_completion.assert_awaited_once()
+
+        # Verify cleanup happens despite error
+        mock_remove.assert_awaited_once_with("/tmp/magda_worktrees/worktree_mock456")
+
+@pytest.mark.asyncio
+async def test_sub_agent_with_isolation_creation_failure():
+    """Tests SubAgent behavior when worktree creation fails."""
+    llm_mock = MagicMock(spec=LLMClient)
+
+    with patch('magda_agent.isolation.git_worktree.GitWorktreeManager.create_worktree_async', new_callable=AsyncMock) as mock_create:
+        mock_create.side_effect = RuntimeError("Git worktree creation failed")
+
+        sub_agent = SubAgent(llm=llm_mock, use_isolation=True)
+        result = await sub_agent.execute(task="Test task", context="Base context")
+
+        assert "Error: Failed to create isolated worktree" in result
+        mock_create.assert_awaited_once()
+        llm_mock.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_git_worktree_manager_create_success():
+    """Tests the GitWorktreeManager creates a worktree."""
+    manager = GitWorktreeManager(base_dir="/tmp/test_worktrees")
+
+    process_mock = MagicMock()
+    process_mock.communicate = AsyncMock(return_value=(b"Success", b""))
+    process_mock.returncode = 0
+
+    with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = process_mock
+
+        path = await manager.create_worktree_async()
+
+        assert path.startswith("/tmp/test_worktrees/worktree_")
+        mock_exec.assert_called_once()
+        assert "git" in mock_exec.call_args[0]
+        assert "worktree" in mock_exec.call_args[0]
+
+@pytest.mark.asyncio
+async def test_git_worktree_manager_remove_success():
+    """Tests the GitWorktreeManager removes a worktree."""
+    manager = GitWorktreeManager(base_dir="/tmp/test_worktrees")
+
+    process_mock = MagicMock()
+    process_mock.communicate = AsyncMock(return_value=(b"Success", b""))
+    process_mock.returncode = 0
+
+    with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = process_mock
+
+        await manager.remove_worktree_async("/tmp/test_worktrees/worktree_abc123")
+
+        mock_exec.assert_called_once()
+        assert "remove" in mock_exec.call_args[0]
+        assert "/tmp/test_worktrees/worktree_abc123" in mock_exec.call_args[0]


### PR DESCRIPTION
Implements git worktree isolation for SubAgents.

---
*PR created automatically by Jules for task [5577451923823016596](https://jules.google.com/task/5577451923823016596) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git worktree isolation for SubAgent execution via `GitWorktreeManager`
> - Introduces a new `magda_agent/isolation/git_worktree.py` module with `GitWorktreeManager`, which asynchronously creates and removes isolated git worktrees using subprocess `git worktree` commands.
> - `SubAgent` accepts a new `use_isolation=True` flag; when set, it creates a worktree before LLM invocation, injects the worktree path into the context, and removes it in a `finally` block regardless of success or failure.
> - If worktree creation fails, `execute()` returns an error string and skips the LLM call entirely.
> - Adds async pytest tests covering isolation success, LLM failure cleanup, worktree creation failure, and `GitWorktreeManager` create/remove flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a6a0de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->