### PR TITLE
Add Magda CLI Interface

### DIFF
--- a/magda_agent/__main__.py
+++ b/magda_agent/__main__.py
@@ -1,0 +1,5 @@
+import sys
+from magda_agent.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/magda_agent/cli.py
+++ b/magda_agent/cli.py
@@ -1,0 +1,95 @@
+import argparse
+import asyncio
+import os
+import sys
+
+def load_env():
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        try:
+            with open(".env", "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith("#") and "=" in line:
+                        key, val = line.split("=", 1)
+                        os.environ[key] = val
+        except FileNotFoundError:
+            pass
+
+async def run_chat_once(message: str):
+    from magda_agent.api import consciousness
+    response = await consciousness.process_input(message)
+    print(response)
+
+async def run_chat_loop():
+    print("Chat mode. Type 'exit' or 'quit' to stop.")
+    from magda_agent.api import consciousness
+    while True:
+        try:
+            user_input = input("> ")
+            if user_input.lower() in ("exit", "quit"):
+                break
+            if not user_input.strip():
+                continue
+            response = await consciousness.process_input(user_input)
+            print(response)
+        except (EOFError, KeyboardInterrupt):
+            break
+
+def get_status():
+    from magda_agent.api import consciousness
+    print(consciousness.get_internal_state())
+
+def get_memory_list():
+    from magda_agent.api import memory_system
+    memories = memory_system.short_term
+    if not memories:
+        print("Memory is empty.")
+    for m in memories:
+        print(f"- {m.content}")
+
+def clear_memory():
+    from magda_agent.api import memory_system
+    memory_system.working_memory.clear()
+    print("Memory cleared.")
+
+def main():
+    load_env()
+    parser = argparse.ArgumentParser(prog="magda", description="Magda Agent CLI")
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    chat_parser = subparsers.add_parser("chat", help="Interactive chat")
+    chat_parser.add_argument("--once", type=str, help="Single request")
+
+    memory_parser = subparsers.add_parser("memory", help="Memory commands")
+    memory_subparsers = memory_parser.add_subparsers(dest="memory_command")
+    memory_subparsers.add_parser("list", help="List memory")
+    memory_subparsers.add_parser("clear", help="Clear memory")
+
+    subparsers.add_parser("status", help="Agent status")
+
+    args = parser.parse_args()
+
+    if args.command == "status":
+        get_status()
+    elif args.command == "memory":
+        if args.memory_command == "list":
+            get_memory_list()
+        elif args.memory_command == "clear":
+            clear_memory()
+        else:
+            memory_parser.print_help()
+    elif args.command == "chat":
+        if args.once:
+            asyncio.run(run_chat_once(args.once))
+        else:
+            asyncio.run(run_chat_loop())
+    else:
+        parser.print_help()
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "magda_agent"
+version = "0.1.0"
+
+[project.scripts]
+magda = "magda_agent.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
+import sys
+from magda_agent.cli import main
+
+class TestCLI(unittest.TestCase):
+    @patch('magda_agent.api.consciousness')
+    @patch('sys.argv', ['magda', 'status'])
+    @patch('builtins.print')
+    def test_status(self, mock_print, mock_c):
+        mock_c.get_internal_state.return_value = "Status: OK"
+        main()
+        mock_print.assert_any_call("Status: OK")
+
+    @patch('magda_agent.api.memory_system')
+    @patch('sys.argv', ['magda', 'memory', 'list'])
+    @patch('builtins.print')
+    def test_memory_list(self, mock_print, mock_mem):
+        mock_entry = MagicMock()
+        mock_entry.content = "Test memory"
+        type(mock_mem).short_term = PropertyMock(return_value=[mock_entry])
+
+        main()
+        mock_print.assert_any_call("- Test memory")
+
+    @patch('magda_agent.api.memory_system')
+    @patch('sys.argv', ['magda', 'memory', 'clear'])
+    @patch('builtins.print')
+    def test_memory_clear(self, mock_print, mock_mem):
+        main()
+        mock_mem.working_memory.clear.assert_called_once()
+        mock_print.assert_any_call("Memory cleared.")


### PR DESCRIPTION
Implement the CLI interface for the magda agent using argparse, providing commands `chat`, `memory list`, `memory clear`, and `status`. Allows direct terminal integration. Also added `__main__.py` to support `python -m magda_agent`. Also created isolated testing module using `PropertyMock`.

---
*PR created automatically by Jules for task [16256301814853316590](https://jules.google.com/task/16256301814853316590) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `magda` CLI with chat, memory, and status subcommands
> - Adds [magda_agent/cli.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/221/files#diff-b48c4714df2582a7bec3bd82dfa8b73ee5daf78baa62672b2b8e308333ec2077) with an `argparse`-based CLI exposing `chat` (interactive loop or `--once` single message), `memory list`, `memory clear`, and `status` subcommands that delegate to the existing `consciousness` and `memory_system` APIs.
> - Adds [magda_agent/__main__.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/221/files#diff-4221ebb0d4e22007d4c8fd9581f16f138595f7765489c9bee8c71b156ce72383) so the package can be invoked via `python -m magda_agent`.
> - Registers a `magda` console script entrypoint in [pyproject.toml](https://github.com/kazah4359-lgtm/Magda-agent/pull/221/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711), making the CLI available after `pip install`.
> - Loads `.env` variables at startup with a fallback line-by-line parser when `python-dotenv` is not installed.
> - Adds unit tests in [tests/test_cli.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/221/files#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032e) covering `status`, `memory list`, and `memory clear`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de374c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->