### PR TITLE
feat: Implement Online RL from User Feedback v6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4123,7 +4123,7 @@
     },
     {
       "id": "online-rl-user-feedback-v6",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online RL from user feedback v6",
@@ -6981,6 +6981,57 @@
       "acceptance": [
         "Evaluator sub-agent critiques inputs and provides actionable feedback.",
         "Tests verify evaluator output format."
+      ]
+    },
+    {
+      "id": "hermes-agent-multi-platform-v1",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Hermes Agent Multi-Platform Support",
+      "description": "Inspired by Hermes trend: Multi-platform integration. Expand channel support to encompass Telegram, Discord, and Slack seamlessly.",
+      "allowed_paths": [
+        "magda_agent/channels/multi_platform_v1.py",
+        "tests/test_multi_platform_v1*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can dispatch to Telegram, Discord, and Slack.",
+        "Tests verify multi-platform routing."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-hooks-v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Plugins",
+      "description": "Inspired by OpenClaw Context Engine trend. Implement a plugin-based context manager allowing custom lifecycle hooks.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_v1.py",
+        "tests/test_context_engine_v1*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine accepts plugins and runs lifecycle hooks.",
+        "Tests verify plugin integration."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-concurrency-v1-unique",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Runtime Tool Concurrency",
+      "description": "Inspired by MCP / OpenAI SDK trend: Runtime function tool concurrency. Implement support for invoking multiple skills concurrently.",
+      "allowed_paths": [
+        "magda_agent/skills/tool_concurrency_v1.py",
+        "tests/test_tool_concurrency_v1*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent correctly schedules multiple tools concurrently.",
+        "Tests verify concurrent invocation."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Online RL from User Feedback v6 (online-rl-user-feedback-v6)
 * [x] MODULE: **Virtual Context Manager** — magda_agent/memory/virtual_context.py.
 * [x] FEATURE: Hermes Skill Creation from Experience (hermes-skill-creation-8563188e)
 * [x] FEATURE: MCP Action Tool Exporter v6 (mcp-action-tool-exporter-v6)

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -39,6 +39,7 @@ from magda_agent.metacognition.tracker import QualityTracker
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.learning.online import OnlineLearner
 from magda_agent.learning.online_rl import OnlineRLIntegrator
+from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
 from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
 from magda_agent.user_model.model import UserModel
 from magda_agent.reflexes.brainstem import Brainstem
@@ -84,6 +85,11 @@ online_learner = OnlineLearner(
 )
 
 online_rl_integrator = OnlineRLIntegrator(
+    habit_tracker=habit_tracker,
+    mirror_neurons=mirror_neurons
+)
+
+online_rl_v6 = OnlineRLFeedbackLoopV6(
     habit_tracker=habit_tracker,
     mirror_neurons=mirror_neurons
 )
@@ -139,6 +145,7 @@ consciousness = Consciousness(
     skill_creator=skill_creator,
     online_learner=online_learner,
     online_rl_integrator=online_rl_integrator,
+    online_rl_v6=online_rl_v6,
     openclaw_rl=openclaw_rl,
     feedback_loop=feedback_loop,
     guardrail=guardrail,

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -27,6 +27,7 @@ from magda_agent.emotions.style_adapter import StyleAdapter
 from magda_agent.user_model.model import UserModel
 from magda_agent.learning.online import OnlineLearner
 from magda_agent.learning.online_rl import OnlineRLIntegrator
+from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
 from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
 from magda_agent.learning.feedback_loop import FeedbackLoop
 from magda_agent.attention.salience import SalienceNetwork
@@ -67,6 +68,7 @@ class Consciousness:
         skill_creator: Optional[SkillCreator] = None,
         online_learner: Optional[OnlineLearner] = None,
         online_rl_integrator: Optional[OnlineRLIntegrator] = None,
+        online_rl_v6: Optional[OnlineRLFeedbackLoopV6] = None,
         openclaw_rl: Optional[OpenClawInteractiveLearner] = None,
         feedback_loop: Optional[FeedbackLoop] = None,
         guardrail: Optional[RealtimeGuardrail] = None,
@@ -100,6 +102,7 @@ class Consciousness:
         self.skill_creator = skill_creator
         self.online_learner = online_learner
         self.online_rl_integrator = online_rl_integrator
+        self.online_rl_v6 = online_rl_v6
         self.openclaw_rl = openclaw_rl
         self.feedback_loop = feedback_loop
         self.guardrail = guardrail
@@ -144,6 +147,8 @@ class Consciousness:
             await self.feedback_loop.process_feedback(user_input, user_id)
         if self.openclaw_rl:
             await self.openclaw_rl.process_next_state_signal(user_input, last_context, user_id)
+        if self.online_rl_v6:
+            await self.online_rl_v6.adjust_behavior(user_input, last_context, user_id)
 
 
         if self.thalamus and not self.thalamus.filter_input(user_input):

--- a/magda_agent/learning/__init__.py
+++ b/magda_agent/learning/__init__.py
@@ -1,3 +1,4 @@
 from .skill_versioning import SkillVersioning
 from .openclaw_rl import OpenClawInteractiveLearner
 from .skill_extraction import SkillExtractor
+from .online_rl_v6 import OnlineRLFeedbackLoopV6

--- a/magda_agent/learning/online_rl_v6.py
+++ b/magda_agent/learning/online_rl_v6.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Optional, Dict
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+class OnlineRLFeedbackLoopV6:
+    """
+    Online Reinforcement Learning loop v6 for adjusting agent behavior parameters
+    based on immediate explicit and implicit user feedback without separate annotation.
+    """
+    def __init__(self, habit_tracker: HabitTracker, mirror_neurons: MirrorNeurons) -> None:
+        """
+        Initializes the OnlineRLFeedbackLoopV6.
+
+        Args:
+            habit_tracker (HabitTracker): Tracks and records skill usage.
+            mirror_neurons (MirrorNeurons): Evaluates implicit feedback (emotional shifts).
+        """
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+        self.reward_parameters: Dict[str, float] = {}
+
+    async def adjust_behavior(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: Optional[int] = None,
+        explicit_score: Optional[float] = None,
+        skill_used: str = "rl_feedback_skill"
+    ) -> None:
+        """
+        Adjusts reward parameters and behavior based on explicit and implicit feedback.
+
+        Args:
+            user_reply (str): The immediate user response.
+            action_context (str): Context of the agent's action.
+            user_id (Optional[int]): User ID.
+            explicit_score (Optional[float]): Explicit numeric feedback from the user.
+            skill_used (str): Skill used for the action.
+        """
+        if not user_reply or not action_context:
+            return
+
+        # Implicit feedback via mirror neurons
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_reply)
+
+        if explicit_score is not None:
+            score = explicit_score
+        else:
+            score = (p_shift + 1.0) * 5.0
+
+        if skill_used not in self.reward_parameters:
+            self.reward_parameters[skill_used] = 1.0
+
+        if score >= 7.0:
+            self.reward_parameters[skill_used] += 0.2
+            self.habit_tracker.record_usage(
+                input_text=action_context,
+                skill_used=skill_used,
+                evaluation_score=score,
+                user_id=user_id
+            )
+            logging.info(f"RL Feedback: Positive adjustment. New param for {skill_used}: {self.reward_parameters[skill_used]:.2f}")
+        else:
+            self.reward_parameters[skill_used] = max(0.1, self.reward_parameters[skill_used] - 0.2)
+            logging.info(f"RL Feedback: Negative adjustment. New param for {skill_used}: {self.reward_parameters[skill_used]:.2f}")

--- a/tests/test_online_rl_v6.py
+++ b/tests/test_online_rl_v6.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+@pytest.fixture
+def mock_habit_tracker():
+    tracker = MagicMock(spec=HabitTracker)
+    return tracker
+
+@pytest.fixture
+def mock_mirror_neurons():
+    neurons = MagicMock(spec=MirrorNeurons)
+    return neurons
+
+@pytest.mark.asyncio
+async def test_online_rl_v6_positive_adjustment(mock_habit_tracker, mock_mirror_neurons):
+    learner = OnlineRLFeedbackLoopV6(mock_habit_tracker, mock_mirror_neurons)
+
+    # Mock positive empathize resulting in high score. In reality, empathize returns Tuple[float, float, float]
+    # For a score of 9.0 without explicit score, (p_shift + 1.0) * 5.0 = 9.0 => p_shift = 0.8
+    mock_mirror_neurons.empathize.return_value = (0.8, 0.1, 0.0)
+
+    await learner.adjust_behavior("Great job", "test_context", user_id=1)
+
+    # Check habit tracker called
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="test_context", skill_used="rl_feedback_skill", evaluation_score=9.0, user_id=1
+    )
+
+    # Check reward parameter
+    assert learner.reward_parameters["rl_feedback_skill"] == 1.2
+
+@pytest.mark.asyncio
+async def test_online_rl_v6_negative_adjustment(mock_habit_tracker, mock_mirror_neurons):
+    learner = OnlineRLFeedbackLoopV6(mock_habit_tracker, mock_mirror_neurons)
+
+    # Mock negative empathize resulting in low score. For score < 7.0, say p_shift = -0.5
+    # score = (-0.5 + 1.0) * 5.0 = 2.5
+    mock_mirror_neurons.empathize.return_value = (-0.5, 0.1, 0.1)
+
+    await learner.adjust_behavior("Terrible", "test_context", user_id=2)
+
+    # Check habit tracker NOT called
+    mock_habit_tracker.record_usage.assert_not_called()
+
+    # Check reward parameter decreased
+    assert learner.reward_parameters["rl_feedback_skill"] == 0.8


### PR DESCRIPTION
Implemented the `online-rl-user-feedback-v6` task as described in `agent_tasks.json`. Created the `OnlineRLFeedbackLoopV6` class to adjust reward parameters based on explicit user feedback and implicit emotional shifts extracted via `MirrorNeurons`. Integrated the new module into `magda_agent/api.py` and the `Consciousness` core loop. Wrote tests ensuring correct positive and negative parameter adjustments. Updated the JSON file correctly by adding 3 new trend-inspired tasks and mapped the task as completed in `backlog.md`.

---
*PR created automatically by Jules for task [3842050018699414082](https://jules.google.com/task/3842050018699414082) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement online RL from user feedback via `OnlineRLFeedbackLoopV6` in `Consciousness`
> - Adds [`OnlineRLFeedbackLoopV6`](https://github.com/kazah4359-lgtm/Magda-agent/pull/218/files#diff-8df439dfff26f38c524a3a1f50d1492ae35fb7999599400994f6d34200db6da1) which maintains per-skill reward parameters updated after each interaction using implicit signals from `MirrorNeurons.empathize` or explicit scores.
> - On a score ≥ 7.0, increases the skill's reward parameter by 0.2 and records usage via `HabitTracker`; otherwise decreases it by 0.2 (floor 0.1).
> - [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/218/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) accepts an optional `online_rl_v6` argument and calls `adjust_behavior` after existing feedback handlers during the post-interaction phase.
> - Two async tests in [`tests/test_online_rl_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/218/files#diff-481d65331adc0f53ca06478ba4d8a844ce9118665b01dcc8c4005bb28c13115a) cover the positive (score 9.0 → parameter 1.2) and negative (score < 7.0 → parameter 0.8) adjustment paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 803db82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->