### PR TITLE
feat: Implement MCPKernel Taint Tracking

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2648,7 +2648,7 @@
     },
     {
       "id": "mcpkernel-taint-tracking-db0c895d",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCPKernel Taint Tracking",
@@ -3596,6 +3596,57 @@
       "acceptance": [
         "Metrics are stored over time across multiple test runs.",
         "Tests verify accumulation of metric data."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v6",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Action Tool Exporter v6",
+      "description": "Inspired by the MCP-совместимость trend: Magda должна уметь экспортировать skills как MCP tools.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter.py",
+        "tests/test_mcp_exporter*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be exported as MCP tools.",
+        "Tests verify successful skill wrapping."
+      ]
+    },
+    {
+      "id": "a2a-delegation-v6",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A delegation v6",
+      "description": "Inspired by trend: A2A поддержка — возможность делегировать задачи другим агентам.",
+      "allowed_paths": [
+        "magda_agent/multi_agent/a2a_delegator.py",
+        "tests/test_a2a_delegator*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can delegate tasks",
+        "Tests verify delegation logic"
+      ]
+    },
+    {
+      "id": "online-learning-v6",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online learning v6",
+      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections).",
+      "allowed_paths": [
+        "magda_agent/learning/online_learning.py",
+        "tests/test_online_learning*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Learning module extracts insights from dialogue in real time",
+        "Tests verify learning loop logic"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: MCPKernel Taint Tracking
 * [x] FEATURE: A2A Peer-to-Peer Task Delegation
 * [x] MODULE: **Context Engine Plugin Architecture** — модуль `magda_agent/memory/context_engine.py`. (2026-06-07)
   Inspired by trend #4 in docs/trends.md: Implement a plugin architecture for the Context Engine to manage context dynamically using lifecycle hooks.

--- a/magda_agent/security/mcp_kernel.py
+++ b/magda_agent/security/mcp_kernel.py
@@ -1,4 +1,6 @@
 import ast
+from magda_agent.safety.taint import is_tainted
+
 import builtins
 from typing import Any, Dict, Optional, Set
 
@@ -37,6 +39,8 @@ class MCPKernel:
             return False
 
     def execute(self, code: str, globals_dict: Optional[Dict[str, Any]] = None, locals_dict: Optional[Dict[str, Any]] = None) -> Any:
+        if is_tainted(code):
+            raise SecurityError("Code is tainted and unsafe to execute.")
         if not self.is_safe(code):
             raise SecurityError("Code contains unsafe operations and was blocked by MCPKernel taint tracking.")
 

--- a/patch_test_fix.py
+++ b/patch_test_fix.py
@@ -1,0 +1,14 @@
+with open('tests/test_mcpkernel_taint.py', 'r') as f:
+    content = f.read()
+
+# Remove the import from the middle
+content = content.replace("from magda_agent.security.mcp_kernel import MCPKernel, SecurityError\n\n", "")
+
+# Add it to the top after import pytest
+content = content.replace("import pytest\n", "import pytest\nfrom magda_agent.security.mcp_kernel import MCPKernel, SecurityError\n")
+
+# Add the return type hint to the test function
+content = content.replace("def test_mcp_kernel_execute_tainted():", "def test_mcp_kernel_execute_tainted() -> None:")
+
+with open('tests/test_mcpkernel_taint.py', 'w') as f:
+    f.write(content)

--- a/tests/test_mcpkernel_taint.py
+++ b/tests/test_mcpkernel_taint.py
@@ -1,4 +1,5 @@
 import pytest
+from magda_agent.security.mcp_kernel import MCPKernel, SecurityError
 from magda_agent.safety.taint import mark_tainted, is_tainted, sanitize
 from magda_agent.safety.runtime_guard import RuntimeGuard, SecurityException
 
@@ -32,3 +33,10 @@ def test_runtime_guard_tainted():
     tainted_cmd = mark_tainted("rm -rf /")
     with pytest.raises(SecurityException, match="tainted and unsafe"):
         RuntimeGuard.execute_safely(dummy_tool, cmd=tainted_cmd)
+
+def test_mcp_kernel_execute_tainted() -> None:
+    """Test MCPKernel with tainted code block."""
+    kernel = MCPKernel()
+    code = mark_tainted("x = 5")
+    with pytest.raises(SecurityError, match="Code is tainted and unsafe to execute."):
+        kernel.execute(code)


### PR DESCRIPTION
Applied taint tracking to the `MCPKernel` module by modifying `execute` in `magda_agent/security/mcp_kernel.py` to check for tainted code. Also added tests with appropriate typing in `tests/test_mcpkernel_taint.py` and generated new trend tasks in `agent_tasks.json`.

---
*PR created automatically by Jules for task [14783441012711240231](https://jules.google.com/task/14783441012711240231) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add taint-tracking check to `MCPKernel.execute` to block tainted code
> Adds a pre-execution taint check in [`mcp_kernel.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/136/files#diff-c9496d67499c3235484d0d78f150458a586927e05d02488038ddb89504aafd84): `MCPKernel.execute` now calls `is_tainted(code)` before any other safety checks and raises `SecurityError('Code is tainted and unsafe to execute.')` if the code is marked tainted. A new test in [`tests/test_mcpkernel_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/136/files#diff-a934d5fe83a75d0703daeab94bc30c5e7e4baad04ebeaaed72cc2510965eb18a) verifies this behavior using `mark_tainted`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eed529e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->