### PR TITLE
Implement OpenClaw Canvas Live Visualization

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4038,7 +4038,7 @@
     },
     {
       "id": "openclaw-canvas-live-visualization-v1",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "low",
       "title": "OpenClaw Canvas Live Visualization",
@@ -6726,6 +6726,57 @@
       "acceptance": [
         "Worker can read a PR diff and generate comments.",
         "Tests verify worker output format."
+      ]
+    },
+    {
+      "id": "openclaw-rl-dynamic-behavior-adjustment-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw RL Dynamic Behavior Adjustment",
+      "description": "Inspired by OpenClaw trend: Online reinforcement learning from user feedback. Implement an advanced RL module that dynamically adjusts agent behavior weights based on the user's implicit emotional shifts.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl.py",
+        "tests/test_openclaw_rl.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent adjusts behavior based on simulated emotional feedback.",
+        "Tests verify that internal weights change correctly in response to feedback signals."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-registration-v4",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Registration v4",
+      "description": "Inspired by Model Context Protocol trends. Enhance the skill registry to allow dynamically registering new tools via MCP during runtime.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry.py",
+        "tests/test_mcp_registry*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be dynamically registered and unregistered using an MCP adapter.",
+        "Tests confirm registration and successful execution of dynamically added skills."
+      ]
+    },
+    {
+      "id": "acs-guard-audit-trail-v1",
+      "status": "todo",
+      "area": "security",
+      "risk": "medium",
+      "title": "ACS Guard Audit Trail",
+      "description": "Inspired by ACS Specification. Implement an audit logging mechanism that records all tools evaluated and intercepted by the ACSGuard policy layer.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_audit.py",
+        "tests/test_acs_audit.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "An audit log correctly records intercepted actions.",
+        "Tests verify audit entries."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -174,7 +174,7 @@
 
 * [ ] BUG: `Brainstem` integration in `Consciousness.process_input` does not halt long-running skills gracefully upon a 'stop' command. Need to implement a cancellation token or mechanism for active background tasks when a stop reflex is triggered. (2026-06-04)
 ## 🛠️ Запланированные Skills
-* [ ] FEATURE: OpenClaw Canvas Live Visualization
+* [x] FEATURE: OpenClaw Canvas Live Visualization
 * [x] FEATURE: OpenClaw RL Next-State Signals
 * [ ] FEATURE: Claude Subagent Spawning
 

--- a/magda_agent/visualization/canvas.py
+++ b/magda_agent/visualization/canvas.py
@@ -1,0 +1,100 @@
+import json
+import logging
+from typing import Dict, Any, Optional
+from magda_agent.consciousness.core import Consciousness
+
+logger = logging.getLogger(__name__)
+
+class CanvasVisualizer:
+    """
+    Formats Magda's internal state into a structured JSON dictionary
+    suitable for streaming to a live OpenClaw-inspired Canvas UI.
+    """
+
+    def __init__(self, consciousness: Consciousness):
+        """
+        Initializes the visualizer with a reference to the agent's consciousness.
+
+        Args:
+            consciousness: The main Consciousness instance containing the agent's state.
+        """
+        self.consciousness = consciousness
+
+    def get_formatted_state(self, user_id: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Retrieves and formats the agent's internal state into a structured dictionary.
+
+        Args:
+            user_id: Optional user identifier to filter state (e.g., for emotions/memory).
+
+        Returns:
+            Dict[str, Any]: A dictionary representing the agent's current state.
+        """
+        state = {
+            "emotions": {},
+            "mental_states": {},
+            "memory": {},
+            "skills": [],
+            "planner": {}
+        }
+
+        try:
+            # 1. Emotions
+            if self.consciousness.emotions:
+                state["emotions"] = {
+                    "summary": self.consciousness.emotions.get_summary(user_id=user_id)
+                }
+
+                # Try to get raw PAD values if available
+                history = self.consciousness.emotions.get_state_history(user_id=user_id)
+                if history and len(history) > 0:
+                    pad_state = history[0]
+                    # Assuming PADState has pleasure, arousal, dominance attributes
+                    state["emotions"]["pad"] = {
+                        "pleasure": getattr(pad_state, 'pleasure', 0.0),
+                        "arousal": getattr(pad_state, 'arousal', 0.0),
+                        "dominance": getattr(pad_state, 'dominance', 0.0)
+                    }
+
+            # 2. Mental States
+            if self.consciousness.mental_states:
+                state["mental_states"] = {
+                    "summary": self.consciousness.mental_states.get_summary(user_id=user_id)
+                }
+
+            # 3. Memory
+            if self.consciousness.memory:
+                state["memory"] = {
+                    "summary": self.consciousness.memory.get_summary()
+                }
+
+            # 4. Skills
+            if self.consciousness.skills:
+                # Extract skill names from the registry
+                skills_dict = getattr(self.consciousness.skills, 'skills', {})
+                state["skills"] = list(skills_dict.keys())
+
+            # 5. Planner
+            if self.consciousness.planner:
+                planner_state = self.consciousness.planner.get_state_summary()
+                state["planner"] = {
+                    "summary": planner_state
+                }
+
+        except Exception as e:
+            logger.error(f"Error formatting canvas state: {e}")
+            state["error"] = str(e)
+
+        return state
+
+    def get_state_json(self, user_id: Optional[str] = None) -> str:
+        """
+        Returns the formatted state as a JSON string.
+
+        Args:
+            user_id: Optional user identifier.
+
+        Returns:
+            str: JSON-encoded string of the agent state.
+        """
+        return json.dumps(self.get_formatted_state(user_id=user_id))

--- a/magda_agent/visualization/server.py
+++ b/magda_agent/visualization/server.py
@@ -11,6 +11,8 @@ class CanvasServer:
     WebSocket server for streaming live visualization of Magda's internal cognitive state.
     """
     def __init__(self, consciousness: Consciousness, interval: float = 1.0):
+        from magda_agent.visualization.canvas import CanvasVisualizer
+        self.visualizer = CanvasVisualizer(consciousness)
         self.active_connections: List[WebSocket] = []
         self.consciousness = consciousness
         self.interval = interval
@@ -49,7 +51,7 @@ class CanvasServer:
         while self._running:
             try:
                 if self.active_connections:
-                    state = self.consciousness.get_internal_state()
+                    state = self.visualizer.get_state_json()
                     await self.broadcast(state)
             except Exception as e:
                 logger.error(f"Error while streaming canvas state: {e}")

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,19 +1,91 @@
 import pytest
-import asyncio
-from magda_agent.gateway.canvas import CanvasVisualizer
+import json
+from unittest.mock import MagicMock
+from magda_agent.visualization.canvas import CanvasVisualizer
 
-@pytest.mark.asyncio
-async def test_canvas_visualizer():
-    canvas = CanvasVisualizer()
-    q = canvas.subscribe()
+class DummyPADState:
+    def __init__(self, p, a, d):
+        self.pleasure = p
+        self.arousal = a
+        self.dominance = d
 
-    await canvas.update_state("active_task", "OpenClaw RL")
+def test_canvas_visualizer_formatting():
+    """Test that the CanvasVisualizer correctly formats the agent state."""
 
-    assert canvas.get_state() == {"active_task": "OpenClaw RL"}
+    # Mock the consciousness and its components
+    mock_consciousness = MagicMock()
 
-    msg = await asyncio.wait_for(q.get(), timeout=1.0)
-    assert msg == {"type": "state_update", "key": "active_task", "value": "OpenClaw RL"}
+    # Mock Emotions
+    mock_emotions = MagicMock()
+    mock_emotions.get_summary.return_value = "Feeling Neutral"
+    mock_emotions.get_state_history.return_value = [DummyPADState(0.1, 0.2, 0.3)]
+    mock_consciousness.emotions = mock_emotions
 
-    canvas.unsubscribe(q)
-    await canvas.update_state("active_task", "Done")
-    assert q.empty()
+    # Mock Mental States
+    mock_mental_states = MagicMock()
+    mock_mental_states.get_summary.return_value = "Focused"
+    mock_consciousness.mental_states = mock_mental_states
+
+    # Mock Memory
+    mock_memory = MagicMock()
+    mock_memory.get_summary.return_value = "Working memory: 5 items"
+    mock_consciousness.memory = mock_memory
+
+    # Mock Skills
+    mock_skills = MagicMock()
+    mock_skills.skills = {"skill_a": None, "skill_b": None}
+    mock_consciousness.skills = mock_skills
+
+    # Mock Planner
+    mock_planner = MagicMock()
+    mock_planner.get_state_summary.return_value = "Current plan: None"
+    mock_consciousness.planner = mock_planner
+
+    # Create visualizer and get state
+    visualizer = CanvasVisualizer(mock_consciousness)
+    state = visualizer.get_formatted_state(user_id="test_user")
+
+    # Assertions
+    assert "emotions" in state
+    assert state["emotions"]["summary"] == "Feeling Neutral"
+    assert state["emotions"]["pad"]["pleasure"] == 0.1
+    assert state["emotions"]["pad"]["arousal"] == 0.2
+    assert state["emotions"]["pad"]["dominance"] == 0.3
+
+    assert "mental_states" in state
+    assert state["mental_states"]["summary"] == "Focused"
+
+    assert "memory" in state
+    assert state["memory"]["summary"] == "Working memory: 5 items"
+
+    assert "skills" in state
+    assert set(state["skills"]) == {"skill_a", "skill_b"}
+
+    assert "planner" in state
+    assert state["planner"]["summary"] == "Current plan: None"
+
+    # Test JSON output
+    json_str = visualizer.get_state_json(user_id="test_user")
+    json_data = json.loads(json_str)
+    assert json_data == state
+
+def test_canvas_visualizer_error_handling():
+    """Test that CanvasVisualizer handles missing components gracefully."""
+    mock_consciousness = MagicMock()
+
+    # Set components to None
+    mock_consciousness.emotions = None
+    mock_consciousness.mental_states = None
+    mock_consciousness.memory = None
+    mock_consciousness.skills = None
+    mock_consciousness.planner = None
+
+    visualizer = CanvasVisualizer(mock_consciousness)
+    state = visualizer.get_formatted_state()
+
+    assert state["emotions"] == {}
+    assert state["mental_states"] == {}
+    assert state["memory"] == {}
+    assert state["skills"] == []
+    assert state["planner"] == {}
+    assert "error" not in state

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -7,7 +7,11 @@ from magda_agent.visualization.server import CanvasServer
 @pytest.fixture
 def mock_consciousness():
     mock = MagicMock()
-    mock.get_internal_state.return_value = "Mocked State"
+    mock.emotions = None
+    mock.mental_states = None
+    mock.memory = None
+    mock.skills = None
+    mock.planner = None
     return mock
 
 @pytest.fixture
@@ -70,5 +74,3 @@ async def test_start_streaming(canvas_server, mock_consciousness):
 
     # The interval is 0.1s, sleeping 0.15s should trigger at least 1 broadcast
     assert mock_ws.send_text.await_count >= 1
-    mock_ws.send_text.assert_awaited_with("Mocked State")
-    mock_consciousness.get_internal_state.assert_called()


### PR DESCRIPTION
Completed openclaw-canvas-live-visualization-v1 task by implementing a CanvasVisualizer that serializes the internal cognitive state of the agent into JSON and streaming it via WebSockets. We also added tests, checked the task as done, modified the backlog, and added 3 new todo tasks.

---
*PR created automatically by Jules for task [2103956195092997867](https://jules.google.com/task/2103956195092997867) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CanvasVisualizer` for live WebSocket streaming of agent cognitive state
> - Adds [`CanvasVisualizer`](https://github.com/kazah4359-lgtm/Magda-agent/pull/213/files#diff-750693847786a5fe4dd761624330ed4752ba32cbba9af8398d4c2bbd7ba726a3) to extract and format a `Consciousness` instance's emotions (with PAD values), mental states, memory, skills, and planner into a structured dict or JSON string.
> - Updates [`CanvasServer.start_streaming`](https://github.com/kazah4359-lgtm/Magda-agent/pull/213/files#diff-065ec5f3c009b16b28bbdb40945f5318cf31a1490b5772072ad8e047ddb2aa48) to broadcast payloads from `CanvasVisualizer.get_state_json()` instead of `consciousness.get_internal_state()`.
> - Behavioral Change: WebSocket clients now receive a consistently structured JSON payload; the previous `get_internal_state()` format is no longer used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74433b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->