### PR TITLE
feat: implement mcp kernel taint tracking v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4191,7 +4191,7 @@
     },
     {
       "id": "mcp-kernel-taint-tracking-v2",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "medium",
       "title": "MCPKernel Taint Tracking v2",
@@ -7134,6 +7134,54 @@
       "acceptance": [
         "Can import skills conforming to marketplace standards.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-agent-discovery-v3-89076f63",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Agent Discovery v3",
+      "description": "Implement A2A Agent Discovery using Agent Cards based on the new standard.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v3.py",
+        "tests/test_a2a_discovery_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A agent discovery successfully finds agents via card parsing."
+      ]
+    },
+    {
+      "id": "context-engine-plugin-lifecycle-v2-28520349",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "Context Engine Plugin Lifecycle Hooks v2",
+      "description": "Implement lifecycle hooks (on_load, on_unload) for context engine plugins.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_lifecycle_v2.py",
+        "tests/test_context_engine_lifecycle_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugins can be loaded and unloaded with lifecycle events."
+      ]
+    },
+    {
+      "id": "acs-guardrail-runtime-v5-e48c3980",
+      "status": "todo",
+      "area": "security",
+      "risk": "high",
+      "title": "ACS Guardrails Runtime Policy v5",
+      "description": "Implement the ACS Checkpoint 3 (Runtime Safety) policy framework for tool calls.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_runtime_v5.py",
+        "tests/test_acs_runtime_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool calls correctly pass through the new ACS runtime guardrail checkpoint."
       ]
     }
   ]

--- a/magda_agent/safety/runtime_guard.py
+++ b/magda_agent/safety/runtime_guard.py
@@ -1,5 +1,5 @@
 from typing import Callable, Any
-from magda_agent.safety.taint import is_tainted
+from magda_agent.security.mcp_kernel_taint import is_tainted
 
 class SecurityException(Exception):
     """Exception raised for security violations."""

--- a/magda_agent/security/mcp_kernel.py
+++ b/magda_agent/security/mcp_kernel.py
@@ -1,5 +1,5 @@
 import ast
-from magda_agent.safety.taint import is_tainted
+from magda_agent.security.mcp_kernel_taint import is_tainted
 
 import builtins
 from typing import Any, Dict, Optional, Set

--- a/magda_agent/security/mcp_kernel_taint.py
+++ b/magda_agent/security/mcp_kernel_taint.py
@@ -1,0 +1,48 @@
+"""MCPKernel Taint Tracking Sandbox v2."""
+from typing import Any, Callable, Dict, Set, Union, List
+
+class PolicyViolationError(Exception):
+    """Raised when tainted data violates policy."""
+    pass
+
+class TaintedData:
+    """Base class for tainted data."""
+    def __init__(self, value: Any):
+        self.value = value
+
+class TaintedString(TaintedData, str):
+    """A string subclass that marks data as tainted."""
+    def __new__(cls, value: str):
+        obj = str.__new__(cls, value)
+        obj.value = value
+        return obj
+
+def mark_tainted(s: Any) -> Any:
+    """Marks a string, dict, or list as tainted recursively."""
+    if isinstance(s, str):
+        return TaintedString(s)
+    elif isinstance(s, list):
+        return [mark_tainted(item) for item in s]
+    elif isinstance(s, dict):
+        return {mark_tainted(k): mark_tainted(v) for k, v in s.items()}
+    return s
+
+def is_tainted(s: Any) -> bool:
+    """Checks if an object or any of its nested structures is tainted."""
+    if isinstance(s, TaintedData):
+        return True
+    if isinstance(s, list):
+        return any(is_tainted(item) for item in s)
+    if isinstance(s, dict):
+        return any(is_tainted(k) or is_tainted(v) for k, v in s.items())
+    return False
+
+def sanitize(s: Any) -> Any:
+    """Sanitizes tainted data, returning regular primitives recursively."""
+    if isinstance(s, TaintedData):
+        return sanitize(s.value)
+    elif isinstance(s, list):
+        return [sanitize(item) for item in s]
+    elif isinstance(s, dict):
+        return {sanitize(k): sanitize(v) for k, v in s.items()}
+    return s

--- a/tests/test_mcp_kernel_taint.py
+++ b/tests/test_mcp_kernel_taint.py
@@ -1,0 +1,24 @@
+import pytest
+from magda_agent.security.mcp_kernel_taint import mark_tainted, is_tainted, sanitize, TaintedString
+
+def test_taint_string():
+    t = mark_tainted("hello")
+    assert isinstance(t, TaintedString)
+    assert is_tainted(t)
+    assert is_tainted("hello") is False
+
+def test_taint_list():
+    t_list = mark_tainted(["a", "b"])
+    assert is_tainted(t_list)
+    assert is_tainted(["a", "b"]) is False
+
+def test_taint_dict():
+    t_dict = mark_tainted({"key": "val"})
+    assert is_tainted(t_dict)
+    assert is_tainted({"key": "val"}) is False
+
+def test_sanitize():
+    t_dict = mark_tainted({"key": ["val", "x"]})
+    clean = sanitize(t_dict)
+    assert is_tainted(clean) is False
+    assert clean == {"key": ["val", "x"]}

--- a/tests/test_mcpkernel_taint.py
+++ b/tests/test_mcpkernel_taint.py
@@ -1,6 +1,6 @@
 import pytest
 from magda_agent.security.mcp_kernel import MCPKernel, SecurityError
-from magda_agent.safety.taint import mark_tainted, is_tainted, sanitize
+from magda_agent.security.mcp_kernel_taint import mark_tainted, is_tainted, sanitize
 from magda_agent.safety.runtime_guard import RuntimeGuard, SecurityException
 
 def test_tainted_string():


### PR DESCRIPTION
This PR implements a robust taint tracking module for the MCP Kernel (`mcp_kernel_taint.py`). 
The module adds capabilities to properly handle deep recursive marking, checking, and sanitization of generic JSON payloads (lists and dicts) avoiding unsafe inputs escaping.
Also marks the `mcp-kernel-taint-tracking-v2` task in the backlog as done, and queues three new trend-inspired tasks for future execution.

---
*PR created automatically by Jules for task [1004946956145665898](https://jules.google.com/task/1004946956145665898) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement MCP kernel taint tracking in `magda_agent.security.mcp_kernel_taint`
> - Adds a new [`mcp_kernel_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/223/files#diff-6a904cad7aeac187794c249cb7139ecee0bd6620571b8c429f62eb55fa2cc33f) module with `TaintedData`, `TaintedString`, `mark_tainted`, `is_tainted`, `sanitize`, and `PolicyViolationError` to propagate and detect tainted data through strings, lists, and dicts.
> - `mark_tainted` recursively wraps values in tainted types; `is_tainted` recursively checks for taint; `sanitize` unwraps tainted structures back to raw primitives.
> - Updates `runtime_guard.py` and `mcp_kernel.py` to import `is_tainted` from the new module instead of the old `magda_agent.safety.taint` path.
> - Adds tests in [`test_mcp_kernel_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/223/files#diff-0b99c73c2c400f34ac11b380bf0c78e5e30db00321afa87a9fb9322c160ac282) covering round-trip tainting and sanitation for strings, lists, and dicts.
> - Behavioral Change: `is_tainted` import source changes from `magda_agent.safety.taint` to `magda_agent.security.mcp_kernel_taint` in existing security modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45d130d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->