### PR TITLE
feat(learning): Implement Online RL from User Feedback v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -3895,7 +3895,7 @@
     },
     {
       "id": "online-rl-feedback-v5-ab746036",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online RL from user feedback v5",
@@ -6416,6 +6416,57 @@
       "acceptance": [
         "Scheduler correctly triggers backup jobs at specified intervals.",
         "Tests mock time and verify backup execution."
+      ]
+    },
+    {
+      "id": "mcp-skill-exporter-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP-compatible Skill Exporter",
+      "description": "Inspired by trend: MCP tools integration. Implement a skill exporter that enables converting Magda skills into standard Model Context Protocol tools for external consumption.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_exporter.py",
+        "tests/test_mcp_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill exporter correctly transforms Magda skills to MCP JSON-RPC format.",
+        "Tests verify the exported skills behave according to MCP standards."
+      ]
+    },
+    {
+      "id": "a2a-secure-delegation-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Secure Auth Delegation",
+      "description": "Inspired by trend: A2A support and token-based auth delegation. Add token auth flow to the Agent-to-Agent protocol integration for secure peer delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth.py",
+        "tests/test_a2a_auth.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A secure token-based authentication handles peer requests.",
+        "Tests verify token validation and rejection of unauthorized delegates."
+      ]
+    },
+    {
+      "id": "context-engine-hooks-v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Lifecycle Hooks",
+      "description": "Inspired by trend: Context Engine plugin interface. Implement lifecycle hooks in memory components allowing dynamic context management plugins to attach and detach.",
+      "allowed_paths": [
+        "magda_agent/memory/context_hooks.py",
+        "tests/test_context_hooks.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine exposes standard lifecycle hooks.",
+        "Tests verify plugins are triggered on hook execution."
       ]
     }
   ]

--- a/magda_agent/learning/rl_feedback.py
+++ b/magda_agent/learning/rl_feedback.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Optional, Dict
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+class OnlineRLFeedbackLoop:
+    """
+    Online Reinforcement Learning loop for adjusting agent behavior parameters
+    based on immediate explicit and implicit user feedback without separate annotation.
+    """
+    def __init__(self, habit_tracker: HabitTracker, mirror_neurons: MirrorNeurons) -> None:
+        """
+        Initializes the OnlineRLFeedbackLoop.
+
+        Args:
+            habit_tracker (HabitTracker): Tracks and records skill usage.
+            mirror_neurons (MirrorNeurons): Evaluates implicit feedback (emotional shifts).
+        """
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+        self.reward_parameters: Dict[str, float] = {}
+
+    async def adjust_behavior(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: Optional[int] = None,
+        explicit_score: Optional[float] = None,
+        skill_used: str = "rl_feedback_skill"
+    ) -> None:
+        """
+        Adjusts reward parameters and behavior based on explicit and implicit feedback.
+
+        Args:
+            user_reply (str): The immediate user response.
+            action_context (str): Context of the agent's action.
+            user_id (Optional[int]): User ID.
+            explicit_score (Optional[float]): Explicit numeric feedback from the user.
+            skill_used (str): Skill used for the action.
+        """
+        if not user_reply or not action_context:
+            return
+
+        # Implicit feedback via mirror neurons
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_reply)
+
+        if explicit_score is not None:
+            score = explicit_score
+        else:
+            score = (p_shift + 1.0) * 5.0
+
+        if skill_used not in self.reward_parameters:
+            self.reward_parameters[skill_used] = 1.0
+
+        if score >= 7.0:
+            self.reward_parameters[skill_used] += 0.2
+            self.habit_tracker.record_usage(
+                input_text=action_context,
+                skill_used=skill_used,
+                evaluation_score=score,
+                user_id=user_id
+            )
+            logging.info(f"RL Feedback: Positive adjustment. New param for {skill_used}: {self.reward_parameters[skill_used]:.2f}")
+        else:
+            self.reward_parameters[skill_used] = max(0.1, self.reward_parameters[skill_used] - 0.2)
+            logging.info(f"RL Feedback: Negative adjustment. New param for {skill_used}: {self.reward_parameters[skill_used]:.2f}")

--- a/tests/test_rl_feedback_v5.py
+++ b/tests/test_rl_feedback_v5.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.rl_feedback import OnlineRLFeedbackLoop
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+@pytest.fixture
+def mock_habit_tracker():
+    return MagicMock(spec=HabitTracker)
+
+@pytest.fixture
+def mock_mirror_neurons():
+    return MagicMock(spec=MirrorNeurons)
+
+@pytest.mark.asyncio
+async def test_adjust_behavior_positive(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.5, 0.1, 0.0) # score = (0.5+1)*5 = 7.5
+    rl_loop = OnlineRLFeedbackLoop(mock_habit_tracker, mock_mirror_neurons)
+
+    await rl_loop.adjust_behavior("Good job", "action ctx", 1, skill_used="test_skill")
+
+    assert rl_loop.reward_parameters["test_skill"] == 1.2
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="action ctx", skill_used="test_skill", evaluation_score=7.5, user_id=1
+    )
+
+@pytest.mark.asyncio
+async def test_adjust_behavior_negative(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (-0.5, 0.1, 0.0) # score = (-0.5+1)*5 = 2.5
+    rl_loop = OnlineRLFeedbackLoop(mock_habit_tracker, mock_mirror_neurons)
+
+    await rl_loop.adjust_behavior("Bad job", "action ctx", 1, skill_used="test_skill")
+
+    assert rl_loop.reward_parameters["test_skill"] == 0.8
+    mock_habit_tracker.record_usage.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_adjust_behavior_explicit_score(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.0, 0.0, 0.0)
+    rl_loop = OnlineRLFeedbackLoop(mock_habit_tracker, mock_mirror_neurons)
+    await rl_loop.adjust_behavior("Okay", "action ctx", 1, explicit_score=8.0, skill_used="test_skill")
+
+    assert rl_loop.reward_parameters["test_skill"] == 1.2
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="action ctx", skill_used="test_skill", evaluation_score=8.0, user_id=1
+    )


### PR DESCRIPTION
This PR implements the "Online RL from user feedback v5" task (id: `online-rl-feedback-v5-ab746036`).

Changes included:
- **`magda_agent/learning/rl_feedback.py`**: A new class `OnlineRLFeedbackLoop` that relies on `HabitTracker` and `MirrorNeurons` to interpret feedback and modify internal reward parameters accordingly.
- **`tests/test_rl_feedback_v5.py`**: Unit tests verifying parameter shifts during positive, negative, and explicit feedback interactions with proper mocking.
- **`agent_tasks.json`**:
  - Set the status of `online-rl-feedback-v5-ab746036` to `done`.
  - Added 3 new tasks (`mcp-skill-exporter-v1`, `a2a-secure-delegation-v1`, `context-engine-hooks-v1`) based on June 2026 AI trends such as MCP tooling, secure A2A delegation, and Context Engine plugin interfaces.

All tests pass without regression and changes strictly adhere to allowed paths constraint.

---
*PR created automatically by Jules for task [10076060136285710795](https://jules.google.com/task/10076060136285710795) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement online RL feedback loop that adjusts per-skill reward parameters from user feedback
> - Adds [`OnlineRLFeedbackLoop`](https://github.com/kazah4359-lgtm/Magda-agent/pull/204/files#diff-97d581b748ac5073d82f8aa9246a5a4671419aa3d4f082527770a97aaec9327e) which maintains a per-skill `reward_parameters` dict, updated by `adjust_behavior` on each user interaction.
> - `adjust_behavior` calls `MirrorNeurons.empathize` to derive an implicit score from the user reply, or accepts an explicit score; scores ≥ 7.0 increment the reward parameter by 0.2 and trigger `HabitTracker.record_usage`, while lower scores decrement it (floor: 0.1).
> - Adds three async tests in [`tests/test_rl_feedback_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/204/files#diff-6453e0f4fe41eab12bbb2dfbbdee1da4d02fc5fa0865790bcd248b10473a9071) covering positive implicit, negative implicit, and explicit score paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d33ab6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->