### PR TITLE
Implement Guardrails Policy Layer

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2737,7 +2737,7 @@
     },
     {
       "id": "guardrails-policy-layer",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Guardrails Policy Layer",
@@ -3787,6 +3787,40 @@
       "acceptance": [
         "Tool-call interceptions are logged to an audit trail",
         "Tests verify that audit logs are correctly generated"
+      ]
+    },
+    {
+      "id": "openai-realtime-guardrail-fallback",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "OpenAI: Realtime Guardrail Fallback",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement realtime guardrail fallback for interrupted actions.",
+      "allowed_paths": [
+        "magda_agent/safety/guardrails.py",
+        "tests/test_guardrails*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Fallback mechanism triggers on blocked calls.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "acs-5-validation-checkpoints-v4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS 5 validation checkpoints v4",
+      "description": "Inspired by ACS trend: 5 validation checkpoints in agentic workflows. Enhance workflow validation logic.",
+      "allowed_paths": [
+        "magda_agent/safety/acs.py",
+        "tests/test_acs*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Workflows are validated against 5 ACS checkpoints",
+        "Tests pass."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,8 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Guardrails Policy Layer (guardrails-policy-layer)
+
 * [x] FEATURE: Online RL Feedback Integration (online-rl-feedback-integration)
 * [x] MODULE: **Agent Teams Git Worktree Isolation** — модуль `magda_agent/agents/team_isolation.py`. (2026-06-07)
 * [x] FEATURE: A2A Peer-to-Peer Task Delegation

--- a/magda_agent/safety/guardrails.py
+++ b/magda_agent/safety/guardrails.py
@@ -1,12 +1,16 @@
 import logging
+import asyncio
 from enum import Enum
-from typing import Any, Tuple, Optional
+from typing import Any, Tuple, Optional, Callable
 from magda_agent.safety.policy import PolicyLayer
 
 class FallbackStrategy(Enum):
     STOP_EXECUTION = "stop_execution"
     REQUEST_REVIEW = "request_review"
     NONE = "none"
+
+class SecurityViolationError(Exception):
+    pass
 
 class RealtimeGuardrail:
     """
@@ -15,6 +19,13 @@ class RealtimeGuardrail:
     """
 
     def __init__(self, policy_layer: PolicyLayer, default_strategy: FallbackStrategy = FallbackStrategy.STOP_EXECUTION):
+        """
+        Initializes the RealtimeGuardrail.
+
+        Args:
+            policy_layer: The PolicyLayer to evaluate actions.
+            default_strategy: The default fallback strategy if an action is denied.
+        """
         self.policy_layer = policy_layer
         self.default_strategy = default_strategy
 
@@ -22,6 +33,14 @@ class RealtimeGuardrail:
         """
         Checks an action against the policy and returns if it's allowed,
         an explanation, and the fallback strategy to apply if denied.
+
+        Args:
+            tool_name: The name of the tool to evaluate.
+            **kwargs: The arguments to pass to the tool.
+
+        Returns:
+            A tuple containing a boolean indicating if the action is allowed,
+            an explanation string, and the fallback strategy.
         """
         allow, explanation = self.policy_layer.evaluate(tool_name, **kwargs)
 
@@ -35,3 +54,38 @@ class RealtimeGuardrail:
         logging.warning(f"RealtimeGuardrail: Violation detected for '{tool_name}'. Strategy: {strategy.value}. Reason: {explanation}")
 
         return False, explanation, strategy
+
+    def execute_with_guardrails(self, tool_func: Callable, tool_name: str, **kwargs: Any) -> Any:
+        """
+        Executes the given tool function if allowed by the guardrails policy.
+        If blocked, executes the fallback strategy.
+        Supports both synchronous and asynchronous tool functions.
+
+        Args:
+            tool_func (Callable): The tool function to execute.
+            tool_name (str): The name of the tool.
+            **kwargs: Arguments to pass to the tool function.
+
+        Returns:
+            Any: The result of the tool execution, or a fallback message if blocked.
+
+        Raises:
+            SecurityViolationError: If the fallback strategy is STOP_EXECUTION.
+        """
+        allow, explanation, strategy = self.check_action(tool_name, **kwargs)
+
+        def handle_fallback() -> Any:
+            if strategy == FallbackStrategy.STOP_EXECUTION:
+                raise SecurityViolationError(f"Action '{tool_name}' blocked: {explanation}")
+            elif strategy == FallbackStrategy.REQUEST_REVIEW:
+                return f"Review requested for action '{tool_name}': {explanation}"
+            return f"Action '{tool_name}' blocked: {explanation}"
+
+        if not allow:
+            if asyncio.iscoroutinefunction(tool_func):
+                async def async_fallback() -> Any:
+                    return handle_fallback()
+                return async_fallback()
+            return handle_fallback()
+
+        return tool_func(**kwargs)

--- a/magda_agent/skills/registry.py
+++ b/magda_agent/skills/registry.py
@@ -17,6 +17,10 @@ class SkillRegistry:
         from magda_agent.safety.agent_guard import AgentGuard
         self.agent_guard = AgentGuard(policy_layer) if policy_layer else None
 
+        # Initialize RealtimeGuardrail
+        from magda_agent.safety.guardrails import RealtimeGuardrail
+        self.realtime_guardrail = RealtimeGuardrail(policy_layer) if policy_layer else None
+
 
     def register_skill(self, name: str, func: Callable, description: str):
         self.skills[name] = func
@@ -40,7 +44,9 @@ class SkillRegistry:
             return f"Error: Skill '{name}' not found."
 
         try:
-            if self.agent_guard is not None:
+            if self.realtime_guardrail is not None:
+                return self.realtime_guardrail.execute_with_guardrails(self.skills[name], name, **kwargs)
+            elif self.agent_guard is not None:
                 return self.agent_guard.execute_tool(self.skills[name], name, **kwargs)
             else:
                 return self.skills[name](**kwargs)

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,54 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.safety.guardrails import RealtimeGuardrail, FallbackStrategy, SecurityViolationError
+from magda_agent.safety.policy import PolicyLayer
+
+def test_allowed_action() -> None:
+    """Tests that an allowed action is executed and returns the result."""
+    policy = PolicyLayer()
+    policy.evaluate = MagicMock(return_value=(True, "Allowed"))
+    guard = RealtimeGuardrail(policy)
+    mock_tool = MagicMock(return_value="Success")
+
+    result = guard.execute_with_guardrails(mock_tool, "safe_tool", arg="value")
+    assert result == "Success"
+    mock_tool.assert_called_once_with(arg="value")
+
+def test_denied_action_stop_execution() -> None:
+    """Tests that a denied action with STOP_EXECUTION strategy raises SecurityViolationError."""
+    policy = PolicyLayer()
+    policy.evaluate = MagicMock(return_value=(False, "Denied"))
+    guard = RealtimeGuardrail(policy, default_strategy=FallbackStrategy.STOP_EXECUTION)
+    mock_tool = MagicMock()
+
+    with pytest.raises(SecurityViolationError, match="Action 'unsafe_tool' blocked: Denied"):
+        guard.execute_with_guardrails(mock_tool, "unsafe_tool", arg="value")
+
+    mock_tool.assert_not_called()
+
+def test_denied_action_request_review() -> None:
+    """Tests that a denied action with REQUEST_REVIEW strategy returns a review message."""
+    policy = PolicyLayer()
+    policy.evaluate = MagicMock(return_value=(False, "Needs Review"))
+    guard = RealtimeGuardrail(policy, default_strategy=FallbackStrategy.REQUEST_REVIEW)
+    mock_tool = MagicMock()
+
+    result = guard.execute_with_guardrails(mock_tool, "unsafe_tool", arg="value")
+    assert result == "Review requested for action 'unsafe_tool': Needs Review"
+    mock_tool.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_denied_action_async_tool() -> None:
+    """Tests that an async tool fallback is handled correctly and returns an awaitable."""
+    policy = PolicyLayer()
+    policy.evaluate = MagicMock(return_value=(False, "Needs Review"))
+    guard = RealtimeGuardrail(policy, default_strategy=FallbackStrategy.REQUEST_REVIEW)
+
+    async def async_mock_tool(arg: str) -> str:
+        return "Async Success"
+
+    result_coro = guard.execute_with_guardrails(async_mock_tool, "unsafe_tool", arg="value")
+    assert asyncio.iscoroutine(result_coro)
+    result = await result_coro
+    assert result == "Review requested for action 'unsafe_tool': Needs Review"


### PR DESCRIPTION
This PR implements a realtime guardrail fallback feature that wraps tool execution, allowing for custom behavior (e.g. STOP_EXECUTION, REQUEST_REVIEW) when a policy violation is detected. It has been integrated into the `SkillRegistry`. New todo tasks based on OpenAI realtime fallback and ACS 5 Validation checkpoints have been added to the task manifest.

---
*PR created automatically by Jules for task [3990274503752626872](https://jules.google.com/task/3990274503752626872) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement guardrails policy layer for tool execution in `SkillRegistry`
> - Adds `execute_with_guardrails` to [`RealtimeGuardrail`](https://github.com/kazah4359-lgtm/Magda-agent/pull/141/files#diff-fa5381fa98cdc402eb97f045f19e40ea13069daa025c155741cbd4797097b874), which evaluates a policy before running a tool and handles three fallback strategies: raise `SecurityViolationError` (STOP_EXECUTION), return a review message (REQUEST_REVIEW), or return a block message.
> - Updates [`SkillRegistry.execute_skill`](https://github.com/kazah4359-lgtm/Magda-agent/pull/141/files#diff-86e5584dfd92efbf66a1e0600c1ab5a5e678bc67b8a389d2501997611f7f2ffa) to route through `RealtimeGuardrail` when a `policy_layer` is configured, falling back to existing `AgentGuard` or direct execution.
> - Introduces `SecurityViolationError` as a catchable exception for blocked actions configured with STOP_EXECUTION.
> - Async tool functions are handled correctly — a coroutine is returned when the fallback path is async.
> - Unit tests in [`tests/test_guardrails.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/141/files#diff-4dbce1805aa2d6470c1a119fa6e2608eb311df060579c08e5f665aaf673d7c36) cover allowed execution, each denial fallback strategy, and async tool handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 688ea0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->