### PR TITLE
feat(planning): Add ReflectionTaskGenerator to autonomously turn reflections into tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4106,7 +4106,7 @@
     },
     {
       "id": "reflection-task-generation-v1",
-      "status": "todo",
+      "status": "done",
       "area": "planning",
       "risk": "medium",
       "title": "Reflection to task generation",
@@ -6925,6 +6925,57 @@
       "allowed_paths": [
         "magda_agent/agents/evaluator_v2.py",
         "tests/test_evaluator_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator sub-agent critiques inputs and provides actionable feedback.",
+        "Tests verify evaluator output format."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backups-v2",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Cron Nightly Backups v2",
+      "description": "Inspired by Hermes Agent trends: Add a scheduled task via the cron operations scheduler to backup episodic memory databases nightly.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_backups_v2.py",
+        "tests/test_cron_backups_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron scheduler triggers backups of sqlite3 databases.",
+        "Tests verify backup routines run successfully."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-registration-v6",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Registration v6",
+      "description": "Inspired by MCP standard trend: Allow dynamically registering new tools over MCP via the skill registry.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry_v6.py",
+        "tests/test_mcp_registry_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be dynamically registered via MCP adapter.",
+        "Tests verify MCP registration logic."
+      ]
+    },
+    {
+      "id": "claude-agent-evaluator-v3",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Claude Agent Evaluator v3",
+      "description": "Inspired by Claude Agent SDK trend: Create a specialized sub-agent for evaluating output from Generator sub-agents.",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_v3.py",
+        "tests/test_evaluator_v3.py",
         "agent_tasks.json"
       ],
       "acceptance": [

--- a/backlog.md
+++ b/backlog.md
@@ -203,3 +203,5 @@
 * [x] FEATURE: Quality metrics longitudinal tracking
 * [x] FEATURE: A2A delegation v6
 * [x] FEATURE: Online learning v6
+
+* [x] MODULE: **Reflection to task generation** (`magda_agent/planning/reflection_tasks.py`). Inspired by trend: Reflection -> new task generation. Agent should generate new tasks based on reflections from previous failures.

--- a/magda_agent/planning/reflection_tasks.py
+++ b/magda_agent/planning/reflection_tasks.py
@@ -1,0 +1,96 @@
+import json
+import logging
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, ValidationError
+
+class GeneratedTask(BaseModel):
+    id: str
+    status: str = "todo"
+    area: str
+    risk: str
+    title: str
+    description: str
+    allowed_paths: List[str]
+    acceptance: List[str]
+
+class ReflectionTaskGenerator:
+    """
+    Translates agent reflections into structured tasks that can be appended
+    to agent_tasks.json.
+    """
+
+    def __init__(self, llm_client: Any):
+        self.llm = llm_client
+
+    async def generate_tasks_from_reflection(self, reflection_text: str, lessons: List[str], anti_patterns: List[str], max_tasks: int = 3) -> List[Dict[str, Any]]:
+        """
+        Takes reflection outputs and generates new actionable tasks.
+        """
+        prompt = f"""
+        You are an AI planner. Your goal is to analyze the agent's recent reflection and generate new structured tasks to improve the agent's codebase or configuration.
+
+        Reflection Summary:
+        {reflection_text}
+
+        Lessons Learned:
+        {json.dumps(lessons)}
+
+        Anti-patterns Detected:
+        {json.dumps(anti_patterns)}
+
+        Generate up to {max_tasks} new, concrete, actionable tasks.
+        They must be focused on code improvements, bug fixes, or new features directly related to the reflections.
+
+        Output ONLY a JSON list of objects matching this exact structure:
+        [
+          {{
+            "id": "unique-task-id-v1",
+            "status": "todo",
+            "area": "planning",  // or memory, safety, agents, etc.
+            "risk": "low",       // low, medium, or high
+            "title": "Short descriptive title",
+            "description": "Detailed explanation of what needs to be done and why, referencing the reflection.",
+            "allowed_paths": ["path/to/file.py", "tests/test_file.py", "agent_tasks.json"],
+            "acceptance": ["Criteria 1", "Criteria 2"]
+          }}
+        ]
+        """
+
+        messages = [
+            {"role": "system", "content": "You output strictly valid JSON conforming to the requested schema. No markdown wrapping."},
+            {"role": "user", "content": prompt}
+        ]
+
+        try:
+            response_text = await self.llm.chat_completion(messages)
+
+            cleaned_response = response_text.strip()
+            if cleaned_response.startswith("```json"):
+                cleaned_response = cleaned_response[7:]
+            if cleaned_response.startswith("```"):
+                cleaned_response = cleaned_response[3:]
+            if cleaned_response.endswith("```"):
+                cleaned_response = cleaned_response[:-3]
+
+            tasks_data = json.loads(cleaned_response.strip())
+
+            if not isinstance(tasks_data, list):
+                logging.error("Task generator output is not a list.")
+                return []
+
+            valid_tasks = []
+            for task_dict in tasks_data:
+                try:
+                    task = GeneratedTask(**task_dict)
+                    valid_tasks.append(task.model_dump())
+                except ValidationError as ve:
+                    logging.error(f"Task validation failed: {ve}")
+
+            return valid_tasks
+
+        except json.JSONDecodeError as e:
+            logging.error(f"Failed to decode task generation JSON: {e}")
+            return []
+        except Exception as e:
+            logging.error(f"Error during task generation: {e}")
+            return []

--- a/magda_agent/subconsciousness/reflection.py
+++ b/magda_agent/subconsciousness/reflection.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 from typing import List
+from magda_agent.planning.reflection_tasks import ReflectionTaskGenerator
 from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import EmotionalEngine
 from magda_agent.memory.storage import MemorySystem
@@ -247,6 +248,30 @@ class Subconsciousness:
 
         for task in proposed_tasks:
             logging.info(f"Subconscious proposed task: {task}")
+
+        # 3.5 Use proposed tasks, lessons, and anti-patterns to generate structured tasks
+        if reflection_text and (lessons or anti_patterns or proposed_tasks):
+            try:
+                task_generator = ReflectionTaskGenerator(self.llm)
+                generated_tasks = await task_generator.generate_tasks_from_reflection(
+                    reflection_text=reflection_text,
+                    lessons=lessons,
+                    anti_patterns=anti_patterns
+                )
+
+                if generated_tasks:
+                    with open("agent_tasks.json", "r") as f:
+                        tasks_data = json.load(f)
+
+                    for new_task in generated_tasks:
+                        tasks_data["tasks"].append(new_task)
+                        logging.info(f"Appended new generated task from reflection: {new_task['id']}")
+
+                    with open("agent_tasks.json", "w") as f:
+                        json.dump(tasks_data, f, ensure_ascii=False, indent=2)
+                        f.write("\n")
+            except Exception as e:
+                logging.error(f"Failed to generate and append structured reflection tasks: {e}")
 
         # 4. Consolidate episodic memory to semantic memory
         await self.consolidate_episodic_to_semantic()

--- a/tests/test_reflection_tasks.py
+++ b/tests/test_reflection_tasks.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.planning.reflection_tasks import ReflectionTaskGenerator
+
+@pytest.mark.asyncio
+async def test_generate_tasks_from_reflection_success():
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='''
+    [
+      {
+        "id": "fix-memory-leak-v1",
+        "status": "todo",
+        "area": "memory",
+        "risk": "medium",
+        "title": "Fix memory leak",
+        "description": "The agent observed high memory usage. Need to fix it.",
+        "allowed_paths": ["magda_agent/memory/storage.py", "tests/test_memory.py", "agent_tasks.json"],
+        "acceptance": ["Memory usage remains stable."]
+      }
+    ]
+    ''')
+
+    generator = ReflectionTaskGenerator(llm_client=mock_llm)
+    tasks = await generator.generate_tasks_from_reflection(
+        "I noticed I am using too much memory.",
+        ["Memory is expensive"],
+        ["Storing everything forever"]
+    )
+
+    assert len(tasks) == 1
+    assert tasks[0]["id"] == "fix-memory-leak-v1"
+    assert tasks[0]["area"] == "memory"
+    assert "agent_tasks.json" in tasks[0]["allowed_paths"]
+
+@pytest.mark.asyncio
+async def test_generate_tasks_from_reflection_invalid_json():
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='''
+    [
+      {
+        "id": "missing-fields",
+        "area": "memory"
+      }
+    ]
+    ''')
+
+    generator = ReflectionTaskGenerator(llm_client=mock_llm)
+    tasks = await generator.generate_tasks_from_reflection(
+        "Reflection", [], []
+    )
+
+    assert len(tasks) == 0
+
+@pytest.mark.asyncio
+async def test_generate_tasks_from_reflection_not_json():
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='This is not a JSON list.')
+
+    generator = ReflectionTaskGenerator(llm_client=mock_llm)
+    tasks = await generator.generate_tasks_from_reflection(
+        "Reflection", [], []
+    )
+
+    assert len(tasks) == 0

--- a/tests/test_subconsciousness.py
+++ b/tests/test_subconsciousness.py
@@ -68,7 +68,7 @@ async def test_subconsciousness_reflect(subconsciousness, mock_llm_client, mock_
     mock_memory_system.consolidate.assert_called_once()
 
     # Verify LLM was called
-    mock_llm_client.chat_completion.assert_called_once()
+    mock_llm_client.chat_completion.assert_called()
 
     # Verify emotions were updated with PARSED values
     mock_emotions.update.assert_called_once_with(0.1, -0.05, 0.15)


### PR DESCRIPTION
Resolves the `reflection-task-generation-v1` task from `agent_tasks.json`.

1. Creates `magda_agent/planning/reflection_tasks.py` exposing `ReflectionTaskGenerator`.
2. Uses Pydantic V2 to enforce schema, and LLM to build new todo tasks out of Subconsciousness reflections.
3. Integrates this into `magda_agent/subconsciousness/reflection.py`.
4. Writes `tests/test_reflection_tasks.py` with full mock tests for success, invalid JSON, and non-JSON edge cases.
5. Updates `agent_tasks.json` with 3 new tasks tracking trending agent architectures (MCP, Claude SDK, Hermes).
6. Updates `backlog.md` with new checkmark for this task.

---
*PR created automatically by Jules for task [197832044026139905](https://jules.google.com/task/197832044026139905) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ReflectionTaskGenerator` to autonomously convert reflections into structured tasks
> - Adds [`ReflectionTaskGenerator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/217/files#diff-0a078afd8abd5d230fc929abc8437f93a288cfbd3877c7482717d3aaeb22fbb5) with a `generate_tasks_from_reflection` async method that sends reflection text, lessons, and anti-patterns to the LLM and parses the response into validated `GeneratedTask` Pydantic models.
> - Integrates task generation into [`Subconsciousness.reflect()`](https://github.com/kazah4359-lgtm/Magda-agent/pull/217/files#diff-27adde86db1e57977c579551004975d419779d0ce3c324009acc3ea257ff5b41): when lessons, anti-patterns, or proposed tasks are present, new tasks are appended to `agent_tasks.json` after each reflection cycle.
> - Adds async tests covering success, invalid schema, and non-JSON LLM responses in [`tests/test_reflection_tasks.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/217/files#diff-1c5de77c5ff4842005850082e2810f57ed8f64f09c66b8a0cb74cbafe84d3a3c).
> - Behavioral Change: `reflect()` now makes additional LLM calls when reflection data is present; existing tests relax the `assert_called_once()` expectation to `assert_called()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0bc90b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->