### PR TITLE
Implement Hermes Skill Creation from Experience

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3654,7 +3654,7 @@
     },
     {
       "id": "hermes-skill-creation-8563188e",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Hermes: Skill Creation from Experience",
@@ -5872,6 +5872,57 @@
         "Audit logger intercepts tool calls via HookRegistry or Registry wrapper.",
         "Tool execution traces are saved to a durable SQLite audit log.",
         "Tests verify logging occurs without breaking tool execution."
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent-85b14c3e",
+      "status": "todo",
+      "title": "Claude Evaluator Subagent",
+      "area": "agents",
+      "risk": "medium",
+      "description": "Inspired by Claude Agent SDK pattern: Implement a standalone Evaluator Subagent that validates outputs of Generator agents within the team before returning the result to the Planner.",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_subagent.py",
+        "tests/test_evaluator_subagent.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagent can score other agents' outputs based on predefined policies.",
+        "Tests mock interactions to verify evaluation logic."
+      ]
+    },
+    {
+      "id": "openclaw-context-compressor-hook",
+      "status": "todo",
+      "title": "OpenClaw Context Compressor Hook",
+      "area": "memory",
+      "risk": "medium",
+      "description": "Inspired by OpenClaw trends: Create a Context Engine lifecycle hook plugin that automatically compresses short-term memory during the `before_retrieval` phase to maintain a compact context window.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_hook.py",
+        "tests/test_compression_hook.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Compression plugin correctly hooks into Context Engine.",
+        "Memory tokens are reduced while retaining semantic importance."
+      ]
+    },
+    {
+      "id": "a2a-delegation-tracing-v4",
+      "status": "todo",
+      "title": "A2A Delegation Tracing v4",
+      "area": "integration",
+      "risk": "medium",
+      "description": "Inspired by A2A Protocol trends: Implement an enterprise-ready tracing integration specifically for tracing A2A peer delegation events.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_tracing_v4.py",
+        "tests/test_a2a_tracing_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A tracing events are securely logged.",
+        "Tests verify log extraction format."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Hermes Skill Creation from Experience (hermes-skill-creation-8563188e)
 * [x] FEATURE: MCP Action Tool Exporter v6 (mcp-action-tool-exporter-v6)
 * [x] FEATURE: AgentBench Multi-domain Evaluation (agentbench-multi-domain-eval)
 * [x] FEATURE: MCPKernel Taint Tracking Sandbox

--- a/magda_agent/skills/__init__.py
+++ b/magda_agent/skills/__init__.py
@@ -58,6 +58,35 @@ def initialize_skills(policy_layer: Optional["PolicyLayer"] = None) -> SkillRegi
         description="Navigates the web by loading URLs and interacting with DOM elements. Input: 'action' string ('load', 'click', 'type') and kwargs ('url', 'element_id', 'text')."
     )
 
+
+    from magda_agent.skills.hermes_skills import HermesSkillCreator
+    def generate_skill_sync(skill_name: str, description: str, instructions: str) -> str:
+        import asyncio
+        from magda_agent.llm_client import LLMClient
+        client = LLMClient()
+        creator = HermesSkillCreator(llm_client=client)
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import threading
+                result = None
+                def run_in_thread():
+                    nonlocal result
+                    result = asyncio.run(creator.generate_skill(skill_name, description, instructions))
+                t = threading.Thread(target=run_in_thread)
+                t.start()
+                t.join()
+                return result
+        except RuntimeError:
+            pass
+        return asyncio.run(creator.generate_skill(skill_name, description, instructions))
+
+    registry.register_skill(
+        name="hermes_skill_creator",
+        func=generate_skill_sync,
+        description="Generate Python code for a new agent skill based on experience. Input: 'skill_name', 'description', 'instructions' strings."
+    )
+
     return registry
 
 from magda_agent.skills.marketplace import fetch_and_register_skills

--- a/magda_agent/skills/hermes_skills.py
+++ b/magda_agent/skills/hermes_skills.py
@@ -1,0 +1,77 @@
+import re
+from typing import Dict, Any, Optional
+
+class HermesSkillCreator:
+    """
+    Creates skills dynamically from agent experience using the LLM client.
+    """
+    def __init__(self, llm_client=None):
+        self.created_skills: Dict[str, str] = {}
+        # In actual usage this would be injected. If None, it will fail when trying to generate.
+        self.llm_client = llm_client
+
+    async def generate_skill(self, name: str, description: str, instructions: str) -> str:
+        """
+        Generates code for a new skill and registers it locally.
+
+        Args:
+            name: Name of the skill.
+            description: Description of the skill.
+            instructions: Instructions for the skill.
+
+        Returns:
+            The generated code.
+        """
+        if not self.llm_client:
+            raise ValueError("llm_client is required for skill generation.")
+
+        prompt = (
+            f"You are a helpful assistant. Write a python function named '{name}'.\n"
+            f"It must accept **kwargs and return a string.\n"
+            f"Description: {description}\n"
+            f"Instructions: {instructions}\n"
+            "Return only the python code block."
+        )
+        messages = [{"role": "user", "content": prompt}]
+
+        response = await self.llm_client.chat_completion(messages=messages)
+
+        # Extract code from response
+        code_match = re.search(r"```python\n(.*?)\n```", response, re.DOTALL)
+        if code_match:
+            code = code_match.group(1)
+        else:
+            code = response # fallback
+
+        self.created_skills[name] = code
+        return code
+
+    def load_skill_dynamically(self, registry: Any, name: str) -> bool:
+        """
+        Loads a generated skill into the provided SkillRegistry.
+
+        Args:
+            registry: The SkillRegistry instance.
+            name: The name of the skill to load.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        if name not in self.created_skills:
+            return False
+
+        code = self.created_skills[name]
+
+        # This is inherently risky, but we are asked to dynamically load python code.
+        # It's an experimental feature for "skills created from experience".
+        local_env = {}
+        try:
+            exec(code, {}, local_env)
+            if name in local_env and callable(local_env[name]):
+                # Assume registry has a register_skill method
+                if hasattr(registry, "register_skill"):
+                    registry.register_skill(name, local_env[name], "Dynamically generated skill")
+                    return True
+            return False
+        except Exception:
+            return False

--- a/tests/test_hermes_skills.py
+++ b/tests/test_hermes_skills.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from magda_agent.skills.hermes_skills import HermesSkillCreator
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.fixture
+def mock_llm_client():
+    client = MagicMock()
+    client.chat_completion = AsyncMock()
+    return client
+
+@pytest.mark.asyncio
+async def test_generate_skill(mock_llm_client):
+    mock_llm_client.chat_completion.return_value = '''
+```python
+def test_skill(**kwargs):
+    """
+    A test skill
+    """
+    return "Skill executed: test_skill"
+```
+'''
+    creator = HermesSkillCreator(llm_client=mock_llm_client)
+    code = await creator.generate_skill("test_skill", "A test skill", "Do testing")
+
+    assert "def test_skill(**kwargs):" in code
+    assert "A test skill" in code
+    assert "test_skill" in creator.created_skills
+
+def test_load_skill_dynamically():
+    creator = HermesSkillCreator()
+    registry = SkillRegistry()
+
+    code = '''
+def test_skill(**kwargs):
+    """
+    A test skill
+    """
+    return "Skill executed: test_skill"
+'''
+    creator.created_skills["test_skill"] = code
+
+    success = creator.load_skill_dynamically(registry, "test_skill")
+    assert success is True
+
+    # The skill should now be in the registry
+    assert registry.has_skill("test_skill")
+
+    # We should be able to execute it
+    result = registry.execute_skill("test_skill")
+    assert "Skill executed: test_skill" in result


### PR DESCRIPTION
Implement Hermes Skill Creation from Experience module

---
*PR created automatically by Jules for task [10336817559317890528](https://jules.google.com/task/10336817559317890528) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `HermesSkillCreator` to generate and load Python skills dynamically via LLM
> - Adds [hermes_skills.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/188/files#diff-6a4348fd14cd47f117a0bf47a64f58e86ee801d287691df593d239c8d77fc756) with `HermesSkillCreator`, which asynchronously prompts an LLM to generate a Python function for a named skill and can load it into a `SkillRegistry` at runtime via `exec`.
> - Registers a `hermes_skill_creator` skill in [skills/__init__.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/188/files#diff-bfa99a5f255fc1d222418cb8c21dfa1cce609468589a12c95c937cd2b77bd315) that wraps the async generation in a sync-safe call (runs in a background thread if an event loop is already active, otherwise uses `asyncio.run` directly).
> - Adds unit tests in [tests/test_hermes_skills.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/188/files#diff-b97e901e18c54ddd16d86bacd5d0d1bf875ae2cb42e4c21ca12ed917bd195af3) covering code extraction from LLM responses and dynamic skill registration.
> - Risk: generated skill code is loaded via `exec` in an isolated namespace with no sandboxing, which carries arbitrary code execution risk.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff1a9ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->