### PR TITLE
Implement Hermes Skill Creation Loop v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4339,7 +4339,7 @@
     },
     {
       "id": "hermes-skill-creation-loop-v2",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "Hermes Skill Creation Loop v2",
@@ -7553,6 +7553,57 @@
       "acceptance": [
         "Audit Logger captures tool calls properly.",
         "Tests confirm redaction of sensitive arguments."
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-integration-v3-bd5e414d",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes-style Skill Marketplace Export v3",
+      "description": "Inspired by Hermes Agent trend: Skill marketplace integration. Add ability to export dynamically created skills to the agentskills.io standard format, expanding on v2.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_exporter_v3.py",
+        "tests/test_marketplace_exporter_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dynamically created skills can be exported to agentskills.io standard format.",
+        "Tests verify the exported format is valid."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-subagent-isolation-v3-56a1b5e7",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Agent Teams Subagent Git Worktree Isolation v3",
+      "description": "Inspired by Claude Agent Teams trend: Implement Subagent spawning with strict Git Worktree isolation and context separation, expanding on v2.",
+      "allowed_paths": [
+        "magda_agent/agents/isolation_v3.py",
+        "tests/test_isolation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents have strictly isolated git worktrees.",
+        "Tests mock git calls and verify isolation paths."
+      ]
+    },
+    {
+      "id": "openclaw-local-first-context-engine-v2-618a2738",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Local-First Context Engine v2",
+      "description": "Inspired by OpenClaw trend: local-first architecture. Ensure the context engine falls back to local resources gracefully when external APIs are unavailable, expanding on previous v1.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_local_v2.py",
+        "tests/test_context_engine_local_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine can operate in a degraded local-first mode.",
+        "Tests mock API failures and verify graceful local fallback."
       ]
     }
   ]

--- a/magda_agent/learning/skill_loop_v2.py
+++ b/magda_agent/learning/skill_loop_v2.py
@@ -1,0 +1,67 @@
+import logging
+from typing import List, Dict, Optional, Any
+import re
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.procedural import ProceduralMemory
+
+class HermesSkillCreationLoopV2:
+    """
+    Agent creates new skills from past executions, inspired by Hermes.
+    """
+    def __init__(self, procedural_memory: ProceduralMemory, llm: LLMClient) -> None:
+        self.procedural_memory = procedural_memory
+        self.llm = llm
+
+    async def analyze_and_create_skill(
+        self,
+        task_description: str,
+        execution_trace: List[Dict[str, Any]],
+        user_id: Optional[int] = None
+    ) -> Optional[str]:
+        """
+        Analyzes an execution trace and attempts to generate a Python skill.
+        If a pattern is detected and valid Python code is generated, it is stored.
+        Returns the name of the new skill if created, else None.
+        """
+        trace_text = ""
+        for i, step in enumerate(execution_trace):
+            action = step.get("action", "unknown action")
+            outcome = step.get("outcome", "unknown outcome")
+            trace_text += f"Step {i+1}: {action} -> {outcome}\n"
+
+        prompt = f"""
+        Analyze the following execution trace of a successful task.
+        If the steps represent a highly reusable procedure, generate a Python function (a 'skill') that encapsulates this logic.
+        Return ONLY valid Python code starting with 'def '. Do not include markdown formatting or explanations.
+        If it's not suitable for a skill, return exactly 'NOT_REUSABLE'.
+
+        Task: {task_description}
+
+        Execution Trace:
+        {trace_text}
+        """
+
+        try:
+            response = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+            code = response.strip()
+
+            if code and code != "NOT_REUSABLE" and code.startswith("def "):
+                # Extract function name from code
+                match = re.search(r"def\s+([a-zA-Z0-9_]+)\(", code)
+                skill_name = match.group(1) if match else "generated_hermes_skill"
+
+                self.procedural_memory.store_procedure(
+                    name=skill_name,
+                    procedure=code,
+                    user_id=user_id,
+                    metadata={"source_task": task_description, "type": "python_skill_loop_v2"}
+                )
+                logging.info(f"Dynamically generated and stored new Python skill: {skill_name}")
+                return skill_name
+            else:
+                logging.info("Execution trace not suitable for skill generation or generation failed.")
+                return None
+        except Exception as e:
+            logging.error(f"Failed to analyze and create skill: {e}")
+            return None

--- a/tests/test_skill_loop_v2.py
+++ b/tests/test_skill_loop_v2.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.learning.skill_loop_v2 import HermesSkillCreationLoopV2
+from magda_agent.memory.procedural import ProceduralMemory
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def procedural_memory() -> ProceduralMemory:
+    mem = MagicMock(spec=ProceduralMemory)
+    return mem
+
+@pytest.fixture
+def llm_client() -> LLMClient:
+    llm = MagicMock(spec=LLMClient)
+    llm.chat_completion = AsyncMock()
+    return llm
+
+@pytest.mark.asyncio
+async def test_analyze_and_create_skill_success(procedural_memory: ProceduralMemory, llm_client: LLMClient) -> None:
+    llm_client.chat_completion.return_value = "def fetch_data(url):\n    pass"
+    loop = HermesSkillCreationLoopV2(procedural_memory, llm_client)
+
+    trace = [{"action": "get url", "outcome": "data fetched"}]
+
+    result = await loop.analyze_and_create_skill("fetch data from api", trace, user_id=1)
+
+    assert result == "fetch_data"
+    procedural_memory.store_procedure.assert_called_once_with(
+        name="fetch_data",
+        procedure="def fetch_data(url):\n    pass",
+        user_id=1,
+        metadata={"source_task": "fetch data from api", "type": "python_skill_loop_v2"}
+    )
+
+@pytest.mark.asyncio
+async def test_analyze_and_create_skill_not_reusable(procedural_memory: ProceduralMemory, llm_client: LLMClient) -> None:
+    llm_client.chat_completion.return_value = "NOT_REUSABLE"
+    loop = HermesSkillCreationLoopV2(procedural_memory, llm_client)
+
+    trace = [{"action": "click button", "outcome": "clicked"}]
+
+    result = await loop.analyze_and_create_skill("click", trace)
+
+    assert result is None
+    procedural_memory.store_procedure.assert_not_called()


### PR DESCRIPTION
Implements the Hermes-style Skill Creation Loop v2 per the task in agent_tasks.json. 
- Implemented `HermesSkillCreationLoopV2` inside `magda_agent/learning/skill_loop_v2.py`.
- Added mock-based pytest unit tests in `tests/test_skill_loop_v2.py`.
- Marked `hermes-skill-creation-loop-v2` as done in `agent_tasks.json`.
- Appended 3 new trend-inspired tasks (Hermes marketplace v3, Claude subagent isolation v3, and OpenClaw local-first context engine v2) to replenish `agent_tasks.json`.
- Maintained safety boundaries and followed allowed paths constraints.

---
*PR created automatically by Jules for task [16921637935014821671](https://jules.google.com/task/16921637935014821671) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `HermesSkillCreationLoopV2` to generate reusable skills from execution traces
> - Adds [`skill_loop_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/232/files#diff-0e8d1cc4df763ff89cacc370858c5bb52a190b16a19ff80604a61076b5cf68f2) with `HermesSkillCreationLoopV2`, which sends an execution trace to an LLM and persists the returned Python function as a skill via `ProceduralMemory`.
> - The `analyze_and_create_skill` method validates that the LLM response is a `def`-prefixed Python function, extracts the function name via regex, and stores it with metadata; returns `None` if the LLM responds with `NOT_REUSABLE` or an error occurs.
> - Adds tests in [`tests/test_skill_loop_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/232/files#diff-2b37efea5bb2b4988aaaa2b42c272364ef3d712f3140c602e3b2b73f0c8e8084) covering the success path and the `NOT_REUSABLE` path using async mocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 438c459.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->