### PR TITLE
feat(evaluation): implement AgentBench Multi-domain Evaluation harness

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3220,7 +3220,7 @@
     },
     {
       "id": "agentbench-multi-domain-eval",
-      "status": "todo",
+      "status": "done",
       "area": "evaluation",
       "risk": "low",
       "title": "AgentBench Multi-domain Evaluation",
@@ -5030,6 +5030,57 @@
       "acceptance": [
         "Importer can fetch and unpack external skill definitions",
         "Tests verify behavior and cache invalidation"
+      ]
+    },
+    {
+      "id": "swe-bench-evaluation-integration",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "SWE-bench Evaluation Integration",
+      "description": "Inspired by trend: SWE-bench Evaluation. Integrate SWE-bench evaluation harness for code agent benchmarking.",
+      "allowed_paths": [
+        "magda_agent/evaluation/swe_bench.py",
+        "tests/test_swe_bench.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Integration with SWE-bench dataset runs local code evaluation",
+        "Tests mock SWE-bench interactions"
+      ]
+    },
+    {
+      "id": "mcp-action-tool-validation-v2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Validation",
+      "description": "Inspired by trend: MCP standards. Validate the schemas of newly registered MCP action tools automatically.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_validator.py",
+        "tests/test_mcp_validator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Validator correctly intercepts and validates tool JSON schemas",
+        "Tests mock MCP schemas and verify correct exception paths"
+      ]
+    },
+    {
+      "id": "persistent-memory-layer-v3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Persistent Memory Layer Expansion",
+      "description": "Inspired by trend: Persistent memory. Extend the context engine to directly persist long-running conversational memory chunks safely.",
+      "allowed_paths": [
+        "magda_agent/memory/persistent_v3.py",
+        "tests/test_persistent_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine saves context across sessions",
+        "Tests verify memory chunks are persisted using mock database clients"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: AgentBench Multi-domain Evaluation (agentbench-multi-domain-eval)
 * [x] FEATURE: MCPKernel Taint Tracking Sandbox
 * [x] FEATURE: OpenClaw Canvas live visualization support (openclaw-live-canvas-visualizer)
 - [x] MCP server-prefixed tools support

--- a/magda_agent/evaluation/agentbench.py
+++ b/magda_agent/evaluation/agentbench.py
@@ -21,8 +21,28 @@ class AgentBenchHarness:
             db_path (str): The path to the SQLite database used by QualityTracker.
         """
         self.tracker = QualityTracker(db_path=db_path)
-        self.suites = ["web_navigation", "os_interaction", "reasoning"]
+        self.suites = ["web_navigation", "os_interaction", "reasoning", "coding"]
         self.llm = LLMClient()
+
+    def compare_with_baseline(self, score: float, suite_name: str) -> bool:
+        """
+        Compares the given score against the suite's baseline.
+
+        Args:
+            score (float): The score to compare.
+            suite_name (str): The name of the suite.
+
+        Returns:
+            bool: True if the score meets or exceeds the baseline, False otherwise.
+        """
+        baselines = {
+            "web_navigation": 0.6,
+            "os_interaction": 0.5,
+            "reasoning": 0.8,
+            "coding": 0.7
+        }
+        return score >= baselines.get(suite_name, 0.5)
+
 
     async def run_evaluation_suite(self, suite_name: str) -> Dict[str, Any]:
         """
@@ -57,7 +77,7 @@ class AgentBenchHarness:
 
         passed = int(score * tasks_run)
 
-        metadata = {"suite": suite_name, "tasks_run": tasks_run, "passed": passed}
+        metadata = {"suite": suite_name, "tasks_run": tasks_run, "passed": passed, "meets_baseline": self.compare_with_baseline(score, suite_name)}
 
         return {
             "score": score,

--- a/tests/test_agentbench.py
+++ b/tests/test_agentbench.py
@@ -13,7 +13,7 @@ def temp_db(tmp_path):
 @patch("magda_agent.evaluation.agentbench.LLMClient")
 async def test_run_evaluation_suite(mock_llm_client, temp_db):
     mock_instance = MagicMock()
-    mock_instance.generate = AsyncMock(side_effect=["0.85", "0.70", "invalid"])
+    mock_instance.generate = AsyncMock(side_effect=["0.85", "0.70", "invalid", "0.90"])
     mock_llm_client.return_value = mock_instance
 
     harness = AgentBenchHarness(db_path=temp_db)
@@ -37,13 +37,13 @@ async def test_run_evaluation_suite(mock_llm_client, temp_db):
 @patch("magda_agent.evaluation.agentbench.LLMClient")
 async def test_trigger_evaluations_logs_metrics(mock_llm_client, temp_db):
     mock_instance = MagicMock()
-    mock_instance.generate = AsyncMock(side_effect=["0.85", "0.70", "0.90"])
+    mock_instance.generate = AsyncMock(side_effect=["0.85", "0.70", "0.90", "0.80"])
     mock_llm_client.return_value = mock_instance
 
     harness = AgentBenchHarness(db_path=temp_db)
 
     results = await harness.trigger_evaluations()
-    assert len(results) == 3
+    assert len(results) == 4
 
     # Verify the metrics were logged to SQLite via QualityTracker
     conn = sqlite3.connect(temp_db)
@@ -52,8 +52,9 @@ async def test_trigger_evaluations_logs_metrics(mock_llm_client, temp_db):
     rows = cursor.fetchall()
     conn.close()
 
-    assert len(rows) == 3
+    assert len(rows) == 4
     metrics = {row[0]: row[1] for row in rows}
     assert metrics["agentbench_reasoning_score"] == 0.90 # the suites are queried in order: web_nav (0.85), os_inter (0.70), reasoning (0.90)
     assert metrics["agentbench_web_navigation_score"] == 0.85
     assert metrics["agentbench_os_interaction_score"] == 0.70
+    assert metrics["agentbench_coding_score"] == 0.80


### PR DESCRIPTION
Implements AgentBench harness for multi-domain evaluation tracking. Updates agent_tasks.json and backlog.md.

---
*PR created automatically by Jules for task [5240723630122057894](https://jules.google.com/task/5240723630122057894) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `coding` suite and baseline comparison to AgentBench evaluation harness
> - Adds `'coding'` to the default evaluation suites in `AgentBenchHarness.__init__`, bringing the total to four suites evaluated on each run.
> - Introduces `AgentBenchHarness.compare_with_baseline`, a method that returns whether a suite score meets per-suite thresholds (web_navigation, os_interaction, reasoning, coding), defaulting to 0.5.
> - Extends `run_evaluation_suite` metadata to include a `meets_baseline` boolean, and updates tests to expect four suite results and four logged metrics including `agentbench_coding_score`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08ed893.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->