### PR TITLE
feat: MCP Context Exporter implementation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2893,7 +2893,7 @@
     },
     {
       "id": "mcp-context-exporter",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Context Exporter",
@@ -4212,6 +4212,40 @@
       ],
       "acceptance": [
         "Context compression successfully reduces prompt size without losing critical facts."
+      ]
+    },
+    {
+      "id": "cron-scheduler-daily-reports-v4",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Scheduled operations: daily reports",
+      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement scheduled daily reports capability.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron.py",
+        "tests/test_cron*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron scheduler handles daily reports.",
+        "Tests verify scheduled execution."
+      ]
+    },
+    {
+      "id": "cross-platform-telegram-channel-v4",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Cross-platform reach: Telegram channel v2",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Add improved Telegram messenger integration.",
+      "allowed_paths": [
+        "magda_agent/channels/telegram.py",
+        "tests/test_telegram*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can receive and send messages via Telegram v2 API.",
+        "Tests mock Telegram API."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_context.py
+++ b/magda_agent/integration/mcp_context.py
@@ -1,0 +1,65 @@
+from typing import Dict, Any, List, Callable, Optional
+from magda_agent.memory.context_engine import ContextEngine
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.memory.semantic import SemanticMemory
+
+class MCPContextExporter:
+    """
+    Exports Magda's Context Engine memory states as MCP tools.
+    """
+    def __init__(self, context_engine: ContextEngine, registry: Optional[SkillRegistry] = None, episodic_memory: Optional[EpisodicMemory] = None, semantic_memory: Optional[SemanticMemory] = None) -> None:
+        """Initialize MCPContextExporter with ContextEngine and optional dependencies."""
+        self.context_engine = context_engine
+        self.registry = registry
+        self.episodic_memory = episodic_memory
+        self.semantic_memory = semantic_memory
+
+        # If a registry is provided, register the tools
+        if self.registry:
+            self._register_tools()
+
+    def _register_tools(self) -> None:
+        """Registers memory context tools to the skill registry."""
+        if not self.registry:
+            return
+
+        self.registry.register_skill(
+            name="get_context",
+            func=self.get_context,
+            description="Retrieves the current context from the context engine using both episodic and semantic memories."
+        )
+
+    def get_context(self, query: str, user_id: int) -> List[Any]:
+        """
+        Retrieves the current context from the context engine.
+        """
+        def base_retrieval(q: str, uid: int) -> List[Any]:
+            """Retrieve from actual episodic and semantic memory."""
+            context_items = []
+            if self.episodic_memory:
+                context_items.extend(self.episodic_memory.recall_events(query=q, top_k=5, user_id=uid))
+            if self.semantic_memory:
+                context_items.extend(self.semantic_memory.recall_facts(query=q, top_k=5, user_id=uid))
+            return context_items
+
+        return self.context_engine.retrieve_context(query, user_id, base_retrieval_func=base_retrieval)
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists exported tools for the context.
+        """
+        return [
+            {
+                "name": "get_context",
+                "description": "Retrieves the current context from the context engine using both episodic and semantic memories.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "user_id": {"type": "integer"}
+                    },
+                    "required": ["query", "user_id"]
+                }
+            }
+        ]

--- a/tests/test_mcp_context.py
+++ b/tests/test_mcp_context.py
@@ -1,0 +1,51 @@
+import pytest
+from magda_agent.integration.mcp_context import MCPContextExporter
+from magda_agent.memory.context_engine import ContextEngine
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.memory.semantic import SemanticMemory
+from unittest.mock import MagicMock
+
+def test_mcp_context_exporter_initialization() -> None:
+    """Tests the initialization of the MCPContextExporter."""
+    mock_engine = MagicMock(spec=ContextEngine)
+    exporter = MCPContextExporter(mock_engine)
+    assert exporter.context_engine == mock_engine
+
+def test_list_tools() -> None:
+    """Tests that list_tools returns the correct MCP tool definition."""
+    mock_engine = MagicMock(spec=ContextEngine)
+    exporter = MCPContextExporter(mock_engine)
+    tools = exporter.list_tools()
+    assert len(tools) == 1
+    assert tools[0]["name"] == "get_context"
+
+def test_get_context() -> None:
+    """Tests retrieving context without backing memories."""
+    mock_engine = MagicMock(spec=ContextEngine)
+    mock_engine.retrieve_context.return_value = [{"mock": "data"}]
+    exporter = MCPContextExporter(mock_engine)
+    result = exporter.get_context("test query", 123)
+    assert result == [{"mock": "data"}]
+    mock_engine.retrieve_context.assert_called_once()
+
+def test_get_context_with_memories() -> None:
+    """Tests retrieving context correctly integrates with backing episodic and semantic memory."""
+    mock_engine = MagicMock(spec=ContextEngine)
+
+    def side_effect(query: str, user_id: int, base_retrieval_func: callable) -> list:
+        return base_retrieval_func(query, user_id)
+
+    mock_engine.retrieve_context.side_effect = side_effect
+
+    mock_episodic = MagicMock(spec=EpisodicMemory)
+    mock_episodic.recall_events.return_value = ["event1"]
+
+    mock_semantic = MagicMock(spec=SemanticMemory)
+    mock_semantic.recall_facts.return_value = ["concept1"]
+
+    exporter = MCPContextExporter(mock_engine, episodic_memory=mock_episodic, semantic_memory=mock_semantic)
+
+    result = exporter.get_context("test query", 123)
+    assert result == ["event1", "concept1"]
+    mock_episodic.recall_events.assert_called_once_with(query="test query", top_k=5, user_id=123)
+    mock_semantic.recall_facts.assert_called_once_with(query="test query", top_k=5, user_id=123)


### PR DESCRIPTION
Implements the MCP Context Exporter task to expose Magda's Context Engine memory states as MCP tools, fulfilling the first todo task in agent_tasks.json and updating its status to done. Adds 2 new actionable tasks inspired by docs/trends.md.

---
*PR created automatically by Jules for task [15105540517003104351](https://jules.google.com/task/15105540517003104351) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPContextExporter` to expose `ContextEngine` context retrieval as an MCP tool
> - Introduces [`MCPContextExporter`](https://github.com/kazah4359-lgtm/Magda-agent/pull/150/files#diff-a74ba44e46dd0e96474fc81559dc2fe6801abf221b602a3da84eac022f0aebc3) in a new `integration` module, wrapping `ContextEngine` as an MCP-compatible tool interface.
> - `get_context(query, user_id)` aggregates results from optional `EpisodicMemory.recall_events` and `SemanticMemory.recall_facts`, passing them as a `base_retrieval_func` to `ContextEngine.retrieve_context`.
> - `list_tools()` returns a JSON schema definition for the `get_context` tool to support tool discovery.
> - If a `SkillRegistry` is passed at construction time, the `get_context` tool is auto-registered during `__init__`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcbf017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->