### PR TITLE
feat: complete ASSERT Policy-Driven Evaluation task

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2665,7 +2665,7 @@
     },
     {
       "id": "assert-policy-evaluation-fbaa6aeb",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "ASSERT Policy-Driven Evaluation",
@@ -3647,6 +3647,57 @@
       "acceptance": [
         "Learning module extracts insights from dialogue in real time",
         "Tests verify learning loop logic"
+      ]
+    },
+    {
+      "id": "hermes-skill-creation-8563188e",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes: Skill Creation from Experience",
+      "description": "Inspired by Hermes Agent trend: Create skills dynamically from agent experience.",
+      "allowed_paths": [
+        "magda_agent/skills/**",
+        "tests/test_hermes_skills*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can generate code for a new skill",
+        "New skill is loaded dynamically"
+      ]
+    },
+    {
+      "id": "claude-context-compression-8e05f169",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "title": "Claude SDK: Context Compression",
+      "description": "Inspired by Claude Agent SDK trend: Implement context compression for subagents.",
+      "allowed_paths": [
+        "magda_agent/memory/**",
+        "tests/test_context_compression*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent contexts are compressed when large",
+        "Compression logic is tested"
+      ]
+    },
+    {
+      "id": "openai-tool-concurrency-f971883d",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI: Runtime Tool Concurrency",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement runtime function tool concurrency.",
+      "allowed_paths": [
+        "magda_agent/skills/**",
+        "tests/test_tool_concurrency*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Multiple tools can run concurrently",
+        "Tests confirm concurrency"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -168,4 +168,4 @@
 * [x] MODULE: **Curiosity Drive** — `magda_agent/exploration/curiosity.py`. (2026-06-05)
   Proactively suggests exploration tasks when boredom is high.
 * [ ] FEATURE: MCPKernel Taint Tracking
-* [ ] FEATURE: ASSERT Policy-Driven Evaluation
+* [x] FEATURE: ASSERT Policy-Driven Evaluation

--- a/magda_agent/safety/assert_eval.py
+++ b/magda_agent/safety/assert_eval.py
@@ -1,0 +1,81 @@
+import json
+import logging
+from typing import Dict, Any, List, Optional
+
+from magda_agent.llm_client import LLMClient
+
+class AssertWorkflowEvaluator:
+    """
+    ASSERT Policy-Driven Evaluation Framework for Agentic Workflows.
+    Evaluates whether a given workflow step or data violates explicit security/safety policies.
+    """
+
+    def __init__(self, llm: LLMClient) -> None:
+        """
+        Initializes the AssertWorkflowEvaluator.
+
+        Args:
+            llm: The LLM client to use for evaluation.
+        """
+        self.llm = llm
+
+    async def evaluate_workflow(self, workflow_data: Dict[str, Any], policies: List[str]) -> bool:
+        """
+        Evaluates a workflow against a set of policies using the LLM.
+
+        Args:
+            workflow_data: The data describing the workflow action or state.
+            policies: A list of explicit policy strings.
+
+        Returns:
+            True if the workflow COMPLIES with all policies (safe), False if it VIOLATES any policy (unsafe).
+        """
+        formatted_policies = "\n".join([f"- {policy}" for policy in policies])
+        workflow_json = json.dumps(workflow_data, indent=2)
+
+        prompt = (
+            "Evaluate the following workflow data against the provided security/safety policies.\n"
+            "Determine if the workflow action violates ANY of these policies.\n\n"
+            f"Policies:\n{formatted_policies}\n\n"
+            f"Workflow Data:\n{workflow_json}\n\n"
+            "Respond ONLY with a JSON object in this exact format:\n"
+            "{\n"
+            '  "is_safe": true,\n'
+            '  "violated_policies": ["Policy description if violated, else empty string"],\n'
+            '  "reason": "Explanation for the decision"\n'
+            "}"
+        )
+
+        messages = [{"role": "system", "content": prompt}]
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.llm.chat_completion(messages, temperature=0.1)
+
+                # Clean up markdown if present
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+                is_safe = evaluation.get("is_safe", False)
+
+                if not is_safe:
+                    violations = evaluation.get("violated_policies", [])
+                    reason = evaluation.get("reason", "No reason provided")
+                    logging.warning(f"ASSERT Workflow Evaluator: Policy violation detected! Reason: {reason}. Violations: {violations}")
+
+                return is_safe
+
+            except json.JSONDecodeError as e:
+                logging.warning(f"ASSERT JSON decoding error attempt {attempt + 1}/{max_retries}: {e}")
+                if attempt == max_retries - 1:
+                    logging.error("ASSERT Evaluator reached max retries. Failing closed (safe=False).")
+                    return False
+            except Exception as e:
+                logging.error(f"ASSERT Evaluator failed: {e}")
+                return False
+
+        return False

--- a/tests/test_assert_eval_workflow.py
+++ b/tests/test_assert_eval_workflow.py
@@ -1,0 +1,80 @@
+import pytest
+import json
+from unittest.mock import AsyncMock
+
+from magda_agent.safety.assert_eval import AssertWorkflowEvaluator
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_llm_client():
+    mock = AsyncMock(spec=LLMClient)
+    return mock
+
+@pytest.fixture
+def evaluator(mock_llm_client):
+    return AssertWorkflowEvaluator(llm=mock_llm_client)
+
+@pytest.mark.asyncio
+async def test_evaluate_workflow_safe(evaluator, mock_llm_client):
+    mock_json_response = '''
+    {
+      "is_safe": true,
+      "violated_policies": [],
+      "reason": "The workflow action complies with all policies."
+    }
+    '''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    workflow_data = {"action": "read_file", "path": "docs/readme.md"}
+    policies = ["Do not access secrets"]
+
+    is_safe = await evaluator.evaluate_workflow(workflow_data, policies)
+    assert is_safe is True
+    mock_llm_client.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluate_workflow_unsafe(evaluator, mock_llm_client):
+    mock_json_response = '''
+    {
+      "is_safe": false,
+      "violated_policies": ["Do not access secrets"],
+      "reason": "The workflow attempts to read a .env file which is forbidden."
+    }
+    '''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    workflow_data = {"action": "read_file", "path": ".env"}
+    policies = ["Do not access secrets"]
+
+    is_safe = await evaluator.evaluate_workflow(workflow_data, policies)
+    assert is_safe is False
+
+@pytest.mark.asyncio
+async def test_evaluate_workflow_invalid_json_retry(evaluator, mock_llm_client):
+    invalid_json = "not json"
+    valid_json = '''
+    {
+      "is_safe": true,
+      "violated_policies": [],
+      "reason": "Success after retry"
+    }
+    '''
+    mock_llm_client.chat_completion.side_effect = [invalid_json, valid_json]
+
+    workflow_data = {"action": "test"}
+    policies = ["Test policy"]
+
+    is_safe = await evaluator.evaluate_workflow(workflow_data, policies)
+    assert is_safe is True
+    assert mock_llm_client.chat_completion.call_count == 2
+
+@pytest.mark.asyncio
+async def test_evaluate_workflow_fail_closed_on_error(evaluator, mock_llm_client):
+    mock_llm_client.chat_completion.side_effect = Exception("API down")
+
+    workflow_data = {"action": "test"}
+    policies = ["Test policy"]
+
+    is_safe = await evaluator.evaluate_workflow(workflow_data, policies)
+    # Evaluator should fail closed (return False) on exception
+    assert is_safe is False


### PR DESCRIPTION
Implements the ASSERT Policy-Driven Evaluation framework in `magda_agent/safety/assert_eval.py` to evaluate workflow safety. Adds corresponding tests and marks the task as completed. Also adds 3 new AI-trend inspired tasks.

---
*PR created automatically by Jules for task [9676464295364697583](https://jules.google.com/task/9676464295364697583) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AssertWorkflowEvaluator` for policy-driven LLM workflow compliance checks
> - Adds [`assert_eval.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/137/files#diff-b72d8ec0ec33a1dcb6b36a87e75d4ef2459bc4fcbb448364e5024957307742b1) with `AssertWorkflowEvaluator`, which takes an `LLMClient` and evaluates workflow data against policies via a structured LLM prompt (temperature=0.1, strict JSON response).
> - Strips markdown fences from LLM responses before JSON parsing, retries up to 3 times on `JSONDecodeError`, logs policy violations as warnings, and fails closed (returns `False`) on unrecoverable errors.
> - Adds tests in [`test_assert_eval_workflow.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/137/files#diff-f73e83f60841acefbd040dd35348d925efb1896e671609f389ccc528f0f62ba2) covering compliant, non-compliant, retry, and fail-closed scenarios using `AsyncMock`.
> - Updates `backlog.md` and `agent_tasks.json` to mark the ASSERT Policy-Driven Evaluation task as complete and add three new backlog tasks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b27092a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->