### PR TITLE
Human-like Mental States (Fear, Desire, Tension)

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -41,6 +41,24 @@
   },
   "tasks": [
     {
+      "id": "cognitive-biases-illusions",
+      "status": "todo",
+      "area": "cognition",
+      "risk": "medium",
+      "title": "Implement Cognitive Biases and Illusions",
+      "description": "Implement cognitive biases and illusions to model human-like irrationality, overconfidence, and optimism in planning and reasoning.",
+      "allowed_paths": [
+        "magda_agent/emotions/**",
+        "magda_agent/planning/**",
+        "tests/test_biases*.py"
+      ],
+      "acceptance": [
+        "MentalStates module supports bias modifiers",
+        "Planner behavior is modulated by optimism/pessimism states",
+        "Tests verify irrational behavior under specific mental conditions"
+      ]
+    },
+    {
       "id": "architecture-contracts",
       "status": "done",
       "area": "architecture",

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Dict, Any, Optional
 from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import EmotionalEngine
+from magda_agent.emotions.mental_states import MentalStates
 from magda_agent.memory.storage import MemorySystem
 from magda_agent.skills.registry import SkillRegistry
 from magda_agent.planning.planner import Planner
@@ -106,6 +107,7 @@ class Consciousness:
         self.skill_versioning = kwargs.get('skill_versioning', None)
         self.style_adapter = style_adapter
         self.user_model = user_model
+        self.mental_states = MentalStates()
 
         if self.global_workspace:
             self.global_workspace.register_listener(self._broadcast_event)
@@ -281,6 +283,7 @@ class Consciousness:
             if self.tracer:
                 self.tracer.add_step("llm_reasoning_start", {"plan_str": plan_str})
             emotion_summary = self.emotions.get_summary(user_id=user_id)
+            emotion_summary += f" | {self.mental_states.get_summary(user_id)}"
             if self.hypothalamus:
                 emotion_summary += f" | {self.hypothalamus.get_drives_summary()}"
 
@@ -357,6 +360,12 @@ class Consciousness:
         if self.confidence_calibrator:
             confidence = await self.confidence_calibrator.estimate_confidence(user_input, response)
             response = self.confidence_calibrator.add_caveat_if_needed(response, confidence)
+
+        # Update mental states based on evaluation
+        if self.evaluator and self.evaluator.last_evaluation:
+            avg_score = self.evaluator.last_evaluation.get("average_score", 10.0)
+            self.mental_states.update_from_action_result(success=(avg_score >= 7.0), user_id=user_id)
+
         if self.tracer:
             self.tracer.add_step("response_generated", {"response": response})
 
@@ -386,6 +395,7 @@ class Consciousness:
         planner_state = self.planner.get_state_summary() if self.planner else "Planner: Not available"
         return f"""
 {self.emotions.get_summary()}
+{self.mental_states.get_summary()}
 {self.memory.get_summary()}
 {self.skills.get_skills_summary()}
 {planner_state}

--- a/magda_agent/emotions/mental_states.py
+++ b/magda_agent/emotions/mental_states.py
@@ -1,0 +1,61 @@
+from typing import Dict, Optional
+
+class MentalState:
+    def __init__(self, fear: float = 0.0, desire: float = 0.5, tension: float = 0.0):
+        self.fear = fear
+        self.desire = desire
+        self.tension = tension
+
+class MentalStates:
+    """
+    Tracks and manages cognitive mental states: Fear, Desire, and Tension.
+    These states complement the PAD emotional model to represent higher-level cognitive drives.
+    """
+    def __init__(self):
+        self._states: Dict[int, MentalState] = {}
+
+    def _get_state(self, user_id: Optional[int]) -> MentalState:
+        u_id = user_id if user_id is not None else -1
+        if u_id not in self._states:
+            self._states[u_id] = MentalState()
+        return self._states[u_id]
+
+    def update_from_action_result(self, success: bool, user_id: Optional[int] = None) -> None:
+        """
+        Updates mental states based on the success or failure of an agent action.
+        """
+        state = self._get_state(user_id)
+        if success:
+            state.fear = self._clamp(state.fear - 0.1)
+            state.desire = self._clamp(state.desire + 0.1)
+            state.tension = self._clamp(state.tension - 0.2)
+        else:
+            state.fear = self._clamp(state.fear + 0.1)
+            state.tension = self._clamp(state.tension + 0.1)
+            state.desire = self._clamp(state.desire - 0.1)
+
+    def get_state_label(self, user_id: Optional[int] = None) -> str:
+        """
+        Maps numerical values to human-readable labels.
+        """
+        state = self._get_state(user_id)
+        if state.desire > 0.7:
+            return "Determined"
+        if state.fear > 0.5:
+            return "Anxious"
+        if state.tension > 0.6:
+            return "Focused"
+        if state.fear < 0.3 and state.tension < 0.3:
+            return "Satisfied"
+        return "Stable"
+
+    def get_summary(self, user_id: Optional[int] = None) -> str:
+        """
+        Returns a formatted summary of the current mental states.
+        """
+        state = self._get_state(user_id)
+        label = self.get_state_label(user_id)
+        return f"Mental State: {label} (Fear: {state.fear:.2f}, Desire: {state.desire:.2f}, Tension: {state.tension:.2f})"
+
+    def _clamp(self, value: float, min_val: float = 0.0, max_val: float = 1.0) -> float:
+        return max(min_val, min(max_val, value))

--- a/magda_agent/main.py
+++ b/magda_agent/main.py
@@ -57,10 +57,36 @@ async def command_state_handler(message: Message) -> None:
     """Returns the internal state of the agent from the microservice."""
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(f"{CONSCIOUSNESS_API_URL}/state")
+            # Pass user_id if available to get user-specific state
+            params = {}
+            if message.from_user and message.from_user.id:
+                params["user_id"] = message.from_user.id
+
+            response = await client.get(f"{CONSCIOUSNESS_API_URL}/state", params=params)
             response.raise_for_status()
             state_info = response.json().get("state", "No state information.")
-            await message.answer(f"<b>My Internal State:</b>\n<pre>{state_info}</pre>")
+
+            # Enhancing presentation
+            lines = state_info.strip().split("\n")
+            formatted_lines = []
+            for line in lines:
+                line = line.strip()
+                if not line: continue
+                if "Current Emotion" in line:
+                    p = float(line.split("P:")[1].split(",")[0])
+                    emoji = "😊" if p > 0 else "😟" if p < 0 else "😐"
+                    formatted_lines.append(f"🎭 <b>Emotions:</b> {emoji} {line}")
+                elif "Mental State" in line:
+                    formatted_lines.append(f"🧠 <b>Mental Profile:</b> {line.replace('Mental State:', '').strip()}")
+                elif "Drives" in line:
+                    formatted_lines.append(f"🔋 <b>Physical State:</b> {line}")
+                elif "Memory" in line:
+                    formatted_lines.append(f"💾 <b>Cognitive Load:</b> {line}")
+                else:
+                    formatted_lines.append(line)
+
+            final_text = "<b>Current Mind Profile:</b>\n\n" + "\n".join(formatted_lines)
+            await message.answer(final_text)
     except Exception as e:
         logging.error(f"Failed to get state: {e}")
         await message.answer("Error: Could not retrieve internal state from Consciousness API.")

--- a/tests/test_mental_states.py
+++ b/tests/test_mental_states.py
@@ -1,0 +1,59 @@
+import pytest
+from magda_agent.emotions.mental_states import MentalStates
+
+def test_mental_states_initialization():
+    ms = MentalStates()
+    summary = ms.get_summary(user_id=123)
+    assert "Fear: 0.00" in summary
+    assert "Desire: 0.50" in summary
+    assert "Tension: 0.00" in summary
+    assert "Satisfied" in summary
+
+def test_update_from_action_result_success():
+    ms = MentalStates()
+    user_id = 1
+    # Success: fear -, desire +, tension --
+    ms.update_from_action_result(success=True, user_id=user_id)
+    state = ms._get_state(user_id)
+    assert state.fear == 0.0
+    assert state.desire == 0.6
+    assert state.tension == 0.0
+
+    # Multiple successes to reach "Determined"
+    for _ in range(3):
+        ms.update_from_action_result(success=True, user_id=user_id)
+
+    assert ms.get_state_label(user_id) == "Determined"
+    assert "Determined" in ms.get_summary(user_id)
+
+def test_update_from_action_result_failure():
+    ms = MentalStates()
+    user_id = 2
+    # Failure: fear +, tension +, desire -
+    ms.update_from_action_result(success=False, user_id=user_id)
+    state = ms._get_state(user_id)
+    assert state.fear == 0.1
+    assert state.tension == 0.1
+    assert state.desire == 0.4
+
+    # Multiple failures to reach "Anxious"
+    for _ in range(5):
+        ms.update_from_action_result(success=False, user_id=user_id)
+
+    assert ms.get_state_label(user_id) == "Anxious"
+
+def test_satisfied_label():
+    ms = MentalStates()
+    user_id = 3
+    state = ms._get_state(user_id)
+    state.fear = 0.1
+    state.tension = 0.1
+    state.desire = 0.5
+    assert ms.get_state_label(user_id) == "Satisfied"
+
+def test_focused_label():
+    ms = MentalStates()
+    user_id = 4
+    state = ms._get_state(user_id)
+    state.tension = 0.7
+    assert ms.get_state_label(user_id) == "Focused"


### PR DESCRIPTION
This PR introduces a "Limbic-inspired" layer to the agent's cognitive architecture by implementing **Mental States**. 

Unlike basic emotions (PAD model), Mental States (Fear, Desire, Tension) represent higher-level cognitive pressures and motivations. 

Key changes:
1. **New Module:** `magda_agent/emotions/mental_states.py` manages metrics for Fear (risk aversion), Desire (motivation), and Tension (goal-oriented pressure).
2. **Cognitive Integration:** The `Consciousness` loop now updates these states based on internal self-evaluation scores. High scores (>= 7.0) act as a "reward" signal, while low scores act as "punishment".
3. **LLM Context:** Mental state summaries are injected into the system prompt to influence the agent's reasoning and tone.
4. **Dashboard:** The Telegram bot `/state` command has been redesigned to show a "Mind Profile" with emojis and bold formatting, making internal metrics more accessible and "human".
5. **Future Roadmap:** Added `cognitive-biases-illusions` to `agent_tasks.json` to continue building toward human-like irrationality modeling.

Verified with unit tests and a successful code review.

---
*PR created automatically by Jules for task [13799243811494495138](https://jules.google.com/task/13799243811494495138) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add human-like mental states (fear, desire, tension) to agent consciousness
> - Introduces [`MentalStates`](https://github.com/kazah4359-lgtm/Magda-agent/pull/205/files#diff-a0c79d855eb42862506ebdfdc1d390cd7a3c9ff7088ae6a11730f22d49a1307e) to track per-user `fear`, `desire`, and `tension` values, initialized at `(0.0, 0.5, 0.0)` and updated after each evaluated action based on `average_score >= 7.0` (success) or below (failure).
> - Integrates mental state summaries into [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/205/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) prompt construction and `get_internal_state`, so LLM reasoning now includes the current mental profile.
> - Updates the `/state` Telegram command in [`main.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/205/files#diff-98ad95189b12dbce626f6a32364418145e82086c844111cab992c357c05ee834) to pass `user_id` and render a formatted, emoji-annotated "Current Mind Profile" instead of raw text.
> - Adds tests in [`tests/test_mental_states.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/205/files#diff-227fe88c2c104829afb3eab09c510e09cc50818715edd65c027602a6b64e85b5) covering initialization defaults, success/failure update deltas, and label transitions (`Determined`, `Anxious`, `Focused`, `Satisfied`).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0f6b41f. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->