### PR TITLE
feat: A2A JSON-RPC Server Interface

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -2977,7 +2977,7 @@
     },
     {
       "id": "a2a-json-rpc-server",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A JSON-RPC Server Interface",
@@ -4418,6 +4418,57 @@
       "acceptance": [
         "ACS Guard implements formal 5 checkpoint interfaces",
         "Tests verify checkpoints block unsafe actions"
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-visual",
+      "status": "todo",
+      "area": "ui",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Live Visualization",
+      "description": "Inspired by OpenClaw trends: Implement a Canvas for live visualization of the agent state.",
+      "allowed_paths": [
+        "magda_agent/ui/canvas.py",
+        "tests/test_canvas.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent state can be visualized in a canvas.",
+        "Canvas module connects successfully."
+      ]
+    },
+    {
+      "id": "openclaw-rl-next-state-signals",
+      "status": "todo",
+      "area": "core",
+      "risk": "high",
+      "title": "OpenClaw RL Next-State Signals",
+      "description": "Inspired by OpenClaw-RL: Implement online reinforcement learning using next-state signals like user replies and tool outputs.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_signals.py",
+        "tests/test_rl_signals.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent learns from next-state signals.",
+        "Feedback updates agent behavior."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-teams",
+      "status": "todo",
+      "area": "core",
+      "risk": "high",
+      "title": "Claude Subagent Spawning",
+      "description": "Inspired by Claude Agent SDK trends: Implement subagent spawning for parallel execution of tasks using git worktree isolation.",
+      "allowed_paths": [
+        "magda_agent/agents/subagents.py",
+        "tests/test_subagents.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents can be spawned.",
+        "Tasks execute in parallel."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+- [x] a2a-json-rpc-server: A2A JSON-RPC Server Interface
 - [x] acs-runtime-safety-controls-v2: ACS runtime safety controls
 * [x] FEATURE: Agent-to-Agent (A2A) Protocol integration
 * [x] FEATURE: Online RL from User Feedback v2 (online-rl-user-feedback-v2)
@@ -162,6 +163,9 @@
 
 * [ ] BUG: `Brainstem` integration in `Consciousness.process_input` does not halt long-running skills gracefully upon a 'stop' command. Need to implement a cancellation token or mechanism for active background tasks when a stop reflex is triggered. (2026-06-04)
 ## 🛠️ Запланированные Skills
+* [ ] FEATURE: OpenClaw Canvas Live Visualization
+* [ ] FEATURE: OpenClaw RL Next-State Signals
+* [ ] FEATURE: Claude Subagent Spawning
 
 * [x] SKILL: **Omnichannel Provider (Работа с провайдерами)** — модуль `magda_agent/skills/omnichannel.py`. (2026-06-04)
   Умение работы с разными провайдерами (Telegram, WhatsApp и другие) для взаимодействия с агентом.

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -23,6 +23,7 @@ from magda_agent.learning.skill_creator import SkillCreator
 from magda_agent.learning.skill_versioning import SkillVersioning
 from magda_agent.skills import initialize_skills
 from magda_agent.planning.planner import Planner
+from magda_agent.integration.a2a_server import A2AServer
 from magda_agent.consciousness.core import Consciousness
 from magda_agent.subconsciousness.reflection import Subconsciousness
 from magda_agent.scheduler.cron import CronScheduler
@@ -174,7 +175,10 @@ autonomous_executor = AutonomousExecutor(
     step_timeout=float(os.getenv("AUTONOMY_STEP_TIMEOUT", "60")),
 )
 
+
 canvas_server = CanvasServer(consciousness=consciousness)
+a2a_server = A2AServer(planner=planner)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -192,6 +196,7 @@ async def lifespan(app: FastAPI):
     memory_system.close()
 
 app = FastAPI(title="Magda Consciousness API", lifespan=lifespan)
+app.mount("/a2a", a2a_server.app)
 
 _PUBLIC_HTTP_PATHS = {"/health"}
 

--- a/magda_agent/integration/a2a_server.py
+++ b/magda_agent/integration/a2a_server.py
@@ -1,0 +1,97 @@
+import json
+from typing import Any, Dict, Optional
+from fastapi import FastAPI, Request, Response
+from magda_agent.planning.planner import Planner
+
+class A2AServer:
+    """
+    A JSON-RPC 2.0 Server interface for the A2A (Agent-to-Agent) Protocol.
+    Receives and parses A2A task delegation requests and routes them to the Planner.
+    """
+    def __init__(self, planner: Planner) -> None:
+        """Initializes the A2AServer with a planner module."""
+        self.planner = planner
+        self.app = FastAPI(title="A2A JSON-RPC Server")
+
+        @self.app.post("/rpc")
+        async def handle_rpc(request: Request) -> Response:
+            """Endpoint that delegates processing to handle_request."""
+            return await self.handle_request(request)
+
+    async def handle_request(self, request: Request) -> Response:
+        """Handles the JSON-RPC request."""
+        try:
+            data = await request.json()
+        except Exception:
+            return Response(content=json.dumps({
+                "jsonrpc": "2.0",
+                "error": {"code": -32700, "message": "Parse error"},
+                "id": None
+            }), media_type="application/json", status_code=400)
+
+        if not isinstance(data, dict):
+            return Response(content=json.dumps({
+                "jsonrpc": "2.0",
+                "error": {"code": -32600, "message": "Invalid Request"},
+                "id": None
+            }), media_type="application/json", status_code=400)
+
+        is_notification = "id" not in data
+        req_id = data.get("id")
+        method = data.get("method")
+        params = data.get("params", {})
+
+        if data.get("jsonrpc") != "2.0" or not method:
+            # If it doesn't have jsonrpc="2.0", it's an invalid request, not a notification
+            return Response(content=json.dumps({
+                "jsonrpc": "2.0",
+                "error": {"code": -32600, "message": "Invalid Request"},
+                "id": req_id
+            }), media_type="application/json", status_code=400)
+
+        if method == "delegate_task":
+            if not isinstance(params, dict):
+                if is_notification:
+                    return Response(status_code=204)
+                return Response(content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32602, "message": "Invalid params"},
+                    "id": req_id
+                }), media_type="application/json", status_code=400)
+
+            task = params.get("task")
+            if not task:
+                if is_notification:
+                    return Response(status_code=204)
+                return Response(content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32602, "message": "Invalid params"},
+                    "id": req_id
+                }), media_type="application/json", status_code=400)
+
+            try:
+                # Route to the Planner. user_id is arbitrarily passed as "A2A_User"
+                await self.planner.generate_plan(user_input=task, user_id="A2A_User")
+                if is_notification:
+                    return Response(status_code=204)
+                return Response(content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "result": {"status": "accepted", "task": task},
+                    "id": req_id
+                }), media_type="application/json")
+            except Exception as e:
+                if is_notification:
+                    return Response(status_code=204)
+                return Response(content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32000, "message": str(e)},
+                    "id": req_id
+                }), media_type="application/json", status_code=500)
+        else:
+            if is_notification:
+                return Response(status_code=204)
+            return Response(content=json.dumps({
+                "jsonrpc": "2.0",
+                "error": {"code": -32601, "message": "Method not found"},
+                "id": req_id
+            }), media_type="application/json", status_code=404)

--- a/tests/test_a2a_server.py
+++ b/tests/test_a2a_server.py
@@ -1,0 +1,69 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock
+from fastapi.testclient import TestClient
+from magda_agent.integration.a2a_server import A2AServer
+from magda_agent.planning.planner import Planner
+
+@pytest.fixture
+def mock_planner():
+    planner = MagicMock(spec=Planner)
+    planner.generate_plan = AsyncMock()
+    return planner
+
+@pytest.fixture
+def test_client(mock_planner):
+    server = A2AServer(planner=mock_planner)
+    return TestClient(server.app)
+
+def test_parse_error(test_client):
+    response = test_client.post("/rpc", data="invalid json")
+    assert response.status_code == 400
+    res = response.json()
+    assert res["error"]["code"] == -32700
+
+def test_invalid_request(test_client):
+    response = test_client.post("/rpc", json={"method": "delegate_task"})
+    assert response.status_code == 400
+    res = response.json()
+    assert res["error"]["code"] == -32600
+
+def test_method_not_found(test_client):
+    response = test_client.post("/rpc", json={"jsonrpc": "2.0", "method": "unknown", "id": 1})
+    assert response.status_code == 404
+    res = response.json()
+    assert res["error"]["code"] == -32601
+
+def test_delegate_task_missing_params(test_client):
+    response = test_client.post("/rpc", json={"jsonrpc": "2.0", "method": "delegate_task", "params": {}, "id": 2})
+    assert response.status_code == 400
+    res = response.json()
+    assert res["error"]["code"] == -32602
+
+def test_delegate_task_success(test_client, mock_planner):
+    response = test_client.post("/rpc", json={
+        "jsonrpc": "2.0",
+        "method": "delegate_task",
+        "params": {"task": "do something"},
+        "id": 3
+    })
+    assert response.status_code == 200
+    res = response.json()
+    assert res["result"]["status"] == "accepted"
+    assert res["result"]["task"] == "do something"
+    mock_planner.generate_plan.assert_called_once()
+
+def test_delegate_task_invalid_params_type(test_client):
+    response = test_client.post("/rpc", json={"jsonrpc": "2.0", "method": "delegate_task", "params": ["task"], "id": 4})
+    assert response.status_code == 400
+    res = response.json()
+    assert res["error"]["code"] == -32602
+
+def test_notification(test_client, mock_planner):
+    response = test_client.post("/rpc", json={
+        "jsonrpc": "2.0",
+        "method": "delegate_task",
+        "params": {"task": "do something silent"}
+    })
+    assert response.status_code == 204
+    mock_planner.generate_plan.assert_called_once()


### PR DESCRIPTION
Implemented a JSON-RPC 2.0 Server interface for the A2A Protocol. Integrated it into the main FastAPI app. Updated task tracker.

---
*PR created automatically by Jules for task [2555232505909538338](https://jules.google.com/task/2555232505909538338) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A JSON-RPC 2.0 server interface at `/a2a/rpc`
> - Adds [a2a_server.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/155/files#diff-3e26ca5cfd4aa46513f90fc76ee061b94aa0b93e6b9430e71f4df273c80d672b) implementing a JSON-RPC 2.0 server with a `delegate_task` method that invokes `Planner.generate_plan` on behalf of external agents.
> - Mounts the A2A sub-application at `/a2a` in [api.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/155/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d), exposing the RPC endpoint at `/a2a/rpc`.
> - Returns standard JSON-RPC error codes for malformed requests and HTTP 204 for notifications (requests without an `id`).
> - Unit tests in [test_a2a_server.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/155/files#diff-41ce628173eed9a2188a37e5837115c9d7f2b755cb89a33e519b22fdcf9911bf) cover parse errors, invalid requests, method-not-found, param validation, successful delegation, and notification handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ca5f1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->