### PR TITLE
MCP Action Tool Exporter v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2772,7 +2772,7 @@
     },
     {
       "id": "mcp-action-tool-exporter-v4",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Exporter",
@@ -3872,6 +3872,40 @@
       "acceptance": [
         "Agent can run against SWE-bench harness.",
         "Tests pass with mock."
+      ]
+    },
+    {
+      "id": "hermes-skill-creation-v2-1052e4b3",
+      "status": "todo",
+      "area": "skills",
+      "risk": "high",
+      "title": "Hermes: Skill Creation from Experience v2",
+      "description": "Inspired by Hermes Agent trend: Skill creation from experience. Implement an automated workflow that generates new reusable Python skills dynamically when the agent detects a repeated pattern in user requests.",
+      "allowed_paths": [
+        "magda_agent/learning/skill_creator.py",
+        "tests/test_skill_creator*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "System synthesizes skills dynamically from chat history.",
+        "Tests verify generation logic."
+      ]
+    },
+    {
+      "id": "online-rl-feedback-v5-ab746036",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL from user feedback v5",
+      "description": "Inspired by trend: Online RL from user feedback. Implement online reinforcement learning to adjust agent behavior based on implicit and explicit feedback without separate annotation.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_feedback.py",
+        "tests/test_rl_feedback*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent adjusts reward parameters based on immediate user feedback.",
+        "Tests confirm RL feedback loop."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+- [x] mcp-action-tool-exporter-v4: MCP Action Tool Exporter
 * [x] FEATURE: Guardrails Policy Layer (guardrails-policy-layer)
 
 * [x] FEATURE: Online RL Feedback Integration (online-rl-feedback-integration)

--- a/magda_agent/integration/mcp_exporter.py
+++ b/magda_agent/integration/mcp_exporter.py
@@ -1,0 +1,71 @@
+from typing import Dict, Any, List
+import uuid
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_export import MagdaMCPAdapter
+
+class MCPExporter:
+    """
+    Exports Magda skills as MCP-compatible JSON-RPC tools.
+    Acts as a server-side bridge.
+    """
+    def __init__(self, registry: SkillRegistry) -> None:
+        """Initialize the MCPExporter with a SkillRegistry."""
+        self.registry = registry
+        self.adapter = MagdaMCPAdapter(registry)
+
+    def export_tools(self) -> List[Dict[str, Any]]:
+        """
+        Returns a list of exported MCP tools.
+        """
+        return self.adapter.list_tools()
+
+    async def handle_rpc_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Handles an incoming JSON-RPC request for a tool execution.
+
+        Args:
+            request: A dictionary representing a JSON-RPC 2.0 request.
+
+        Returns:
+            A dictionary representing a JSON-RPC 2.0 response.
+        """
+        req_id = request.get("id", str(uuid.uuid4()))
+        method = request.get("method")
+        params = request.get("params", {})
+
+        if request.get("jsonrpc") != "2.0":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32600, "message": "Invalid Request"}
+            }
+
+        if not method:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": "Method not found"}
+            }
+
+        if not self.registry.has_skill(method):
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method '{method}' not found"}
+            }
+
+        adapter_result = await self.adapter.call_tool_async(method, params)
+
+        if adapter_result.get("isError"):
+            error_msg = adapter_result.get("content", [{"text": "Unknown error"}])[0].get("text")
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32000, "message": error_msg}
+            }
+
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": adapter_result
+        }

--- a/tests/test_mcp_exporter.py
+++ b/tests/test_mcp_exporter.py
@@ -1,0 +1,83 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.integration.mcp_exporter import MCPExporter
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.fixture
+def registry():
+    reg = SkillRegistry()
+
+    async def dummy_skill(param1: str) -> str:
+        """Dummy async skill."""
+        return f"Result: {param1}"
+
+    def dummy_sync_skill(param2: int) -> int:
+        """Dummy sync skill."""
+        return param2 * 2
+
+    reg.register_skill("dummy_skill", dummy_skill, "A dummy async skill")
+    reg.register_skill("dummy_sync_skill", dummy_sync_skill, "A dummy sync skill")
+    return reg
+
+@pytest.fixture
+def exporter(registry):
+    return MCPExporter(registry)
+
+def test_export_tools(exporter):
+    tools = exporter.export_tools()
+    assert len(tools) == 2
+    names = [t["name"] for t in tools]
+    assert "dummy_skill" in names
+    assert "dummy_sync_skill" in names
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_success(exporter):
+    req = {
+        "jsonrpc": "2.0",
+        "method": "dummy_skill",
+        "params": {"param1": "test"},
+        "id": 1
+    }
+    res = await exporter.handle_rpc_request(req)
+    assert res["jsonrpc"] == "2.0"
+    assert res["id"] == 1
+    assert "result" in res
+    assert not res["result"]["isError"]
+    assert res["result"]["content"][0]["text"] == "Result: test"
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_invalid_method(exporter):
+    req = {
+        "jsonrpc": "2.0",
+        "method": "non_existent_skill",
+        "params": {},
+        "id": 2
+    }
+    res = await exporter.handle_rpc_request(req)
+    assert "error" in res
+    assert res["error"]["code"] == -32601
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_invalid_jsonrpc(exporter):
+    req = {
+        "method": "dummy_skill",
+        "params": {"param1": "test"},
+        "id": 3
+    }
+    res = await exporter.handle_rpc_request(req)
+    assert "error" in res
+    assert res["error"]["code"] == -32600
+
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_error_in_tool(exporter):
+    req = {
+        "jsonrpc": "2.0",
+        "method": "dummy_skill",
+        "params": {}, # Missing required param
+        "id": 4
+    }
+    res = await exporter.handle_rpc_request(req)
+    # The registry catches exceptions and returns "Error executing skill..." which adapter wraps as normal string result.
+    assert "result" in res
+    assert res["result"]["content"][0]["text"].startswith("Error executing skill")


### PR DESCRIPTION
Implements the MCP Exporter as per the mcp-action-tool-exporter-v4 task.

---
*PR created automatically by Jules for task [681870238725279440](https://jules.google.com/task/681870238725279440) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPExporter` to expose Magda skills as MCP JSON-RPC tools
> - Introduces [mcp_exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/143/files#diff-2fc4adfe3dfe68fdd56e055504fc2790338d65fdda87236e866fcbaf91f8cde5) with a new `MCPExporter` class that wraps `SkillRegistry` and `MagdaMCPAdapter` to expose registered skills as MCP-compatible tools.
> - `export_tools()` delegates to `adapter.list_tools()` to return current tool descriptors; `handle_rpc_request()` handles JSON-RPC 2.0 requests asynchronously, mapping adapter errors to standard codes (-32600, -32601, -32000).
> - Adds pytest coverage in [test_mcp_exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/143/files#diff-c8233512ac47a7f069faf85a52ae07fbcf6a267271d62ab2d6ce54813d32f76b) for tool listing, successful dispatch, and all error paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3563383.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->