### PR TITLE
Cross Platform Reach Implementation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3552,7 +3552,7 @@
     },
     {
       "id": "cross-platform-reach-v1",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach implementation",
@@ -5717,6 +5717,57 @@
       "acceptance": [
         "Context Engine plugin interface added for MCP tools.",
         "Lifecycle hooks correctly trigger before and after tool usage."
+      ]
+    },
+    {
+      "id": "hermes-skill-experience-creation-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes-style Skill Creation from Experience",
+      "description": "Inspired by Hermes Agent trend: Implement a self-improving agent capability that automatically creates and refines skills based on past experience and execution trace history.",
+      "allowed_paths": [
+        "magda_agent/learning/experience_skills.py",
+        "tests/test_experience_skills.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module can parse execution traces and synthesize new Python skills.",
+        "Tests verify skill creation and storage in procedural memory."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-v1-fix2",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude-style Subagent Spawning and Context Compression",
+      "description": "Inspired by Claude Agent SDK: Implement dynamic subagent spawning for parallel execution with compressed context passing to optimize token usage.",
+      "allowed_paths": [
+        "magda_agent/architecture/subagent_spawning.py",
+        "tests/test_subagent_spawning.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Manager can spawn subagents with isolated context boundaries.",
+        "Tests verify context compression before passing to subagents."
+      ]
+    },
+    {
+      "id": "openai-mcp-function-concurrency-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI Agents SDK MCP Function Concurrency",
+      "description": "Inspired by OpenAI Agents SDK: Implement runtime function tool concurrency specifically for MCP server-prefixed tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency.py",
+        "tests/test_mcp_concurrency.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP tools can be executed concurrently using asyncio.gather.",
+        "Tests verify concurrent execution and result aggregation."
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -54,6 +54,7 @@ from magda_agent.memory.context_engine import ContextEngine
 from magda_agent.memory.default_context_plugin import DefaultContextPlugin
 from magda_agent.tracing.tracer import ThoughtChainTracer
 from magda_agent.architecture.sub_agents import SubAgentRPCManager
+from magda_agent.integration.cross_platform import CrossPlatformDispatcher
 
 logging.basicConfig(level=logging.INFO)
 
@@ -180,6 +181,7 @@ autonomous_executor = AutonomousExecutor(
 canvas_server = CanvasServer(consciousness=consciousness)
 a2a_server = A2AServer(planner=planner)
 rpc_manager = SubAgentRPCManager(llm=llm_client)
+cross_platform_dispatcher = CrossPlatformDispatcher()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/magda_agent/integration/__init__.py
+++ b/magda_agent/integration/__init__.py
@@ -5,5 +5,6 @@ Integration module for Magda agent.
 from magda_agent.integration.a2a_discovery import AgentCard, A2ADiscovery
 from magda_agent.integration.a2a_delegation import A2ADelegator
 from magda_agent.integration.a2a import A2AManager
+from magda_agent.integration.cross_platform import CrossPlatformDispatcher
 
-__all__ = ["AgentCard", "A2ADiscovery", "A2ADelegator", "A2AManager"]
+__all__ = ["AgentCard", "A2ADiscovery", "A2ADelegator", "A2AManager", "CrossPlatformDispatcher"]

--- a/magda_agent/integration/cross_platform.py
+++ b/magda_agent/integration/cross_platform.py
@@ -1,0 +1,58 @@
+from typing import Dict, Any, List, Optional
+import logging
+import asyncio
+
+class CrossPlatformDispatcher:
+    """
+    Dispatcher to send messages across multiple platforms simultaneously.
+    Supports multi-channel reach (e.g., Telegram, Discord, Slack, etc.) from a single agent.
+    """
+    def __init__(self):
+        """Initializes the CrossPlatformDispatcher with an empty registry of platforms."""
+        self.platforms: Dict[str, Any] = {}
+
+    def register_platform(self, platform_name: str, client: Any) -> None:
+        """
+        Registers a platform client.
+
+        Args:
+            platform_name: The name of the platform (e.g., 'telegram', 'discord').
+            client: The client object that handles message sending for this platform.
+                    It must have a `send_message(user_id, message)` async method.
+        """
+        self.platforms[platform_name] = client
+        logging.info(f"Platform registered: {platform_name}")
+
+    async def broadcast(self, user_id: str, message: str) -> Dict[str, str]:
+        """
+        Broadcasts a message to all registered platforms concurrently.
+
+        Args:
+            user_id: The identifier for the user (could be interpreted differently by each platform or a mapped ID).
+            message: The message to send.
+
+        Returns:
+            A dictionary mapping platform names to their delivery status (e.g., 'success', 'failed').
+        """
+        if not self.platforms:
+            logging.warning("No platforms registered for broadcast.")
+            return {}
+
+        results = {}
+        async def send_to_platform(name: str, client: Any):
+            try:
+                # Ensure the client has a send_message method
+                if hasattr(client, 'send_message'):
+                    await client.send_message(user_id, message)
+                    results[name] = 'success'
+                else:
+                    results[name] = 'failed: send_message method missing'
+            except Exception as e:
+                logging.error(f"Failed to send message to {name}: {e}")
+                results[name] = f'error: {str(e)}'
+
+        tasks = [send_to_platform(name, client) for name, client in self.platforms.items()]
+        await asyncio.gather(*tasks)
+
+        logging.info(f"Broadcasted to {len(self.platforms)} platforms. Results: {results}")
+        return results

--- a/tests/test_cross_platform.py
+++ b/tests/test_cross_platform.py
@@ -1,0 +1,58 @@
+import pytest
+import asyncio
+from magda_agent.integration.cross_platform import CrossPlatformDispatcher
+
+class MockClient:
+    """Mock client for testing."""
+    def __init__(self, should_fail=False):
+        self.messages = []
+        self.should_fail = should_fail
+
+    async def send_message(self, user_id: str, message: str) -> None:
+        if self.should_fail:
+            raise Exception("Mock failure")
+        self.messages.append((user_id, message))
+
+class BadMockClient:
+    """Mock client without send_message method."""
+    pass
+
+@pytest.mark.asyncio
+async def test_cross_platform_dispatcher_success():
+    dispatcher = CrossPlatformDispatcher()
+    client1 = MockClient()
+    client2 = MockClient()
+
+    dispatcher.register_platform("telegram", client1)
+    dispatcher.register_platform("discord", client2)
+
+    results = await dispatcher.broadcast("user123", "Hello World!")
+
+    assert results == {"telegram": "success", "discord": "success"}
+    assert client1.messages == [("user123", "Hello World!")]
+    assert client2.messages == [("user123", "Hello World!")]
+
+@pytest.mark.asyncio
+async def test_cross_platform_dispatcher_partial_failure():
+    dispatcher = CrossPlatformDispatcher()
+    client_success = MockClient()
+    client_fail = MockClient(should_fail=True)
+    client_bad = BadMockClient()
+
+    dispatcher.register_platform("slack", client_success)
+    dispatcher.register_platform("whatsapp", client_fail)
+    dispatcher.register_platform("signal", client_bad)
+
+    results = await dispatcher.broadcast("user456", "Test message")
+
+    assert results["slack"] == "success"
+    assert results["whatsapp"] == "error: Mock failure"
+    assert "failed" in results["signal"]
+
+    assert client_success.messages == [("user456", "Test message")]
+
+@pytest.mark.asyncio
+async def test_cross_platform_dispatcher_empty():
+    dispatcher = CrossPlatformDispatcher()
+    results = await dispatcher.broadcast("user1", "msg")
+    assert results == {}


### PR DESCRIPTION
Implemented cross platform dispatcher for broadcasting messages and updated tasks.

---
*PR created automatically by Jules for task [13332508858521801664](https://jules.google.com/task/13332508858521801664) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CrossPlatformDispatcher` to broadcast messages concurrently across registered platforms
> - Introduces [`cross_platform.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/185/files#diff-8694c81e738e511a6d7f4549179e1ed0970f97c68b81b556f65fd76a4efa9b1f) with a `CrossPlatformDispatcher` class that maintains a registry of platform clients and broadcasts messages to all of them concurrently via `asyncio.gather`.
> - Each broadcast call returns a per-platform status dict with `success`, `failed: send_message method missing`, or `error: <message>` entries.
> - Exposes the dispatcher at package level via [`magda_agent/integration/__init__.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/185/files#diff-9941be1a897291a10303e2474eeb897699c98c6adfb02bb703e9fddbc0833b00) and instantiates a module-level singleton in [`magda_agent/api.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/185/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d).
> - Adds tests covering full success, partial failure (missing method + raised exception), and empty-registry cases in [`tests/test_cross_platform.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/185/files#diff-76510adb39672af64a98d9edffa72f641ec8f007e6678ec51d905ce8e88d53d5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 332457d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->