### PR TITLE
Implement Hermes Skill Generation and add new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3705,7 +3705,7 @@
     },
     {
       "id": "hermes-skill-experience-generation",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Creation from Experience",
@@ -5957,6 +5957,40 @@
       "acceptance": [
         "Tainted strings correctly propagate origin.",
         "Tests verify tracking."
+      ]
+    },
+    {
+      "id": "openclaw-context-compressor-v2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenClaw Context Compressor",
+      "description": "Inspired by OpenClaw trends: Create a skill that automatically compresses short-term memory during the `before_retrieval` phase.",
+      "allowed_paths": [
+        "magda_agent/skills/compression_v2.py",
+        "tests/test_compression_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Compression plugin correctly hooks into Context Engine.",
+        "Tests verify memory tokens are reduced."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-registration-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Registration",
+      "description": "Inspired by MCP trends: Implement an endpoint to dynamically register new MCP tools at runtime.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_dynamic.py",
+        "tests/test_mcp_dynamic.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dynamic registration endpoint is functional.",
+        "Tests verify tools are registered properly."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -110,7 +110,7 @@
 * [x] FEATURE: Agent-to-Agent (A2A) Protocol integration
 * [x] FEATURE: Online RL from User Feedback v2 (online-rl-user-feedback-v2)
 * [x] FEATURE: Longitudinal Quality Metrics (longitudinal-quality-metrics-v2)
-* [x] FEATURE: Skill creation from experience
+* [x] FEATURE: Skill creation from experience (hermes-skill-experience-generation)
 - [x] agent-guard-runtime-safety-v4: Agent Guard Runtime Safety Controls
 - [x] mcp-action-tool-exporter-v4: MCP Action Tool Exporter
 * [x] FEATURE: Guardrails Policy Layer (guardrails-policy-layer)

--- a/magda_agent/skills/__init__.py
+++ b/magda_agent/skills/__init__.py
@@ -60,6 +60,7 @@ def initialize_skills(policy_layer: Optional["PolicyLayer"] = None) -> SkillRegi
 
 
     from magda_agent.skills.hermes_skills import HermesSkillCreator
+    from magda_agent.skills.skill_generator import SkillGenerator
     def generate_skill_sync(skill_name: str, description: str, instructions: str) -> str:
         import asyncio
         from magda_agent.llm_client import LLMClient
@@ -81,10 +82,40 @@ def initialize_skills(policy_layer: Optional["PolicyLayer"] = None) -> SkillRegi
             pass
         return asyncio.run(creator.generate_skill(skill_name, description, instructions))
 
+    def generate_skill_from_queries_sync(queries: list[str]) -> Optional[str]:
+        """
+        Synchronously wraps the generate_skill_from_queries coroutine.
+        """
+        import asyncio
+        from magda_agent.llm_client import LLMClient
+        client = LLMClient()
+        generator = SkillGenerator(llm_client=client)
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import threading
+                result = None
+                def run_in_thread():
+                    nonlocal result
+                    result = asyncio.run(generator.generate_skill_from_queries(queries))
+                t = threading.Thread(target=run_in_thread)
+                t.start()
+                t.join()
+                return result
+        except RuntimeError:
+            pass
+        return asyncio.run(generator.generate_skill_from_queries(queries))
+
     registry.register_skill(
         name="hermes_skill_creator",
         func=generate_skill_sync,
         description="Generate Python code for a new agent skill based on experience. Input: 'skill_name', 'description', 'instructions' strings."
+    )
+
+    registry.register_skill(
+        name="hermes_skill_generator",
+        func=generate_skill_from_queries_sync,
+        description="Generate Python code for a new agent skill based on repeated user queries. Input: 'queries' list of strings."
     )
 
     return registry

--- a/magda_agent/skills/skill_generator.py
+++ b/magda_agent/skills/skill_generator.py
@@ -1,0 +1,48 @@
+import re
+import logging
+from typing import Dict, Any, Optional
+
+class SkillGenerator:
+    """
+    Synthesizes executable python scripts dynamically for new agent skills based on repeated user queries.
+    Inspired by Hermes Agent trend.
+    """
+    def __init__(self, llm_client: Optional[Any] = None) -> None:
+        """
+        Initializes the SkillGenerator with an LLM client.
+        """
+        self.llm_client = llm_client
+        self.synthesized_skills: Dict[str, str] = {}
+
+    async def generate_skill_from_queries(self, queries: list[str]) -> Optional[str]:
+        """
+        Synthesizes a python skill based on user queries, conforming to sandbox policies.
+        """
+        if not self.llm_client:
+            raise ValueError("llm_client is required for skill synthesis.")
+
+        combined_queries = "\n- ".join(queries)
+        prompt = (
+            "You are an AI assistant. The user has repeatedly asked the following queries:\n"
+            f"- {combined_queries}\n\n"
+            "Create a single python function named 'synthesized_skill' that accepts **kwargs and returns a string.\n"
+            "This function must not use the os or sys modules to ensure sandbox policy compliance.\n"
+            "Return only the python code block."
+        )
+        messages = [{"role": "user", "content": prompt}]
+
+        response = await self.llm_client.chat_completion(messages=messages)
+
+        code_match = re.search(r"```python\n(.*?)\n```", response, re.DOTALL)
+        if code_match:
+            code = code_match.group(1)
+        else:
+            code = response
+
+        # Basic sandbox validation
+        if "import os" in code or "import sys" in code:
+            logging.error("Synthesized skill violates sandbox policy.")
+            return None
+
+        self.synthesized_skills["synthesized_skill"] = code
+        return code

--- a/tests/test_skill_generator.py
+++ b/tests/test_skill_generator.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.skills.skill_generator import SkillGenerator
+
+@pytest.fixture
+def mock_llm_client() -> MagicMock:
+    """
+    Provides a mocked LLMClient.
+    """
+    client = MagicMock()
+    client.chat_completion = AsyncMock()
+    return client
+
+@pytest.mark.asyncio
+async def test_generate_skill_from_queries(mock_llm_client: MagicMock) -> None:
+    """
+    Tests that a skill is generated from user queries.
+    """
+    mock_llm_client.chat_completion.return_value = '''```python
+def synthesized_skill(**kwargs):
+    return "This is a synthesized skill."
+```'''
+    generator = SkillGenerator(llm_client=mock_llm_client)
+    queries = ["What time is it?", "Tell me the time", "Current time"]
+    code = await generator.generate_skill_from_queries(queries)
+
+    assert code is not None
+    assert "def synthesized_skill(**kwargs):" in code
+    assert "synthesized_skill" in generator.synthesized_skills
+
+@pytest.mark.asyncio
+async def test_generate_skill_sandbox_violation(mock_llm_client: MagicMock) -> None:
+    """
+    Tests that a skill violating sandbox policies is rejected.
+    """
+    mock_llm_client.chat_completion.return_value = '''```python
+import os
+def synthesized_skill(**kwargs):
+    return os.getenv("PATH")
+```'''
+    generator = SkillGenerator(llm_client=mock_llm_client)
+    queries = ["Show environment variables"]
+    code = await generator.generate_skill_from_queries(queries)
+
+    assert code is None
+    assert "synthesized_skill" not in generator.synthesized_skills


### PR DESCRIPTION
Implements SkillGenerator to synthesize python scripts based on queries and updates agent_tasks.json.

---
*PR created automatically by Jules for task [9709858022663564312](https://jules.google.com/task/9709858022663564312) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Hermes skill generation from repeated user queries via LLM
> - Adds [`SkillGenerator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/192/files#diff-5d28f8f75d55a4292f15e9798735290f1ec821c852a53680f64accffc83fe5ef) class with an async `generate_skill_from_queries` method that builds a prompt from a list of queries, calls the LLM, extracts a fenced Python code block, and caches the result internally.
> - Registers a new `hermes_skill_generator` skill in [`skills/__init__.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/192/files#diff-bfa99a5f255fc1d222418cb8c21dfa1cce609468589a12c95c937cd2b77bd315) via a sync wrapper that handles both running and non-running event loops.
> - Sandbox validation rejects generated code that imports `os` or `sys`, returning `None` for unsafe output.
> - Adds two new tasks (`openclaw-context-compressor-v2`, `mcp-dynamic-tool-registration-v1`) to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/192/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) and marks one existing task as done.
> - Risk: generated code is only checked for `os`/`sys` imports; other unsafe patterns are not blocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95cc383.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->