### PR TITLE
feat: Implement MCP JSON-RPC interface and replenish tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4157,7 +4157,7 @@
     },
     {
       "id": "mcp-json-rpc-interface-v1",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP JSON-RPC Interface",
@@ -7083,6 +7083,57 @@
       "acceptance": [
         "WebSocket payload contains valid multi-agent node isolation metrics.",
         "Tests verify WS payloads."
+      ]
+    },
+    {
+      "id": "openclaw-online-rl-integration-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw Online RL Integration",
+      "description": "Inspired by OpenClaw trends: Implement OpenClaw-RL to capture next-state signals and update agent weights.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl.py",
+        "tests/test_openclaw_rl.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "OpenClaw-RL logic is implemented.",
+        "Tests verify weight updates based on feedback."
+      ]
+    },
+    {
+      "id": "acs-guard-tool-sandboxing-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Guard Tool Sandboxing",
+      "description": "Inspired by ACS Spec trends: Introduce a taint tracking mechanism to sandbox MCP tool executions dynamically.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_sandboxing.py",
+        "tests/test_acs_sandboxing.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tracking is implemented.",
+        "Tests verify sandboxing of restricted tools."
+      ]
+    },
+    {
+      "id": "hermes-agent-skill-marketplace-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Agent Skill Marketplace",
+      "description": "Inspired by Hermes Agent trends: Create an interface for discovering and importing skills from agentskills.io format.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_import.py",
+        "tests/test_marketplace_import.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Can import skills conforming to marketplace standards.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_server.py
+++ b/magda_agent/integration/mcp_server.py
@@ -1,0 +1,43 @@
+import json
+from typing import Dict, Any, List
+from magda_agent.integration.mcp_exporter import MCPExporter
+
+class MCPServer:
+    """
+    MCP JSON-RPC protocol server interface.
+    Handles raw JSON-RPC string payloads and returns JSON string responses.
+    """
+    def __init__(self, exporter: MCPExporter) -> None:
+        """Initializes the MCPServer with an MCPExporter."""
+        self.exporter = exporter
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        List exported tools.
+
+        Returns:
+            A list of MCP-compatible tool definitions.
+        """
+        return self.exporter.export_tools()
+
+    async def handle_request(self, payload: str) -> str:
+        """
+        Process a JSON-RPC payload string.
+
+        Args:
+            payload: A JSON string representing the RPC request.
+
+        Returns:
+            A JSON string representing the RPC response.
+        """
+        try:
+            request = json.loads(payload)
+        except json.JSONDecodeError:
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error"}
+            })
+
+        response = await self.exporter.handle_rpc_request(request)
+        return json.dumps(response)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,43 @@
+import json
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.integration.mcp_exporter import MCPExporter
+
+@pytest.fixture
+def mock_exporter() -> MCPExporter:
+    exporter = MagicMock(spec=MCPExporter)
+    exporter.export_tools.return_value = [{"name": "mock_tool"}]
+    async_mock = AsyncMock()
+    async_mock.return_value = {"jsonrpc": "2.0", "id": 1, "result": "mock_result"}
+    exporter.handle_rpc_request = async_mock
+    return exporter
+
+def test_list_tools(mock_exporter: MCPExporter) -> None:
+    """Tests listing tools."""
+    server = MCPServer(mock_exporter)
+    tools = server.list_tools()
+    assert len(tools) == 1
+    assert tools[0]["name"] == "mock_tool"
+
+@pytest.mark.asyncio
+async def test_handle_request_valid_json(mock_exporter: MCPExporter) -> None:
+    """Tests handling a valid JSON-RPC payload."""
+    server = MCPServer(mock_exporter)
+    payload = json.dumps({"jsonrpc": "2.0", "method": "mock_tool", "id": 1})
+    response_str = await server.handle_request(payload)
+    response = json.loads(response_str)
+    assert response["jsonrpc"] == "2.0"
+    assert response["result"] == "mock_result"
+    mock_exporter.handle_rpc_request.assert_called_once_with({"jsonrpc": "2.0", "method": "mock_tool", "id": 1})
+
+@pytest.mark.asyncio
+async def test_handle_request_invalid_json(mock_exporter: MCPExporter) -> None:
+    """Tests handling an invalid JSON payload."""
+    server = MCPServer(mock_exporter)
+    payload = "invalid json"
+    response_str = await server.handle_request(payload)
+    response = json.loads(response_str)
+    assert response["error"]["code"] == -32700
+    assert response["error"]["message"] == "Parse error"
+    mock_exporter.handle_rpc_request.assert_not_called()


### PR DESCRIPTION
This PR implements the MCP JSON-RPC server interface task (`mcp-json-rpc-interface-v1`).

### Changes
*   **`magda_agent/integration/mcp_server.py`**: Created `MCPServer` to act as an interface for JSON-RPC string payloads, delegating underlying logic to `MCPExporter`.
*   **`tests/test_mcp_server.py`**: Added unit tests to ensure `MCPServer` correctly parses payloads and returns valid stringified JSON responses using mocked MCP dependencies.
*   **`agent_tasks.json`**:
    *   Marked `mcp-json-rpc-interface-v1` as `"done"`.
    *   Added 3 new actionable, trend-inspired "todo" tasks (`openclaw-online-rl-integration-v1`, `acs-guard-tool-sandboxing-v1`, `hermes-agent-skill-marketplace-v1`) to the manifest.

All tests and validation scripts pass successfully.

---
*PR created automatically by Jules for task [1366886041108662328](https://jules.google.com/task/1366886041108662328) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `MCPServer` JSON-RPC interface with parse error handling
> - Adds [`MCPServer`](https://github.com/kazah4359-lgtm/Magda-agent/pull/220/files#diff-d8bbff3549c271dc4a43334c75b2f77fb5e6774432a2fde4b7c21a990c910b01) wrapping `MCPExporter`, exposing `list_tools()` and async `handle_request(payload)` methods.
> - Returns a standard JSON-RPC parse error (code `-32700`) when the payload is invalid JSON; delegates valid requests to `MCPExporter.handle_rpc_request`.
> - Adds unit tests in [`tests/test_mcp_server.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/220/files#diff-17c8e7f22653bec6c1a174647a95472a9689a7569031e4f9d5c92e32366438f6) covering tool listing, valid request handling, and invalid JSON error responses.
> - Replenishes [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/220/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) with three new task entries (`openclaw-online-rl-integration-v1`, `acs-guard-tool-sandboxing-v1`, `hermes-agent-skill-marketplace-v1`) and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20fd14d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->