### PR TITLE
feat(memory): implement OpenClaw context compressor

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3741,7 +3741,7 @@
     },
     {
       "id": "openclaw-context-compression",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Compression",
@@ -6025,6 +6025,57 @@
       "acceptance": [
         "Dynamic registration endpoint handles async safely.",
         "Tests verify tools are registered properly."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-integration-f03dd8e2",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Integration",
+      "description": "Inspired by OpenClaw trend: Canvas for live visualization. Implement a module in the visualization directory to track agent state.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas.py",
+        "tests/test_canvas_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas class handles agent state correctly.",
+        "Tests mock components and verify state parsing."
+      ]
+    },
+    {
+      "id": "claude-team-isolation-e8e2a610",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude SDK Git Worktree Isolation",
+      "description": "Inspired by Claude Agent SDK trend: Agent Teams with git worktree isolation. Implement a worktree isolator for subagents running code locally.",
+      "allowed_paths": [
+        "magda_agent/architecture/worktree_isolation.py",
+        "tests/test_worktree_isolation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WorktreeIsolator isolates subagents.",
+        "Tests verify worktree tracking."
+      ]
+    },
+    {
+      "id": "agentskills-mcp-converter-7a0a55ff",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "AgentSkills to MCP Converter",
+      "description": "Inspired by MCP standards. Implement a converter that exports legacy Magda skills to standard MCP JSON-RPC.",
+      "allowed_paths": [
+        "magda_agent/integration/agentskills_mcp.py",
+        "tests/test_agentskills_mcp.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Converter wraps Magda skills into MCP compatible schemas.",
+        "Tests verify correct JSON-RPC output formatting."
       ]
     }
   ]

--- a/magda_agent/memory/__init__.py
+++ b/magda_agent/memory/__init__.py
@@ -5,6 +5,7 @@ from .semantic import SemanticMemory
 from .procedural import ProceduralMemory
 from .context_engine import ContextEngine, ContextPlugin
 from .hermes_persistent import HermesPersistentMemory
+from .compressor import ContextCompressor
 
 __all__ = [
     "MemorySystem",
@@ -15,5 +16,6 @@ __all__ = [
     "ProceduralMemory",
     "ContextEngine",
     "ContextPlugin",
-    "HermesPersistentMemory"
+    "HermesPersistentMemory",
+    "ContextCompressor"
 ]

--- a/magda_agent/memory/compressor.py
+++ b/magda_agent/memory/compressor.py
@@ -1,0 +1,95 @@
+import logging
+from typing import List, Optional
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.working import MemoryEntry
+
+class ContextCompressor:
+    """
+    Context compressor that selectively summarizes older memory entries to fit within
+    limited context windows and filters low-salience memories.
+    """
+    def __init__(self, llm: LLMClient):
+        """
+        Initialize the ContextCompressor.
+
+        Args:
+            llm: The LLM client used for summarizing text.
+        """
+        self.llm = llm
+
+    async def compress_text(self, text: str, max_tokens: int = 1000) -> str:
+        """
+        Compresses a given text to reduce its token size while maintaining key points.
+
+        Args:
+            text: The input text to compress.
+            max_tokens: A simulated max token limit based on text length.
+
+        Returns:
+            The compressed text, or the original text if it's within limits or if compression fails.
+        """
+        # Roughly estimating tokens by length (1 token ~ 4 chars)
+        if len(text) <= max_tokens * 4:
+            return text
+
+        logging.info("Compressing text to fit context limits.")
+        prompt = f"Summarize the following text, maintaining key points, to fit within a smaller context window:\n\n{text}"
+        messages = [
+            {"role": "system", "content": "You are a context compression engine. Return only the compressed text."},
+            {"role": "user", "content": prompt}
+        ]
+
+        try:
+            compressed = await self.llm.chat_completion(messages, temperature=0.3)
+            return compressed.strip()
+        except Exception as e:
+            logging.error(f"Failed to compress text: {e}")
+            return text
+
+    def filter_low_salience(self, memories: List[MemoryEntry], threshold: float = 0.5) -> List[MemoryEntry]:
+        """
+        Selectively filters out low-salience memories.
+
+        Args:
+            memories: A list of memory entries.
+            threshold: The importance threshold. Memories below this are filtered out.
+
+        Returns:
+            A list of memory entries with importance >= threshold.
+        """
+        return [m for m in memories if m.importance >= threshold]
+
+    async def compress_memories(self, memories: List[MemoryEntry], max_tokens: int = 1000, threshold: float = 0.5) -> List[MemoryEntry]:
+        """
+        Filters low-salience memories and compresses the remaining content if it exceeds the limit.
+
+        Args:
+            memories: A list of memory entries.
+            max_tokens: The simulated token limit for the total text.
+            threshold: The importance threshold for filtering.
+
+        Returns:
+            A list of compressed memory entries. If compressed, it will be a single summarized entry.
+        """
+        filtered = self.filter_low_salience(memories, threshold)
+        if not filtered:
+            return []
+
+        combined_text = "\n".join(m.content for m in filtered)
+        if len(combined_text) <= max_tokens * 4:
+            return filtered
+
+        compressed_text = await self.compress_text(combined_text, max_tokens)
+
+        # Average importance of the summarized memories
+        avg_importance = sum(m.importance for m in filtered) / len(filtered)
+        first = filtered[0]
+
+        summary_entry = MemoryEntry(
+            content=compressed_text,
+            importance=avg_importance,
+            emotional_state=first.emotional_state,
+            tags=first.tags,
+            user_id=first.user_id
+        )
+        return [summary_entry]

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.memory.compressor import ContextCompressor
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+@pytest.fixture
+def mock_llm():
+    llm = MagicMock()
+    llm.chat_completion = AsyncMock(return_value="Compressed summary.")
+    return llm
+
+@pytest.fixture
+def compressor(mock_llm):
+    return ContextCompressor(llm=mock_llm)
+
+@pytest.mark.asyncio
+async def test_compress_text_within_limits(compressor, mock_llm):
+    text = "Short text"
+    result = await compressor.compress_text(text, max_tokens=100)
+    assert result == "Short text"
+    mock_llm.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compress_text_exceeds_limits(compressor, mock_llm):
+    text = "A" * 5000
+    result = await compressor.compress_text(text, max_tokens=100)
+    assert result == "Compressed summary."
+    mock_llm.chat_completion.assert_called_once()
+
+def test_filter_low_salience(compressor):
+    pad = PADState(pleasure=0.0, arousal=0.0, dominance=0.0)
+    mem1 = MemoryEntry(content="High", importance=0.8, emotional_state=pad)
+    mem2 = MemoryEntry(content="Low", importance=0.2, emotional_state=pad)
+
+    filtered = compressor.filter_low_salience([mem1, mem2], threshold=0.5)
+    assert len(filtered) == 1
+    assert filtered[0].content == "High"
+
+@pytest.mark.asyncio
+async def test_compress_memories_filters_and_compresses(compressor, mock_llm):
+    pad = PADState(pleasure=0.0, arousal=0.0, dominance=0.0)
+    mem1 = MemoryEntry(content="A" * 2500, importance=0.8, emotional_state=pad)
+    mem2 = MemoryEntry(content="Low", importance=0.2, emotional_state=pad)
+    mem3 = MemoryEntry(content="B" * 2500, importance=0.9, emotional_state=pad)
+
+    result = await compressor.compress_memories([mem1, mem2, mem3], max_tokens=100, threshold=0.5)
+
+    assert len(result) == 1
+    assert result[0].content == "Compressed summary."
+    assert result[0].importance == pytest.approx(0.85)
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Implements the OpenClaw context compressor module to selectively summarize and filter memory entries, updates tests, and completes the associated task.

---
*PR created automatically by Jules for task [17148654859213562811](https://jules.google.com/task/17148654859213562811) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ContextCompressor` to compress and filter LLM memory entries by size and importance
> - Adds [`compressor.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/194/files#diff-386fc025ef167927db7f74d4305ca10f245d1421887aae36e2e90ede4782878b) with a `ContextCompressor` class that provides three operations: filtering memories below an importance threshold, compressing oversized text via LLM, and compressing a list of `MemoryEntry` objects into a single summarized entry when combined size exceeds `max_tokens*4`.
> - When compression is triggered, the LLM is called with `temperature=0.3`; on failure, the original text is returned as a fallback.
> - The compressed `MemoryEntry` preserves averaged importance and copies `emotional_state`, `tags`, and `user_id` from the first filtered entry.
> - Exposes `ContextCompressor` publicly via [`magda_agent/memory/__init__.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/194/files#diff-4258855e4c47783d18091948edc9e2f0542d960080a68bff988263214bec429d).
> - Tests in [`tests/test_compressor.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/194/files#diff-ce1e6f73a314693741f80b5ca7b0737cb75f4b29d029d91e739201c981ce64cd) cover the no-compression path, LLM compression path, importance filtering, and end-to-end memory summarization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f44199.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->