### PR TITLE
feat: implement OpenClaw-RL online reinforcement learning from next-state signals

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3288,7 +3288,7 @@
     },
     {
       "id": "openclaw-rl-next-state-signals-v3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Online reinforcement learning from Next-State",
@@ -5217,6 +5217,59 @@
       "acceptance": [
         "CronScheduler can schedule and execute tasks periodically.",
         "Pytest tests verify scheduling logic."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-expansion-v1",
+      "status": "todo",
+      "area": "orchestration",
+      "risk": "medium",
+      "title": "Hermes-inspired Cron Scheduler Expansion",
+      "description": "Inspired by Hermes Agent trend: Expand the CronScheduler to support dynamic job registration at runtime and daily reporting functions.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_v5.py",
+        "tests/test_cron_v5*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "CronScheduler can dynamically register and execute new jobs.",
+        "A daily report skeleton job is added.",
+        "Pytest tests verify registration logic."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-compression-v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Compression",
+      "description": "Inspired by MemGPT/Letta pattern and Claude Context Compression trends: Implement a context compression mechanism within the ContextEngine to summarize older memory chunks automatically.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine.py",
+        "tests/test_context_engine*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context compression summarizes older memories.",
+        "Tests verify that context length stays within bounds without losing key facts."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-concurrency-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Runtime Function Tool Concurrency",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement runtime function tool concurrency specifically for external MCP action tools to speed up parallel API calls.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry.py",
+        "magda_agent/skills/mcp_engine.py",
+        "tests/test_mcp_concurrency.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Multiple independent MCP tools can be executed concurrently.",
+        "Tests mock concurrent execution and verify completion times."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -172,7 +172,7 @@
 * [ ] BUG: `Brainstem` integration in `Consciousness.process_input` does not halt long-running skills gracefully upon a 'stop' command. Need to implement a cancellation token or mechanism for active background tasks when a stop reflex is triggered. (2026-06-04)
 ## 🛠️ Запланированные Skills
 * [ ] FEATURE: OpenClaw Canvas Live Visualization
-* [ ] FEATURE: OpenClaw RL Next-State Signals
+* [x] FEATURE: OpenClaw RL Next-State Signals
 * [ ] FEATURE: Claude Subagent Spawning
 
 * [x] SKILL: **Omnichannel Provider (Работа с провайдерами)** — модуль `magda_agent/skills/omnichannel.py`. (2026-06-04)

--- a/magda_agent/learning/openclaw_rl.py
+++ b/magda_agent/learning/openclaw_rl.py
@@ -20,7 +20,7 @@ class OpenClawInteractiveLearner:
         self.mirror_neurons = mirror_neurons
         self.user_model = user_model
 
-    async def process_next_state_signal(self, user_reply: str, action_context: str, user_id: int) -> None:
+    async def process_next_state_signal(self, user_reply: str, action_context: str, user_id: int, tool_output: Optional[str] = None) -> None:
         """
         Analyzes the user's reply as a next-state signal, and reinforces habits and updates preferences.
 
@@ -28,11 +28,16 @@ class OpenClawInteractiveLearner:
             user_reply (str): The text of the user's reply.
             action_context (str): The context of the action that was taken.
             user_id (int): The user's ID.
+            tool_output (Optional[str], optional): The output of the tool, if any. Defaults to None.
         """
         if not user_reply or not action_context:
             return
 
-        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_reply)
+        signal_text = user_reply
+        if tool_output:
+            signal_text += f" [Tool Output: {tool_output}]"
+
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(signal_text)
         model_data = self.user_model.get_model(user_id)
 
         if p_shift > 0.0:

--- a/tests/test_openclaw_rl.py
+++ b/tests/test_openclaw_rl.py
@@ -63,3 +63,26 @@ async def test_openclaw_rl_negative_signal(mock_habit_tracker, mock_mirror_neuro
     model_data = user_model.get_model(2)
     assert model_data["preferences"]["last_p_shift"] == -0.3
     assert "(cautious)" in model_data["communication_style"]
+
+@pytest.mark.asyncio
+async def test_openclaw_rl_tool_output(mock_habit_tracker: MagicMock, mock_mirror_neurons: MagicMock, user_model: UserModel) -> None:
+    """Tests that the OpenClawInteractiveLearner correctly processes next-state signals with tool outputs."""
+    learner = OpenClawInteractiveLearner(mock_habit_tracker, mock_mirror_neurons, user_model)
+
+    # Mock positive empathize
+    mock_mirror_neurons.empathize.return_value = (0.5, 0.1, 0.0)
+
+    await learner.process_next_state_signal("This is fine", "test_context", 3, tool_output="Success: data saved")
+
+    # Check mirror neurons called with both
+    mock_mirror_neurons.empathize.assert_called_once_with("This is fine [Tool Output: Success: data saved]")
+
+    # Check habit tracker
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="test_context", skill_used="rl_skill", evaluation_score=10.0, user_id=3
+    )
+
+    # Check user model modification
+    model_data = user_model.get_model(3)
+    assert model_data["preferences"]["last_p_shift"] == 0.5
+    assert "(friendly)" in model_data["communication_style"]


### PR DESCRIPTION
This PR implements the OpenClaw-RL online reinforcement learning module by updating `OpenClawInteractiveLearner` to correctly process `tool_output` next-state signals. It updates the agent task JSON, appends 3 new trending task descriptions, and updates the backlog. Tests verify the tool output interpolations.

---
*PR created automatically by Jules for task [15832687990532264071](https://jules.google.com/task/15832687990532264071) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional `tool_output` parameter to `OpenClawInteractiveLearner.process_next_state_signal`
> Extends `process_next_state_signal` in [openclaw_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/174/files#diff-97cf6ce0be050f90c1268294aaba45efca5e6d006d2802e9455ecce9876f92e0) to accept an optional `tool_output` string. When provided, the tool output is appended to the user reply before being passed to `mirror_neurons.empathize`, affecting PAD emotional shifts and downstream habit reinforcement and user model updates. A new async test in [test_openclaw_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/174/files#diff-60ecd10f73cb3d406902c93c229c0e66d5e2e15377ec865e376abc2aa004d2f1) validates this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91abd04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->