### PR TITLE
Feature: Claude Subagent Spawning

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4072,7 +4072,7 @@
     },
     {
       "id": "claude-subagent-spawning-v1",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Subagent Spawning",
@@ -6828,6 +6828,57 @@
       "acceptance": [
         "Skills can be exported as MCP tools dynamically.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-local-first-gateway-v1-unique",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "OpenClaw Local-First Gateway",
+      "description": "Inspired by OpenClaw trends: Implement a local-first gateway control plane to proxy messages from channels before they reach consciousness.",
+      "allowed_paths": [
+        "magda_agent/gateway/local_first.py",
+        "tests/test_local_first_gateway.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Gateway proxies and normalizes messages.",
+        "Tests verify local-first routing."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v9-unique",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Exporter v9",
+      "description": "Inspired by MCP trends: Extend the tool exporter to support the latest JSON-RPC standard used by MCP tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_export_v9.py",
+        "tests/test_mcp_export_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tools can be exported compliant with MCP v9 JSON-RPC.",
+        "Tests confirm exported schema validity."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backups-v1-unique",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Cron Nightly Backups",
+      "description": "Inspired by Hermes Agent trends: Add a scheduled task via the cron operations scheduler to backup episodic memory databases nightly.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_backups.py",
+        "tests/test_cron_backups.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron scheduler triggers backups of sqlite3 databases.",
+        "Tests verify backup routines run successfully."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -176,7 +176,7 @@
 ## 🛠️ Запланированные Skills
 * [x] FEATURE: OpenClaw Canvas Live Visualization
 * [x] FEATURE: OpenClaw RL Next-State Signals
-* [ ] FEATURE: Claude Subagent Spawning
+* [x] FEATURE: Claude Subagent Spawning
 
 * [x] SKILL: **Omnichannel Provider (Работа с провайдерами)** — модуль `magda_agent/skills/omnichannel.py`. (2026-06-04)
   Умение работы с разными провайдерами (Telegram, WhatsApp и другие) для взаимодействия с агентом.

--- a/magda_agent/agents/spawner.py
+++ b/magda_agent/agents/spawner.py
@@ -1,0 +1,43 @@
+import asyncio
+import logging
+from typing import List, Dict, Any, Optional
+
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.llm_client import LLMClient
+
+class SubagentSpawner:
+    """
+    SubagentSpawner dynamically spawns SubAgents for concurrent tasks.
+    Inspired by Claude Agent SDK: Agent Teams and Subagent spawning.
+    """
+    def __init__(self, llm: LLMClient):
+        """
+        Initializes the SubagentSpawner.
+
+        Args:
+            llm: The Language Model client to be used by spawned SubAgents.
+        """
+        self.llm = llm
+
+    async def spawn_and_execute(self, tasks: List[Dict[str, Any]], base_context: str, use_isolation: bool = True) -> List[str]:
+        """
+        Spawns subagents dynamically to execute multiple tasks concurrently.
+
+        Args:
+            tasks: A list of task dictionaries containing a 'description' field.
+            base_context: The shared context passed to all subagents.
+            use_isolation: Whether to use Git Worktree isolation for each subagent.
+
+        Returns:
+            A list of execution results corresponding to the tasks.
+        """
+        logging.info(f"SubagentSpawner spawning {len(tasks)} isolated subagents for parallel execution.")
+
+        async def run_subagent(task_spec: Dict[str, Any]) -> str:
+            system_prompt: Optional[str] = task_spec.get('system_prompt', None)
+            sub_agent = SubAgent(llm=self.llm, system_prompt=system_prompt, use_isolation=use_isolation)
+            task_description = task_spec.get('description', 'Unknown task')
+            return await sub_agent.execute(task=task_description, context=base_context)
+
+        results = await asyncio.gather(*(run_subagent(task) for task in tasks))
+        return list(results)

--- a/magda_agent/agents/team_orchestrator.py
+++ b/magda_agent/agents/team_orchestrator.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import List, Dict, Any
 
-from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.agents.spawner import SubagentSpawner
 from magda_agent.llm_client import LLMClient
 
 class TeamOrchestrator:
@@ -14,17 +14,11 @@ class TeamOrchestrator:
         Initializes the TeamOrchestrator.
         """
         self.llm = llm
+        self.spawner = SubagentSpawner(llm=llm)
 
     async def parallel_execute(self, tasks: List[Dict[str, Any]], base_context: str) -> List[str]:
         """
-        Executes multiple tasks in parallel using isolated SubAgents.
+        Executes multiple tasks in parallel using isolated SubAgents dynamically spawned.
         """
-        logging.info(f"Orchestrating {len(tasks)} parallel subagent tasks.")
-
-        async def run_task(task_spec: Dict[str, Any]) -> str:
-            sub_agent = SubAgent(llm=self.llm, use_isolation=True)
-            task_description = task_spec.get('description', 'Unknown task')
-            return await sub_agent.execute(task=task_description, context=base_context)
-
-        results = await asyncio.gather(*(run_task(task) for task in tasks))
-        return list(results)
+        logging.info(f"Orchestrating {len(tasks)} parallel subagent tasks via SubagentSpawner.")
+        return await self.spawner.spawn_and_execute(tasks, base_context, use_isolation=True)

--- a/tests/test_spagentspawner.py
+++ b/tests/test_spagentspawner.py
@@ -1,0 +1,65 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from magda_agent.agents.spawner import SubagentSpawner
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_subagent_spawner_spawn_and_execute():
+    """
+    Tests that the SubagentSpawner correctly spawns subagents and executes tasks in parallel.
+    """
+    mock_llm = MagicMock(spec=LLMClient)
+    # The SubAgent internally calls context_compressor which calls LLMClient.chat_completion
+    # We mock LLMClient's chat_completion to return a predictable response
+    mock_llm.chat_completion = AsyncMock(return_value="Mocked subagent response")
+
+    spawner = SubagentSpawner(llm=mock_llm)
+
+    tasks = [
+        {"description": "Task 1", "system_prompt": "Prompt 1"},
+        {"description": "Task 2"},
+    ]
+    base_context = "Base Context"
+
+    # Mock GitWorktreeManager to avoid actual git operations during tests
+    with patch("magda_agent.agents.sub_agent.GitWorktreeManager") as MockGitWorktreeManager:
+        mock_manager_instance = MockGitWorktreeManager.return_value
+        mock_manager_instance.create_worktree_async = AsyncMock(return_value="/tmp/mock_worktree")
+        mock_manager_instance.remove_worktree_async = AsyncMock()
+
+        results = await spawner.spawn_and_execute(tasks, base_context=base_context, use_isolation=True)
+
+        assert len(results) == 2
+        assert results[0] == "Mocked subagent response"
+        assert results[1] == "Mocked subagent response"
+
+        # Check that worktree manager methods were called for both subagents
+        assert mock_manager_instance.create_worktree_async.call_count == 2
+        assert mock_manager_instance.remove_worktree_async.call_count == 2
+
+@pytest.mark.asyncio
+async def test_subagent_spawner_no_isolation():
+    """
+    Tests that the SubagentSpawner correctly executes tasks when use_isolation is False.
+    """
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat_completion = AsyncMock(return_value="Mocked response no isolation")
+
+    spawner = SubagentSpawner(llm=mock_llm)
+
+    tasks = [
+        {"description": "Task A"},
+    ]
+    base_context = "Base Context"
+
+    # with use_isolation=False, GitWorktreeManager should not be initialized
+    with patch("magda_agent.agents.sub_agent.GitWorktreeManager") as MockGitWorktreeManager:
+        results = await spawner.spawn_and_execute(tasks, base_context=base_context, use_isolation=False)
+
+        assert len(results) == 1
+        assert results[0] == "Mocked response no isolation"
+
+        # GitWorktreeManager should not be used
+        MockGitWorktreeManager.assert_not_called()

--- a/tests/test_team_orchestrator.py
+++ b/tests/test_team_orchestrator.py
@@ -1,37 +1,29 @@
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, AsyncMock, patch
+
 from magda_agent.agents.team_orchestrator import TeamOrchestrator
 from magda_agent.llm_client import LLMClient
 
 @pytest.mark.asyncio
 async def test_parallel_execute_success():
-    """Tests that TeamOrchestrator spawns parallel sub-agents correctly."""
+    """Tests that TeamOrchestrator spawns parallel sub-agents correctly using SubagentSpawner."""
     llm_mock = MagicMock(spec=LLMClient)
-    orchestrator = TeamOrchestrator(llm=llm_mock)
 
-    tasks = [
-        {"description": "Task 1"},
-        {"description": "Task 2"}
-    ]
+    with patch('magda_agent.agents.team_orchestrator.SubagentSpawner') as MockSpawner:
+        mock_spawner_instance = MockSpawner.return_value
+        mock_spawner_instance.spawn_and_execute = AsyncMock(return_value=["Result 1", "Result 2"])
 
-    with patch('magda_agent.agents.team_orchestrator.SubAgent') as MockSubAgent:
-        mock_instance_1 = MagicMock()
-        mock_instance_1.execute = AsyncMock(return_value="Result 1")
+        orchestrator = TeamOrchestrator(llm=llm_mock)
 
-        mock_instance_2 = MagicMock()
-        mock_instance_2.execute = AsyncMock(return_value="Result 2")
-
-        # Return mock_instance_1 first, then mock_instance_2
-        MockSubAgent.side_effect = [mock_instance_1, mock_instance_2]
+        tasks = [
+            {"description": "Task 1"},
+            {"description": "Task 2"}
+        ]
 
         results = await orchestrator.parallel_execute(tasks, base_context="Context")
 
         assert len(results) == 2
-        assert "Result 1" in results
-        assert "Result 2" in results
-
-        assert MockSubAgent.call_count == 2
-        MockSubAgent.assert_called_with(llm=llm_mock, use_isolation=True)
-
-        mock_instance_1.execute.assert_awaited_once_with(task="Task 1", context="Context")
-        mock_instance_2.execute.assert_awaited_once_with(task="Task 2", context="Context")
+        assert results[0] == "Result 1"
+        assert results[1] == "Result 2"
+        mock_spawner_instance.spawn_and_execute.assert_called_once_with(tasks, "Context", use_isolation=True)


### PR DESCRIPTION
Implements Claude SDK trend: Subagent spawning in spawner.py. Added new `SubagentSpawner` class, integrated it into `TeamOrchestrator`, added corresponding tests, updated backlog, marked task as done, and added 3 new tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [12207286274398662227](https://jules.google.com/task/12207286274398662227) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SubagentSpawner` to concurrently spawn and execute subagents
> - Introduces [`SubagentSpawner`](https://github.com/kazah4359-lgtm/Magda-agent/pull/215/files#diff-daeb62991649bed05ae78cf05571b8c566c7f87c6b1f92b9f0ff4b1a2e8a76c3), a new class that accepts an `LLMClient` and exposes `spawn_and_execute` to run multiple `SubAgent` instances concurrently via `asyncio.gather`.
> - [`TeamOrchestrator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/215/files#diff-fcb0c824a65fe41b5929e4721a905268ba63fde924f02d53132c19cff32e02d2) now delegates parallel execution to `SubagentSpawner` instead of managing `SubAgent` instantiation and `asyncio.gather` directly.
> - Supports optional per-task system prompts and an `use_isolation` flag for Git worktree isolation.
> - Tests in [`tests/test_spagentspawner.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/215/files#diff-501a2fe70801f8f8b063996694695b0bf9791257ead9e59ae16c4b81b5d5a3b4) cover both isolated and non-isolated execution paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5cb4416.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->