### PR TITLE
Implement Hermes Persistent Memory for User Profiles

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3376,7 +3376,7 @@
     },
     {
       "id": "hermes-persistent-memory-v1",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Hermes Persistent Memory",

--- a/magda_agent/memory/__init__.py
+++ b/magda_agent/memory/__init__.py
@@ -4,5 +4,16 @@ from .episodic import EpisodicMemory
 from .semantic import SemanticMemory
 from .procedural import ProceduralMemory
 from .context_engine import ContextEngine, ContextPlugin
+from .hermes_persistent import HermesPersistentMemory
 
-__all__ = ["MemorySystem", "WorkingMemory", "MemoryEntry", "EpisodicMemory", "SemanticMemory", "ProceduralMemory", "ContextEngine", "ContextPlugin"]
+__all__ = [
+    "MemorySystem",
+    "WorkingMemory",
+    "MemoryEntry",
+    "EpisodicMemory",
+    "SemanticMemory",
+    "ProceduralMemory",
+    "ContextEngine",
+    "ContextPlugin",
+    "HermesPersistentMemory"
+]

--- a/magda_agent/memory/hermes_persistent.py
+++ b/magda_agent/memory/hermes_persistent.py
@@ -1,0 +1,113 @@
+import json
+import os
+import time
+import logging
+from typing import Dict, Any, List, Optional
+from magda_agent.llm_client import LLMClient
+
+class HermesPersistentMemory:
+    """
+    Persistent user profile memory inspired by Hermes Agent.
+    Accumulates traits, facts, and stats about a user over time.
+    """
+    def __init__(self, persist_dir: str = "./user_profiles", llm: Optional[LLMClient] = None):
+        self.persist_dir = persist_dir
+        self.llm = llm
+        if not os.path.exists(self.persist_dir):
+            os.makedirs(self.persist_dir, exist_ok=True)
+
+    def get_profile(self, user_id: int) -> Dict[str, Any]:
+        """Retrieve the persistent profile for a specific user."""
+        path = self._get_path(user_id)
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as e:
+                logging.error(f"Error loading Hermes profile for {user_id}: {e}")
+
+        # Initial profile
+        return {
+            "user_id": user_id,
+            "traits": [], # E.g. "prefers concise answers", "highly technical"
+            "facts": [],  # E.g. "Lives in Berlin", "Uses Python"
+            "stats": {
+                "interaction_count": 0,
+                "first_seen": time.time(),
+                "last_seen": time.time()
+            },
+            "version": 1
+        }
+
+    def _get_path(self, user_id: int) -> str:
+        return os.path.join(self.persist_dir, f"hermes_{user_id}.json")
+
+    def save_profile(self, user_id: int, profile: Dict[str, Any]):
+        """Save the user profile to disk."""
+        path = self._get_path(user_id)
+        try:
+            profile["stats"]["last_seen"] = time.time()
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(profile, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logging.error(f"Error saving Hermes profile for {user_id}: {e}")
+
+    async def update_from_interaction(self, user_id: int, interaction_text: str):
+        """
+        Update the persistent profile based on a new interaction.
+        Uses an LLM to extract stable traits and facts.
+        """
+        profile = self.get_profile(user_id)
+        profile["stats"]["interaction_count"] += 1
+
+        if not self.llm:
+            logging.warning("No LLM client available for Hermes profile update.")
+            self.save_profile(user_id, profile)
+            return
+
+        prompt = f"""
+        Analyze the following interaction and update the user profile.
+        Identify any new stable traits (behavioral patterns, preferences) or facts about the user.
+        Return ONLY a JSON object with new traits and facts to be added.
+        Do not remove existing information unless it's explicitly contradicted.
+
+        Current Profile:
+        {json.dumps(profile, indent=2)}
+
+        New Interaction:
+        {interaction_text}
+
+        Output format: {{"traits": ["new_trait1", ...], "facts": ["new_fact1", ...]}}
+        """
+
+        try:
+            response = await self.llm.chat_completion([
+                {"role": "system", "content": "You maintain user profiles. Return strictly valid JSON."},
+                {"role": "user", "content": prompt}
+            ], temperature=0.1)
+
+            json_str = response.strip()
+            # Basic JSON extraction from markdown
+            if "```json" in json_str:
+                json_str = json_str.split("```json")[1].split("```")[0]
+            elif "```" in json_str:
+                json_str = json_str.split("```")[1].split("```")[0]
+
+            updates = json.loads(json_str.strip())
+
+            # Merge updates ensuring uniqueness
+            new_traits = updates.get("traits", [])
+            for trait in new_traits:
+                if trait not in profile["traits"]:
+                    profile["traits"].append(trait)
+
+            new_facts = updates.get("facts", [])
+            for fact in new_facts:
+                if fact not in profile["facts"]:
+                    profile["facts"].append(fact)
+
+            self.save_profile(user_id, profile)
+            logging.info(f"Updated Hermes profile for user {user_id}")
+        except Exception as e:
+            logging.error(f"Error updating Hermes profile: {e}")
+            self.save_profile(user_id, profile)

--- a/tests/test_hermes_persistent.py
+++ b/tests/test_hermes_persistent.py
@@ -1,0 +1,59 @@
+import pytest
+import os
+import json
+import asyncio
+import time
+from unittest.mock import AsyncMock
+from magda_agent.memory.hermes_persistent import HermesPersistentMemory
+
+@pytest.mark.asyncio
+async def test_hermes_initial_profile(tmp_path):
+    user_id = 111
+    memory = HermesPersistentMemory(persist_dir=str(tmp_path))
+    profile = memory.get_profile(user_id)
+
+    assert profile["user_id"] == user_id
+    assert profile["traits"] == []
+    assert profile["facts"] == []
+    assert profile["stats"]["interaction_count"] == 0
+    assert "first_seen" in profile["stats"]
+
+@pytest.mark.asyncio
+async def test_hermes_update_interaction(tmp_path):
+    user_id = 222
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = '{"traits": ["helpful"], "facts": ["Lives in London"]}'
+
+    memory = HermesPersistentMemory(persist_dir=str(tmp_path), llm=mock_llm)
+
+    await memory.update_from_interaction(user_id, "Hello, I live in London and I try to be helpful.")
+
+    profile = memory.get_profile(user_id)
+    assert profile["stats"]["interaction_count"] == 1
+    assert "helpful" in profile["traits"]
+    assert "Lives in London" in profile["facts"]
+
+    # Second interaction
+    mock_llm.chat_completion.return_value = '{"traits": ["technical"], "facts": ["Uses Python"]}'
+    await memory.update_from_interaction(user_id, "I also use Python for my technical projects.")
+
+    profile = memory.get_profile(user_id)
+    assert profile["stats"]["interaction_count"] == 2
+    assert "helpful" in profile["traits"]
+    assert "technical" in profile["traits"]
+    assert "Lives in London" in profile["facts"]
+    assert "Uses Python" in profile["facts"]
+
+@pytest.mark.asyncio
+async def test_hermes_persistence(tmp_path):
+    user_id = 333
+    memory = HermesPersistentMemory(persist_dir=str(tmp_path))
+    profile = memory.get_profile(user_id)
+    profile["traits"].append("persistent")
+    memory.save_profile(user_id, profile)
+
+    # Re-initialize
+    memory2 = HermesPersistentMemory(persist_dir=str(tmp_path))
+    profile2 = memory2.get_profile(user_id)
+    assert "persistent" in profile2["traits"]
+    assert profile2["user_id"] == user_id


### PR DESCRIPTION
This change implements the persistent user profile memory system inspired by the Hermes Agent trend. The `HermesPersistentMemory` module allows the agent to build a long-term model of the user, extracting stable traits (preferences, personality) and facts from interactions using an LLM. 

Key features:
- Automatic JSON-based profile persistence.
- Incremental updates through interaction analysis.
- Tracking of interaction statistics (counts, first/last seen).
- Full test coverage for initialization, LLM-driven updates, and persistence.

---
*PR created automatically by Jules for task [17268439968407797628](https://jules.google.com/task/17268439968407797628) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `HermesPersistentMemory` for per-user profile storage with LLM-driven updates
> - Introduces [`HermesPersistentMemory`](https://github.com/kazah4359-lgtm/Magda-agent/pull/179/files#diff-d0ae138b911b169ebbe26d99387d1c817f1f3f845eb13c6e1f3a0c7bbddd6905) that stores per-user profiles (traits, facts, stats) as JSON files on disk.
> - `get_profile` loads an existing profile or returns a default; `save_profile` updates `last_seen` and writes to disk.
> - `update_from_interaction` is an async method that increments `interaction_count` and, when an `LLMClient` is provided, extracts new traits and facts from interaction text, merges them into the profile, and saves.
> - Exports `HermesPersistentMemory` from `magda_agent.memory` and adds three async pytest tests covering default profiles, LLM-driven updates, and persistence across re-instantiation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40fc9f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->