### PR TITLE
Implement Magentic-One Orchestration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3759,7 +3759,7 @@
     },
     {
       "id": "magentic-one-orchestration",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Magentic-One Orchestration",
@@ -6076,6 +6076,57 @@
       "acceptance": [
         "Converter wraps Magda skills into MCP compatible schemas.",
         "Tests verify correct JSON-RPC output formatting."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v1-af26a87c",
+      "status": "todo",
+      "title": "MCP Action Tool Exporter",
+      "area": "integration",
+      "risk": "medium",
+      "description": "Inspired by the trend: MCP-compatible tools. Export Magda's action tools as standard MCP JSON-RPC endpoints.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter.py",
+        "tests/test_mcp_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP action tool exporter is implemented.",
+        "Tests verify tool schema conversion."
+      ]
+    },
+    {
+      "id": "online-rl-user-feedback-v1-cf2a4ca2",
+      "status": "todo",
+      "title": "Online RL from User Feedback",
+      "area": "learning",
+      "risk": "high",
+      "description": "Inspired by OpenClaw trends: Online learning from interactions. Implement a module that updates tool execution weights based on user feedback.",
+      "allowed_paths": [
+        "magda_agent/learning/online_feedback_rl.py",
+        "tests/test_online_feedback_rl.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module parses user feedback and adjusts weights.",
+        "Tests verify weight adjustments."
+      ]
+    },
+    {
+      "id": "discord-bridge-integration-v1-76aaabb3",
+      "status": "todo",
+      "title": "Discord Bridge Integration",
+      "area": "integration",
+      "risk": "medium",
+      "description": "Inspired by trend: Cross-platform reach. Add a bridge for Discord integration to allow the agent to run on Discord.",
+      "allowed_paths": [
+        "magda_agent/integration/discord_bridge.py",
+        "tests/test_discord_bridge.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Discord bridge handles incoming messages and forwards to agent.",
+        "Tests mock Discord API and verify handling."
       ]
     }
   ]

--- a/magda_agent/agents/__init__.py
+++ b/magda_agent/agents/__init__.py
@@ -1,3 +1,4 @@
+from .magentic_one import MagenticOneOrchestrator
 from .teams import TeamManager
 
-__all__ = ["TeamManager"]
+__all__ = ["TeamManager", "MagenticOneOrchestrator"]

--- a/magda_agent/agents/magentic_one.py
+++ b/magda_agent/agents/magentic_one.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import logging
+from typing import List, Dict, Any
+from magda_agent.llm_client import LLMClient
+
+class MagenticOneOrchestrator:
+    """
+    Implements a multi-agent orchestration pattern inspired by Microsoft's Magentic-One.
+
+    This orchestrator uses a primary Orchestrator agent to plan, delegate, and review
+    tasks executed by a team of specialized agents.
+    """
+
+    def __init__(self, llm: LLMClient):
+        """
+        Initializes the MagenticOneOrchestrator.
+
+        Args:
+            llm (LLMClient): The language model client to be used.
+        """
+        self.llm = llm
+
+    async def orchestrate(self, task: str, max_iterations: int = 3) -> str:
+        """
+        Orchestrates the execution of a complex task by planning, delegating, and reviewing.
+
+        Args:
+            task (str): The main task to accomplish.
+            max_iterations (int): Maximum number of plan-execute-review loops.
+
+        Returns:
+            str: The final result of the orchestration process.
+        """
+        context: List[str] = []
+
+        for iteration in range(max_iterations):
+            # Step 1: Planning
+            plan = await self._plan(task, context)
+
+            # Step 2: Delegation and Execution
+            execution_results = await self._execute_plan(plan)
+            context.extend(execution_results)
+
+            # Step 3: Review
+            is_complete, final_result = await self._review(task, context)
+            if is_complete:
+                return final_result
+
+        return f"Task incomplete after {max_iterations} iterations. Last context: {context}"
+
+    async def _plan(self, task: str, context: List[str]) -> List[Dict[str, Any]]:
+        """
+        Creates a plan by generating subtasks based on the main task and current context.
+        """
+        prompt = (
+            f"Plan task: {task}. Context: {context}. "
+            "Return ONLY a valid JSON list of dictionaries. Each dictionary must have 'id' and 'description' keys."
+        )
+        response = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+        try:
+            # Attempt to parse the JSON response from the LLM
+            # Sometimes LLMs wrap JSON in markdown blocks
+            clean_response = response.strip()
+            if clean_response.startswith("```json"):
+                clean_response = clean_response[7:-3].strip()
+            elif clean_response.startswith("```"):
+                clean_response = clean_response[3:-3].strip()
+
+            parsed_plan = json.loads(clean_response)
+            if isinstance(parsed_plan, list) and len(parsed_plan) > 0 and 'id' in parsed_plan[0] and 'description' in parsed_plan[0]:
+                return parsed_plan
+        except Exception as e:
+            logging.error(f"Failed to parse plan JSON: {e}. Raw response: {response}")
+
+        # Fallback plan if parsing fails
+        return [{"id": "fallback_subtask", "description": f"Attempt subtask for {task}"}]
+
+    async def _execute_plan(self, plan: List[Dict[str, Any]]) -> List[str]:
+        """
+        Executes a plan by delegating subtasks to specialized agents (simulated here).
+        """
+        results = []
+        for step in plan:
+            prompt = f"Execute subtask: {step['description']}"
+            res = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+            results.append(res)
+        return results
+
+    async def _review(self, task: str, context: List[str]) -> tuple[bool, str]:
+        """
+        Reviews the current context to determine if the main task is complete.
+        """
+        prompt = f"Review task: {task}. Context: {context}. Is complete? Return YES or NO, then the result."
+        res = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+
+        is_complete = "YES" in res.upper()
+        return is_complete, res

--- a/tests/test_magentic_one.py
+++ b/tests/test_magentic_one.py
@@ -1,0 +1,63 @@
+import pytest
+import json
+from unittest.mock import AsyncMock
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.magentic_one import MagenticOneOrchestrator
+
+@pytest.mark.asyncio
+async def test_magentic_one_orchestrator_success():
+    mock_llm = AsyncMock(spec=LLMClient)
+
+    # Mock behavior:
+    # Plan call: returns JSON string
+    # Execute call: returns "Subtask done"
+    # Review call: returns "YES Result complete"
+    mock_llm.chat_completion.side_effect = [
+        '[{"id": "test_1", "description": "Execute first part of task"}]',
+        "Subtask done",
+        "YES Result complete"
+    ]
+
+    orchestrator = MagenticOneOrchestrator(llm=mock_llm)
+    result = await orchestrator.orchestrate("Do the task")
+
+    assert result == "YES Result complete"
+    assert mock_llm.chat_completion.call_count == 3
+
+@pytest.mark.asyncio
+async def test_magentic_one_orchestrator_max_iterations():
+    mock_llm = AsyncMock(spec=LLMClient)
+
+    # Mock behavior to always say NO, testing the iteration loop limit.
+    # 3 iterations * 3 LLM calls each = 9 calls total.
+    mock_llm.chat_completion.side_effect = [
+        '[{"id": "test_1", "description": "Execute first part of task"}]', "Execute", "NO",
+        '[{"id": "test_1", "description": "Execute first part of task"}]', "Execute", "NO",
+        '[{"id": "test_1", "description": "Execute first part of task"}]', "Execute", "NO"
+    ]
+
+    orchestrator = MagenticOneOrchestrator(llm=mock_llm)
+    result = await orchestrator.orchestrate("Do the task", max_iterations=3)
+
+    assert "Task incomplete after 3 iterations" in result
+    assert mock_llm.chat_completion.call_count == 9
+
+@pytest.mark.asyncio
+async def test_magentic_one_orchestrator_invalid_json():
+    mock_llm = AsyncMock(spec=LLMClient)
+
+    # Mock behavior:
+    # Plan call: returns Invalid JSON string
+    # Execute call: returns "Fallback task executed"
+    # Review call: returns "YES Result complete"
+    mock_llm.chat_completion.side_effect = [
+        'Invalid JSON',
+        "Fallback task executed",
+        "YES Result complete"
+    ]
+
+    orchestrator = MagenticOneOrchestrator(llm=mock_llm)
+    result = await orchestrator.orchestrate("Do the task")
+
+    assert result == "YES Result complete"
+    assert mock_llm.chat_completion.call_count == 3


### PR DESCRIPTION
Implement the Magentic-One Orchestration module, handling plan-delegate-review looping and updating agent_tasks.json

---
*PR created automatically by Jules for task [7011623282387686873](https://jules.google.com/task/7011623282387686873) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `MagenticOneOrchestrator` for iterative multi-step LLM task orchestration
> - Adds [`MagenticOneOrchestrator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/195/files#diff-e91f428deacafd33b28f06a80a42e4cd7b7c7463426c4320a03a054f262ef320) with an async `orchestrate` method that runs up to `max_iterations` plan/execute/review cycles using an injected `LLMClient`.
> - Planning parses a JSON list of subtasks from the LLM response, with a fallback to a single default subtask on parse failure.
> - Review completion is determined by the presence of "YES" (case-insensitive) in the LLM response; on exhausting iterations, a fallback message with the last context is returned.
> - Exports `MagenticOneOrchestrator` from the `magda_agent.agents` package via [`__init__.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/195/files#diff-fa900b4016010fe52234afe82624594ecbd71593b94c5c1ed463400b2259bcc8).
> - Covers success, max-iterations, and invalid-JSON fallback scenarios in [`tests/test_magentic_one.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/195/files#diff-d8d37f497200fb15e18dcf254b1d93b7458c4cab5711990542531497fe7e03e1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c72a11e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->