### PR TITLE
feat: Longitudinal quality metrics

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2843,7 +2843,7 @@
     },
     {
       "id": "longitudinal-quality-metrics-v2",
-      "status": "todo",
+      "status": "done",
       "area": "evaluation",
       "risk": "low",
       "title": "Longitudinal quality metrics",
@@ -4062,6 +4062,57 @@
       "acceptance": [
         "Orchestrator can spawn multiple subagents",
         "Tests verify parallel execution"
+      ]
+    },
+    {
+      "id": "post-merge-smoke-tests-v1",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Post-merge smoke tests",
+      "description": "Inspired by trend: Post-merge smoke tests. Implement a workflow to automatically run smoke tests after merges to ensure stability.",
+      "allowed_paths": [
+        "magda_agent/evaluation/smoke.py",
+        "tests/test_smoke*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Smoke tests run automatically.",
+        "Tests cover main functionality."
+      ]
+    },
+    {
+      "id": "reflection-task-generation-v1",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Reflection to task generation",
+      "description": "Inspired by trend: Reflection -> new task generation. Agent should generate new tasks based on reflections from previous failures.",
+      "allowed_paths": [
+        "magda_agent/planning/reflection_tasks.py",
+        "tests/test_reflection_tasks*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent translates reflections into structured tasks.",
+        "Tests verify generation logic."
+      ]
+    },
+    {
+      "id": "online-rl-user-feedback-v6",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL from user feedback v6",
+      "description": "Inspired by trend: Online RL from user feedback. Implement online reinforcement learning to adjust agent behavior based on user responses.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl_v6.py",
+        "tests/test_online_rl_v6*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent adjusts reward parameters based on feedback.",
+        "Tests confirm RL feedback loop."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Longitudinal Quality Metrics (longitudinal-quality-metrics-v2)
 * [x] FEATURE: Skill creation from experience
 - [x] agent-guard-runtime-safety-v4: Agent Guard Runtime Safety Controls
 - [x] mcp-action-tool-exporter-v4: MCP Action Tool Exporter

--- a/magda_agent/evaluation/longitudinal.py
+++ b/magda_agent/evaluation/longitudinal.py
@@ -1,0 +1,32 @@
+from magda_agent.metacognition.tracker import QualityTracker
+from typing import Dict, Any, List
+
+class LongitudinalEvaluator:
+    """Evaluates agent performance over multiple iterations."""
+    def __init__(self, db_path: str = "./metrics_db.sqlite3"):
+        self.tracker = QualityTracker(db_path=db_path)
+
+    def evaluate_trend(self, metric_name: str, limit: int = 10) -> Dict[str, Any]:
+        """Calculates trend and average over multiple entries."""
+        metrics = self.tracker.get_metrics(metric_name, limit)
+        if not metrics:
+            return {"metric_name": metric_name, "trend": "unknown", "average": 0.0, "data_points": 0}
+
+        # metrics are ordered by timestamp DESC
+        values = [m["value"] for m in metrics]
+        avg = sum(values) / len(values)
+
+        trend = "stable"
+        if len(values) > 1:
+            # values[0] is the newest, values[-1] is the oldest
+            if values[0] > values[-1]:
+                trend = "improving"
+            elif values[0] < values[-1]:
+                trend = "declining"
+
+        return {
+            "metric_name": metric_name,
+            "trend": trend,
+            "average": avg,
+            "data_points": len(values)
+        }

--- a/tests/test_longitudinal_metrics.py
+++ b/tests/test_longitudinal_metrics.py
@@ -1,0 +1,27 @@
+import pytest
+import sqlite3
+from magda_agent.evaluation.longitudinal import LongitudinalEvaluator
+from magda_agent.metacognition.tracker import QualityTracker
+
+def create_mock_evaluator():
+    evaluator = LongitudinalEvaluator(":memory:")
+    # We need to artificially set timestamps to ensure correct DESC ordering
+    # since fast execution might result in the same timestamp for all rows.
+    conn = evaluator.tracker._get_connection()
+    cursor = conn.cursor()
+    cursor.execute("INSERT INTO metrics (metric_name, value, timestamp) VALUES ('accuracy', 0.5, '2026-06-08 21:00:00')")
+    cursor.execute("INSERT INTO metrics (metric_name, value, timestamp) VALUES ('accuracy', 0.6, '2026-06-08 21:01:00')")
+    cursor.execute("INSERT INTO metrics (metric_name, value, timestamp) VALUES ('accuracy', 0.8, '2026-06-08 21:02:00')")
+    conn.commit()
+    return evaluator
+
+def test_longitudinal_evaluator():
+    evaluator = create_mock_evaluator()
+
+    trend = evaluator.evaluate_trend("accuracy", limit=3)
+
+    assert trend["metric_name"] == "accuracy"
+    # The newest is 0.8, the oldest is 0.5. 0.8 > 0.5 => improving
+    assert trend["trend"] == "improving"
+    assert trend["data_points"] == 3
+    assert round(trend["average"], 2) == 0.63


### PR DESCRIPTION
Implements `LongitudinalEvaluator` to aggregate metrics from `QualityTracker` and determine trends. Updates task status and adds new AI trend-inspired tasks to `agent_tasks.json` and syncs `backlog.md`.

---
*PR created automatically by Jules for task [9860531584504250935](https://jules.google.com/task/9860531584504250935) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add longitudinal quality metrics evaluation via `LongitudinalEvaluator`
> - Introduces [`LongitudinalEvaluator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/147/files#diff-1fa44e87ec13e1b0e16a42139e8aaeb2965f5d4d856bd2267f0adabeb8bd50a0) with an `evaluate_trend` method that queries a `QualityTracker`, computes an average, and classifies the trend as improving/declining/stable by comparing newest vs oldest values in DESC timestamp order.
> - Returns a dict with `metric_name`, `trend`, `average`, and `data_points`; returns an "unknown" trend with zeros when no data is available.
> - Adds a unit test in [`tests/test_longitudinal_metrics.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/147/files#diff-6d478fc46ca69ace4f2c9f1d392fc13a93802eac9b2013c9b61fbe94da4372ad) using an in-memory DB with explicit timestamps to verify trend classification and average computation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dd2610.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->