### PR TITLE
feat: Agent Teams Git Worktree Isolation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4140,7 +4140,7 @@
     },
     {
       "id": "agent-teams-git-worktree-v1",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "Agent Teams Git Worktree Isolation",
@@ -7032,6 +7032,57 @@
       "acceptance": [
         "Agent correctly schedules multiple tools concurrently.",
         "Tests verify concurrent invocation."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-evaluator-v1",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "MCP Dynamic Evaluator Plugin",
+      "description": "Inspired by MCP standards trend: Develop an evaluator plugin that evaluates new skills against an MCP dynamic verification sandbox.",
+      "allowed_paths": [
+        "magda_agent/evaluation/mcp_eval.py",
+        "tests/test_mcp_eval.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator uses MCP registry sandboxes correctly.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "acs-guard-memory-policy-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Guard Memory Access Policy",
+      "description": "Inspired by ACS Specification trend: Implement an ACS runtime policy layer for restricting sub-agent access to user-specific memory stores.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_memory.py",
+        "tests/test_acs_memory.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy blocks unauthorized memory reads based on user_id context.",
+        "Tests confirm all checkpoints."
+      ]
+    },
+    {
+      "id": "openclaw-multi-agent-canvas-v1",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Multi-Agent Canvas Extension",
+      "description": "Inspired by OpenClaw Canvas trend: Extend the Canvas WebSockets to stream sub-agent states and isolate them visually in the client.",
+      "allowed_paths": [
+        "magda_agent/visualization/multi_agent_stream.py",
+        "tests/test_multi_agent_stream.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket payload contains valid multi-agent node isolation metrics.",
+        "Tests verify WS payloads."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -118,7 +118,7 @@
 * [x] FEATURE: Guardrails Policy Layer (guardrails-policy-layer)
 
 * [x] FEATURE: Online RL Feedback Integration (online-rl-feedback-integration)
-* [x] MODULE: **Agent Teams Git Worktree Isolation** — модуль `magda_agent/agents/team_isolation.py`. (2026-06-07)
+* [x] MODULE: **Agent Teams Git Worktree Isolation** — `magda_agent/agents/isolation.py`. (2026-06-07)
 * [x] FEATURE: A2A Peer-to-Peer Task Delegation
 * [x] MODULE: **Context Engine Plugin Architecture** — модуль `magda_agent/memory/context_engine.py`. (2026-06-07)
   Inspired by trend #4 in docs/trends.md: Implement a plugin architecture for the Context Engine to manage context dynamically using lifecycle hooks.

--- a/magda_agent/agents/isolation.py
+++ b/magda_agent/agents/isolation.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from typing import Optional
+
+class IsolationManager:
+    """
+    Manages git worktree isolation for Agent Teams.
+    """
+    def __init__(self, base_dir: str = "/tmp/magda_team_worktrees") -> None:
+        """
+        Initializes the isolation manager.
+        """
+        self.base_dir = base_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+
+    async def create_isolated_environment(self, branch_name: Optional[str] = None) -> str:
+        """
+        Creates an isolated git worktree environment.
+        """
+        env_id = str(uuid.uuid4())[:8]
+        env_path = os.path.join(self.base_dir, f"env_{env_id}")
+
+        if branch_name:
+            cmd = ["git", "worktree", "add", "-b", branch_name, env_path, "HEAD"]
+        else:
+            cmd = ["git", "worktree", "add", "-d", env_path, "HEAD"]
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                error_msg = stderr.decode()
+                logging.error(f"Failed to create isolated environment: {error_msg}")
+                raise RuntimeError(f"Git worktree creation failed: {error_msg}")
+
+            logging.info(f"Created isolated environment at {env_path}")
+            return env_path
+        except Exception as e:
+            logging.error(f"Error executing git worktree add: {e}")
+            raise
+
+    async def teardown_isolated_environment(self, env_path: str) -> None:
+        """
+        Tears down and removes an isolated git worktree environment.
+        """
+        cmd = ["git", "worktree", "remove", "--force", env_path]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                logging.error(f"Failed to remove isolated environment: {stderr.decode()}")
+                if os.path.exists(env_path):
+                    shutil.rmtree(env_path)
+            else:
+                logging.info(f"Removed isolated environment at {env_path}")
+        except Exception as e:
+            logging.error(f"Error executing git worktree remove: {e}")
+            if os.path.exists(env_path):
+                shutil.rmtree(env_path)

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -1,0 +1,43 @@
+import pytest
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+from magda_agent.agents.isolation import IsolationManager
+
+@pytest.mark.asyncio
+async def test_create_isolated_environment_success():
+    """Tests creating an isolated worktree environment successfully."""
+    manager = IsolationManager(base_dir="/tmp/test_isolation")
+
+    process_mock = MagicMock()
+    process_mock.communicate = AsyncMock(return_value=(b"Success", b""))
+    process_mock.returncode = 0
+
+    with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = process_mock
+
+        path = await manager.create_isolated_environment()
+
+        assert path.startswith("/tmp/test_isolation/env_")
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert "git" in args
+        assert "worktree" in args
+
+@pytest.mark.asyncio
+async def test_teardown_isolated_environment_success():
+    """Tests tearing down an isolated worktree environment successfully."""
+    manager = IsolationManager(base_dir="/tmp/test_isolation")
+
+    process_mock = MagicMock()
+    process_mock.communicate = AsyncMock(return_value=(b"Success", b""))
+    process_mock.returncode = 0
+
+    with patch('asyncio.create_subprocess_exec', new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = process_mock
+
+        await manager.teardown_isolated_environment("/tmp/test_isolation/env_abc")
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert "remove" in args
+        assert "/tmp/test_isolation/env_abc" in args


### PR DESCRIPTION
- Implemented `IsolationManager` in `magda_agent/agents/isolation.py`
- Wrote mocked tests in `tests/test_isolation.py`
- Updated `agent_tasks.json` by setting status to "done" and added 3 new tasks
- Updated `backlog.md` with module completion state

---
*PR created automatically by Jules for task [6902637383762671636](https://jules.google.com/task/6902637383762671636) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `IsolationManager` for git worktree-based isolation of Agent Teams
> - Introduces [`IsolationManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/219/files#diff-eab5c979b05bed6da966b2b2da2a77f20f53c88d2839d3c15bbc6325d77c929e) with async methods `create_isolated_environment` and `teardown_isolated_environment` to manage per-team git worktrees under a configurable base directory (default `/tmp/magda_team_worktrees`).
> - `create_isolated_environment` runs `git worktree add` via `asyncio.create_subprocess_exec`, generating a UUID-based directory name and optionally creating a new branch.
> - `teardown_isolated_environment` runs `git worktree remove --force` and falls back to `shutil.rmtree` if the git command fails.
> - Adds async pytest coverage in [`tests/test_isolation.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/219/files#diff-bf1a402436e78e06f9fe0ce12aad5347696ac6f82f184ca5a24fb3524f7642cd) for both success paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a59735.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->