### PR TITLE
Feature: A2A Protocol integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2909,7 +2909,7 @@
     },
     {
       "id": "a2a-protocol-integration-v4",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "Agent-to-Agent (A2A) Protocol integration",
@@ -4246,6 +4246,38 @@
       "acceptance": [
         "Agent can receive and send messages via Telegram v2 API.",
         "Tests mock Telegram API."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-visualization-v2",
+      "status": "todo",
+      "area": "ui",
+      "risk": "medium",
+      "title": "Canvas Live Visualization UI",
+      "description": "Inspired by OpenClaw trend: Add a Canvas interface for live visual feedback of agent state and outputs.",
+      "allowed_paths": [
+        "magda_agent/ui/canvas.py",
+        "tests/test_canvas.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas interface correctly initializes and visualizes text/objects dynamically."
+      ]
+    },
+    {
+      "id": "claude-dependency-graph-planner-v2",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Task system with dependency graphs",
+      "description": "Inspired by Claude SDK trend: Update the planner module to support resolving complex task dependency graphs during execution.",
+      "allowed_paths": [
+        "magda_agent/planning/dependency_graph.py",
+        "tests/test_dependency_graph.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner can traverse and execute tasks based on DAG dependencies."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Agent-to-Agent (A2A) Protocol integration
 * [x] FEATURE: Online RL from User Feedback v2 (online-rl-user-feedback-v2)
 * [x] FEATURE: Longitudinal Quality Metrics (longitudinal-quality-metrics-v2)
 * [x] FEATURE: Skill creation from experience

--- a/magda_agent/integration/a2a_protocol_integration.py
+++ b/magda_agent/integration/a2a_protocol_integration.py
@@ -1,0 +1,47 @@
+from typing import Dict, Any, List, Optional
+import logging
+from magda_agent.integration.a2a_discovery import AgentCard
+from magda_agent.integration.a2a_protocol import A2AProtocolManager
+
+class A2AProtocolIntegration:
+    """
+    Integration layer for the A2A Protocol, wrapping A2AProtocolManager to provide
+    an interface for discovering peers via Agent Cards and delegating peer-to-peer tasks.
+    """
+    def __init__(self, manager: A2AProtocolManager) -> None:
+        """
+        Initializes the A2A Protocol Integration.
+
+        Args:
+            manager: An instance of A2AProtocolManager.
+        """
+        self.manager = manager
+
+    async def start_and_discover(self, mock_network_cards: Optional[List[str]] = None) -> List[AgentCard]:
+        """
+        Starts the local manager to broadcast its card and discovers peers.
+
+        Args:
+            mock_network_cards: Optional list of raw JSON card payloads for mock discovery.
+
+        Returns:
+            A list of discovered AgentCard objects.
+        """
+        logging.info("A2AProtocolIntegration: Starting and discovering peers...")
+        await self.manager.start()
+        await self.manager.discover_peers(mock_network_cards=mock_network_cards)
+        return self.manager.get_known_peers()
+
+    async def execute_task_with_peer(self, capability: str, task_context: Dict[str, Any]) -> str:
+        """
+        Delegates a peer-to-peer task using the protocol manager.
+
+        Args:
+            capability: The capability required to perform the task.
+            task_context: Context for the task to be delegated.
+
+        Returns:
+            A result string describing the delegation success or failure.
+        """
+        logging.info(f"A2AProtocolIntegration: Executing task requiring '{capability}' with peer...")
+        return await self.manager.delegate_task(capability, task_context)

--- a/tests/test_a2a_protocol_integration.py
+++ b/tests/test_a2a_protocol_integration.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from magda_agent.integration.a2a_discovery import AgentCard
+from magda_agent.integration.a2a_protocol import A2AProtocolManager
+from magda_agent.integration.a2a_protocol_integration import A2AProtocolIntegration
+
+@pytest.fixture
+def mock_agent_card():
+    return AgentCard(
+        agent_id="test-peer-999",
+        name="TestPeer",
+        description="A test peer agent",
+        capabilities=["code_execution"],
+        endpoints={"mcp": "http://peer.local:9000"}
+    )
+
+@pytest.fixture
+def local_card():
+    return AgentCard("local", "local", "local", [], {})
+
+@pytest.mark.asyncio
+async def test_a2a_protocol_integration_discovery(mock_agent_card, local_card):
+    manager = A2AProtocolManager(local_card)
+    integration = A2AProtocolIntegration(manager)
+    peers = await integration.start_and_discover([mock_agent_card.to_json()])
+    assert len(peers) == 1
+    assert peers[0].agent_id == "test-peer-999"
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_a2a_protocol_integration_execute_task(mock_post, mock_agent_card, local_card):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": {"status": "Success"}}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    manager = A2AProtocolManager(local_card)
+    integration = A2AProtocolIntegration(manager)
+    await integration.start_and_discover([mock_agent_card.to_json()])
+    result = await integration.execute_task_with_peer("code_execution", {"task": "test"})
+    assert result == "Delegated to Agent TestPeer: Success"


### PR DESCRIPTION
Implemented Agent-to-Agent (A2A) protocol integration v4. This includes creating the A2AProtocolIntegration module which acts as a wrapper for peer discovery and P2P task delegation. Unit tests and mocking have been included. Additionally updated agent_tasks.json and backlog.md as per AI Agent trends.

---
*PR created automatically by Jules for task [3762203644943158930](https://jules.google.com/task/3762203644943158930) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A Protocol integration layer with peer discovery and task delegation
> - Introduces [`A2AProtocolIntegration`](https://github.com/kazah4359-lgtm/Magda-agent/pull/151/files#diff-140ebae5388a1f859689937c044bb7b51461b3d4aac40f6a136f3f49bcd7e85a) as a wrapper around `A2AProtocolManager`, exposing `start_and_discover` and `execute_task_with_peer` coroutines.
> - `start_and_discover` starts the manager, discovers peers via mock network cards, and returns the list of known `AgentCard` peers.
> - `execute_task_with_peer` delegates a task to a peer by capability name and returns the result string.
> - Adds integration tests in [`tests/test_a2a_protocol_integration.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/151/files#diff-24316f04c777fba0bd0fc9c10e774ce84bcca88a5dcb5f0a4f83f8204ac3ce5c) covering discovery and task delegation with a patched HTTP client.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized accb2d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->