### PR TITLE
Prempti Audit Trail

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2543,7 +2543,7 @@
     },
     {
       "id": "prempti-audit-trail-v2",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "medium",
       "title": "Prempti: Tool-call interception and audit trail",
@@ -3369,6 +3369,41 @@
         "Fallback is triggered on guardrail violation.",
         "System gracefully degrades without crashing.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "hermes-persistent-memory-v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Hermes Persistent Memory",
+      "description": "Inspired by Hermes Agent trend: Persistent memory: чем дольше работает, тем лучше знает пользователя. Implement a persistent user profile memory.",
+      "allowed_paths": [
+        "magda_agent/memory/hermes_persistent.py",
+        "tests/test_hermes_persistent.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Persistent memory stores user traits over time",
+        "Tests verify trait accumulation"
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-hooks",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "OpenClaw Context Engine Lifecycle Hooks",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Implement lifecycle hooks for plugins.",
+      "allowed_paths": [
+        "magda_agent/architecture/context_hooks.py",
+        "tests/test_context_hooks.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugins can register lifecycle hooks",
+        "Hooks are triggered accurately",
+        "Tests verify hook execution"
       ]
     }
   ]

--- a/magda_agent/tracing/prempti_audit.py
+++ b/magda_agent/tracing/prempti_audit.py
@@ -1,0 +1,65 @@
+import time
+import copy
+from typing import Dict, Any, List, Optional
+
+class PremptiAuditLogger:
+    """
+    Records and queries tool invocations (what, when, why, result, duration).
+    Sanitizes sensitive data to prevent secret leakage.
+    """
+
+    SENSITIVE_KEYS = {"password", "secret", "key", "token", "auth", "credential", "env"}
+
+    def __init__(self) -> None:
+        """Initializes the PremptiAuditLogger."""
+        self.trail: List[Dict[str, Any]] = []
+
+    def _sanitize(self, data: Any) -> Any:
+        """Recursively sanitizes sensitive data from dictionaries and lists."""
+        if isinstance(data, dict):
+            sanitized = {}
+            for k, v in data.items():
+                if any(sensitive in k.lower() for sensitive in self.SENSITIVE_KEYS):
+                    if isinstance(v, dict):
+                        sanitized[k] = self._sanitize(v)
+                    elif isinstance(v, list):
+                        sanitized[k] = ["***" if not isinstance(item, (dict, list)) else self._sanitize(item) for item in v]
+                    else:
+                        sanitized[k] = "***"
+                else:
+                    sanitized[k] = self._sanitize(v)
+            return sanitized
+        elif isinstance(data, list):
+            return [self._sanitize(item) for item in data]
+        return copy.deepcopy(data)
+
+    def log_call(self, tool_name: str, kwargs: Dict[str, Any], why: str, result: Any, duration: float = 0.0) -> None:
+        """Logs a tool call with metadata."""
+        entry = {
+            "timestamp": time.time(),
+            "tool_name": tool_name,
+            "kwargs": self._sanitize(kwargs),
+            "why": why,
+            "result": self._sanitize(result),
+            "duration": duration
+        }
+        self.trail.append(entry)
+
+    def query(self, tool_name: Optional[str] = None, start_time: Optional[float] = None, end_time: Optional[float] = None) -> List[Dict[str, Any]]:
+        """Queries the audit log."""
+        results = self.trail
+        if tool_name:
+            results = [e for e in results if e["tool_name"] == tool_name]
+        if start_time is not None:
+            results = [e for e in results if e["timestamp"] >= start_time]
+        if end_time is not None:
+            results = [e for e in results if e["timestamp"] <= end_time]
+        return results
+
+    def get_all(self) -> List[Dict[str, Any]]:
+        """Returns all log entries."""
+        return self.trail
+
+    def clear(self) -> None:
+        """Clears the audit log."""
+        self.trail.clear()

--- a/tests/test_prempti_audit.py
+++ b/tests/test_prempti_audit.py
@@ -1,0 +1,84 @@
+import pytest
+import time
+from magda_agent.tracing.prempti_audit import PremptiAuditLogger
+
+def test_prempti_audit_logger_log_call() -> None:
+    """Test that log_call correctly appends an entry to the trail."""
+    logger = PremptiAuditLogger()
+    logger.log_call(
+        tool_name="test_tool",
+        kwargs={"arg1": "value1"},
+        why="Because testing",
+        result="Success",
+        duration=0.5
+    )
+
+    trail = logger.get_all()
+    assert len(trail) == 1
+    assert trail[0]["tool_name"] == "test_tool"
+    assert trail[0]["kwargs"] == {"arg1": "value1"}
+    assert trail[0]["why"] == "Because testing"
+    assert trail[0]["result"] == "Success"
+    assert trail[0]["duration"] == 0.5
+    assert "timestamp" in trail[0]
+
+def test_prempti_audit_logger_query() -> None:
+    """Test that query correctly filters log entries."""
+    logger = PremptiAuditLogger()
+    start_time = time.time()
+
+    logger.log_call("tool1", {}, "why1", "res1", 0.1)
+    time.sleep(0.01)
+    mid_time = time.time()
+    time.sleep(0.01)
+    logger.log_call("tool2", {}, "why2", "res2", 0.2)
+
+    assert len(logger.query(tool_name="tool1")) == 1
+    assert len(logger.query(tool_name="tool2")) == 1
+    assert len(logger.query(tool_name="tool3")) == 0
+
+    assert len(logger.query(start_time=start_time, end_time=mid_time)) == 1
+    assert logger.query(start_time=start_time, end_time=mid_time)[0]["tool_name"] == "tool1"
+
+def test_prempti_audit_logger_sanitize() -> None:
+    """Test that sensitive data is correctly sanitized."""
+    logger = PremptiAuditLogger()
+    sensitive_kwargs = {
+        "password": "my_secret_password",
+        "api_key": "1234567890",
+        "normal_arg": "normal_value",
+        "nested": {
+            "token": "secret_token",
+            "auth_header": "Bearer xyz"
+        },
+        "list_of_secrets": [{"secret_key": "abc"}, {"normal": "def"}]
+    }
+
+    logger.log_call("test_tool", sensitive_kwargs, "testing", "Success", 0.1)
+
+    trail = logger.get_all()
+    logged_kwargs = trail[0]["kwargs"]
+
+    assert logged_kwargs["password"] == "***"
+    assert logged_kwargs["api_key"] == "***"
+    assert logged_kwargs["normal_arg"] == "normal_value"
+    assert logged_kwargs["nested"]["token"] == "***"
+    assert logged_kwargs["nested"]["auth_header"] == "***"
+    assert logged_kwargs["list_of_secrets"][0]["secret_key"] == "***"
+    assert logged_kwargs["list_of_secrets"][1]["normal"] == "def"
+
+def test_prempti_audit_logger_sanitize_list() -> None:
+    """Test that sensitive lists of primitives are correctly sanitized."""
+    logger = PremptiAuditLogger()
+    sensitive_kwargs = {
+        "api_keys": ["secret1", "secret2"],
+        "normal_list": ["val1", "val2"]
+    }
+
+    logger.log_call("test_tool", sensitive_kwargs, "testing", "Success", 0.1)
+
+    trail = logger.get_all()
+    logged_kwargs = trail[0]["kwargs"]
+
+    assert logged_kwargs["api_keys"] == ["***", "***"]
+    assert logged_kwargs["normal_list"] == ["val1", "val2"]


### PR DESCRIPTION
Implement Prempti Audit Trail and update tasks

---
*PR created automatically by Jules for task [4588086291025419388](https://jules.google.com/task/4588086291025419388) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PremptiAuditLogger` to record and query sanitized tool call audit trails
> - Adds [`prempti_audit.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/129/files#diff-d37464cd85df47244b295efd6f24e655a69e64a78f98e936436bd12ef654c13c) with a `PremptiAuditLogger` class that stores in-memory audit entries for each tool invocation, including timestamp, tool name, kwargs, result, reason, and duration.
> - Sensitive fields (passwords, tokens, keys, credentials, etc.) are recursively masked as `'***'` based on key name matching before storage.
> - Supports filtering entries by tool name and/or time window via `query()`, and full access via `get_all()` and `clear()`.
> - Adds four unit tests in [`tests/test_prempti_audit.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/129/files#diff-b0bf04d575a263cc7244a9efc8da5c5859b9ac19bb016a25cd081ad51531a761) covering logging, querying, and sanitization of nested dicts and primitive lists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d82e73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->