### PR TITLE
feat: Implement Claude Dependency Graph Task System

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4055,7 +4055,7 @@
     },
     {
       "id": "claude-dependency-graph-task-system-v1",
-      "status": "todo",
+      "status": "done",
       "area": "planning",
       "risk": "medium",
       "title": "Claude Dependency Graph Task System",
@@ -6777,6 +6777,57 @@
       "acceptance": [
         "An audit log correctly records intercepted actions.",
         "Tests verify audit entries."
+      ]
+    },
+    {
+      "id": "openclaw-rl-user-feedback-v5",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL User Feedback v5",
+      "description": "Inspired by OpenClaw trends: Implement continuous online reinforcement learning from user feedback for adapting agent behavior parameters.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v5.py",
+        "tests/test_openclaw_rl_v5*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent adjusts to user feedback dynamically.",
+        "Tests verify learning state updates."
+      ]
+    },
+    {
+      "id": "acs-guard-runtime-safety-controls-v6",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Guard Runtime Safety Controls v6",
+      "description": "Inspired by ACS trends: Implement an advanced runtime safety policy to intercept and validate tool execution across all skills.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_v6.py",
+        "tests/test_acs_guard_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy guard successfully intercepts unsafe executions.",
+        "Tests verify all 5 check points."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-action-tool-v7",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "MCP Dynamic Action Tool v7",
+      "description": "Inspired by MCP standard trend: Enhance skill registry to allow dynamic exporting and registration of action tools over MCP.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_export_v7.py",
+        "tests/test_mcp_export_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be exported as MCP tools dynamically.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/planning/dependency_graph.py
+++ b/magda_agent/planning/dependency_graph.py
@@ -1,0 +1,79 @@
+import logging
+from typing import List, Dict, Any, Set
+
+class DependencyGraph:
+    """
+    Utility class for resolving task dependencies and computing topological sorts
+    for execution plans. Implements the dependency graph task system for Claude multi-agent orchestration.
+    """
+
+    @staticmethod
+    def get_executable_steps(plan_steps: List[Dict[str, Any]], completed_step_ids: Set[str]) -> List[Dict[str, Any]]:
+        """
+        Returns a list of steps that have all their dependencies met and are not yet completed.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries. Each should have 'id' and 'dependencies'.
+            completed_step_ids (Set[str]): A set of IDs of steps that have already been completed.
+
+        Returns:
+            List[Dict[str, Any]]: A list of steps ready for execution.
+        """
+        executable_steps = []
+        for step in plan_steps:
+            step_id = step.get("id")
+            if not step_id or step_id in completed_step_ids:
+                continue
+
+            dependencies = step.get("dependencies", [])
+            # A step is executable if all its dependencies are in completed_step_ids
+            if all(dep in completed_step_ids for dep in dependencies):
+                executable_steps.append(step)
+
+        return executable_steps
+
+    @staticmethod
+    def topological_sort(plan_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Returns a topologically sorted list of steps using Kahn's algorithm.
+        Raises ValueError if a cycle is detected.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries.
+
+        Returns:
+            List[Dict[str, Any]]: The sorted steps.
+        """
+        # Build adjacency list
+        adj: Dict[str, List[str]] = {step.get("id", ""): [] for step in plan_steps if step.get("id")}
+        in_degree: Dict[str, int] = {step.get("id", ""): 0 for step in plan_steps if step.get("id")}
+
+        step_map = {step.get("id"): step for step in plan_steps if step.get("id")}
+
+        for step in plan_steps:
+            step_id = step.get("id")
+            if not step_id:
+                continue
+            for dep in step.get("dependencies", []):
+                if dep in adj:
+                    adj[dep].append(step_id)
+                    in_degree[step_id] += 1
+                else:
+                    logging.warning(f"Dependency {dep} for step {step_id} not found in plan steps.")
+
+        # Kahn's algorithm
+        queue = [node for node, deg in in_degree.items() if deg == 0]
+        sorted_ids = []
+
+        while queue:
+            node = queue.pop(0)
+            sorted_ids.append(node)
+            for neighbor in adj.get(node, []):
+                in_degree[neighbor] -= 1
+                if in_degree[neighbor] == 0:
+                    queue.append(neighbor)
+
+        if len(sorted_ids) != len(adj):
+            raise ValueError("Cycle detected in plan dependencies")
+
+        return [step_map[node] for node in sorted_ids]

--- a/magda_agent/planning/planner.py
+++ b/magda_agent/planning/planner.py
@@ -6,7 +6,7 @@ from magda_agent.llm_client import LLMClient
 from magda_agent.skills.registry import SkillRegistry
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.agents.teams import TeamManager
-from magda_agent.planning.dag_planner import DAGPlanner
+from magda_agent.planning.dependency_graph import DependencyGraph
 from magda_agent.emotions.mental_states import MentalState
 
 
@@ -195,7 +195,7 @@ class Planner:
                     return []
 
             try:
-                plan_steps = DAGPlanner.topological_sort(plan_steps)
+                plan_steps = DependencyGraph.topological_sort(plan_steps)
             except ValueError as ve:
                 logging.error(f"Plan cycle validation failed: {ve}")
                 self.clear_pending_plan(user_id=user_id)
@@ -254,7 +254,7 @@ class Planner:
     def get_executable_steps(self, user_id: Optional[Any] = None) -> List[Dict[str, Any]]:
         state = self.get_user_state(user_id)
         completed_ids: Set[str] = {step.get("id") for step in state.completed_steps if step.get("id")}
-        return DAGPlanner.get_executable_steps(state.current_plan, completed_ids)
+        return DependencyGraph.get_executable_steps(state.current_plan, completed_ids)
 
     def get_state_summary(self, user_id: Optional[Any] = None) -> str:
         state = self.get_user_state(user_id)

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,0 +1,61 @@
+import pytest
+from magda_agent.planning.dependency_graph import DependencyGraph
+
+def test_get_executable_steps():
+    plan_steps = [
+        {"id": "step1", "dependencies": []},
+        {"id": "step2", "dependencies": ["step1"]},
+        {"id": "step3", "dependencies": ["step1", "step2"]}
+    ]
+
+    # Initially only step1 is executable
+    exec_steps = DependencyGraph.get_executable_steps(plan_steps, set())
+    assert len(exec_steps) == 1
+    assert exec_steps[0]["id"] == "step1"
+
+    # After step1, step2 is executable
+    exec_steps = DependencyGraph.get_executable_steps(plan_steps, {"step1"})
+    assert len(exec_steps) == 1
+    assert exec_steps[0]["id"] == "step2"
+
+    # After step1 and step2, step3 is executable
+    exec_steps = DependencyGraph.get_executable_steps(plan_steps, {"step1", "step2"})
+    assert len(exec_steps) == 1
+    assert exec_steps[0]["id"] == "step3"
+
+    # After all are completed, no executable steps remain
+    exec_steps = DependencyGraph.get_executable_steps(plan_steps, {"step1", "step2", "step3"})
+    assert len(exec_steps) == 0
+
+def test_topological_sort_success():
+    plan_steps = [
+        {"id": "step3", "dependencies": ["step2"]},
+        {"id": "step1", "dependencies": []},
+        {"id": "step2", "dependencies": ["step1"]}
+    ]
+
+    sorted_steps = DependencyGraph.topological_sort(plan_steps)
+    sorted_ids = [step["id"] for step in sorted_steps]
+
+    assert sorted_ids == ["step1", "step2", "step3"]
+
+def test_topological_sort_cycle():
+    plan_steps = [
+        {"id": "step1", "dependencies": ["step3"]},
+        {"id": "step2", "dependencies": ["step1"]},
+        {"id": "step3", "dependencies": ["step2"]}
+    ]
+
+    with pytest.raises(ValueError, match="Cycle detected in plan dependencies"):
+        DependencyGraph.topological_sort(plan_steps)
+
+def test_topological_sort_missing_dependency():
+    """
+    Test that an unknown dependency is ignored but logged.
+    """
+    plan_steps = [
+        {"id": "step1", "dependencies": ["unknown_step"]}
+    ]
+    sorted_steps = DependencyGraph.topological_sort(plan_steps)
+    assert len(sorted_steps) == 1
+    assert sorted_steps[0]["id"] == "step1"


### PR DESCRIPTION
This PR resolves the `claude-dependency-graph-task-system-v1` task by introducing a more sophisticated object-oriented `DependencyGraph` system for task dependency resolution in the planner. It replaces the old static `DAGPlanner`.

Includes tests, agent_tasks.json state updates, and three new todo tasks.

---
*PR created automatically by Jules for task [1763404325589757946](https://jules.google.com/task/1763404325589757946) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `DAGPlanner` with new `DependencyGraph` class for plan step ordering
> - Introduces [`DependencyGraph`](https://github.com/kazah4359-lgtm/Magda-agent/pull/214/files#diff-4623f39142c18d13cd5d3491a814055ce813b36e801914a75eb26c44975375a7) with two static methods: `get_executable_steps` (filters steps ready to run given a completed-ID set) and `topological_sort` (Kahn's algorithm, raises `ValueError` on cycles, warns on missing dependencies).
> - Updates [`planner.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/214/files#diff-0dba6309dba5da62981c561d46f8b9e2e8128b6e7c999b43517c44d1e5735abb) to import and call `DependencyGraph` in place of the former `DAGPlanner` for both sorting and executable-step selection.
> - Adds [`tests/test_dependency_graph.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/214/files#diff-d59d9683214e6e0d1fa95062e00d103080c653fcbabf8830018b8bbac231b595) covering step progression, successful sort, cycle detection, and missing-dependency handling.
> - Behavioral Change: callers that previously imported `DAGPlanner` directly will need to switch to `DependencyGraph`; runtime behavior of the planner is otherwise unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e7a978.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->