### PR TITLE
feat: implement hierarchical agent delegation with isolation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3340,7 +3340,7 @@
     },
     {
       "id": "hierarchical-agent-delegation-isolation",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Hierarchical agent delegation with isolation",
@@ -5355,6 +5355,42 @@
       "acceptance": [
         "Subagent can continuously poll uncompressed episodic memories and generate concise summaries",
         "Tests verify subagent loop runs asynchronously using mocks"
+      ]
+    },
+    {
+      "id": "magentic-one-orchestrator-pattern",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Magentic-One Multi-Agent Orchestrator",
+      "description": "Inspired by Microsoft's Magentic-One pattern: Implement a multi-agent orchestrator that dynamically adjusts the sub-agent team size based on task difficulty.",
+      "allowed_paths": [
+        "magda_agent/architecture/magentic_one.py",
+        "tests/test_magentic_one.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Orchestrator correctly evaluates task difficulty.",
+        "Orchestrator spawns proportional number of sub-agents.",
+        "Tests verify dynamic scaling logic."
+      ]
+    },
+    {
+      "id": "virtual-context-manager-letta",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "MemGPT/Letta Virtual Context Management",
+      "description": "Inspired by MemGPT/Letta standard: Implement a virtual context management module that automatically pages out semantic memories.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context.py",
+        "tests/test_virtual_context.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module calculates token length of current working context.",
+        "Module pages out older memories correctly.",
+        "Tests verify paging behavior with mock context."
       ]
     }
   ]

--- a/magda_agent/architecture/hierarchical_delegation.py
+++ b/magda_agent/architecture/hierarchical_delegation.py
@@ -1,0 +1,34 @@
+import asyncio
+import logging
+from typing import List, Dict, Any
+
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.llm_client import LLMClient
+
+class HierarchicalDelegator:
+    """
+    Delegates tasks to a team of isolated sub-agents executing in parallel.
+    """
+    def __init__(self, llm: LLMClient):
+        """
+        Initializes the HierarchicalDelegator.
+        """
+        self.llm = llm
+
+    async def delegate_tasks(self, tasks: List[str], base_context: str) -> List[Dict[str, Any]]:
+        """
+        Delegates multiple tasks to isolated sub-agents concurrently.
+        """
+        logging.info(f"HierarchicalDelegator delegating {len(tasks)} tasks.")
+
+        async def execute_isolated_task(task: str) -> Dict[str, Any]:
+            sub_agent = SubAgent(llm=self.llm, use_isolation=True)
+            try:
+                result = await sub_agent.execute(task=task, context=base_context)
+                return {"task": task, "status": "success", "result": result}
+            except Exception as e:
+                logging.error(f"Task delegation failed: {e}")
+                return {"task": task, "status": "error", "error": str(e)}
+
+        results = await asyncio.gather(*(execute_isolated_task(task) for task in tasks))
+        return list(results)

--- a/tests/test_hierarchical_delegation.py
+++ b/tests/test_hierarchical_delegation.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from magda_agent.architecture.hierarchical_delegation import HierarchicalDelegator
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_delegate_tasks_success():
+    """Test that HierarchicalDelegator successfully delegates tasks to subagents in isolation."""
+    llm = MagicMock(spec=LLMClient)
+
+    tasks = ["Task 1", "Task 2"]
+    base_context = "Initial context"
+
+    mock_sub_agent_instance = MagicMock()
+    mock_sub_agent_instance.execute = AsyncMock(side_effect=["Result 1", "Result 2"])
+
+    with patch("magda_agent.architecture.hierarchical_delegation.SubAgent", return_value=mock_sub_agent_instance) as mock_sub_agent_cls:
+        delegator = HierarchicalDelegator(llm=llm)
+        results = await delegator.delegate_tasks(tasks, base_context)
+
+        assert len(results) == 2
+        assert results[0] == {"task": "Task 1", "status": "success", "result": "Result 1"}
+        assert results[1] == {"task": "Task 2", "status": "success", "result": "Result 2"}
+
+        # SubAgent should be instantiated twice with use_isolation=True
+        assert mock_sub_agent_cls.call_count == 2
+        mock_sub_agent_cls.assert_any_call(llm=llm, use_isolation=True)
+
+        # Execute should be called twice
+        assert mock_sub_agent_instance.execute.call_count == 2
+        mock_sub_agent_instance.execute.assert_any_call(task="Task 1", context=base_context)
+        mock_sub_agent_instance.execute.assert_any_call(task="Task 2", context=base_context)
+
+@pytest.mark.asyncio
+async def test_delegate_tasks_failure():
+    """Test that HierarchicalDelegator handles execution errors."""
+    llm = MagicMock(spec=LLMClient)
+
+    tasks = ["Task 1"]
+
+    mock_sub_agent_instance = MagicMock()
+    mock_sub_agent_instance.execute = AsyncMock(side_effect=Exception("Failed"))
+
+    with patch("magda_agent.architecture.hierarchical_delegation.SubAgent", return_value=mock_sub_agent_instance):
+        delegator = HierarchicalDelegator(llm=llm)
+        results = await delegator.delegate_tasks(tasks, "")
+
+        assert len(results) == 1
+        assert results[0] == {"task": "Task 1", "status": "error", "error": "Failed"}


### PR DESCRIPTION
Inspired by the trend of hierarchical delegation with git worktree isolation, this PR adds a `HierarchicalDelegator` to dynamically spawn and execute multiple parallel tasks in isolated environments. The `agent_tasks.json` was updated to mark the task as done and add new tasks for Magentic-One and Letta virtual context.

---
*PR created automatically by Jules for task [13226581863187081912](https://jules.google.com/task/13226581863187081912) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `HierarchicalDelegator` class to delegate tasks to isolated sub-agents in parallel
> - Introduces [`HierarchicalDelegator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/177/files#diff-558bca9a151a3dbdae92a9abe061f5436472711a98cc7ccb098d339b4c599708) which creates an isolated `SubAgent` per task and runs all tasks concurrently via `asyncio.gather`.
> - Each task returns a structured result dict with `status: 'success'` or `status: 'error'`, catching per-task exceptions without failing the full batch.
> - Adds pytest coverage in [`tests/test_hierarchical_delegation.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/177/files#diff-cb3f27661f8cade7760144cc31ea26393334b2bb7ecfe050d5b4260451feb510) for both the success path and per-task error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 019c8a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->