### PR TITLE
Implement multiple agent tasks and trend-inspired features

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3569,7 +3569,7 @@
     },
     {
       "id": "skill-marketplace-agentskills-v1",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Skill marketplace compatibility",
@@ -3586,7 +3586,7 @@
     },
     {
       "id": "quality-metrics-longitudinal-v1",
-      "status": "todo",
+      "status": "done",
       "area": "evaluation",
       "risk": "low",
       "title": "Quality metrics longitudinal tracking",
@@ -3620,7 +3620,7 @@
     },
     {
       "id": "a2a-delegation-v6",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A delegation v6",
@@ -3637,7 +3637,7 @@
     },
     {
       "id": "online-learning-v6",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online learning v6",
@@ -5768,6 +5768,57 @@
       "acceptance": [
         "MCP tools can be executed concurrently using asyncio.gather.",
         "Tests verify concurrent execution and result aggregation."
+      ]
+    },
+    {
+      "id": "a2a-delegation-v8",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "A2A Delegation Protocol v8",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) open standard. Implement A2A delegation allowing the agent to delegate sub-plans to peers.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegation.py",
+        "tests/test_a2a_delegation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A Delegator can delegate sub-plans to peers.",
+        "Tests mock peer responses and verify delegation."
+      ]
+    },
+    {
+      "id": "openclaw-context-hooks-v5",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Hooks V5",
+      "description": "Inspired by trend: plugin architecture. Integrate the HookRegistry inside ContextEngine to let plugins register on initialization.",
+      "allowed_paths": [
+        "magda_agent/architecture/context_hooks_v5.py",
+        "magda_agent/memory/context_engine.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "HookRegistry is used by ContextEngine",
+        "Tests verify initialization and hook forwarding"
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v8",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Action Tool Exporter v8",
+      "description": "Inspired by trend: MCP (Model Context Protocol). Expand MCP exporter to wrap internal skills into standard JSON-RPC 2.0 interface.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter.py",
+        "tests/test_mcp_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be exported as MCP tools.",
+        "Tests verify JSON-RPC formatted responses."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -197,3 +197,6 @@
   Интеграция: Вызывается в `api.py` при старте.
   Тесты: mock _get_now, проверить логику scheduler._execute_job.
 * [x] FEATURE: Online RL from User Feedback v4 (online-rl-from-feedback-v4)
+* [x] FEATURE: Quality metrics longitudinal tracking
+* [x] FEATURE: A2A delegation v6
+* [x] FEATURE: Online learning v6

--- a/magda_agent/evaluation/longitudinal_metrics.py
+++ b/magda_agent/evaluation/longitudinal_metrics.py
@@ -1,0 +1,66 @@
+import sqlite3
+import datetime
+from typing import Dict, Any, List
+
+class LongitudinalMetricsTracker:
+    """
+    Tracks and persists code quality metrics over time across multiple test runs.
+    """
+    def __init__(self, db_path: str = "./longitudinal_metrics_db.sqlite3"):
+        self.db_path = db_path
+        self._init_db()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self) -> None:
+        """Initializes the database schema."""
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS code_metrics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    metric_name TEXT NOT NULL,
+                    value REAL NOT NULL,
+                    timestamp TEXT NOT NULL
+                )
+            """)
+            conn.commit()
+
+    def record_metric(self, metric_name: str, value: float) -> None:
+        """
+        Records a single metric value.
+
+        Args:
+            metric_name (str): The name of the metric (e.g., 'test_coverage', 'complexity').
+            value (float): The value of the metric.
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+            timestamp = datetime.datetime.now(datetime.UTC).isoformat()
+            cursor.execute(
+                "INSERT INTO code_metrics (metric_name, value, timestamp) VALUES (?, ?, ?)",
+                (metric_name, value, timestamp)
+            )
+            conn.commit()
+
+    def get_metrics_history(self, metric_name: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """
+        Retrieves the history of a specific metric.
+
+        Args:
+            metric_name (str): The name of the metric.
+            limit (int): The maximum number of historical records to fetch.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries containing metric history.
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT value, timestamp FROM code_metrics WHERE metric_name = ? ORDER BY timestamp DESC LIMIT ?",
+                (metric_name, limit)
+            )
+            rows = cursor.fetchall()
+
+        return [{"value": row[0], "timestamp": row[1]} for row in rows]

--- a/magda_agent/learning/online_learning.py
+++ b/magda_agent/learning/online_learning.py
@@ -1,0 +1,45 @@
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+class OnlineLearnerModule:
+    """
+    Extracts insights from dialogue in real time to enable online learning.
+    """
+    def __init__(self, db_connection: Any = None):
+        self.db = db_connection
+        self.insights: List[Dict[str, Any]] = []
+
+    def process_dialogue(self, user_message: str, agent_response: str) -> None:
+        """
+        Processes a dialogue turn to extract immediate insights.
+        """
+        # Very simple heuristic: if user says "don't" or "never", it's a constraint insight.
+        if "don't" in user_message.lower() or "never" in user_message.lower():
+            insight = {
+                "type": "constraint",
+                "content": user_message,
+                "context_response": agent_response
+            }
+            self.insights.append(insight)
+            logger.info(f"Learned constraint insight: {insight}")
+
+        # If user says "always" or "must", it's a preference insight.
+        elif "always" in user_message.lower() or "must" in user_message.lower():
+            insight = {
+                "type": "preference",
+                "content": user_message,
+                "context_response": agent_response
+            }
+            self.insights.append(insight)
+            logger.info(f"Learned preference insight: {insight}")
+
+    def get_recent_insights(self) -> List[Dict[str, Any]]:
+        """
+        Returns the recently extracted insights.
+        """
+        return self.insights
+
+    def clear_insights(self) -> None:
+        self.insights = []

--- a/magda_agent/multi_agent/a2a_delegator.py
+++ b/magda_agent/multi_agent/a2a_delegator.py
@@ -1,0 +1,40 @@
+from typing import Any, Dict, Optional
+import aiohttp
+import logging
+
+logger = logging.getLogger(__name__)
+
+class A2ADelegator:
+    """
+    Handles delegating tasks to other agents via the A2A protocol.
+    """
+    def __init__(self, peer_registry_url: Optional[str] = None):
+        self.peer_registry_url = peer_registry_url
+
+    async def delegate_task(self, task_description: str, peer_url: str) -> Dict[str, Any]:
+        """
+        Delegates a task to a specific peer agent.
+
+        Args:
+            task_description: The description of the task to delegate.
+            peer_url: The API endpoint of the peer agent.
+
+        Returns:
+            The response from the peer agent.
+        """
+        try:
+            async with aiohttp.ClientSession() as session:
+                payload = {
+                    "jsonrpc": "2.0",
+                    "method": "execute_task",
+                    "params": {"task": task_description},
+                    "id": 1
+                }
+                async with session.post(peer_url, json=payload) as response:
+                    response.raise_for_status()
+                    result = await response.json()
+                    logger.info(f"Successfully delegated task to {peer_url}")
+                    return result
+        except Exception as e:
+            logger.error(f"Failed to delegate task to {peer_url}: {e}")
+            return {"error": str(e), "status": "failed"}

--- a/tests/test_a2a_delegator.py
+++ b/tests/test_a2a_delegator.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from magda_agent.multi_agent.a2a_delegator import A2ADelegator
+
+@pytest.mark.asyncio
+async def test_delegate_task_success():
+    delegator = A2ADelegator()
+    peer_url = "http://peer-agent/api/v1/a2a"
+    task = "analyze data"
+
+    expected_response = {
+        "jsonrpc": "2.0",
+        "result": {"status": "completed", "output": "analysis done"},
+        "id": 1
+    }
+
+    with patch('aiohttp.ClientSession.post') as mock_post:
+        mock_response = AsyncMock()
+        mock_response.json.return_value = expected_response
+        mock_response.raise_for_status = MagicMock()
+
+        mock_post.return_value.__aenter__.return_value = mock_response
+
+        result = await delegator.delegate_task(task, peer_url)
+
+        assert result == expected_response
+        mock_post.assert_called_once_with(
+            peer_url,
+            json={"jsonrpc": "2.0", "method": "execute_task", "params": {"task": task}, "id": 1}
+        )
+
+@pytest.mark.asyncio
+async def test_delegate_task_failure():
+    delegator = A2ADelegator()
+    peer_url = "http://peer-agent/api/v1/a2a"
+    task = "analyze data"
+
+    with patch('aiohttp.ClientSession.post') as mock_post:
+        mock_post.side_effect = Exception("Connection error")
+
+        result = await delegator.delegate_task(task, peer_url)
+
+        assert result["status"] == "failed"
+        assert "Connection error" in result["error"]

--- a/tests/test_longitudinal_metrics.py
+++ b/tests/test_longitudinal_metrics.py
@@ -1,7 +1,39 @@
 import pytest
 import sqlite3
+import os
+from magda_agent.evaluation.longitudinal_metrics import LongitudinalMetricsTracker
 from magda_agent.evaluation.longitudinal import LongitudinalEvaluator
 from magda_agent.metacognition.tracker import QualityTracker
+
+@pytest.fixture
+def test_db_path():
+    path = "./test_longitudinal_metrics_db.sqlite3"
+    yield path
+    if os.path.exists(path):
+        os.remove(path)
+
+def test_record_and_retrieve_metric(test_db_path):
+    tracker = LongitudinalMetricsTracker(db_path=test_db_path)
+
+    # Record metrics
+    tracker.record_metric("test_coverage", 85.5)
+    tracker.record_metric("test_coverage", 86.2)
+    tracker.record_metric("code_complexity", 10.5)
+
+    # Retrieve metrics
+    coverage_history = tracker.get_metrics_history("test_coverage", limit=10)
+    complexity_history = tracker.get_metrics_history("code_complexity", limit=10)
+    empty_history = tracker.get_metrics_history("non_existent_metric", limit=10)
+
+    assert len(coverage_history) == 2
+    # Since they are ordered by timestamp DESC, the last one added should be first
+    assert coverage_history[0]["value"] == 86.2
+    assert coverage_history[1]["value"] == 85.5
+
+    assert len(complexity_history) == 1
+    assert complexity_history[0]["value"] == 10.5
+
+    assert len(empty_history) == 0
 
 def create_mock_evaluator():
     evaluator = LongitudinalEvaluator(":memory:")

--- a/tests/test_online_learning_module.py
+++ b/tests/test_online_learning_module.py
@@ -1,0 +1,39 @@
+import pytest
+from magda_agent.learning.online_learning import OnlineLearnerModule
+
+def test_online_learning_extracts_constraint():
+    learner = OnlineLearnerModule()
+
+    user_msg = "Please don't use markdown in your replies."
+    agent_msg = "I will format my text accordingly."
+
+    learner.process_dialogue(user_msg, agent_msg)
+
+    insights = learner.get_recent_insights()
+    assert len(insights) == 1
+    assert insights[0]["type"] == "constraint"
+    assert insights[0]["content"] == user_msg
+
+def test_online_learning_extracts_preference():
+    learner = OnlineLearnerModule()
+
+    user_msg = "You must always be polite."
+    agent_msg = "I will be polite."
+
+    learner.process_dialogue(user_msg, agent_msg)
+
+    insights = learner.get_recent_insights()
+    assert len(insights) == 1
+    assert insights[0]["type"] == "preference"
+    assert insights[0]["content"] == user_msg
+
+def test_online_learning_no_insight():
+    learner = OnlineLearnerModule()
+
+    user_msg = "What is the weather?"
+    agent_msg = "It is sunny."
+
+    learner.process_dialogue(user_msg, agent_msg)
+
+    insights = learner.get_recent_insights()
+    assert len(insights) == 0


### PR DESCRIPTION
Implemented multiple tasks and features: Quality Metrics Longitudinal Tracking, A2A Delegation v6, Online Learning v6, and resolved Skill Marketplace compatibility. Added 3 new trend-inspired tasks to agent_tasks.json.

---
*PR created automatically by Jules for task [11754790654226768087](https://jules.google.com/task/11754790654226768087) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A task delegation, longitudinal metrics tracking, and online learning modules
> - Adds [`A2ADelegator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/186/files#diff-fa54cf8d9b15bfeeaae2dd4826f9d1d5e3caa46d896832ac6c8997140d2b1a85) which sends tasks to peer agents via JSON-RPC 2.0 over HTTP using `aiohttp`, returning a structured failure object on error.
> - Adds [`LongitudinalMetricsTracker`](https://github.com/kazah4359-lgtm/Magda-agent/pull/186/files#diff-ece78b33d68149f720c894dc1e0ad7a4e5527bd8078660295efe56b07c7603c1) which persists code quality metrics with UTC timestamps to a local SQLite database and supports retrieval ordered by most recent.
> - Adds [`OnlineLearnerModule`](https://github.com/kazah4359-lgtm/Magda-agent/pull/186/files#diff-6b4fb9e611036d4111818df6873067f73f2fdbe0e1d24830ac8b40ad4255c87c) which extracts `constraint` or `preference` insights from user messages using keyword heuristics and stores them in memory.
> - Adds tests covering success/failure paths for all three modules, including an isolated on-disk SQLite fixture for metrics tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 257601d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->