### PR TITLE
feat: Realtime Guardrail Fallback

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3793,7 +3793,7 @@
     },
     {
       "id": "openai-realtime-guardrail-fallback",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "OpenAI: Realtime Guardrail Fallback",
@@ -6161,6 +6161,40 @@
       "acceptance": [
         "Skill discovery pipeline correctly identifies new capabilities.",
         "Tests mock LLM responses and verify extraction."
+      ]
+    },
+    {
+      "id": "hermes-persistent-memory-v2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Hermes Persistent Memory Update",
+      "description": "Inspired by Hermes Agent trend: Persistent memory so the agent knows the user better over time. Update the persistent memory to be deeper.",
+      "allowed_paths": [
+        "magda_agent/memory/hermes_persistent_v2.py",
+        "tests/test_hermes_persistent_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Persistent memory correctly tracks deeper user preferences.",
+        "Tests use mock DB to verify tracking."
+      ]
+    },
+    {
+      "id": "openclaw-rl-next-state-signals-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Next State Signals",
+      "description": "Inspired by OpenClaw trend: OpenClaw-RL online reinforcement learning from next-state signals (user replies, tool outputs).",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_signals.py",
+        "tests/test_openclaw_rl_signals.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "OpenClaw-RL module processes next-state signals.",
+        "Tests verify signal parsing."
       ]
     }
   ]

--- a/magda_agent/safety/guardrails.py
+++ b/magda_agent/safety/guardrails.py
@@ -95,6 +95,9 @@ class RealtimeGuardrail:
             async def async_exec() -> Any:
                 try:
                     return await tool_func(**kwargs)
+                except asyncio.CancelledError:
+                    logging.warning(f"Action '{tool_name}' was interrupted (CancelledError). Re-raising to preserve loop state.")
+                    raise
                 except Exception as e:
                     logging.error(f"Error executing tool '{tool_name}': {e}")
                     # Return sensible fallback on exception
@@ -103,6 +106,9 @@ class RealtimeGuardrail:
         else:
             try:
                 return tool_func(**kwargs)
+            except KeyboardInterrupt:
+                logging.warning(f"Action '{tool_name}' was interrupted (KeyboardInterrupt). Re-raising to preserve application state.")
+                raise
             except Exception as e:
                 logging.error(f"Error executing tool '{tool_name}': {e}")
                 # Return sensible fallback on exception

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -91,3 +91,30 @@ async def test_allowed_action_async_exception_fallback() -> None:
     assert asyncio.iscoroutine(result_coro)
     result = await result_coro
     assert result == "Action 'failing_async_tool' failed during execution: Async Test Error"
+
+@pytest.mark.asyncio
+async def test_allowed_action_async_interrupted_fallback() -> None:
+    """Tests that an allowed async action handles CancelledError properly by re-raising."""
+    policy = PolicyLayer()
+    policy.evaluate = MagicMock(return_value=(True, "Allowed"))
+    guard = RealtimeGuardrail(policy)
+
+    async def interrupted_async_tool(arg: str) -> str:
+        raise asyncio.CancelledError()
+
+    result_coro = guard.execute_with_guardrails(interrupted_async_tool, "interrupted_async_tool", arg="value")
+    assert asyncio.iscoroutine(result_coro)
+    with pytest.raises(asyncio.CancelledError):
+        await result_coro
+
+def test_allowed_action_interrupted_fallback() -> None:
+    """Tests that an allowed sync action handles KeyboardInterrupt properly by re-raising."""
+    policy = PolicyLayer()
+    policy.evaluate = MagicMock(return_value=(True, "Allowed"))
+    guard = RealtimeGuardrail(policy)
+
+    def interrupted_tool(arg: str) -> str:
+        raise KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt):
+        guard.execute_with_guardrails(interrupted_tool, "interrupted_tool", arg="value")


### PR DESCRIPTION
# Realtime Guardrail Fallback (Interrupted Actions)

This PR addresses the `openai-realtime-guardrail-fallback` task from the backlog by implementing a fix in the safety policy layer.

## Changes:
1. **Control-flow exceptions:** Modified `RealtimeGuardrail.execute_with_guardrails` to catch `asyncio.CancelledError` and `KeyboardInterrupt` explicitly. Instead of logging them as generic errors and swallowing them (returning a string), these critical exceptions are now correctly re-raised to maintain the system's asynchronous integrity.
2. **Task completion:** Marked `openai-realtime-guardrail-fallback` as "done" in `agent_tasks.json`.
3. **Trend adoption:** Appended two new tasks (`hermes-persistent-memory-v2` and `openclaw-rl-next-state-signals-v2`) to `agent_tasks.json` based on the trends read from `docs/trends.md`.
4. **Testing:** Implemented `test_allowed_action_async_interrupted_fallback` and `test_allowed_action_interrupted_fallback` in `tests/test_guardrails.py` to ensure interrupted tasks natively bubble up their respective `Exception`.

---
*PR created automatically by Jules for task [7778804919628361779](https://jules.google.com/task/7778804919628361779) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-raise `asyncio.CancelledError` and `KeyboardInterrupt` in `RealtimeGuardrail.execute_with_guardrails`
> Previously, all exceptions raised by allowed tools were caught by a generic `except Exception` block and converted to a fallback string. This caused interrupt-style signals to be silently swallowed.
>
> - Adds a dedicated `except asyncio.CancelledError` block in the async path that logs a warning and re-raises the exception.
> - Adds a dedicated `except KeyboardInterrupt` block in the sync path with the same behavior.
> - Behavioral Change: code that previously received a fallback string on `CancelledError` or `KeyboardInterrupt` will now see those exceptions propagate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 609a65a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->