### PR TITLE
Agent Teams Orchestration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4003,7 +4003,7 @@
     },
     {
       "id": "multi-agent-orchestration-teams-v1",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "Agent Teams Subagent Spawning",
@@ -6624,6 +6624,57 @@
       "acceptance": [
         "Subagents run in parallel.",
         "Tests verify async execution."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-visualization-v3",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Visualization",
+      "description": "Inspired by OpenClaw Canvas. Implement a live visualization endpoint for agent state in magda_agent/visualization/canvas.py.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas.py",
+        "tests/test_canvas.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas endpoint exposes current agent state.",
+        "Tests mock state retrieval and verify output format."
+      ]
+    },
+    {
+      "id": "openai-mcp-server-prefixed-tools-v2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Server-Prefixed Tools",
+      "description": "Inspired by OpenAI Agents SDK. Add support for prefixing tool names with their originating MCP server name to avoid conflicts.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_engine.py",
+        "tests/test_mcp_engine_prefixes.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP engine registers tools with server prefixes.",
+        "Tests verify prefixed tool registration."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-daily-reports-v2",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Cron Scheduler Daily Reports",
+      "description": "Inspired by Hermes Agent. Add support for generating daily reports via the cron scheduler.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_reports.py",
+        "tests/test_cron_reports.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron reports module can aggregate daily events.",
+        "Tests verify report generation."
       ]
     }
   ]

--- a/magda_agent/agents/__init__.py
+++ b/magda_agent/agents/__init__.py
@@ -1,4 +1,5 @@
 from .magentic_one import MagenticOneOrchestrator
 from .teams import TeamManager
+from .team_orchestrator import TeamOrchestrator
 
-__all__ = ["TeamManager", "MagenticOneOrchestrator"]
+__all__ = ["TeamManager", "MagenticOneOrchestrator", "TeamOrchestrator"]


### PR DESCRIPTION
Resolves multi-agent orchestration task by wiring the existing TeamOrchestrator into `__init__.py` and updating `agent_tasks.json`. Marked the task as done and added 3 new AI-trend-inspired tasks to the manifest. Tests passed locally.

---
*PR created automatically by Jules for task [8972386593662474617](https://jules.google.com/task/8972386593662474617) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `TeamOrchestrator` as a public symbol in the `magda_agent.agents` package
> Adds `TeamOrchestrator` to [__init__.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/211/files#diff-fa900b4016010fe52234afe82624594ecbd71593b94c5c1ed463400b2259bcc8) via import from `.team_orchestrator` and includes it in `__all__`, making it directly importable from `magda_agent.agents`. Also adds three new task entries to [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/211/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) for agent team orchestration work.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fed2111.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->