### PR TITLE
Centralized Autonomous Task Scheduling

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2597,7 +2597,7 @@
     },
     {
       "id": "scheduled-operations-cron-like-v2",
-      "status": "todo",
+      "status": "done",
       "area": "scheduler",
       "risk": "low",
       "title": "Scheduled operations for autonomous tasks",

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -26,6 +26,7 @@ from magda_agent.planning.planner import Planner
 from magda_agent.consciousness.core import Consciousness
 from magda_agent.subconsciousness.reflection import Subconsciousness
 from magda_agent.scheduler.cron import CronScheduler
+from magda_agent.scheduler.autonomous_tasks import run_health_check, report_quality_metrics
 from magda_agent.autonomy.task_store import TaskStore, TaskStatus
 from magda_agent.autonomy.executor import AutonomousExecutor
 from magda_agent.memory.long_term import LongTermMemory
@@ -135,7 +136,26 @@ consciousness = Consciousness(
     skill_versioning=skill_versioning,
 )
 
+subconsciousness = Subconsciousness(
+    llm=llm_client,
+    emotions=emotional_engine,
+    memory=memory_system,
+    procedural_memory=procedural_memory,
+    semantic_memory=semantic_memory,
+    interval=300
+)
+
 cron_scheduler = CronScheduler()
+
+# Schedule Subconsciousness reflection
+# Default interval was 300 seconds, which is every 5 minutes
+cron_scheduler.schedule("*/5 * * * *", subconsciousness.reflect, name="reflection")
+
+# Schedule autonomous health check every hour
+cron_scheduler.schedule("0 * * * *", run_health_check, name="health_check")
+
+# Schedule quality metrics report every day at midnight
+cron_scheduler.schedule("0 0 * * *", report_quality_metrics, name="quality_report", tracker=quality_tracker)
 
 task_store = TaskStore(path=os.getenv("AUTONOMY_TASKS_PATH", "./autonomy_tasks.json"))
 autonomous_executor = AutonomousExecutor(
@@ -147,25 +167,14 @@ autonomous_executor = AutonomousExecutor(
 
 canvas_server = CanvasServer(consciousness=consciousness)
 
-subconsciousness = Subconsciousness(
-    llm=llm_client,
-    emotions=emotional_engine,
-    memory=memory_system,
-    procedural_memory=procedural_memory,
-    semantic_memory=semantic_memory,
-    interval=300
-)
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
-    asyncio.create_task(subconsciousness.start())
     asyncio.create_task(cron_scheduler.start())
     await autonomous_executor.start()
     asyncio.create_task(canvas_server.start_streaming())
     yield
     # Shutdown
-    await subconsciousness.stop()
     await cron_scheduler.stop()
     await autonomous_executor.stop()
     await canvas_server.stop_streaming()

--- a/magda_agent/scheduler/autonomous_tasks.py
+++ b/magda_agent/scheduler/autonomous_tasks.py
@@ -1,0 +1,32 @@
+import logging
+import asyncio
+from datetime import datetime
+from typing import Optional
+from magda_agent.metacognition.tracker import QualityTracker
+
+logger = logging.getLogger(__name__)
+
+async def run_health_check():
+    """
+    A simple autonomous health check task.
+    """
+    logger.info("Autonomous Health Check: All systems nominal.")
+    return {"status": "ok", "timestamp": datetime.now().isoformat()}
+
+async def report_quality_metrics(tracker: QualityTracker):
+    """
+    Autonomous task to aggregate and report quality metrics.
+    """
+    metrics = tracker.get_longitudinal_metrics()
+    logger.info(f"Autonomous Quality Report: {metrics}")
+    # In a real scenario, this might send an email or a message to a dev channel
+    return metrics
+
+async def consolidate_memory_task(memory_system: any):
+    """
+    Autonomous task to trigger memory consolidation if not already handled.
+    """
+    logger.info("Autonomous Memory Consolidation starting...")
+    memory_system.consolidate()
+    logger.info("Autonomous Memory Consolidation complete.")
+    return True

--- a/magda_agent/scheduler/cron.py
+++ b/magda_agent/scheduler/cron.py
@@ -25,13 +25,14 @@ class CronScheduler:
         self._task: asyncio.Task = None
         self.result_callback = result_callback
 
-    def schedule(self, cron_expr: str, func: Callable[..., Coroutine[Any, Any, Any]], *args, **kwargs) -> None:
+    def schedule(self, cron_expr: str, func: Callable[..., Coroutine[Any, Any, Any]], name: str = None, *args, **kwargs) -> None:
         """
         Schedules a task to run according to a cron expression.
 
         Args:
             cron_expr: The cron expression (e.g., "*/5 * * * *").
             func: The async function to execute.
+            name: Optional name for the task.
             *args: Arguments to pass to the function.
             **kwargs: Keyword arguments to pass to the function.
         """
@@ -42,7 +43,10 @@ class CronScheduler:
         itr = croniter(cron_expr, now)
         next_run = itr.get_next(datetime)
 
+        job_name = name or func.__name__
+
         job = {
+            "name": job_name,
             "cron_expr": cron_expr,
             "func": func,
             "args": args,
@@ -51,7 +55,16 @@ class CronScheduler:
             "iterator": itr
         }
         self.jobs.append(job)
-        logger.info(f"Scheduled task {func.__name__} with cron '{cron_expr}', next run: {next_run}")
+        logger.info(f"Scheduled task '{job_name}' with cron '{cron_expr}', next run: {next_run}")
+
+    def task(self, cron_expr: str, name: str = None):
+        """
+        A decorator to schedule a task.
+        """
+        def decorator(func: Callable[..., Coroutine[Any, Any, Any]]):
+            self.schedule(cron_expr, func, name=name)
+            return func
+        return decorator
 
     def _get_now(self) -> datetime:
         """
@@ -101,10 +114,11 @@ class CronScheduler:
         Executes a scheduled job and optionally calls the result callback.
         """
         func = job["func"]
+        name = job["name"]
         try:
-            logger.info(f"Executing scheduled task: {func.__name__}")
+            logger.info(f"Executing scheduled task: {name}")
             result = await func(*job["args"], **job["kwargs"])
             if self.result_callback and result is not None:
                 await self.result_callback(result)
         except Exception as e:
-            logger.error(f"Error executing scheduled task {func.__name__}: {e}", exc_info=True)
+            logger.error(f"Error executing scheduled task {name}: {e}", exc_info=True)

--- a/magda_agent/subconsciousness/reflection.py
+++ b/magda_agent/subconsciousness/reflection.py
@@ -33,19 +33,12 @@ class Subconsciousness:
 
     async def start(self):
         """Start the background reflection loop."""
-        self.is_running = True
-        self._stop_event.clear()
-        logging.info("Subconsciousness reflection loop started.")
-        while self.is_running:
-            try:
-                await asyncio.wait_for(self._stop_event.wait(), timeout=self.interval)
-            except asyncio.TimeoutError:
-                await self.reflect()
+        # This is now handled by CronScheduler in api.py
+        logging.warning("Subconsciousness.start() is deprecated. Use CronScheduler instead.")
 
     async def stop(self):
-        self.is_running = False
-        self._stop_event.set()
-        logging.info("Subconsciousness reflection loop stopped.")
+        # This is now handled by CronScheduler in api.py
+        logging.warning("Subconsciousness.stop() is deprecated. Use CronScheduler instead.")
 
     async def consolidate_episodic_to_semantic(self):
         """

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -43,9 +43,9 @@ async def test_generator_agent_with_mcp_client():
         []
     ]
 
-    mock_planner.completed_steps = []
-    def mock_mark_completed(idx, result_str):
-        mock_planner.completed_steps.append({"skill": "test_mcp.run", "result": result_str, "description": "test_step"})
+    mock_planner.get_completed_steps.return_value = []
+    def mock_mark_completed(idx, result_str, user_id=None):
+        mock_planner.get_completed_steps.return_value.append({"skill": "test_mcp.run", "result": result_str, "description": "test_step"})
 
     mock_planner.mark_step_completed.side_effect = mock_mark_completed
 
@@ -80,9 +80,9 @@ async def test_generator_agent_mcp_timeout():
         []
     ]
 
-    mock_planner.completed_steps = []
-    def mock_mark_completed(idx, result_str):
-        mock_planner.completed_steps.append({"skill": "slow_mcp.tool", "result": result_str, "description": "slow_step"})
+    mock_planner.get_completed_steps.return_value = []
+    def mock_mark_completed(idx, result_str, user_id=None):
+        mock_planner.get_completed_steps.return_value.append({"skill": "slow_mcp.tool", "result": result_str, "description": "slow_step"})
 
     mock_planner.mark_step_completed.side_effect = mock_mark_completed
 

--- a/tests/test_realtime_guardrail.py
+++ b/tests/test_realtime_guardrail.py
@@ -31,18 +31,18 @@ async def test_guardrail_allows_legit_action():
 
     # Let's mock the planner more realistically for the loop
     current_plan = [{"skill": "test_skill", "description": "test"}]
-    def mock_get_current_plan():
+    def mock_get_current_plan(user_id=None):
         return current_plan
 
-    def mock_mark_completed(index, result):
+    def mock_mark_completed(index, result, user_id=None):
         nonlocal current_plan
         step = current_plan.pop(index)
         step['result'] = result
-        agent.planner.completed_steps.append(step)
+        planner.get_completed_steps.return_value.append(step)
 
     planner.get_current_plan.side_effect = mock_get_current_plan
     planner.mark_step_completed.side_effect = mock_mark_completed
-    planner.completed_steps = []
+    planner.get_completed_steps.return_value = []
 
     result = await agent.execute_plan("user input")
 
@@ -66,16 +66,17 @@ async def test_guardrail_stops_on_violation():
 
     # Setup planner
     current_plan = [{"skill": "dangerous_skill", "description": "dangerous"}]
-    planner.get_current_plan.side_effect = lambda: current_plan
+    planner.get_current_plan.side_effect = lambda user_id=None: current_plan
     planner.completed_steps = []
 
-    def mock_mark_completed(index, result):
+    def mock_mark_completed(index, result, user_id=None):
         nonlocal current_plan
         step = current_plan.pop(index)
         step['result'] = result
-        agent.planner.completed_steps.append(step)
+        planner.get_completed_steps.return_value.append(step)
 
     planner.mark_step_completed.side_effect = mock_mark_completed
+    planner.get_completed_steps.return_value = []
 
     result = await agent.execute_plan("user input")
 
@@ -100,16 +101,17 @@ async def test_guardrail_review_required():
 
     # Setup planner
     current_plan = [{"skill": "sketchy_skill", "description": "sketchy"}]
-    planner.get_current_plan.side_effect = lambda: current_plan
+    planner.get_current_plan.side_effect = lambda user_id=None: current_plan
     planner.completed_steps = []
 
-    def mock_mark_completed(index, result):
+    def mock_mark_completed(index, result, user_id=None):
         nonlocal current_plan
         step = current_plan.pop(index)
         step['result'] = result
-        agent.planner.completed_steps.append(step)
+        planner.get_completed_steps.return_value.append(step)
 
     planner.mark_step_completed.side_effect = mock_mark_completed
+    planner.get_completed_steps.return_value = []
 
     result = await agent.execute_plan("user input")
 

--- a/tests/test_scheduler_cron.py
+++ b/tests/test_scheduler_cron.py
@@ -18,10 +18,29 @@ async def test_scheduler_accepts_cron_expression(scheduler):
     scheduler.schedule("* * * * *", dummy_task)
     assert len(scheduler.jobs) == 1
     assert scheduler.jobs[0]["cron_expr"] == "* * * * *"
+    assert scheduler.jobs[0]["name"] == "dummy_task"
+
+    # Named task
+    scheduler.schedule("* * * * *", dummy_task, name="custom_name")
+    assert len(scheduler.jobs) == 2
+    assert scheduler.jobs[1]["name"] == "custom_name"
 
     # Invalid cron
     with pytest.raises(ValueError, match="Invalid cron expression"):
         scheduler.schedule("invalid cron", dummy_task)
+
+@pytest.mark.asyncio
+async def test_scheduler_decorator(scheduler):
+    @scheduler.task("*/5 * * * *", name="decorated_task")
+    async def my_task():
+        return "done"
+
+    assert len(scheduler.jobs) == 1
+    assert scheduler.jobs[0]["name"] == "decorated_task"
+    assert scheduler.jobs[0]["cron_expr"] == "*/5 * * * *"
+
+    result = await scheduler.jobs[0]["func"]()
+    assert result == "done"
 
 @pytest.mark.asyncio
 async def test_scheduler_executes_task_on_schedule():

--- a/tests/test_subconsciousness.py
+++ b/tests/test_subconsciousness.py
@@ -98,26 +98,3 @@ async def test_subconsciousness_reflect_no_short_term(subconsciousness, mock_llm
     # Verify LLM was NOT called
     mock_llm_client.chat_completion.assert_not_called()
 
-@pytest.mark.asyncio
-async def test_subconsciousness_stop_promptly(subconsciousness):
-    import asyncio
-
-    # Run start() as a background task
-    task = asyncio.create_task(subconsciousness.start())
-
-    # Yield control to let the task start and reach the wait_for
-    await asyncio.sleep(0)
-
-    assert subconsciousness.is_running is True
-
-    # Call stop
-    await subconsciousness.stop()
-
-    # The task should complete quickly without waiting the full interval (10s)
-    # wait_for will throw TimeoutError if it doesn't complete within 1s
-    try:
-        await asyncio.wait_for(task, timeout=1.0)
-    except asyncio.TimeoutError:
-        pytest.fail("Subconsciousness.start() did not stop promptly.")
-
-    assert subconsciousness.is_running is False

--- a/tests/test_three_agent.py
+++ b/tests/test_three_agent.py
@@ -23,15 +23,15 @@ async def test_generator_agent():
 
     mock_planner = MagicMock()
 
-    def mock_get_current_plan():
+    def mock_get_current_plan(user_id=None):
         if getattr(mock_planner, 'cleared', False):
             return []
         return [{"skill": "test_skill", "skill_kwargs": {}}]
     mock_planner.cleared = False
     mock_planner.get_current_plan.side_effect = mock_get_current_plan
 
-    mock_planner.completed_steps = [{"description": "step1", "skill": "test_skill", "result": "success"}]
-    def mock_mark_completed(*args):
+    mock_planner.get_completed_steps.return_value = [{"description": "step1", "skill": "test_skill", "result": "success"}]
+    def mock_mark_completed(*args, **kwargs):
         mock_planner.cleared = True
     mock_planner.mark_step_completed.side_effect = mock_mark_completed
 


### PR DESCRIPTION
This change introduces a robust, centralized scheduling system for autonomous background tasks. It moves away from scattered custom loops (like in Subconsciousness) to a unified CronScheduler that supports standard cron expressions, job names, and a decorator-based registration API. The change also adds example autonomous tasks for health monitoring and quality reporting, further automating the agent's internal maintenance. Unit tests were updated to reflect the new API requirements of the Planner and GeneratorAgent components.

---
*PR created automatically by Jules for task [15059296861560931263](https://jules.google.com/task/15059296861560931263) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize autonomous task scheduling under CronScheduler
> - Moves subconscious reflection, health checks, and quality metrics reporting out of ad-hoc background tasks and into a centralized `CronScheduler`: reflection runs every 5 minutes, health checks hourly, and quality metrics daily at midnight.
> - Adds three async task functions in [`autonomous_tasks.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/133/files#diff-11dca18415f57d27892059a435288904dc14e581aed73748598ce4d1f837ddda): `run_health_check`, `report_quality_metrics`, and `consolidate_memory_task`.
> - Adds a `@scheduler.task` decorator to [`cron.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/133/files#diff-8cec5731cd57d079895e111dcfefeb9aac851ba659e29fbd25a9de6ed0478321) for declarative job registration, and adds named job support to `CronScheduler.schedule`.
> - Deprecates `Subconsciousness.start()` and `Subconsciousness.stop()` in [`reflection.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/133/files#diff-27adde86db1e57977c579551004975d419779d0ce3c324009acc3ea257ff5b41); both now emit deprecation warnings and no longer manage a background loop.
> - Behavioral Change: the `api.lifespan` no longer starts or stops the `Subconsciousness` loop directly; all periodic scheduling is now owned by `CronScheduler`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1960dbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->