### PR TITLE
Implement Cognitive Biases and Illusions

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -42,7 +42,7 @@
   "tasks": [
     {
       "id": "cognitive-biases-illusions",
-      "status": "todo",
+      "status": "done",
       "area": "cognition",
       "risk": "medium",
       "title": "Implement Cognitive Biases and Illusions",

--- a/magda_agent/agents/planner_agent.py
+++ b/magda_agent/agents/planner_agent.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, List, Dict, Any
 from magda_agent.planning.planner import Planner
+from magda_agent.emotions.mental_states import MentalState
 
 class PlannerAgent:
     """
@@ -12,7 +13,7 @@ class PlannerAgent:
 
 
 
-    async def plan(self, user_input: str, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    async def plan(self, user_input: str, user_id: Optional[str] = None, mental_state: Optional[MentalState] = None) -> List[Dict[str, Any]]:
         """
         Generates a plan based on the user input.
         If a plan step requires a capability available on an external agent, it delegates the sub-plan.
@@ -22,7 +23,7 @@ class PlannerAgent:
 
         current_plan = self.planner.get_current_plan(user_id=user_id)
         if not current_plan:
-            await self.planner.generate_plan(user_input, user_id=user_id)
+            await self.planner.generate_plan(user_input, user_id=user_id, mental_state=mental_state)
             current_plan = self.planner.get_current_plan(user_id=user_id)
 
         # Retrieve plan and automatically delegate steps if an A2A Delegator is available

--- a/magda_agent/agents/triad_coordinator.py
+++ b/magda_agent/agents/triad_coordinator.py
@@ -27,12 +27,13 @@ class TriadCoordinator:
         user_id: Optional[str] = None,
         message_builder: Optional[Callable[[str], List[Dict[str, Any]]]] = None,
         pre_generation_hook: Optional[Callable[[], None]] = None,
-        policies: Optional[List[str]] = None
+        policies: Optional[List[str]] = None,
+        mental_state: Optional[Any] = None
     ) -> str:
         """
         Executes the triad flow: Plan -> Execute -> Generate -> Evaluate.
         """
-        await self.planner_agent.plan(user_input, user_id=user_id)
+        await self.planner_agent.plan(user_input, user_id=user_id, mental_state=mental_state)
         plan_str = await self.generator_agent.execute_plan(user_input, user_id=user_id)
 
         messages = []

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -352,7 +352,8 @@ class Consciousness:
                 user_id=user_id,
                 message_builder=message_builder,
                 pre_generation_hook=pre_generation_hook,
-                policies=policies
+                policies=policies,
+                mental_state=self.mental_states._get_state(user_id)
             )
         except ActionIgnored as e:
             return str(e)

--- a/magda_agent/emotions/mental_states.py
+++ b/magda_agent/emotions/mental_states.py
@@ -1,10 +1,12 @@
 from typing import Dict, Optional
 
 class MentalState:
-    def __init__(self, fear: float = 0.0, desire: float = 0.5, tension: float = 0.0):
+    def __init__(self, fear: float = 0.0, desire: float = 0.5, tension: float = 0.0, optimism: float = 0.5, overconfidence: float = 0.0):
         self.fear = fear
         self.desire = desire
         self.tension = tension
+        self.optimism = optimism
+        self.overconfidence = overconfidence
 
 class MentalStates:
     """
@@ -29,10 +31,22 @@ class MentalStates:
             state.fear = self._clamp(state.fear - 0.1)
             state.desire = self._clamp(state.desire + 0.1)
             state.tension = self._clamp(state.tension - 0.2)
+            state.optimism = self._clamp(state.optimism + 0.05)
+            state.overconfidence = self._clamp(state.overconfidence + 0.05)
         else:
             state.fear = self._clamp(state.fear + 0.1)
             state.tension = self._clamp(state.tension + 0.1)
             state.desire = self._clamp(state.desire - 0.1)
+            state.optimism = self._clamp(state.optimism - 0.1)
+            state.overconfidence = self._clamp(state.overconfidence - 0.05)
+
+    def apply_bias_modifier(self, optimism_mod: float = 0.0, overconfidence_mod: float = 0.0, user_id: Optional[int] = None) -> None:
+        """
+        Manually apply modifiers to cognitive biases.
+        """
+        state = self._get_state(user_id)
+        state.optimism = self._clamp(state.optimism + optimism_mod)
+        state.overconfidence = self._clamp(state.overconfidence + overconfidence_mod)
 
     def get_state_label(self, user_id: Optional[int] = None) -> str:
         """
@@ -55,7 +69,7 @@ class MentalStates:
         """
         state = self._get_state(user_id)
         label = self.get_state_label(user_id)
-        return f"Mental State: {label} (Fear: {state.fear:.2f}, Desire: {state.desire:.2f}, Tension: {state.tension:.2f})"
+        return f"Mental State: {label} (Fear: {state.fear:.2f}, Desire: {state.desire:.2f}, Tension: {state.tension:.2f}, Optimism: {state.optimism:.2f}, Overconfidence: {state.overconfidence:.2f})"
 
     def _clamp(self, value: float, min_val: float = 0.0, max_val: float = 1.0) -> float:
         return max(min_val, min(max_val, value))

--- a/magda_agent/planning/planner.py
+++ b/magda_agent/planning/planner.py
@@ -7,6 +7,7 @@ from magda_agent.skills.registry import SkillRegistry
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.agents.teams import TeamManager
 from magda_agent.planning.dag_planner import DAGPlanner
+from magda_agent.emotions.mental_states import MentalState
 
 
 class PlanStep(BaseModel):
@@ -119,7 +120,7 @@ class Planner:
     def paused_plan(self, value: Optional[Dict[str, Any]]) -> None:
         self.get_user_state().paused_plan = value
 
-    async def generate_plan(self, user_input: str, user_id: int = None) -> List[Dict[str, Any]]:
+    async def generate_plan(self, user_input: str, user_id: int = None, mental_state: Optional[MentalState] = None) -> List[Dict[str, Any]]:
         logging.info("Generating plan for input")
         state = self.get_user_state(user_id)
         skills_desc = self.skills.get_skills_summary()
@@ -137,6 +138,19 @@ class Planner:
             "- 'acceptance': an array of string acceptance criteria\n"
             "Only output the JSON object, nothing else."
         )
+
+        if mental_state:
+            bias_instructions = []
+            if mental_state.optimism > 0.7:
+                bias_instructions.append("You are feeling very optimistic. You can take more risks and propose more ambitious steps.")
+            elif mental_state.optimism < 0.3:
+                bias_instructions.append("You are feeling pessimistic. Be cautious and prioritize safety and verification in your plan.")
+
+            if mental_state.overconfidence > 0.7:
+                bias_instructions.append("You are very confident in your abilities. You might skip some redundant verification steps or combine multiple complex operations.")
+
+            if bias_instructions:
+                system_prompt += "\n\nCognitive Bias Modifiers:\n" + "\n".join(bias_instructions)
 
         if self.habit_tracker:
             suggested_strategy = self.habit_tracker.suggest_strategy(user_input, user_id=user_id)

--- a/tests/test_biases.py
+++ b/tests/test_biases.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.emotions.mental_states import MentalStates, MentalState
+from magda_agent.planning.planner import Planner
+from magda_agent.llm_client import LLMClient
+from magda_agent.skills.registry import SkillRegistry
+
+def test_mental_states_biases():
+    ms = MentalStates()
+    user_id = 123
+
+    # Initial state
+    state = ms._get_state(user_id)
+    assert state.optimism == 0.5
+    assert state.overconfidence == 0.0
+
+    # Success update
+    ms.update_from_action_result(success=True, user_id=user_id)
+    # optimism: 0.5 -> 0.55
+    # overconfidence: 0.0 -> 0.05
+    assert abs(state.optimism - 0.55) < 1e-9
+    assert abs(state.overconfidence - 0.05) < 1e-9
+
+    # Failure update
+    ms.update_from_action_result(success=False, user_id=user_id)
+    # optimism: 0.55 -> 0.45
+    # overconfidence: 0.05 -> 0.0
+    assert abs(state.optimism - 0.45) < 1e-9
+    assert abs(state.overconfidence - 0.0) < 1e-9
+
+    # Manual modifier
+    ms.apply_bias_modifier(optimism_mod=0.5, overconfidence_mod=0.8, user_id=user_id)
+    # optimism: 0.45 + 0.5 = 0.95
+    # overconfidence: 0.0 + 0.8 = 0.8
+    assert abs(state.optimism - 0.95) < 1e-9
+    assert abs(state.overconfidence - 0.8) < 1e-9
+
+@pytest.mark.asyncio
+async def test_planner_bias_modulation():
+    llm = MagicMock(spec=LLMClient)
+    llm.chat_completion = AsyncMock(return_value='{"goal": "test", "constraints": [], "risk": "low", "steps": [], "acceptance": []}')
+    skills = MagicMock(spec=SkillRegistry)
+    skills.get_skills_summary.return_value = "No skills"
+
+    planner = Planner(llm=llm, skills=skills)
+
+    # High optimism mental state
+    high_bias = MentalState(optimism=0.9, overconfidence=0.9)
+    await planner.generate_plan("Do something", mental_state=high_bias)
+
+    # Verify LLM was called with bias instructions
+    args, _ = llm.chat_completion.call_args
+    system_prompt = args[0][0]["content"]
+    assert "optimistic" in system_prompt
+    assert "very confident in your abilities" in system_prompt
+
+    # Low optimism
+    low_bias = MentalState(optimism=0.1)
+    await planner.generate_plan("Do something", mental_state=low_bias)
+    args, _ = llm.chat_completion.call_args
+    system_prompt = args[0][0]["content"]
+    assert "pessimistic" in system_prompt
+    assert "cautious" in system_prompt.lower()

--- a/tests/test_three_agent.py
+++ b/tests/test_three_agent.py
@@ -14,7 +14,7 @@ async def test_planner_agent():
     plan = await agent.plan("test input")
 
     assert plan == [{"step": 1}]
-    mock_planner.generate_plan.assert_called_once_with("test input", user_id=None)
+    mock_planner.generate_plan.assert_called_once_with("test input", user_id=None, mental_state=None)
 
 @pytest.mark.asyncio
 async def test_generator_agent():

--- a/tests/test_triad_coordinator.py
+++ b/tests/test_triad_coordinator.py
@@ -28,7 +28,7 @@ async def test_triad_coordinator():
     )
 
     assert res == "final response"
-    planner.plan.assert_called_once_with("hello", user_id="123")
+    planner.plan.assert_called_once_with("hello", user_id="123", mental_state=None)
     generator.execute_plan.assert_called_once_with("hello", user_id="123")
     message_builder.assert_called_once_with("plan string")
     pre_hook.assert_called_once()


### PR DESCRIPTION
This PR implements the `cognitive-biases-illusions` task by introducing mathematical models for optimism and overconfidence within the agent's mental state. These biases are dynamically updated based on the outcome of agent actions (reinforcement) and are used to modulate the Planner's behavior by injecting specific cognitive bias instructions into the LLM's system prompt. This allows the agent to exhibit human-like irrationality, such as increased risk-taking when optimistic or excessive caution when pessimistic.

---
*PR created automatically by Jules for task [8501776662201855108](https://jules.google.com/task/8501776662201855108) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement cognitive biases in planning via `MentalState` optimism and overconfidence
> - Adds `optimism` and `overconfidence` fields to `MentalState` in [mental_states.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/206/files#diff-a0c79d855eb42862506ebdfdc1d390cd7a3c9ff7088ae6a11730f22d49a1307e), updated by action outcomes (success/failure) and adjustable via a new `apply_bias_modifier` method.
> - `Planner.generate_plan` in [planner.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/206/files#diff-0dba6309dba5da62981c561d46f8b9e2e8128b6e7c999b43517c44d1e5735abb) now accepts an optional `mental_state` and injects bias instructions into the LLM system prompt when optimism or overconfidence cross defined thresholds (>0.7 or <0.3).
> - The bias-aware `mental_state` is propagated from `Consciousness` through `TriadCoordinator` and `PlannerAgent` to the planner on each coordination cycle.
> - Behavioral Change: `MentalStates.get_summary` now returns a redacted string, affecting any logs or displays that previously showed detailed state values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bb42bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->