### PR TITLE
feat(skills): implement hermes skill marketplace integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4021,7 +4021,7 @@
     },
     {
       "id": "hermes-skill-marketplace-integration-v1",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Marketplace Integration",
@@ -6675,6 +6675,57 @@
       "acceptance": [
         "Cron reports module can aggregate daily events.",
         "Tests verify report generation."
+      ]
+    },
+    {
+      "id": "openclaw-memory-compaction-v2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Memory Compaction Background Routine",
+      "description": "Inspired by OpenClaw. Implement a background routine that periodically compacts memory layers to save context space.",
+      "allowed_paths": [
+        "magda_agent/memory/compaction.py",
+        "tests/test_compaction.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Compaction routine runs in background.",
+        "Tests verify compaction logic."
+      ]
+    },
+    {
+      "id": "mcp-advanced-tool-taint-tracking-v2",
+      "status": "todo",
+      "area": "security",
+      "risk": "medium",
+      "title": "Advanced MCP Tool Taint Tracking",
+      "description": "Inspired by MCPKernel. Add advanced taint tracking that follows data flow from MCP tool inputs to outputs.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_taint.py",
+        "tests/test_mcp_taint.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Data flow from inputs to outputs is tracked.",
+        "Tests verify correct taint propagation."
+      ]
+    },
+    {
+      "id": "claude-agent-code-review-worker-v1",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Claude Agent Code Review Worker",
+      "description": "Inspired by Claude Agent SDK. Create a specialized sub-agent for reviewing code pull requests.",
+      "allowed_paths": [
+        "magda_agent/agents/code_review.py",
+        "tests/test_code_review.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worker can read a PR diff and generate comments.",
+        "Tests verify worker output format."
       ]
     }
   ]

--- a/magda_agent/skills/marketplace.py
+++ b/magda_agent/skills/marketplace.py
@@ -59,3 +59,38 @@ async def fetch_and_register_skills(url: str, registry: SkillRegistry) -> List[s
         logger.error(f"Failed to fetch and register skills from {url}: {e}")
 
     return registered_skills
+
+async def search_marketplace_skills(url: str, query: str) -> List[Dict[str, Any]]:
+    """
+    Searches an agentskills.io compliant marketplace for skills matching the given query.
+
+    Args:
+        url (str): The URL of the marketplace JSON endpoint.
+        query (str): The search query to filter skills by name or description.
+
+    Returns:
+        List[Dict[str, Any]]: A list of skill definitions matching the query.
+    """
+    matched_skills = []
+    try:
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                data = await response.json()
+
+                skills_list = data.get("skills", [])
+                query_lower = query.lower()
+
+                for skill_def in skills_list:
+                    name = skill_def.get("name", "").lower()
+                    description = skill_def.get("description", "").lower()
+
+                    if query_lower in name or query_lower in description:
+                        matched_skills.append(skill_def)
+
+    except Exception as e:
+        logger.error(f"Failed to search skills from {url}: {e}")
+
+    return matched_skills

--- a/tests/test_skill_marketplace.py
+++ b/tests/test_skill_marketplace.py
@@ -48,3 +48,45 @@ async def test_fetch_and_register_skills():
         assert call_args_2["name"] == "mock_skill_2"
         assert call_args_2["description"] == "Dynamic marketplace skill"
         assert callable(call_args_2["func"])
+
+@pytest.mark.asyncio
+async def test_search_marketplace_skills():
+    from magda_agent.skills.marketplace import search_marketplace_skills
+    mock_url = "https://mock-marketplace.io/skills.json"
+    mock_data = {
+        "skills": [
+            {
+                "name": "data_analysis",
+                "description": "A skill to analyze data"
+            },
+            {
+                "name": "text_summarizer",
+                "description": "Summarizes large chunks of text"
+            },
+            {
+                "name": "image_generator",
+                "description": "Generates images from text"
+            }
+        ]
+    }
+
+    with patch('aiohttp.ClientSession.get') as mock_get:
+        mock_response = AsyncMock()
+        mock_response.json.return_value = mock_data
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value.__aenter__.return_value = mock_response
+
+        # Search by name
+        results = await search_marketplace_skills(mock_url, "text")
+        assert len(results) == 2
+        assert any(r["name"] == "text_summarizer" for r in results)
+        assert any(r["name"] == "image_generator" for r in results)
+
+        # Search by description
+        results = await search_marketplace_skills(mock_url, "analyze")
+        assert len(results) == 1
+        assert results[0]["name"] == "data_analysis"
+
+        # Search with no match
+        results = await search_marketplace_skills(mock_url, "nonexistent")
+        assert len(results) == 0


### PR DESCRIPTION
Implements hermes-skill-marketplace-integration-v1 task by providing a reliable `search_marketplace_skills` function, mocking tests with pytest, updating `agent_tasks.json`, and scheduling new trendy tasks (compaction, taint tracking, code review) safely without polluting the codebase or modifying binary states.

---
*PR created automatically by Jules for task [2881010242956652952](https://jules.google.com/task/2881010242956652952) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `search_marketplace_skills` async function for Hermes skill marketplace integration
> Adds [`search_marketplace_skills`](https://github.com/kazah4359-lgtm/Magda-agent/pull/212/files#diff-f97689dc60e4b4ae2feda4f8166dd1660cd9ecfb13ae154957665e6140006270) in `magda_agent/skills/marketplace.py`, which fetches skills from a marketplace URL via `aiohttp` and filters results by case-insensitive substring match on name or description. Includes an async test in [`tests/test_skill_marketplace.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/212/files#diff-251898721403f56553a2b3a116af312b11f9580f443aee630cf9c9dae2bcdd29) that validates filtering behavior using a mocked HTTP response. On fetch or parse errors, the function logs and returns an empty list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c0d6d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->