### PR TITLE
OpenClaw Canvas Live Visualizer

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3103,7 +3103,7 @@
     },
     {
       "id": "openclaw-live-canvas-visualizer",
-      "status": "todo",
+      "status": "done",
       "area": "gateway",
       "risk": "medium",
       "title": "Canvas live visualization support",
@@ -4724,6 +4724,57 @@
       "acceptance": [
         "Director agent delegates to workers",
         "Orchestration handles Magentic-One pattern"
+      ]
+    },
+    {
+      "id": "falco-prempti-interception",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Falco Prempti Tool Interception",
+      "description": "Inspired by trend: Prempti (Falco): tool-call interception + audit trail. Implement tool call auditing.",
+      "allowed_paths": [
+        "magda_agent/safety/audit.py",
+        "tests/test_audit.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audit logs are generated",
+        "Tests verify interception"
+      ]
+    },
+    {
+      "id": "hermes-skill-experience",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Skill Creation from Experience",
+      "description": "Inspired by trend: Skill creation from experience (Hermes). Implement experience to skill creation.",
+      "allowed_paths": [
+        "magda_agent/learning/experience.py",
+        "tests/test_experience.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Experience is converted to skills",
+        "Skills are validated"
+      ]
+    },
+    {
+      "id": "mcpkernel-taint-tracking-v3",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCPKernel Taint Tracking",
+      "description": "Inspired by trend: MCPKernel: taint tracking + sandboxed execution.",
+      "allowed_paths": [
+        "magda_agent/safety/taint.py",
+        "tests/test_taint.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tainted inputs are tracked",
+        "Sandboxed execution is verified"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: OpenClaw Canvas live visualization support (openclaw-live-canvas-visualizer)
 - [x] MCP server-prefixed tools support
 * [x] FEATURE: Cross-platform reach across channels (cross-platform-reach-channels)
 * [x] FEATURE: Agent Teams sub-agents spawning (agent-teams-sub-agents)

--- a/magda_agent/gateway/canvas.py
+++ b/magda_agent/gateway/canvas.py
@@ -1,0 +1,37 @@
+import asyncio
+import json
+from typing import Dict, Any, List
+
+class CanvasVisualizer:
+    """
+    OpenClaw trend: Canvas live visualization.
+    Maintains agent state and streams updates to subscribed clients.
+    """
+    def __init__(self):
+        self._state: Dict[str, Any] = {}
+        self._subscribers: List[asyncio.Queue] = []
+
+    def get_state(self) -> Dict[str, Any]:
+        """Returns the current canvas state."""
+        return dict(self._state)
+
+    async def update_state(self, key: str, value: Any) -> None:
+        """Updates a state variable and broadcasts to subscribers."""
+        self._state[key] = value
+        await self._broadcast({"type": "state_update", "key": key, "value": value})
+
+    async def _broadcast(self, message: Dict[str, Any]) -> None:
+        """Sends message to all active subscribers."""
+        for q in self._subscribers:
+            await q.put(message)
+
+    def subscribe(self) -> asyncio.Queue:
+        """Subscribes a new client and returns a queue for reading updates."""
+        q = asyncio.Queue()
+        self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue) -> None:
+        """Unsubscribes a client queue."""
+        if q in self._subscribers:
+            self._subscribers.remove(q)

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,0 +1,19 @@
+import pytest
+import asyncio
+from magda_agent.gateway.canvas import CanvasVisualizer
+
+@pytest.mark.asyncio
+async def test_canvas_visualizer():
+    canvas = CanvasVisualizer()
+    q = canvas.subscribe()
+
+    await canvas.update_state("active_task", "OpenClaw RL")
+
+    assert canvas.get_state() == {"active_task": "OpenClaw RL"}
+
+    msg = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert msg == {"type": "state_update", "key": "active_task", "value": "OpenClaw RL"}
+
+    canvas.unsubscribe(q)
+    await canvas.update_state("active_task", "Done")
+    assert q.empty()


### PR DESCRIPTION
Implements CanvasVisualizer state tracking, updates task manifest, adds new tasks based on trends, and updates backlog.

---
*PR created automatically by Jules for task [2195144696905987635](https://jules.google.com/task/2195144696905987635) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CanvasVisualizer` for live canvas state visualization
> - Adds [canvas.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/162/files#diff-0e071520a64672c08fab1c5a85a2a179242bb22e834dc67342e886df01677500) with a new `CanvasVisualizer` class that maintains a shared state dictionary and broadcasts updates to subscribers via `asyncio.Queue`.
> - Callers subscribe via `subscribe()`, receive `state_update` messages on each `update_state()` call, and can unsubscribe to stop receiving messages.
> - Adds async tests in [test_canvas.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/162/files#diff-e74e95979bacb06e84b46294efec175efbdd0a4cd59948bfbdeeaf1d8cc33950) covering subscribe, state update, broadcast receipt, and unsubscribe behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eab0e05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->