### PR TITLE
feat: implement online rl from user feedback v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3186,7 +3186,7 @@
     },
     {
       "id": "online-rl-from-feedback-v4",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online RL from user feedback v4",
@@ -4928,6 +4928,57 @@
       "acceptance": [
         "Can provision and run commands in a simulated remote VM",
         "Tests verify boundaries and credentials protection"
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-system",
+      "status": "todo",
+      "area": "scheduler",
+      "risk": "high",
+      "title": "Hermes Cron Scheduler System",
+      "description": "Inspired by trend: Cron scheduler: daily reports, nightly backups, scheduled tasks (Hermes). Implement a robust cron scheduling system for autonomous background tasks.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron.py",
+        "tests/test_cron.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "System can parse cron expressions and schedule tasks",
+        "Tests verify tasks trigger at correct times without overlapping"
+      ]
+    },
+    {
+      "id": "openai-realtime-guardrail-fallback-v2",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "OpenAI Realtime Guardrail Fallback",
+      "description": "Inspired by trend: Realtime guardrail fallback (OpenAI). Implement dynamic fallback strategies when runtime safety guardrails block a tool call.",
+      "allowed_paths": [
+        "magda_agent/safety/fallback.py",
+        "tests/test_fallback.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Fallback mechanisms intercept blocked actions and substitute safer alternatives",
+        "Tests verify that fallback is triggered appropriately"
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Claude Evaluator Subagent",
+      "description": "Inspired by trend: Planner, Generator, Evaluator pattern (Claude). Implement an Evaluator Subagent to review Generator outputs against Planner constraints.",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator.py",
+        "tests/test_evaluator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator Subagent can successfully score outputs against defined constraints",
+        "Tests verify the evaluator detects and rejects flawed outputs"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -195,3 +195,4 @@
   Отвечает за cron-подобные фоновые задачи без участия пользователя.
   Интеграция: Вызывается в `api.py` при старте.
   Тесты: mock _get_now, проверить логику scheduler._execute_job.
+* [x] FEATURE: Online RL from User Feedback v4 (online-rl-from-feedback-v4)

--- a/magda_agent/learning/online_rl.py
+++ b/magda_agent/learning/online_rl.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Optional, Dict
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
 
@@ -18,6 +18,7 @@ class OnlineRLIntegrator:
         """
         self.habit_tracker = habit_tracker
         self.mirror_neurons = mirror_neurons
+        self.skill_weights: Dict[str, float] = {}
 
     async def process_feedback(self, user_reply: str, action_context: str, user_id: Optional[int] = None, explicit_score: Optional[float] = None, tool_success: bool = False, skill_used: str = "rl_feedback_skill") -> None:
         """
@@ -45,13 +46,18 @@ class OnlineRLIntegrator:
         if tool_success:
             weight += 2.0
 
+        if skill_used not in self.skill_weights:
+            self.skill_weights[skill_used] = 1.0
+
         if weight >= 8.0:
+            self.skill_weights[skill_used] += 0.1
             self.habit_tracker.record_usage(
                 input_text=action_context,
                 skill_used=skill_used,
                 evaluation_score=weight,
                 user_id=user_id
             )
-            logging.info(f"Online RL: Positive feedback (weight={weight:.2f}). Recorded usage.")
+            logging.info(f"Online RL: Positive feedback (weight={weight:.2f}). Recorded usage. New weight for {skill_used}: {self.skill_weights[skill_used]:.2f}")
         else:
-            logging.info(f"Online RL: Negative/Neutral feedback (weight={weight:.2f}). No usage recorded.")
+            self.skill_weights[skill_used] = max(0.1, self.skill_weights[skill_used] - 0.1)
+            logging.info(f"Online RL: Negative/Neutral feedback (weight={weight:.2f}). No usage recorded. New weight for {skill_used}: {self.skill_weights[skill_used]:.2f}")

--- a/tests/test_online_rl.py
+++ b/tests/test_online_rl.py
@@ -17,7 +17,7 @@ async def test_process_feedback_positive(mock_habit_tracker, mock_mirror_neurons
     mock_mirror_neurons.empathize.return_value = (0.8, 0.1, 0.0)
     integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
 
-    await integrator.process_feedback("Great job!", "test_context", user_id=1)
+    await integrator.process_feedback("Great job!", "test_context", user_id=1, skill_used="rl_feedback_skill")
 
     # weight = (0.8 + 1.0) * 5.0 = 9.0
     mock_habit_tracker.record_usage.assert_called_once_with(
@@ -26,13 +26,15 @@ async def test_process_feedback_positive(mock_habit_tracker, mock_mirror_neurons
         evaluation_score=9.0,
         user_id=1
     )
+    assert integrator.skill_weights["rl_feedback_skill"] == 1.1
 
 @pytest.mark.asyncio
 async def test_process_feedback_negative(mock_habit_tracker, mock_mirror_neurons):
     mock_mirror_neurons.empathize.return_value = (-0.5, 0.1, 0.0)
     integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
 
-    await integrator.process_feedback("Terrible.", "test_context", user_id=1)
+    await integrator.process_feedback("Terrible.", "test_context", user_id=1, skill_used="rl_feedback_skill")
 
     # weight = (-0.5 + 1.0) * 5.0 = 2.5 (less than 8.0)
     mock_habit_tracker.record_usage.assert_not_called()
+    assert integrator.skill_weights["rl_feedback_skill"] == 0.9


### PR DESCRIPTION
Implemented task `online-rl-from-feedback-v4` by adding dynamic skill weights to the `OnlineRLIntegrator`. Added relevant tests, completed the task in `agent_tasks.json` and `backlog.md`, and generated 3 new trend-inspired tasks as instructed.

---
*PR created automatically by Jules for task [8476890205598660464](https://jules.google.com/task/8476890205598660464) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement per-skill weight tracking in `OnlineRLIntegrator.process_feedback`
> - Adds a `skill_weights` dict to `OnlineRLIntegrator` to track a float weight per skill across feedback calls.
> - On positive feedback (score ≥ 8.0), increments the skill weight by 0.1 and records usage via `habit_tracker`; on negative/neutral feedback, decrements by 0.1 with a floor of 0.1.
> - Updates tests in [test_online_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/168/files#diff-7fadaa25c3a80fe952799e27c42c90786d879064fafa3db850c10cce77a521d3) to assert weight becomes 1.1 after positive and 0.9 after negative feedback for a given skill.
> - Behavioral Change: `process_feedback` now mutates shared instance state (`skill_weights`), so repeated calls accumulate weight changes across the lifetime of the integrator.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdd02c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->