### PR TITLE
feat: Agent Teams Parallel Subagents

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2561,7 +2561,7 @@
     },
     {
       "id": "agent-teams-parallel-subagents-v2",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "Agent Teams: Parallel Subagent Execution",
@@ -3404,6 +3404,42 @@
         "Plugins can register lifecycle hooks",
         "Hooks are triggered accurately",
         "Tests verify hook execution"
+      ]
+    },
+    {
+      "id": "a2a-discovery-agent-cards-v1",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "A2A Discovery via Agent Cards",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
+      "allowed_paths": [
+        "magda_agent/architecture/a2a_discovery.py",
+        "tests/test_a2a_discovery*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can broadcast and receive Agent Cards",
+        "Discovered agents are registered in local cache",
+        "Tests mock network operations"
+      ]
+    },
+    {
+      "id": "acs-guardrails-policy-layer-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Guardrails Policy Layer",
+      "description": "Inspired by trend: ACS (Agent Control Specification) - 5 validation checkpoints. Implement a comprehensive policy layer implementing the 5 standard ACS checkpoints for tool execution.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_policy.py",
+        "tests/test_acs_policy*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "All 5 ACS checkpoints are validated before tool execution",
+        "Violation triggers clear FallbackStrategy",
+        "Tests verify each checkpoint"
       ]
     }
   ]

--- a/magda_agent/agents/team_orchestrator.py
+++ b/magda_agent/agents/team_orchestrator.py
@@ -1,0 +1,30 @@
+import asyncio
+import logging
+from typing import List, Dict, Any
+
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.llm_client import LLMClient
+
+class TeamOrchestrator:
+    """
+    Orchestrates the execution of multiple parallel subagents for a set of tasks.
+    """
+    def __init__(self, llm: LLMClient):
+        """
+        Initializes the TeamOrchestrator.
+        """
+        self.llm = llm
+
+    async def parallel_execute(self, tasks: List[Dict[str, Any]], base_context: str) -> List[str]:
+        """
+        Executes multiple tasks in parallel using isolated SubAgents.
+        """
+        logging.info(f"Orchestrating {len(tasks)} parallel subagent tasks.")
+
+        async def run_task(task_spec: Dict[str, Any]) -> str:
+            sub_agent = SubAgent(llm=self.llm, use_isolation=True)
+            task_description = task_spec.get('description', 'Unknown task')
+            return await sub_agent.execute(task=task_description, context=base_context)
+
+        results = await asyncio.gather(*(run_task(task) for task in tasks))
+        return list(results)

--- a/tests/test_team_orchestrator.py
+++ b/tests/test_team_orchestrator.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from magda_agent.agents.team_orchestrator import TeamOrchestrator
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_parallel_execute_success():
+    """Tests that TeamOrchestrator spawns parallel sub-agents correctly."""
+    llm_mock = MagicMock(spec=LLMClient)
+    orchestrator = TeamOrchestrator(llm=llm_mock)
+
+    tasks = [
+        {"description": "Task 1"},
+        {"description": "Task 2"}
+    ]
+
+    with patch('magda_agent.agents.team_orchestrator.SubAgent') as MockSubAgent:
+        mock_instance_1 = MagicMock()
+        mock_instance_1.execute = AsyncMock(return_value="Result 1")
+
+        mock_instance_2 = MagicMock()
+        mock_instance_2.execute = AsyncMock(return_value="Result 2")
+
+        # Return mock_instance_1 first, then mock_instance_2
+        MockSubAgent.side_effect = [mock_instance_1, mock_instance_2]
+
+        results = await orchestrator.parallel_execute(tasks, base_context="Context")
+
+        assert len(results) == 2
+        assert "Result 1" in results
+        assert "Result 2" in results
+
+        assert MockSubAgent.call_count == 2
+        MockSubAgent.assert_called_with(llm=llm_mock, use_isolation=True)
+
+        mock_instance_1.execute.assert_awaited_once_with(task="Task 1", context="Context")
+        mock_instance_2.execute.assert_awaited_once_with(task="Task 2", context="Context")


### PR DESCRIPTION
Implements the agent-teams-parallel-subagents-v2 task. Includes a TeamOrchestrator that can execute parallel subagents using git worktree isolation. Updates agent_tasks.json and appends two new tasks inspired by trends.

---
*PR created automatically by Jules for task [14636753734615869614](https://jules.google.com/task/14636753734615869614) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TeamOrchestrator` to run agent sub-tasks in parallel
> - Adds [team_orchestrator.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/130/files#diff-fcb0c824a65fe41b5929e4721a905268ba63fde924f02d53132c19cff32e02d2) with a `TeamOrchestrator` class that accepts an `LLMClient` and exposes a `parallel_execute` async method.
> - `parallel_execute` instantiates one `SubAgent(use_isolation=True)` per task and fans out execution using `asyncio.gather`, returning results in input order.
> - Adds [tests/test_team_orchestrator.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/130/files#diff-91949219d8c6912552940810aa32216f91fbcfbc6cf9c6773609559f0a79981c) covering correct SubAgent construction, argument passing, and result ordering via `AsyncMock`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f43947c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->