### PR TITLE
feat: A2A Peer-to-Peer Task Delegation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2614,7 +2614,7 @@
     },
     {
       "id": "a2a-peer-task-delegation-v2",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Peer-to-Peer Task Delegation",
@@ -3494,6 +3494,57 @@
         "RL model dynamically updates from next-state signals",
         "Model improvements are verified in tests",
         "Tests pass"
+      ]
+    },
+    {
+      "id": "hermes-cron-daily-reports-v2",
+      "status": "todo",
+      "area": "scheduler",
+      "risk": "low",
+      "title": "Hermes Cron Daily Reports",
+      "description": "Inspired by Hermes Agent trend: Cron scheduler: daily reports, nightly backups. Implement a cron-like scheduler capable of running daily report tasks.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_reports.py",
+        "tests/test_cron_reports.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler can register daily report tasks.",
+        "Tests mock time and verify tasks are triggered."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugin-lifecycle",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Lifecycle Plugins",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_lifecycle.py",
+        "tests/test_context_engine_lifecycle.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugins can register lifecycle hooks.",
+        "Tests verify hooks are invoked appropriately during retrieval."
+      ]
+    },
+    {
+      "id": "acs-5-validation-checkpoints-v3",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS 5 Validation Checkpoints v3",
+      "description": "Inspired by ACS (Agent Control Specification) trend: 5 validation checkpoints in agentic workflows. Ensure all actions pass through 5 checks before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_checkpoints.py",
+        "tests/test_acs_checkpoints.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Actions are evaluated against 5 security checkpoints.",
+        "Tests mock violating actions and verify rejection."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: A2A Peer-to-Peer Task Delegation
 * [x] MODULE: **Context Engine Plugin Architecture** — модуль `magda_agent/memory/context_engine.py`. (2026-06-07)
   Inspired by trend #4 in docs/trends.md: Implement a plugin architecture for the Context Engine to manage context dynamically using lifecycle hooks.
 * [x] FEATURE: Agent Team Delegation Protocol (agent-team-delegation-protocol)

--- a/magda_agent/integration/a2a_delegation.py
+++ b/magda_agent/integration/a2a_delegation.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 import logging
 from magda_agent.integration.a2a_discovery import A2ADiscovery
+import httpx
 
 class A2ADelegator:
     """
@@ -12,10 +13,11 @@ class A2ADelegator:
         """
         self.discovery = discovery
 
+
     async def delegate_subplan(self, capability: str, plan_context: Dict[str, Any]) -> str:
         """
         Finds an agent capable of executing the requested capability and delegates
-        the subplan to it. In a real environment, this would establish an MCP connection.
+        the subplan to it dynamically over the network using httpx.
 
         Args:
             capability: The required capability (e.g., 'code_execution').
@@ -33,5 +35,25 @@ class A2ADelegator:
         target_agent = agents[0]
 
         logging.info(f"Delegating sub-plan to Agent: {target_agent.name} (ID: {target_agent.agent_id})")
-        # Mocking the MCP call and returning a successful result
-        return f"Delegated to Agent {target_agent.name}"
+
+        endpoint = target_agent.endpoints.get("mcp")
+        if not endpoint:
+            return f"Agent {target_agent.name} missing MCP endpoint"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "execute_subplan",
+            "params": {"capability": capability, "context": plan_context}
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(endpoint, json=payload, timeout=10.0)
+                response.raise_for_status()
+                data = response.json()
+                result = data.get("result", {})
+                return f"Delegated to Agent {target_agent.name}: {result.get('status', 'Success')}"
+        except Exception as e:
+            logging.error(f"Failed to delegate to {target_agent.name} at {endpoint}: {e}")
+            return f"Delegation to {target_agent.name} failed: {e}"

--- a/tests/test_a2a_delegation.py
+++ b/tests/test_a2a_delegation.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, patch
 from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
 from magda_agent.integration.a2a_delegation import A2ADelegator
 from magda_agent.agents.planner_agent import PlannerAgent
@@ -30,9 +30,16 @@ def a2a_delegator(a2a_discovery):
     return A2ADelegator(a2a_discovery)
 
 @pytest.mark.asyncio
-async def test_a2a_delegator_finds_agent(a2a_delegator):
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_a2a_delegator_finds_agent(mock_post, a2a_delegator):
+    from unittest.mock import MagicMock
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": {"status": "Success"}}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
     result = await a2a_delegator.delegate_subplan("coding", {"task": "Write hello world"})
-    assert result == "Delegated to Agent TestAgent"
+    assert result == "Delegated to Agent TestAgent: Success"
 
 @pytest.mark.asyncio
 async def test_a2a_delegator_no_agent(a2a_delegator):
@@ -40,12 +47,19 @@ async def test_a2a_delegator_no_agent(a2a_delegator):
     assert result == "No agent found"
 
 @pytest.mark.asyncio
-async def test_planner_agent_delegation(a2a_delegator):
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_planner_agent_delegation(mock_post, a2a_delegator):
     # Test PlannerAgent integrates with A2ADelegator
     planner_agent = PlannerAgent(planner=None, a2a_delegator=a2a_delegator)
 
+    from unittest.mock import MagicMock
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": {"status": "Success"}}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
     result = await planner_agent.delegate_subplan("coding", {"task": "Refactor module"})
-    assert result == "Delegated to Agent TestAgent"
+    assert result == "Delegated to Agent TestAgent: Success"
 
 @pytest.mark.asyncio
 async def test_planner_agent_no_delegator():
@@ -56,12 +70,20 @@ async def test_planner_agent_no_delegator():
     assert result == "Delegation failed: No A2ADelegator configured."
 
 @pytest.mark.asyncio
-async def test_planner_agent_plan_delegation(a2a_delegator):
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_planner_agent_plan_delegation(mock_post, a2a_delegator):
+    from unittest.mock import MagicMock
     mock_planner = MagicMock()
     mock_planner.get_current_plan.return_value = [
         {"id": "step_1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "Delegate coding task"}
     ]
     planner_agent = PlannerAgent(planner=mock_planner, a2a_delegator=a2a_delegator)
 
+    from unittest.mock import MagicMock
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": {"status": "Success"}}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
     plan = await planner_agent.plan("do coding task")
-    assert plan[0]["result"] == "Delegated to Agent TestAgent"
+    assert plan[0]["result"] == "Delegated to Agent TestAgent: Success"

--- a/tests/test_a2a_peer_delegation.py
+++ b/tests/test_a2a_peer_delegation.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_delegation import A2ADelegator
+import httpx
+
+@pytest.fixture
+def mock_agent_card():
+    return AgentCard(
+        agent_id="test-agent-123",
+        name="TestAgent",
+        description="A test agent",
+        capabilities=["coding", "analysis"],
+        endpoints={"mcp": "http://localhost:9000"}
+    )
+
+@pytest.fixture
+def a2a_discovery(mock_agent_card):
+    # local card doesn't matter for finding remote agents here
+    local_card = AgentCard("local", "local", "local", [], {})
+    discovery = A2ADiscovery(local_card)
+    # manually inject the mock agent
+    discovery._discovered_agents[mock_agent_card.agent_id] = mock_agent_card
+    discovery._capability_index["coding"] = [mock_agent_card.agent_id]
+    discovery._capability_index["analysis"] = [mock_agent_card.agent_id]
+    return discovery
+
+@pytest.fixture
+def a2a_delegator(a2a_discovery):
+    return A2ADelegator(a2a_discovery)
+
+@pytest.mark.asyncio
+async def test_a2a_delegator_finds_agent_success(a2a_delegator):
+    with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+        # For an AsyncMock, when the code does `await client.post()`, it gets what is set as return_value.
+        # But our code then calls `response.raise_for_status()` and `response.json()`
+        # which means response itself can just be a regular Mock.
+        from unittest.mock import MagicMock
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": {"status": "Success"}}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = await a2a_delegator.delegate_subplan("coding", {"task": "Write hello world"})
+        assert result == "Delegated to Agent TestAgent: Success"
+        mock_post.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_a2a_delegator_finds_agent_failure(a2a_delegator):
+    with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = httpx.RequestError("Network error")
+
+        result = await a2a_delegator.delegate_subplan("coding", {"task": "Write hello world"})
+        assert result == "Delegation to TestAgent failed: Network error"
+        mock_post.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_a2a_delegator_no_agent(a2a_delegator):
+    result = await a2a_delegator.delegate_subplan("drawing", {"task": "Draw a cat"})
+    assert result == "No agent found"
+
+@pytest.mark.asyncio
+async def test_a2a_delegator_missing_endpoint(a2a_discovery):
+    agent_without_endpoint = AgentCard(
+        agent_id="test-agent-456",
+        name="BadAgent",
+        description="A bad test agent",
+        capabilities=["cooking"],
+        endpoints={}
+    )
+    a2a_discovery._discovered_agents[agent_without_endpoint.agent_id] = agent_without_endpoint
+    a2a_discovery._capability_index["cooking"] = [agent_without_endpoint.agent_id]
+
+    delegator = A2ADelegator(a2a_discovery)
+    result = await delegator.delegate_subplan("cooking", {"task": "Bake a cake"})
+    assert result == "Agent BadAgent missing MCP endpoint"


### PR DESCRIPTION
Implementation of the A2A peer-to-peer task delegation mechanism, dynamically routing tasks to peers over the network. Includes pytest tests and 3 new agent tasks.

---
*PR created automatically by Jules for task [14044296848812839281](https://jules.google.com/task/14044296848812839281) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement A2A peer-to-peer task delegation via HTTP in `A2ADelegator.delegate_subplan`
> - Replaces the mocked return value in `delegate_subplan` with a real async HTTP call using `httpx`, posting a JSON-RPC `execute_subplan` payload to the target agent's MCP endpoint.
> - Returns a formatted success string with agent name and status on success, or a formatted failure message on exception; also reports when the selected agent has no MCP endpoint.
> - Updates existing tests in [test_a2a_delegation.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/134/files#diff-aaef19c58ed00f96582ff19c938d1502ef202197388b383adaa5e8664e4d131d) to mock `httpx.AsyncClient.post` and expect the new message format, and adds a new test module [test_a2a_peer_delegation.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/134/files#diff-4da4f845d30e377004026c8b146e5dd14d3ac7119741b39ba6c686ad75d8fc8d) covering success, failure, no-agent, and missing-endpoint paths.
> - Behavioral Change: `delegate_subplan` now makes a network call with a 10s timeout; any network failure is caught, logged, and returned as a failure message rather than raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df0f4fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->