### PR TITLE
feat: Implement Online RL from user feedback

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2860,7 +2860,7 @@
     },
     {
       "id": "online-rl-user-feedback-v2",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online RL from user feedback",
@@ -4113,6 +4113,57 @@
       "acceptance": [
         "Agent adjusts reward parameters based on feedback.",
         "Tests confirm RL feedback loop."
+      ]
+    },
+    {
+      "id": "agent-teams-git-worktree-v1",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Agent Teams Git Worktree Isolation",
+      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation. Implement isolation layer using git worktrees.",
+      "allowed_paths": [
+        "magda_agent/agents/isolation.py",
+        "tests/test_isolation*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Isolation module creates git worktrees.",
+        "Tests verify worktree creation and teardown."
+      ]
+    },
+    {
+      "id": "mcp-json-rpc-interface-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP JSON-RPC Interface",
+      "description": "Inspired by trend: MCP-совместимость (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_server.py",
+        "tests/test_mcp_server*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP server successfully processes JSON-RPC.",
+        "Tests verify JSON-RPC compliance."
+      ]
+    },
+    {
+      "id": "agentbench-eval-multi-domain-v1",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "AgentBench Multi-Domain Evaluation",
+      "description": "Inspired by trend: Evaluation (бенчмарки) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
+      "allowed_paths": [
+        "magda_agent/evaluation/agentbench.py",
+        "tests/test_agentbench*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can run against AgentBench evaluation harness.",
+        "Tests mock external calls."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Online RL from User Feedback v2 (online-rl-user-feedback-v2)
 * [x] FEATURE: Longitudinal Quality Metrics (longitudinal-quality-metrics-v2)
 * [x] FEATURE: Skill creation from experience
 - [x] agent-guard-runtime-safety-v4: Agent Guard Runtime Safety Controls

--- a/magda_agent/learning/online_rl.py
+++ b/magda_agent/learning/online_rl.py
@@ -19,7 +19,7 @@ class OnlineRLIntegrator:
         self.habit_tracker = habit_tracker
         self.mirror_neurons = mirror_neurons
 
-    async def process_feedback(self, user_reply: str, action_context: str, user_id: Optional[int] = None) -> None:
+    async def process_feedback(self, user_reply: str, action_context: str, user_id: Optional[int] = None, explicit_score: Optional[float] = None, tool_success: bool = False, skill_used: str = "rl_feedback_skill") -> None:
         """
         Processes explicit and implicit feedback signals to adjust habit weights.
 
@@ -27,20 +27,28 @@ class OnlineRLIntegrator:
             user_reply (str): The user's reply.
             action_context (str): The context of the action taken.
             user_id (Optional[int]): The ID of the user.
+            explicit_score (Optional[float]): Explicit user feedback score (e.g. from 0 to 10).
+            tool_success (bool): Whether the tool execution was successful.
+            skill_used (str): The name of the skill used.
         """
         if not user_reply or not action_context:
             return
 
         p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_reply)
 
-        # Calculate a dynamic weight based on the pleasure shift.
-        # Scale the p_shift (-1.0 to 1.0) to a score (0 to 10).
-        weight = (p_shift + 1.0) * 5.0
+        if explicit_score is not None:
+            base_score = explicit_score
+        else:
+            base_score = (p_shift + 1.0) * 5.0
+
+        weight = base_score
+        if tool_success:
+            weight += 2.0
 
         if weight >= 8.0:
             self.habit_tracker.record_usage(
                 input_text=action_context,
-                skill_used="rl_feedback_skill",
+                skill_used=skill_used,
                 evaluation_score=weight,
                 user_id=user_id
             )

--- a/tests/test_online_rl_feedback.py
+++ b/tests/test_online_rl_feedback.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.online_rl import OnlineRLIntegrator
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+@pytest.fixture
+def mock_habit_tracker():
+    return MagicMock(spec=HabitTracker)
+
+@pytest.fixture
+def mock_mirror_neurons():
+    return MagicMock(spec=MirrorNeurons)
+
+@pytest.mark.asyncio
+async def test_process_feedback_implicit_positive(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.8, 0.1, 0.0)
+    integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
+
+    await integrator.process_feedback("Great job!", "test_context", user_id=1)
+
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="test_context",
+        skill_used="rl_feedback_skill",
+        evaluation_score=9.0,
+        user_id=1
+    )
+
+@pytest.mark.asyncio
+async def test_process_feedback_explicit_score(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.0, 0.0, 0.0)
+    integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
+
+    await integrator.process_feedback("Okay", "test_context", explicit_score=9.0, skill_used="custom_skill")
+
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="test_context",
+        skill_used="custom_skill",
+        evaluation_score=9.0,
+        user_id=None
+    )
+
+@pytest.mark.asyncio
+async def test_process_feedback_tool_success(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.5, 0.0, 0.0)
+    integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
+    # base_score = 7.5. tool_success + 2.0 = 9.5
+    await integrator.process_feedback("Good", "test_context", tool_success=True)
+
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="test_context",
+        skill_used="rl_feedback_skill",
+        evaluation_score=9.5,
+        user_id=None
+    )


### PR DESCRIPTION
Implements online RL feedback loop with explicit scores and tool success signals. Closes online-rl-user-feedback-v2.

---
*PR created automatically by Jules for task [16913027524918115139](https://jules.google.com/task/16913027524918115139) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement online RL from user feedback in `OnlineRLIntegrator.process_feedback`
> - Extends [`process_feedback`](https://github.com/kazah4359-lgtm/Magda-agent/pull/148/files#diff-1c74ea82824e53562a7f2b01bee8140b59b07638206de4dc001d3b8c00009ddc) to accept `explicit_score` (overrides implicit sentiment-derived score), `tool_success` (adds +2.0 to the computed weight), and `skill_used` (replaces the previously hardcoded skill name).
> - Adds three async pytest tests in [`tests/test_online_rl_feedback.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/148/files#diff-3dc1152d65fc3935e939656663ca825bb1abe94fa2dba05d879c808c9179344e) covering the implicit path, explicit score override, and `tool_success` bonus.
> - Behavioral Change: callers relying on the implicit score alone will now get a higher recorded evaluation when `tool_success=True` is passed, and the recorded skill name changes if `skill_used` is supplied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f351002.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->