### PR TITLE
feat: Add agentskills.io compatibility exporter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2960,7 +2960,7 @@
     },
     {
       "id": "skill-marketplace-agentskills-compatibility",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "Skill marketplace compatibility",
@@ -4382,6 +4382,42 @@
       "acceptance": [
         "Agent utilizes online RL signals to optimize behavior.",
         "Tests verify learning process."
+      ]
+    },
+    {
+      "id": "claude-subagent-worktree",
+      "status": "todo",
+      "area": "execution",
+      "risk": "high",
+      "title": "Agent Teams Worktree Isolation",
+      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
+      "allowed_paths": [
+        "magda_agent/agents/subagent.py",
+        "magda_agent/isolation/git_worktree.py",
+        "tests/test_git_worktree.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "SubAgents can spawn in isolated git worktrees",
+        "Changes in worktree do not affect main repo until merged",
+        "Tests verify isolation and lifecycle"
+      ]
+    },
+    {
+      "id": "acs-guardrails-checkpoint-interface",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Control Checkpoints Interface",
+      "description": "Inspired by trend: ACS (Agent Control Specification) — 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard.py",
+        "tests/test_acs_guard.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS Guard implements formal 5 checkpoint interfaces",
+        "Tests verify checkpoints block unsafe actions"
       ]
     }
   ]

--- a/magda_agent/integration/skill_marketplace.py
+++ b/magda_agent/integration/skill_marketplace.py
@@ -1,0 +1,66 @@
+from typing import Dict, Any, List, Callable
+import inspect
+from magda_agent.skills.registry import SkillRegistry
+
+class AgentSkillsExporter:
+    """
+    Exports Magda skills as agentskills.io compatible JSON objects.
+    """
+    def __init__(self, registry: SkillRegistry) -> None:
+        self.registry = registry
+
+    def _get_json_schema(self, func: Callable) -> Dict[str, Any]:
+        """
+        Extracts JSON schema parameters from the function signature.
+        """
+        if hasattr(func, "__mcp_schema__"):
+            return getattr(func, "__mcp_schema__")
+
+        sig = inspect.signature(func)
+        properties = {}
+        required = []
+
+        for name, param in sig.parameters.items():
+            if name in ('self', 'kwargs', 'args'):
+                continue
+
+            param_type = "string"
+            if param.annotation is not inspect.Parameter.empty:
+                if param.annotation is int:
+                    param_type = "integer"
+                elif param.annotation is float:
+                    param_type = "number"
+                elif param.annotation is bool:
+                    param_type = "boolean"
+                elif param.annotation is list or param.annotation is List:
+                    param_type = "array"
+                elif param.annotation is dict or param.annotation is Dict:
+                    param_type = "object"
+
+            properties[name] = {"type": param_type}
+
+            if param.default is inspect.Parameter.empty:
+                required.append(name)
+
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": required
+        }
+
+    def export_skills(self) -> List[Dict[str, Any]]:
+        """
+        Exports all registered skills to an agentskills.io compatible format.
+        """
+        skills = []
+        for name, func in self.registry.skills.items():
+            description = self.registry.descriptions.get(name, "")
+            schema = self._get_json_schema(func)
+
+            skills.append({
+                "name": name,
+                "description": description,
+                "parameters": schema
+            })
+
+        return skills

--- a/tests/test_skill_marketplace_integration.py
+++ b/tests/test_skill_marketplace_integration.py
@@ -1,0 +1,30 @@
+import pytest
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.integration.skill_marketplace import AgentSkillsExporter
+
+def mock_skill(query: str, max_results: int = 5) -> str:
+    """A mock skill for testing."""
+    return f"Results for {query}"
+
+def test_agent_skills_exporter_format() -> None:
+    """Tests the format of exported agentskills.io schemas."""
+    registry = SkillRegistry()
+    registry.register_skill("mock_skill", mock_skill, "A mock skill for testing.")
+    exporter = AgentSkillsExporter(registry)
+    exported = exporter.export_skills()
+
+    assert len(exported) == 1
+    skill = exported[0]
+
+    assert skill["name"] == "mock_skill"
+    assert skill["description"] == "A mock skill for testing."
+    assert "parameters" in skill
+
+    params = skill["parameters"]
+    assert params["type"] == "object"
+    assert "query" in params["properties"]
+    assert params["properties"]["query"]["type"] == "string"
+    assert "max_results" in params["properties"]
+    assert params["properties"]["max_results"]["type"] == "integer"
+    assert "query" in params["required"]
+    assert "max_results" not in params["required"]


### PR DESCRIPTION
Implements AgentSkillsExporter for agentskills.io standard. Updates task list with new trend inspired tasks.

---
*PR created automatically by Jules for task [9926166674067218087](https://jules.google.com/task/9926166674067218087) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AgentSkillsExporter` to export registered skills in agentskills.io format
> - Adds [`AgentSkillsExporter`](https://github.com/kazah4359-lgtm/Magda-agent/pull/154/files#diff-e1a1bfadcaded866f2226a6fda9ae9392f76dec12b0bc70e7b6281f5b00dcca7) that wraps a `SkillRegistry` and exposes an `export_skills` method returning a list of skill dicts compatible with agentskills.io.
> - Derives JSON Schema for each skill's parameters from Python type annotations, with support for overriding via a `__mcp_schema__` attribute on the function.
> - Adds a unit test in [`tests/test_skill_marketplace_integration.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/154/files#diff-deda6654d74097def45414ab3ee65e35cb7a3e9a29f1800656b2052c7f992341) covering parameter type inference and required field detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e2d754.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->