### PR TITLE
feat: implement virtual context management and compression

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3322,7 +3322,7 @@
     },
     {
       "id": "memory-virtual-context-compression",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Virtual context management and compression",
@@ -5304,6 +5304,57 @@
       "acceptance": [
         "A2A tracing module can record and retrieve delegation traces",
         "Tests mock tracing and verify output structure"
+      ]
+    },
+    {
+      "id": "mcp-agentskills-marketplace-integration",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP AgentSkills Marketplace Integration",
+      "description": "Inspired by trend: Skill marketplace (agentskills.io). Allow Magda to fetch and register compatible skills dynamically from a marketplace.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace.py",
+        "tests/test_marketplace.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Marketplace integration can fetch available tools",
+        "Marketplace can parse MCP JSON schemas correctly"
+      ]
+    },
+    {
+      "id": "a2a-discovery-agent-cards-v3",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Discovery Agent Cards v3",
+      "description": "Inspired by A2A standard trend: Implement standardized Agent Cards for P2P agent discovery in the a2a integration layer.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_cards.py",
+        "tests/test_a2a_cards.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent Card format handles capability lists and capabilities matching",
+        "Tests verify card parsing and schema validation"
+      ]
+    },
+    {
+      "id": "claude-context-compression-subagent",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "title": "Claude-style Context Compression Subagent",
+      "description": "Inspired by Claude Context Compression trend: Spin up a lightweight context compression subagent that continuously summarizes episodic memory in the background.",
+      "allowed_paths": [
+        "magda_agent/agents/compression_subagent.py",
+        "tests/test_compression_subagent.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent can continuously poll uncompressed episodic memories and generate concise summaries",
+        "Tests verify subagent loop runs asynchronously using mocks"
       ]
     }
   ]

--- a/magda_agent/memory/virtual_context.py
+++ b/magda_agent/memory/virtual_context.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
+from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import PADState
 from magda_agent.memory.working import MemoryEntry
 
@@ -12,6 +13,35 @@ class VirtualContextManager:
     VirtualContextManager handles paging out old short-term memory (WorkingMemory)
     into EpisodicMemory, and paging it back in when requested via semantic search.
     """
+    def __init__(self, llm_client: Optional['LLMClient'] = None) -> None:
+        """Initializes the VirtualContextManager with an optional LLM client."""
+        self.llm_client = llm_client
+
+    async def compress_context(self, entries: List['MemoryEntry']) -> 'MemoryEntry':
+        """
+        Compresses multiple memory entries into a single summary entry.
+        """
+        if not entries:
+            raise ValueError("No entries to compress")
+
+        combined_text = "\n".join(e.content for e in entries)
+
+        if self.llm_client:
+            prompt = [{"role": "system", "content": "Summarize these memory entries concisely."},
+                      {"role": "user", "content": combined_text}]
+            summary = await self.llm_client.chat_completion(prompt)
+        else:
+            summary = f"Summary of {len(entries)} items: {combined_text[:50]}..."
+
+        user_id = entries[0].user_id
+        avg_importance = sum(e.importance for e in entries) / len(entries)
+        avg_p = sum(e.emotional_state.pleasure for e in entries) / len(entries)
+        avg_a = sum(e.emotional_state.arousal for e in entries) / len(entries)
+        avg_d = sum(e.emotional_state.dominance for e in entries) / len(entries)
+        state = PADState(avg_p, avg_a, avg_d)
+
+        return MemoryEntry(content=summary, importance=avg_importance, emotional_state=state, user_id=user_id)
+
 
     async def page_out(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, count: int = 1) -> None:
         """
@@ -22,6 +52,14 @@ class VirtualContextManager:
             return
 
         to_remove = entries[:count]
+        if len(to_remove) > 1:
+            try:
+                # Attempt to compress context before paging out
+                compressed_entry = await self.compress_context(to_remove)
+                to_remove = [compressed_entry]
+            except Exception as e:
+                logging.error(f"Context compression failed during page_out: {e}")
+
         for entry in to_remove:
             metadata = {
                 "paged_out": True,

--- a/tests/test_virtual_context.py
+++ b/tests/test_virtual_context.py
@@ -1,3 +1,4 @@
+from unittest.mock import AsyncMock
 import pytest
 from magda_agent.memory.virtual_context import VirtualContextManager
 from magda_agent.memory.working import WorkingMemory, MemoryEntry
@@ -55,3 +56,32 @@ async def test_virtual_context_page_in():
     entries = wm.get_entries(user_id=2)
     assert len(entries) == 1
     assert "Historical facts about Python" in entries[0].content
+
+@pytest.mark.asyncio
+async def test_virtual_context_compress_without_llm() -> None:
+    """Test that context compression works with fallback summary when LLM is absent."""
+    vcm = VirtualContextManager()
+    state = PADState(0.1, 0.2, 0.3)
+    e1 = MemoryEntry("First", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second", 0.5, state, user_id=1)
+
+    summary = await vcm.compress_context([e1, e2])
+    assert "Summary of 2 items: First\nSecond" in summary.content
+    assert summary.importance == 0.5
+    assert summary.user_id == 1
+
+@pytest.mark.asyncio
+async def test_virtual_context_compress_with_llm() -> None:
+    """Test that context compression leverages the LLM client to generate summaries."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "Mocked Summary"
+    vcm = VirtualContextManager(llm_client=mock_llm)
+
+    state = PADState(0.1, 0.2, 0.3)
+    e1 = MemoryEntry("First", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second", 0.5, state, user_id=1)
+
+    summary = await vcm.compress_context([e1, e2])
+    assert summary.content == "Mocked Summary"
+    assert summary.importance == 0.5
+    assert summary.user_id == 1


### PR DESCRIPTION
Implements virtual context management and compression by injecting an LLM client into VirtualContextManager, updating agent tasks, and adding fully mocked tests. All pre-commit steps and constraints have been verified.

---
*PR created automatically by Jules for task [11305260397802882579](https://jules.google.com/task/11305260397802882579) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement context compression in `VirtualContextManager` using optional LLM summarization
> - Adds a `compress_context` method to [`VirtualContextManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/176/files#diff-753a92d4a4e6dcaa5f5c6ace96f8edce760eaac00102b309d237867b619b5e3e) that reduces multiple `MemoryEntry` objects into a single summarized entry, averaging importance and PAD state across inputs.
> - When an `LLMClient` is provided at construction time, compression uses an async `chat_completion` call with a summarization prompt; otherwise a fallback string summary is produced.
> - Updates `page_out` to compress multiple evicted entries into one before writing to episodic memory, falling back to uncompressed paging on error.
> - Adds async tests covering both LLM-backed and fallback compression paths in [`tests/test_virtual_context.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/176/files#diff-cdc3a39943ae60247f27460659e25f9ed0f330835002ecbe84e4046f60a27c9d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c103d72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->