### PR TITLE
feat: Implement MemGPT Virtual Context v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4305,7 +4305,7 @@
     },
     {
       "id": "memgpt-virtual-context-v2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT Virtual Context Integration v2",
@@ -7451,6 +7451,57 @@
       "acceptance": [
         "Evaluator subagent can check generated outputs against strict system policies.",
         "Tests verify that policy violations result in rejected output evaluations."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-concurrency-v2-a9a0b782",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP concurrent action tool execution v2",
+      "description": "Inspired by MCP standard trend: Implement runtime function tool concurrency for executing multiple tools at once without waiting for sequential completion.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_router_v2_concurrency.py",
+        "tests/test_mcp_router_v2_concurrency.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Router can execute multiple tools concurrently.",
+        "Tests verify concurrent execution timing and results."
+      ]
+    },
+    {
+      "id": "agent-teams-subagent-isolation-v2-49252226",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Agent Teams Subagent Git Worktree Isolation v2",
+      "description": "Inspired by Claude Agent Teams trend: Implement Subagent spawning with strict Git Worktree isolation and context context separation.",
+      "allowed_paths": [
+        "magda_agent/agents/isolation_v2.py",
+        "tests/test_isolation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents have strictly isolated git worktrees.",
+        "Tests mock git calls and verify isolation paths."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-visualization-v2-553ba456",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Visualization WebSockets v2",
+      "description": "Inspired by OpenClaw trend: Provide Canvas for live visualization of the internal cognitive state using FastAPI WebSockets.",
+      "allowed_paths": [
+        "magda_agent/visualization/server_v2.py",
+        "tests/test_visualization_server_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket server is capable of streaming cognitive state representations.",
+        "Tests verify WebSocket stream output mocking asyncio event loops."
       ]
     }
   ]

--- a/magda_agent/memory/virtual_context_v2.py
+++ b/magda_agent/memory/virtual_context_v2.py
@@ -1,0 +1,131 @@
+import logging
+from typing import TYPE_CHECKING, List, Optional
+from magda_agent.llm_client import LLMClient
+from magda_agent.emotions.engine import PADState
+from magda_agent.memory.working import MemoryEntry
+
+if TYPE_CHECKING:
+    from magda_agent.memory.working import WorkingMemory
+    from magda_agent.memory.episodic import EpisodicMemory
+
+class VirtualContextManagerV2:
+    """
+    VirtualContextManagerV2 handles advanced virtual context management for
+    explicitly paging out old short-term memory (WorkingMemory) into EpisodicMemory,
+    and paging it back in when requested.
+    """
+    def __init__(self, llm_client: Optional['LLMClient'] = None) -> None:
+        """
+        Initializes the VirtualContextManagerV2.
+
+        Args:
+            llm_client: An optional LLMClient for advanced summarization during compression.
+        """
+        self.llm_client = llm_client
+
+    async def compress_context(self, entries: List['MemoryEntry']) -> 'MemoryEntry':
+        """
+        Compresses multiple memory entries into a single summary entry.
+
+        Args:
+            entries: A list of MemoryEntry objects to compress.
+
+        Returns:
+            A new MemoryEntry containing the summarized context.
+
+        Raises:
+            ValueError: If the entries list is empty.
+        """
+        if not entries:
+            raise ValueError("No entries to compress")
+
+        combined_text = "\n".join(e.content for e in entries)
+
+        if self.llm_client:
+            prompt = [{"role": "system", "content": "Summarize these memory entries concisely."},
+                      {"role": "user", "content": combined_text}]
+            summary = await self.llm_client.chat_completion(prompt)
+        else:
+            summary = f"Summary of {len(entries)} items: {combined_text[:50]}..."
+
+        user_id = entries[0].user_id
+        avg_importance = sum(e.importance for e in entries) / len(entries)
+        avg_p = sum(e.emotional_state.pleasure for e in entries) / len(entries)
+        avg_a = sum(e.emotional_state.arousal for e in entries) / len(entries)
+        avg_d = sum(e.emotional_state.dominance for e in entries) / len(entries)
+        state = PADState(avg_p, avg_a, avg_d)
+
+        return MemoryEntry(content=summary, importance=avg_importance, emotional_state=state, user_id=user_id)
+
+    async def page_out_explicit(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, count: int = 1) -> None:
+        """
+        Explicitly move the oldest `count` entries from WorkingMemory to EpisodicMemory.
+        This provides more explicit pagination control compared to basic implicit paging out.
+
+        Args:
+            working_memory: The WorkingMemory instance to page out from.
+            episodic_memory: The EpisodicMemory instance to page out into.
+            user_id: The ID of the user.
+            count: Number of oldest entries to page out.
+        """
+        entries = working_memory.get_entries(user_id=user_id)
+        if not entries:
+            return
+
+        to_remove = entries[:count]
+        if len(to_remove) > 1:
+            try:
+                # Attempt to compress context before paging out
+                compressed_entry = await self.compress_context(to_remove)
+                to_remove = [compressed_entry]
+            except Exception as e:
+                logging.error(f"Context compression failed during page_out_explicit: {e}")
+
+        # We need the original entries to remove from working memory by their IDs
+        # If compressed, to_remove only contains the new compressed entry,
+        # so we also need to iterate over the original `entries[:count]` to remove them
+        original_to_remove = entries[:count]
+
+        for entry in to_remove:
+            metadata = {
+                "paged_out_explicitly": True,
+                "importance": entry.importance,
+                "pad_p": entry.emotional_state.pleasure,
+                "pad_a": entry.emotional_state.arousal,
+                "pad_d": entry.emotional_state.dominance
+            }
+            if entry.tags:
+                metadata["tags"] = ",".join(entry.tags)
+
+            episodic_memory.store_event(
+                text=entry.content,
+                metadata=metadata,
+                user_id=user_id
+            )
+            logging.debug(f"Paged out memory entry {entry.id} for user {user_id}")
+
+        for orig_entry in original_to_remove:
+            working_memory.remove(orig_entry.id, user_id=user_id)
+
+    async def page_in_explicit(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, query: str, top_k: int = 5) -> None:
+        """
+        Explicitly recall relevant events from EpisodicMemory and load them into WorkingMemory
+        based on a search query.
+
+        Args:
+            working_memory: The WorkingMemory instance to page in to.
+            episodic_memory: The EpisodicMemory instance to page in from.
+            user_id: The ID of the user.
+            query: The semantic search query.
+            top_k: The number of results to fetch.
+        """
+        events = episodic_memory.recall_events(query=query, top_k=top_k, user_id=user_id)
+        for event_text in events:
+            entry = MemoryEntry(
+                content=event_text,
+                importance=0.5,
+                emotional_state=PADState(0, 0, 0),
+                user_id=user_id
+            )
+            await working_memory.add(entry)
+            logging.debug(f"Paged in explicit memory entry for user {user_id}: {event_text[:30]}...")

--- a/tests/test_virtual_context_v2.py
+++ b/tests/test_virtual_context_v2.py
@@ -1,0 +1,85 @@
+from unittest.mock import AsyncMock
+import pytest
+from magda_agent.memory.virtual_context_v2 import VirtualContextManagerV2
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.emotions.engine import PADState
+import asyncio
+
+@pytest.mark.asyncio
+async def test_virtual_context_v2_page_out_explicit() -> None:
+    wm = WorkingMemory(limit=5)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v2_out"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV2()
+
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("First Item", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second Item", 0.6, state, user_id=1)
+    e3 = MemoryEntry("Third Item", 0.7, state, user_id=1)
+
+    await wm.add(e1)
+    await wm.add(e2)
+    await wm.add(e3)
+
+    assert len(wm.get_entries(user_id=1)) == 3
+
+    # Explicitly page out the first 2 items
+    await vcm.page_out_explicit(wm, em, user_id=1, count=2)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 1
+    assert entries[0].content == "Third Item"
+
+    # Verify Episodic Memory has the paged out entry/entries
+    episodic_events = em.get_all_events(user_id=1)
+    assert len(episodic_events) > 0
+    # The paged out metadata should indicate explicit page out
+    assert episodic_events[0]["metadata"]["paged_out_explicitly"] == True
+
+@pytest.mark.asyncio
+async def test_virtual_context_v2_page_in_explicit() -> None:
+    wm = WorkingMemory(limit=5)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v2_in"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV2()
+
+    em.store_event("Historical facts about Python explicitly", metadata={"paged_out_explicitly": True}, user_id=2)
+
+    await vcm.page_in_explicit(wm, em, user_id=2, query="Python facts", top_k=1)
+
+    entries = wm.get_entries(user_id=2)
+    assert len(entries) == 1
+    assert "Historical facts about Python explicitly" in entries[0].content
+
+@pytest.mark.asyncio
+async def test_virtual_context_v2_compress_without_llm() -> None:
+    """Test that context compression works with fallback summary when LLM is absent."""
+    vcm = VirtualContextManagerV2()
+    state = PADState(0.1, 0.2, 0.3)
+    e1 = MemoryEntry("First", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second", 0.5, state, user_id=1)
+
+    summary = await vcm.compress_context([e1, e2])
+    assert "Summary of 2 items: First\nSecond" in summary.content
+    assert summary.importance == 0.5
+    assert summary.user_id == 1
+
+@pytest.mark.asyncio
+async def test_virtual_context_v2_compress_with_llm() -> None:
+    """Test that context compression leverages the LLM client to generate summaries."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "Mocked Summary V2"
+    vcm = VirtualContextManagerV2(llm_client=mock_llm)
+
+    state = PADState(0.1, 0.2, 0.3)
+    e1 = MemoryEntry("First", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second", 0.5, state, user_id=1)
+
+    summary = await vcm.compress_context([e1, e2])
+    assert summary.content == "Mocked Summary V2"
+    assert summary.importance == 0.5
+    assert summary.user_id == 1


### PR DESCRIPTION
Implemented VirtualContextManagerV2 explicitly paging out WorkingMemory entries to EpisodicMemory with LLM compression capabilities and paging them in on demand. We also added tests using an AsyncMock for LLMClient and explicitly named test collections for EpisodicMemory to avoid transient test state leaks. We marked memgpt-virtual-context-v2 as done in agent_tasks.json and appended three new priority trend tasks with safe ID generation.

---
*PR created automatically by Jules for task [9344738829960224638](https://jules.google.com/task/9344738829960224638) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement MemGPT Virtual Context v2 with compression and explicit paging
> - Adds [`VirtualContextManagerV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/230/files#diff-c812571519b22b4e3bcd132e466dbdfa27e0d261841a9ca82cd6ae751ab12631) with `compress_context`, `page_out_explicit`, and `page_in_explicit` async methods to manage memory movement between `WorkingMemory` and `EpisodicMemory`.
> - `compress_context` merges multiple `MemoryEntry` items into one by averaging importance and PAD state values, using an LLM client for summarization when provided, or a heuristic fallback string.
> - `page_out_explicit` moves the oldest N `WorkingMemory` entries for a user into `EpisodicMemory`, compressing them first if more than one entry is selected.
> - `page_in_explicit` recalls events from `EpisodicMemory` via a text query and loads them back into `WorkingMemory` as new `MemoryEntry` objects.
> - Async pytest coverage is added in [`tests/test_virtual_context_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/230/files#diff-90340335fdde24cfd34074f174cc77235ea950b51b8604f140db0d4b431cfa1d) for all three methods, including LLM mock and fallback paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ffee23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->