### PR TITLE
Implement Discord bridge integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6114,7 +6114,7 @@
     },
     {
       "id": "discord-bridge-integration-v1-76aaabb3",
-      "status": "todo",
+      "status": "done",
       "title": "Discord Bridge Integration",
       "area": "integration",
       "risk": "medium",
@@ -6382,6 +6382,40 @@
       "acceptance": [
         "Outputs from tools are taint-tracked.",
         "Tests verify the tracking logic."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugin-v4-abc123",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Plugin Architecture v4",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface with lifecycle hooks. Implement a robust plugin architecture for the context engine.",
+      "allowed_paths": [
+        "magda_agent/memory/context_plugin_v4.py",
+        "tests/test_context_plugin_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin architecture supports registering and running lifecycle hooks.",
+        "Tests verify hook execution and context management."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-nightly-v2-def456",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Hermes Cron Scheduler Nightly Backups v2",
+      "description": "Inspired by Hermes Agent trend: Cron scheduler for nightly backups. Implement scheduled backup operations for memory layers.",
+      "allowed_paths": [
+        "magda_agent/operations/nightly_backup_v2.py",
+        "tests/test_nightly_backup_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler correctly triggers backup jobs at specified intervals.",
+        "Tests mock time and verify backup execution."
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -55,6 +55,7 @@ from magda_agent.memory.default_context_plugin import DefaultContextPlugin
 from magda_agent.tracing.tracer import ThoughtChainTracer
 from magda_agent.architecture.sub_agents import SubAgentRPCManager
 from magda_agent.integration.cross_platform import CrossPlatformDispatcher
+from magda_agent.integration.discord_bridge import DiscordBridge
 
 logging.basicConfig(level=logging.INFO)
 
@@ -183,6 +184,10 @@ a2a_server = A2AServer(planner=planner)
 rpc_manager = SubAgentRPCManager(llm=llm_client)
 cross_platform_dispatcher = CrossPlatformDispatcher()
 
+discord_bridge = DiscordBridge(token=os.getenv("DISCORD_BOT_TOKEN", "dummy"), agent_callback=consciousness.process_input)
+cross_platform_dispatcher.register_platform("discord", discord_bridge)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -191,12 +196,14 @@ async def lifespan(app: FastAPI):
     asyncio.create_task(operations_scheduler.start())
     await autonomous_executor.start()
     asyncio.create_task(canvas_server.start_streaming())
+    asyncio.create_task(discord_bridge.start())
     yield
     # Shutdown
     await cron_scheduler.stop()
     await operations_scheduler.stop()
     await autonomous_executor.stop()
     await canvas_server.stop_streaming()
+    await discord_bridge.stop()
     memory_system.close()
 
 app = FastAPI(title="Magda Consciousness API", lifespan=lifespan)

--- a/magda_agent/integration/__init__.py
+++ b/magda_agent/integration/__init__.py
@@ -6,5 +6,6 @@ from magda_agent.integration.a2a_discovery import AgentCard, A2ADiscovery
 from magda_agent.integration.a2a_delegation import A2ADelegator
 from magda_agent.integration.a2a import A2AManager
 from magda_agent.integration.cross_platform import CrossPlatformDispatcher
+from magda_agent.integration.discord_bridge import DiscordBridge
 
-__all__ = ["AgentCard", "A2ADiscovery", "A2ADelegator", "A2AManager", "CrossPlatformDispatcher"]
+__all__ = ["AgentCard", "A2ADiscovery", "A2ADelegator", "A2AManager", "CrossPlatformDispatcher", "DiscordBridge"]

--- a/magda_agent/integration/discord_bridge.py
+++ b/magda_agent/integration/discord_bridge.py
@@ -1,0 +1,119 @@
+"""
+Discord Bridge Module.
+
+This module implements a bridge for Discord integration, allowing the agent
+to receive and respond to messages on Discord.
+"""
+import asyncio
+import logging
+from typing import Callable, Awaitable, Any, Optional
+import discord
+
+logger = logging.getLogger(__name__)
+
+class DiscordBridge:
+    """Bridge for Discord integration."""
+
+    def __init__(self, token: str, agent_callback: Callable[[str, Optional[int]], Awaitable[str]]):
+        """
+        Initialize the Discord Bridge.
+
+        Args:
+            token: The Discord bot token.
+            agent_callback: An async callback function taking (user_input, user_id) and returning a response.
+        """
+        self.token = token
+        self.agent_callback = agent_callback
+        self.is_running = False
+
+        # Configure intents
+        intents = discord.Intents.default()
+        intents.message_content = True
+        self.client = discord.Client(intents=intents)
+
+        @self.client.event
+        async def on_message(message: discord.Message) -> None:
+            # Ignore messages from the bot itself
+            if message.author == self.client.user:
+                return
+
+            response = await self.on_message(str(message.author.id), message.content)
+            if response:
+                await message.channel.send(response)
+
+        @self.client.event
+        async def on_ready() -> None:
+            logger.info(f"Discord bridge connected as {self.client.user}")
+
+    async def start(self) -> None:
+        """Start the Discord bridge."""
+        if self.token == "dummy" or not self.token:
+            logger.warning("Discord token not provided or is 'dummy'. Discord bridge running in mock mode.")
+            self.is_running = True
+            return
+
+        logger.info("Starting Discord bridge...")
+        self.is_running = True
+        try:
+            await self.client.start(self.token)
+        except Exception as e:
+            logger.error(f"Failed to start Discord client: {e}")
+            self.is_running = False
+
+    async def stop(self) -> None:
+        """Stop the Discord bridge."""
+        logger.info("Stopping Discord bridge...")
+        self.is_running = False
+        if self.token != "dummy" and self.token:
+            await self.client.close()
+
+    async def on_message(self, user_id: str, content: str) -> Optional[str]:
+        """
+        Handle incoming message from Discord.
+
+        Args:
+            user_id: The ID of the user who sent the message.
+            content: The content of the message.
+
+        Returns:
+            The response from the agent, or None if the bridge is not running.
+        """
+        if not self.is_running:
+            logger.warning("Received message while bridge is stopped.")
+            return None
+
+        logger.info(f"Received message from {user_id}: {content}")
+        try:
+            uid = int(user_id) if user_id.isdigit() else None
+            response = await self.agent_callback(content, uid)
+            return response
+        except Exception as e:
+            logger.error(f"Error in agent callback: {e}")
+            return "Error processing request."
+
+    async def send_message(self, user_id: str, message: str) -> None:
+        """
+        Send a message to a user on Discord. Used for cross-platform integration.
+
+        Args:
+            user_id: The Discord user ID.
+            message: The message to send.
+        """
+        if not self.is_running:
+            logger.warning("Cannot send message, bridge is stopped.")
+            return
+
+        logger.info(f"Sending message to {user_id} on Discord.")
+        if self.token == "dummy" or not self.token:
+            # Mock sending
+            return
+
+        try:
+            uid = int(user_id)
+            user = await self.client.fetch_user(uid)
+            if user:
+                await user.send(message)
+            else:
+                logger.error(f"User {user_id} not found on Discord.")
+        except Exception as e:
+            logger.error(f"Error sending message to {user_id} on Discord: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ datasets<3.0.0
 croniter
 websockets==12.0
 PyYAML
+discord.py>=2.3.2

--- a/tests/test_discord_bridge.py
+++ b/tests/test_discord_bridge.py
@@ -1,0 +1,65 @@
+"""Tests for Discord Bridge module."""
+import pytest
+import asyncio
+from unittest.mock import AsyncMock
+
+from magda_agent.integration.discord_bridge import DiscordBridge
+
+@pytest.mark.asyncio
+async def test_discord_bridge_start_stop():
+    """Test starting and stopping the Discord bridge."""
+    mock_callback = AsyncMock()
+    bridge = DiscordBridge("dummy", mock_callback)
+
+    assert not bridge.is_running
+    await bridge.start()
+    assert bridge.is_running
+    await bridge.stop()
+    assert not bridge.is_running
+
+@pytest.mark.asyncio
+async def test_discord_bridge_on_message():
+    """Test handling a message when the bridge is running."""
+    mock_callback = AsyncMock(return_value="Hello from agent")
+    bridge = DiscordBridge("dummy", mock_callback)
+
+    await bridge.start()
+    response = await bridge.on_message("123", "Hi there")
+
+    assert response == "Hello from agent"
+    mock_callback.assert_called_once_with("Hi there", 123)
+
+@pytest.mark.asyncio
+async def test_discord_bridge_stopped():
+    """Test handling a message when the bridge is stopped."""
+    mock_callback = AsyncMock()
+    bridge = DiscordBridge("dummy", mock_callback)
+
+    response = await bridge.on_message("123", "Hi there")
+
+    assert response is None
+    mock_callback.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_discord_bridge_error_in_callback():
+    """Test handling an error in the agent callback."""
+    mock_callback = AsyncMock(side_effect=Exception("Test error"))
+    bridge = DiscordBridge("dummy", mock_callback)
+
+    await bridge.start()
+    response = await bridge.on_message("123", "Hi there")
+
+    assert response == "Error processing request."
+
+@pytest.mark.asyncio
+async def test_discord_bridge_send_message():
+    """Test sending a message to Discord."""
+    mock_callback = AsyncMock()
+    bridge = DiscordBridge("dummy", mock_callback)
+
+    await bridge.start()
+    # Should not raise any exceptions
+    await bridge.send_message("user123", "Response")
+
+    await bridge.stop()
+    await bridge.send_message("user123", "Response")


### PR DESCRIPTION
Implements Discord Bridge module using discord.py. Wires it into api.py and __init__.py, registers it as a cross-platform dispatcher. Updates task status in agent_tasks.json, and adds new agent tasks inspired by recent trends. Also adds mock tests.

---
*PR created automatically by Jules for task [16842241830960493018](https://jules.google.com/task/16842241830960493018) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement Discord bridge integration for the agent
> - Adds [`DiscordBridge`](https://github.com/kazah4359-lgtm/Magda-agent/pull/203/files#diff-f755225a4fcb16c77d6c8db279378532adae5573532971a5a832523ab2dda0a0) class wrapping `discord.py` with start/stop lifecycle, inbound message handling via an agent callback, and outbound DM support by user ID.
> - Registers the bridge with `CrossPlatformDispatcher` under the `'discord'` platform and ties its lifecycle to the FastAPI app via [`api.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/203/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d).
> - Supports a mock mode when `DISCORD_BOT_TOKEN` is unset or `'dummy'`, skipping network connection while keeping `is_running=True`.
> - Adds `discord.py>=2.3.2` to [`requirements.txt`](https://github.com/kazah4359-lgtm/Magda-agent/pull/203/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552) and unit tests in [`tests/test_discord_bridge.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/203/files#diff-79994286cacdce01144c083a81e097bd5a2237de291317e3fba87c9ccb15314b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e600b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->