### PR TITLE
Implement Claude SDK context compression

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -29,7 +29,7 @@
       "medium"
     ],
     "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks — never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
-    "max_todo_tasks": 314
+    "max_todo_tasks": 316
   },
   "autonomous_loop_policy": {
     "operating_model": "docs/jules_autonomous_loop.md",
@@ -3671,7 +3671,7 @@
     },
     {
       "id": "claude-context-compression-8e05f169",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "high",
       "title": "Claude SDK: Context Compression",
@@ -5923,6 +5923,40 @@
       "acceptance": [
         "A2A tracing events are securely logged.",
         "Tests verify log extraction format."
+      ]
+    },
+    {
+      "id": "agent-guard-runtime-governance-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Agent Guard Runtime Governance v1",
+      "description": "Inspired by trend: Agent Guard runtime governance layer between agent and outside world. Implement policy layer for tool execution.",
+      "allowed_paths": [
+        "magda_agent/safety/agent_guard.py",
+        "tests/test_agent_guard.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent Guard intercepts tool calls and validates against policy.",
+        "Tests verify policy enforcement."
+      ]
+    },
+    {
+      "id": "mcp-kernel-taint-tracking-v2-fixed",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCPKernel Taint Tracking v2",
+      "description": "Inspired by trend: MCPKernel taint tracking. Implement robust string taint tracking for sandboxed execution.",
+      "allowed_paths": [
+        "magda_agent/safety/taint_tracking_v2.py",
+        "tests/test_taint_tracking_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tainted strings correctly propagate origin.",
+        "Tests verify tracking."
       ]
     }
   ]

--- a/magda_agent/agents/sub_agent.py
+++ b/magda_agent/agents/sub_agent.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 from magda_agent.llm_client import LLMClient
 from magda_agent.isolation.git_worktree import GitWorktreeManager
+from magda_agent.memory.subagent_compression import SubagentContextCompressor
 
 class SubAgent:
     """
@@ -16,6 +17,7 @@ class SubAgent:
         self.system_prompt = system_prompt or "You are an isolated Sub-Agent executing a specific task."
         self.use_isolation = use_isolation
         self.worktree_manager = GitWorktreeManager() if use_isolation else None
+        self.context_compressor = SubagentContextCompressor(llm=llm)
 
     async def execute(self, task: str, context: str) -> str:
         """
@@ -35,7 +37,9 @@ class SubAgent:
                 logging.error(f"Failed to create isolated worktree: {e}")
                 return f"Error: Failed to create isolated worktree - {e}"
 
+        # Compress the combined context if it's too large
         full_context = f"Parent Context:\n{current_context}\n\nAssigned Task:\n{task}"
+        full_context = await self.context_compressor.compress_context(full_context)
         messages = [
             {"role": "system", "content": self.system_prompt},
             {"role": "user", "content": full_context}

--- a/magda_agent/memory/subagent_compression.py
+++ b/magda_agent/memory/subagent_compression.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Optional
+from magda_agent.llm_client import LLMClient
+
+class SubagentContextCompressor:
+    """
+    Compresses large contexts for subagents to optimize token usage.
+    Inspired by Claude Agent SDK context compression.
+    """
+    def __init__(self, llm: LLMClient):
+        self.llm = llm
+
+    async def compress_context(self, context: str, max_length: int = 2000) -> str:
+        """
+        Compresses the context if it exceeds the max_length.
+        """
+        if len(context) <= max_length:
+            return context
+
+        logging.info(f"Compressing subagent context of length {len(context)}")
+        prompt = "Please summarize the following context concisely, preserving all essential details and constraints for a sub-agent task:\n\n" + context
+
+        messages = [
+            {"role": "system", "content": "You are a context compression engine. Return only the compressed context."},
+            {"role": "user", "content": prompt}
+        ]
+
+        try:
+            compressed = await self.llm.chat_completion(messages, temperature=0.3)
+            return compressed.strip()
+        except Exception as e:
+            logging.error(f"Failed to compress context: {e}")
+            return context  # Fallback to original context

--- a/tests/test_context_compression.py
+++ b/tests/test_context_compression.py
@@ -1,0 +1,29 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.memory.subagent_compression import SubagentContextCompressor
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_compress_context_short():
+    """Test that short context is not compressed."""
+    llm_mock = MagicMock(spec=LLMClient)
+    compressor = SubagentContextCompressor(llm=llm_mock)
+
+    context = "Short context"
+    result = await compressor.compress_context(context, max_length=100)
+
+    assert result == "Short context"
+    llm_mock.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compress_context_long():
+    """Test that long context is compressed."""
+    llm_mock = MagicMock(spec=LLMClient)
+    llm_mock.chat_completion = AsyncMock(return_value="Compressed context summary.")
+    compressor = SubagentContextCompressor(llm=llm_mock)
+
+    context = "A" * 3000
+    result = await compressor.compress_context(context, max_length=2000)
+
+    assert result == "Compressed context summary."
+    llm_mock.chat_completion.assert_called_once()


### PR DESCRIPTION
Implement subagent context compression as defined in agent_tasks.json task claude-context-compression-8e05f169. High risk task, waiting for human review.

---
*PR created automatically by Jules for task [4188338251943549547](https://jules.google.com/task/4188338251943549547) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context compression to `SubAgent` using `SubagentContextCompressor`
> - Introduces [`SubagentContextCompressor`](https://github.com/kazah4359-lgtm/Magda-agent/pull/189/files#diff-fbd3e5b3085737dd54884aef2eab03111da9f1729a742957610fee4683211c22) which uses an LLM call (temperature=0.3) to summarize contexts exceeding 2000 characters before they are sent to `llm.chat_completion`.
> - [`SubAgent.execute`](https://github.com/kazah4359-lgtm/Magda-agent/pull/189/files#diff-df53a1af21c739156ec01ab3f9e6fe116e387a785159253beb8287a93261cd89) now runs the context through the compressor after building `full_context`, replacing the user message content with the compressed summary when applicable.
> - Falls back to the original context if the LLM compression call fails.
> - Behavioral Change: the user message sent to the sub-agent LLM may now be a compressed summary rather than the original context for inputs longer than 2000 characters.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3dc239.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->