### PR TITLE
feat(agent-teams): resolve agent-teams-sub-agents and add new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3033,7 +3033,7 @@
     },
     {
       "id": "agent-teams-sub-agents",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams sub-agents spawning",
@@ -4520,6 +4520,57 @@
       "acceptance": [
         "MCPKernel blocks tainted inputs from execution.",
         "Sandboxing works properly."
+      ]
+    },
+    {
+      "id": "scheduled-operations-cron-v2",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Scheduled operations cron-like tasks",
+      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Add a new generic cron scheduler for tasks.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_v2.py",
+        "tests/test_cron_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can schedule tasks autonomously.",
+        "Tests verify scheduled execution."
+      ]
+    },
+    {
+      "id": "cross-platform-reach-v2",
+      "status": "todo",
+      "area": "channels",
+      "risk": "medium",
+      "title": "Cross-platform reach channels",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Expand channel adapters for more platforms.",
+      "allowed_paths": [
+        "magda_agent/channels/reach_v2.py",
+        "tests/test_reach_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent supports multiple communication channels out of the box.",
+        "Tests verify cross-platform message formatting."
+      ]
+    },
+    {
+      "id": "online-learning-from-dialogue-v3",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online learning from dialogue v3",
+      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections). Implement immediate context integration.",
+      "allowed_paths": [
+        "magda_agent/learning/dialogue_v3.py",
+        "tests/test_dialogue_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent immediately adjusts behavior based on current dialogue.",
+        "Tests verify prompt and dialogue learning updates."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,8 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Agent Teams sub-agents spawning (agent-teams-sub-agents)
+
 - [x] a2a-async-auth-tracing: A2A Enterprise-Ready Async Auth and Tracing
 - [x] a2a-json-rpc-server: A2A JSON-RPC Server Interface
 - [x] acs-runtime-safety-controls-v2: ACS runtime safety controls

--- a/magda_agent/agents/teams.py
+++ b/magda_agent/agents/teams.py
@@ -1,6 +1,6 @@
 import asyncio
-import logging
 from typing import List, Dict, Any
+import logging
 
 from magda_agent.agents.sub_agent import SubAgent
 from magda_agent.llm_client import LLMClient
@@ -9,15 +9,25 @@ class TeamManager:
     """
     Manages the execution of multiple sub-agents in parallel using git worktree isolation.
     """
-    def __init__(self, llm: LLMClient):
+    def __init__(self, llm: LLMClient) -> None:
         """
         Initializes the TeamManager.
+
+        Args:
+            llm (LLMClient): The LLM client to be passed to sub-agents.
         """
         self.llm = llm
 
     async def spawn_and_execute(self, tasks: List[Dict[str, Any]], context: str) -> List[str]:
         """
         Executes a list of tasks concurrently by spawning isolated SubAgents.
+
+        Args:
+            tasks (List[Dict[str, Any]]): A list of task specifications.
+            context (str): The common context for the tasks.
+
+        Returns:
+            List[str]: A list of results from the sub-agents.
         """
         logging.info(f"TeamManager spawning {len(tasks)} isolated sub-agents.")
 

--- a/tests/test_agent_teams_spawning.py
+++ b/tests/test_agent_teams_spawning.py
@@ -1,0 +1,55 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from magda_agent.agents.teams import TeamManager
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_team_manager_spawn_and_execute_parallel():
+    """
+    Tests that TeamManager spawns sub-agents and executes them in parallel.
+    """
+    llm_mock = MagicMock(spec=LLMClient)
+
+    manager = TeamManager(llm=llm_mock)
+
+    tasks = [
+        {"description": "Task 1: Search logs"},
+        {"description": "Task 2: Analyze performance"},
+        {"description": "Task 3: Write report"}
+    ]
+
+    with patch('magda_agent.agents.teams.SubAgent.execute', new_callable=AsyncMock) as mock_execute:
+        # Mock responses based on the task description
+        async def mock_execute_side_effect(task, context):
+            # Sleep to simulate some work and allow testing of parallel execution
+            await asyncio.sleep(0.01)
+            return f"Result for {task}"
+
+        mock_execute.side_effect = mock_execute_side_effect
+
+        results = await manager.spawn_and_execute(tasks=tasks, context="System Context")
+
+        assert len(results) == 3
+        assert results == [
+            "Result for Task 1: Search logs",
+            "Result for Task 2: Analyze performance",
+            "Result for Task 3: Write report"
+        ]
+
+        assert mock_execute.call_count == 3
+        # Verify the context is passed to execute
+        mock_execute.assert_any_call(task="Task 1: Search logs", context="System Context")
+        mock_execute.assert_any_call(task="Task 2: Analyze performance", context="System Context")
+        mock_execute.assert_any_call(task="Task 3: Write report", context="System Context")
+
+@pytest.mark.asyncio
+async def test_team_manager_empty_tasks():
+    """
+    Tests TeamManager with an empty task list.
+    """
+    llm_mock = MagicMock(spec=LLMClient)
+    manager = TeamManager(llm=llm_mock)
+
+    results = await manager.spawn_and_execute(tasks=[], context="System Context")
+    assert results == []


### PR DESCRIPTION
Resolves agent-teams-sub-agents task.

---
*PR created automatically by Jules for task [5609696318620412827](https://jules.google.com/task/5609696318620412827) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for `TeamManager.spawn_and_execute` and new agent task backlog entries
> - Adds two async tests in [tests/test_agent_teams_spawning.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/158/files#diff-a6ac4f71a823176060ab90c8c05c5ecd788647c4f9153142c4f4061fd766cd5d): one verifying parallel sub-agent execution returns correct results, and one verifying empty task lists return an empty list.
> - Marks the `agent-teams-sub-agents` task as done in [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/158/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) and adds three new tasks: `scheduled-operations-cron-v2`, `cross-platform-reach-v2`, and `online-learning-from-dialogue-v3`.
> - Expands docstrings in [magda_agent/agents/teams.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/158/files#diff-bce7347d8723f89f3f56a9dd03e93d22a29651fc91267b288756a29b4768a034) with argument and return type documentation; no logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce3f62e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->