### PR TITLE
feat: MCP Tools Integration Engine

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2470,7 +2470,7 @@
     },
     {
       "id": "mcp-tools-integration-v2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Tools Integration Engine",
@@ -3179,6 +3179,57 @@
       "acceptance": [
         "Agent can execute multiple tool calls concurrently",
         "Tests mock tools and verify concurrent execution speeds up processing"
+      ]
+    },
+    {
+      "id": "online-rl-from-feedback-v4",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL from user feedback v4",
+      "description": "Inspired by trend: Online RL from user feedback. Implement online reinforcement learning to adjust agent behavior based on implicit and explicit feedback.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl.py",
+        "tests/test_online_rl.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can update its model dynamically based on feedback",
+        "Tests verify RL logic"
+      ]
+    },
+    {
+      "id": "assert-policy-framework",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "ASSERT Policy-Driven Evaluation",
+      "description": "Inspired by trend: ASSERT (Microsoft): policy-driven evaluation framework. Introduce a policy-driven evaluation framework for the agent.",
+      "allowed_paths": [
+        "magda_agent/evaluation/assert_eval.py",
+        "tests/test_assert_eval.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy framework correctly evaluates agent responses",
+        "Tests verify evaluation correctness"
+      ]
+    },
+    {
+      "id": "agentbench-multi-domain-eval",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "low",
+      "title": "AgentBench Multi-domain Evaluation",
+      "description": "Inspired by trend: AgentBench: multi-domain. Integrate multi-domain benchmark tests into the agent's evaluation pipeline.",
+      "allowed_paths": [
+        "magda_agent/evaluation/agentbench.py",
+        "tests/test_agentbench.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "AgentBench tests can be run against the agent",
+        "Tests pass the multi-domain benchmark baseline"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: MCP Tools Integration Engine (mcp-tools-integration-v2)
 
 - [x] acs-runtime-safety-controls-v4: ACS Runtime Safety Controls v4
 * [x] FEATURE: A2A Agent Discovery v4 (a2a-agent-discovery-v4)

--- a/magda_agent/skills/mcp_engine.py
+++ b/magda_agent/skills/mcp_engine.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Dict, Any
+from magda_agent.skills.mcp_client import MCPClient
+from magda_agent.skills.registry import SkillRegistry
+
+class MCPEngine:
+    """
+    Engine to seamlessly import and execute external MCP tools, converting them
+    into Magda's native procedural skills dynamically.
+    """
+    def __init__(self, registry: SkillRegistry, mcp_client: MCPClient) -> None:
+        """
+        Initializes the MCPEngine.
+
+        Args:
+            registry (SkillRegistry): Magda's native skill registry.
+            mcp_client (MCPClient): The MCP client used for remote tool execution.
+        """
+        self.registry = registry
+        self.mcp_client = mcp_client
+
+    def import_mcp_tool(self, tool_def: Dict[str, Any], connection_info: Dict[str, Any]) -> None:
+        """
+        Reads MCP standard tool definitions and wraps them into Magda's SkillRegistry.
+
+        Args:
+            tool_def (Dict[str, Any]): Definition containing at least "name" and "description".
+                                       Optionally contains "inputSchema".
+            connection_info (Dict[str, Any]): Information needed to execute the remote tool.
+        """
+        tool_name = tool_def.get("name")
+        if not tool_name:
+            raise ValueError("MCP tool definition must include a 'name'.")
+
+        description = tool_def.get("description", "Imported MCP tool.")
+        input_schema = tool_def.get("inputSchema", {})
+
+        # 1. Register the remote tool routing with the MCPClient
+        self.mcp_client.register_remote_tool(tool_name, connection_info)
+
+        # 2. Create the wrapper skill that delegates to MCPClient
+        async def mcp_wrapper_skill(**kwargs: Any) -> Any:
+            """
+            Dynamically executes the imported MCP tool via the MCPClient.
+
+            Args:
+                kwargs: Arguments to pass to the MCP tool.
+
+            Returns:
+                Any: Result of the MCP tool execution.
+            """
+            return await self.mcp_client.execute_tool(tool_name, **kwargs)
+
+        # Add the schema attribute so MagdaMCPAdapter natively picks it up if needed.
+        setattr(mcp_wrapper_skill, "__mcp_schema__", input_schema)
+        # Preserve original name in __name__ for generic introspection
+        setattr(mcp_wrapper_skill, "__name__", tool_name)
+
+        # 3. Register natively in Magda's SkillRegistry
+        self.registry.register_skill(
+            name=tool_name,
+            func=mcp_wrapper_skill,
+            description=description
+        )
+
+        logging.info(f"Dynamically wrapped MCP tool '{tool_name}' into Magda skill registry.")

--- a/tests/test_mcp_engine.py
+++ b/tests/test_mcp_engine.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.skills.mcp_engine import MCPEngine
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_client import MCPClient
+
+def test_mcp_engine_import() -> None:
+    """Verify MCPEngine reads MCP standard tool definitions and wraps them."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_client.register_remote_tool = MagicMock()
+
+    engine = MCPEngine(registry, mcp_client)
+
+    tool_def = {
+        "name": "external_weather",
+        "description": "Get current weather.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            },
+            "required": ["location"]
+        }
+    }
+    connection_info = {"url": "http://localhost:8000/mcp"}
+
+    engine.import_mcp_tool(tool_def, connection_info)
+
+    # Verify tool routing is registered
+    mcp_client.register_remote_tool.assert_called_once_with("external_weather", connection_info)
+
+    # Verify skill is dynamically registered in Magda
+    assert registry.has_skill("external_weather")
+    assert registry.descriptions["external_weather"] == "Get current weather."
+
+    # Verify schema preservation
+    skill_func = registry.skills["external_weather"]
+    assert hasattr(skill_func, "__mcp_schema__")
+    assert getattr(skill_func, "__mcp_schema__") == tool_def["inputSchema"]
+
+@pytest.mark.asyncio
+async def test_mcp_engine_wrapper_execution() -> None:
+    """Verify the dynamically wrapped skill executes correctly."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_client.execute_tool = AsyncMock(return_value="Sunny, 25C")
+
+    engine = MCPEngine(registry, mcp_client)
+
+    tool_def = {"name": "external_weather"}
+    connection_info = {"url": "mock"}
+
+    engine.import_mcp_tool(tool_def, connection_info)
+
+    result = await registry.execute_skill("external_weather", location="Paris")
+
+    assert result == "Sunny, 25C"
+    mcp_client.execute_tool.assert_awaited_once_with("external_weather", location="Paris")
+
+def test_mcp_engine_invalid_tool_def() -> None:
+    """Verify MCPEngine raises ValueError on invalid tool definition without a name."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    engine = MCPEngine(registry, mcp_client)
+
+    with pytest.raises(ValueError, match="must include a 'name'"):
+        engine.import_mcp_tool({"description": "No name tool"}, {})


### PR DESCRIPTION
Implement MCP tools integration engine to dynamically register standard MCP tools into Magda's skill registry.

---
*PR created automatically by Jules for task [15081403019759795278](https://jules.google.com/task/15081403019759795278) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPEngine` to register external MCP tools as local skills in `SkillRegistry`
> - Introduces [`mcp_engine.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/125/files#diff-26572b42493a12c4ec9d8bfa23bfc751544330482e76b956aebd528de7d4c9df) with `MCPEngine`, which wraps MCP tool definitions as async callables and registers them into `SkillRegistry` via `MCPClient`.
> - `import_mcp_tool` validates the tool definition, calls `MCPClient.register_remote_tool`, and attaches the input schema to the wrapper via `__mcp_schema__`.
> - Raises `ValueError` if the tool definition lacks a `name`.
> - Adds tests in [`tests/test_mcp_engine.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/125/files#diff-e02d1cbf73a1d0311aedb16f5b572e14dd6d1f3ce9d577f07d7d08aa08c6cc8a) covering import, wrapper execution, and invalid tool definitions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7978f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->