### PR TITLE
Feature: Prempti Audit Trail

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3776,7 +3776,7 @@
     },
     {
       "id": "prempti-audit-trail",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "medium",
       "title": "Prempti Audit Trail",
@@ -6127,6 +6127,40 @@
       "acceptance": [
         "Discord bridge handles incoming messages and forwards to agent.",
         "Tests mock Discord API and verify handling."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-integration-v3",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Integration v3",
+      "description": "Inspired by OpenClaw trend: Canvas for live visualization. Implement an advanced module in the visualization directory to track agent state.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_v3.py",
+        "tests/test_canvas_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas v3 handles complex agent state properly.",
+        "Tests mock components and verify state transitions."
+      ]
+    },
+    {
+      "id": "hermes-skill-discovery-v2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Skill Discovery v2",
+      "description": "Inspired by Hermes Agent trend: Self-improving agent that discovers skills. Create a skill discovery pipeline.",
+      "allowed_paths": [
+        "magda_agent/skills/discovery_v2.py",
+        "tests/test_discovery_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill discovery pipeline correctly identifies new capabilities.",
+        "Tests mock LLM responses and verify extraction."
       ]
     }
   ]

--- a/magda_agent/safety/acs_guard_v2.py
+++ b/magda_agent/safety/acs_guard_v2.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Dict, Any, Tuple, Optional
 from magda_agent.safety.policy import PolicyLayer
+from magda_agent.security.audit_trail import PremptiAuditLogger
+
 
 class SecurityViolationError(Exception):
     """Exception raised when an action is blocked by the ACS Guard V2."""
@@ -21,6 +23,7 @@ class ACSGuardV2:
         """
         self.logger = logging.getLogger(__name__)
         self.policy_layer = policy_layer
+        self.audit_logger = PremptiAuditLogger()
 
     def checkpoint_1_input_validation(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
@@ -117,7 +120,22 @@ class ACSGuardV2:
             passed, reason = checkpoint(workflow_data)
             if not passed:
                 self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
+                self.audit_logger.log_call(
+                    tool_name=workflow_data.get("tool", "unknown"),
+                    kwargs=workflow_data.get("kwargs", {}),
+                    why=f"Checkpoint {i} Failed: {reason}",
+                    result="blocked",
+                    duration=0.0
+                )
                 raise SecurityViolationError(f"Action blocked by ACS checkpoint {i}: {reason}")
             self.logger.debug(f"ACS Checkpoint {i} Passed: {reason}")
+
+        self.audit_logger.log_call(
+            tool_name=workflow_data.get("tool", "unknown"),
+            kwargs=workflow_data.get("kwargs", {}),
+            why="All 5 checkpoints passed.",
+            result="allowed",
+            duration=0.0
+        )
 
         return workflow_data

--- a/magda_agent/security/audit_trail.py
+++ b/magda_agent/security/audit_trail.py
@@ -1,0 +1,76 @@
+import time
+import copy
+from typing import Dict, Any, List, Optional
+
+class PremptiAuditLogger:
+    """
+    An audit logger for tool-call interceptions with sanitization.
+    Inspired by Prempti (Falco).
+    """
+
+    def __init__(self, max_capacity: int = 1000):
+        self.logs: List[Dict[str, Any]] = []
+        self.max_capacity = max_capacity
+
+        self.sensitive_keys = {
+            "password", "api_key", "token", "auth_header", "secret_key",
+            "api_keys" # handle lists
+        }
+
+    def _sanitize(self, data: Any, key_name: str = "", force_sanitize: bool = False) -> Any:
+        """
+        Recursively sanitize sensitive data.
+        If force_sanitize is True, all primitive values are redacted.
+        """
+        is_sensitive = force_sanitize or any(sec in key_name.lower() for sec in self.sensitive_keys)
+
+        if isinstance(data, dict):
+            sanitized_dict = {}
+            for k, v in data.items():
+                sanitized_dict[k] = self._sanitize(v, k, force_sanitize=is_sensitive)
+            return sanitized_dict
+        elif isinstance(data, list):
+            return [self._sanitize(item, key_name, force_sanitize=is_sensitive) for item in data]
+        else:
+             # Primitive value
+             if is_sensitive:
+                 return "***"
+             return data
+
+
+    def log_call(self, tool_name: str, kwargs: Dict[str, Any], why: str, result: str, duration: float) -> None:
+        """Logs a tool call with sanitized kwargs."""
+
+        entry = {
+            "timestamp": time.time(),
+            "tool_name": tool_name,
+            "kwargs": self._sanitize(copy.deepcopy(kwargs)),
+            "why": why,
+            "result": result,
+            "duration": duration
+        }
+
+        self.logs.append(entry)
+        if len(self.logs) > self.max_capacity:
+            self.logs.pop(0)
+
+    def get_all(self) -> List[Dict[str, Any]]:
+        """Returns all audit logs."""
+        return self.logs
+
+    def query(self, tool_name: Optional[str] = None, start_time: Optional[float] = None, end_time: Optional[float] = None) -> List[Dict[str, Any]]:
+        """Queries the audit logs based on filters."""
+        results = []
+        for log in self.logs:
+            if tool_name and log["tool_name"] != tool_name:
+                continue
+            if start_time and log["timestamp"] < start_time:
+                continue
+            if end_time and log["timestamp"] > end_time:
+                continue
+            results.append(log)
+        return results
+
+    def clear(self) -> None:
+        """Clears all audit logs."""
+        self.logs = []

--- a/tests/test_prempti_audit.py
+++ b/tests/test_prempti_audit.py
@@ -1,6 +1,6 @@
 import pytest
 import time
-from magda_agent.tracing.prempti_audit import PremptiAuditLogger
+from magda_agent.security.audit_trail import PremptiAuditLogger
 
 def test_prempti_audit_logger_log_call() -> None:
     """Test that log_call correctly appends an entry to the trail."""
@@ -51,7 +51,8 @@ def test_prempti_audit_logger_sanitize() -> None:
             "token": "secret_token",
             "auth_header": "Bearer xyz"
         },
-        "list_of_secrets": [{"secret_key": "abc"}, {"normal": "def"}]
+        "list_of_secrets": [{"secret_key": "abc"}, {"normal": "def"}],
+        "auth_header": {"Authorization": "Bearer secret_token"}
     }
 
     logger.log_call("test_tool", sensitive_kwargs, "testing", "Success", 0.1)
@@ -66,6 +67,7 @@ def test_prempti_audit_logger_sanitize() -> None:
     assert logged_kwargs["nested"]["auth_header"] == "***"
     assert logged_kwargs["list_of_secrets"][0]["secret_key"] == "***"
     assert logged_kwargs["list_of_secrets"][1]["normal"] == "def"
+    assert logged_kwargs["auth_header"]["Authorization"] == "***"
 
 def test_prempti_audit_logger_sanitize_list() -> None:
     """Test that sensitive lists of primitives are correctly sanitized."""
@@ -82,3 +84,11 @@ def test_prempti_audit_logger_sanitize_list() -> None:
 
     assert logged_kwargs["api_keys"] == ["***", "***"]
     assert logged_kwargs["normal_list"] == ["val1", "val2"]
+
+def test_prempti_audit_logger_clear() -> None:
+    """Test that clear empties the logs."""
+    logger = PremptiAuditLogger()
+    logger.log_call("test_tool", {}, "testing", "Success", 0.1)
+    assert len(logger.get_all()) == 1
+    logger.clear()
+    assert len(logger.get_all()) == 0


### PR DESCRIPTION
Implements audit trail for tool-call interceptions.

---
*PR created automatically by Jules for task [16164090298153563330](https://jules.google.com/task/16164090298153563330) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PremptiAuditLogger` audit trail with sanitized tool-call logging in `ACSGuardV2`
> - Adds [`PremptiAuditLogger`](https://github.com/kazah4359-lgtm/Magda-agent/pull/196/files#diff-8b45eb85bfad8a92aaa8fa8599891cd8432a011e3c748fb823eaeefd8ae853e1) with bounded capacity, recursive sanitization of sensitive keys (`password`, `api_key`, `token`, `auth_header`, `secret_key`, `api_keys`), and support for retrieval, filtering by tool name/time range, and clearing.
> - Integrates the audit logger into [`ACSGuardV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/196/files#diff-9ad017b3d658bb642ae4e5678e46cccc9bcdc8b909eb22bb04e12de4f68f1b57), logging a `blocked` entry before raising `SecurityViolationError` on checkpoint failure, and an `allowed` entry when all 5 checkpoints pass.
> - Extends tests in [`test_prempti_audit.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/196/files#diff-b0bf04d575a263cc7244a9efc8da5c5859b9ac19bb016a25cd081ad51531a761) to cover nested `auth_header` sanitization and `clear()` behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3532f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->