### PR TITLE
feat: implement robust runtime function tool concurrency v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3237,7 +3237,7 @@
     },
     {
       "id": "runtime-function-tool-concurrency-v2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Runtime function tool concurrency v2",
@@ -5081,6 +5081,57 @@
       "acceptance": [
         "Context engine saves context across sessions",
         "Tests verify memory chunks are persisted using mock database clients"
+      ]
+    },
+    {
+      "id": "mcp-export-error-translation-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Exporter error translation",
+      "description": "Inspired by MCP standard trend: Ensure MCPExporter correctly translates MagdaMCPAdapter string errors starting with 'Error' into standard JSON-RPC errors.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter.py",
+        "tests/test_mcp_exporter*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Errors starting with 'Error' return valid JSON-RPC error format.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-peer-delegation-discovery-v2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A Peer Delegation Discovery",
+      "description": "Inspired by A2A Protocol trend: Implement discovery using Agent Cards for the peer-to-peer task delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a.py",
+        "tests/test_a2a*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent Cards can be broadcast and discovered.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "context-engine-plugin-lifecycle-v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine plugin lifecycle hooks",
+      "description": "Inspired by OpenClaw trend: Implement Context Engine plugin interface with before_retrieval and after_retrieval lifecycle hooks.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine.py",
+        "tests/test_context_engine*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lifecycle hooks fire correctly before and after memory fetch.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_engine.py
+++ b/magda_agent/skills/mcp_engine.py
@@ -38,10 +38,14 @@ class MCPEngine:
         # 1. Register the remote tool routing with the MCPClient
         self.mcp_client.register_remote_tool(tool_name, connection_info)
 
+        import asyncio
+        import concurrent.futures
+
         # 2. Create the wrapper skill that delegates to MCPClient
-        async def mcp_wrapper_skill(**kwargs: Any) -> Any:
+        def mcp_wrapper_skill(**kwargs: Any) -> Any:
             """
             Dynamically executes the imported MCP tool via the MCPClient.
+            Runs synchronously to safely integrate with Magda's executor.
 
             Args:
                 kwargs: Arguments to pass to the MCP tool.
@@ -49,7 +53,13 @@ class MCPEngine:
             Returns:
                 Any: Result of the MCP tool execution.
             """
-            return await self.mcp_client.execute_tool(tool_name, **kwargs)
+            coro = self.mcp_client.execute_tool(tool_name, **kwargs)
+            try:
+                loop = asyncio.get_running_loop()
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    return pool.submit(asyncio.run, coro).result()
+            except RuntimeError:
+                return asyncio.run(coro)
 
         # Add the schema attribute so MagdaMCPAdapter natively picks it up if needed.
         setattr(mcp_wrapper_skill, "__mcp_schema__", input_schema)

--- a/tests/test_mcp_engine.py
+++ b/tests/test_mcp_engine.py
@@ -53,7 +53,7 @@ async def test_mcp_engine_wrapper_execution() -> None:
 
     engine.import_mcp_tool(tool_def, connection_info)
 
-    result = await registry.execute_skill("external_weather", location="Paris")
+    result = registry.execute_skill("external_weather", location="Paris")
 
     assert result == "Sunny, 25C"
     mcp_client.execute_tool.assert_awaited_once_with("external_weather", location="Paris")

--- a/tests/test_tool_concurrency_v2.py
+++ b/tests/test_tool_concurrency_v2.py
@@ -1,0 +1,27 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock
+from magda_agent.skills.concurrency import ConcurrentSkillExecutor
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_engine import MCPEngine
+from magda_agent.skills.mcp_client import MCPClient
+
+@pytest.mark.asyncio
+async def test_mcp_wrapper_concurrency() -> None:
+    """Tests that MCP tools can be executed concurrently without returning unawaited coroutines."""
+    registry = SkillRegistry()
+    mcp_client = AsyncMock(spec=MCPClient)
+    mcp_client.execute_tool.return_value = "mcp tool success"
+    mcp_client.register_remote_tool = AsyncMock()
+
+    engine = MCPEngine(registry, mcp_client)
+    tool_def = {"name": "test_mcp_tool", "description": "test", "inputSchema": {}}
+    engine.import_mcp_tool(tool_def, {})
+
+    executor = ConcurrentSkillExecutor(registry)
+
+    # Execute concurrently
+    calls = [{"name": "test_mcp_tool", "kwargs": {"param": 1}} for _ in range(3)]
+    results = await executor.execute_concurrently(calls)
+
+    assert results == ["mcp tool success", "mcp tool success", "mcp tool success"]


### PR DESCRIPTION
Resolves runtime-function-tool-concurrency-v2 by making mcp_wrapper_skill a synchronous wrapper using asyncio/ThreadPoolExecutor. Adds concurrent tests, updates existing tests, and updates agent tasks with 3 new trending tasks.

---
*PR created automatically by Jules for task [17572220208280327802](https://jules.google.com/task/17572220208280327802) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register MCP tools as synchronous wrappers to support concurrent execution
> - Changes `MCPEngine.import_mcp_tool` in [mcp_engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/171/files#diff-26572b42493a12c4ec9d8bfa23bfc751544330482e76b956aebd528de7d4c9df) to register a synchronous wrapper instead of an async one, so callers receive concrete results rather than unawaited coroutines.
> - The wrapper runs the underlying async `MCPClient.execute_tool` coroutine via `asyncio.run`; if an event loop is already running, it dispatches to a `ThreadPoolExecutor` to avoid deadlocks.
> - Adds a concurrency test in [test_tool_concurrency_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/171/files#diff-eaa8f2dcbacb4a5bfb226535043852545622d6aeae123a7e6a3dc45fcedc959a) that verifies three concurrent `ConcurrentSkillExecutor` calls return concrete results.
> - Behavioral Change: any code that previously `await`ed the result of an imported MCP tool must now call it synchronously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5eb44f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->