### PR TITLE
feat: Subagent spawning via OpenClaw context engine

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4356,7 +4356,7 @@
     },
     {
       "id": "agent-teams-subagent-spawning",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Subagent spawning via OpenClaw context engine",
@@ -7604,6 +7604,57 @@
       "acceptance": [
         "Context engine can operate in a degraded local-first mode.",
         "Tests mock API failures and verify graceful local fallback."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-streaming-v1-uuid",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Task Delegation Streaming Interface",
+      "description": "Inspired by trend: A2A open standard. Implement a streaming interface for A2A peer-to-peer task delegation to support long-horizon task coordination.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_streaming.py",
+        "tests/test_a2a_streaming.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A streaming interface supports chunked updates for task delegation.",
+        "Tests verify chunked response processing."
+      ]
+    },
+    {
+      "id": "mcp-kernel-sandbox-taint-policy-v1-uuid",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Kernel Taint Tracking Policy Engine",
+      "description": "Inspired by trend: MCPKernel taint tracking + sandboxed execution. Build a dynamic taint tracking policy engine to restrict untrusted tool outputs.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_taint_policy.py",
+        "tests/test_mcp_taint_policy.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint policy engine evaluates data streams before execution.",
+        "Tests ensure malicious untrusted output is blocked."
+      ]
+    },
+    {
+      "id": "openclaw-rl-interactive-feedback-v1-uuid",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Interactive Feedback Formatter",
+      "description": "Inspired by trend: OpenClaw-RL interactive learning. Implement an interactive feedback formatter to capture explicit and implicit user signals during conversations.",
+      "allowed_paths": [
+        "magda_agent/learning/interactive_feedback.py",
+        "tests/test_interactive_feedback.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Feedback formatter correctly parses user corrections.",
+        "Tests ensure parsed signals are accurately extracted."
       ]
     }
   ]

--- a/magda_agent/agents/team_spawning.py
+++ b/magda_agent/agents/team_spawning.py
@@ -1,0 +1,67 @@
+import asyncio
+import logging
+from typing import List, Dict, Any
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.context_engine import ContextEngine
+from magda_agent.agents.spawner import SubagentSpawner
+
+class ContextAwareTeamSpawner:
+    """
+    Spawns SubAgents with context dynamically managed by the OpenClaw ContextEngine.
+    """
+    def __init__(self, llm: LLMClient, context_engine: ContextEngine) -> None:
+        """
+        Initializes the ContextAwareTeamSpawner.
+
+        Args:
+            llm: The Language Model client to be used by spawned SubAgents.
+            context_engine: The ContextEngine to enrich task context.
+        """
+        self.llm = llm
+        self.context_engine = context_engine
+        self.spawner = SubagentSpawner(llm=llm)
+
+    async def spawn_and_execute(self, tasks: List[Dict[str, Any]], base_context: str, user_id: int, use_isolation: bool = True) -> List[str]:
+        """
+        Spawns subagents dynamically to execute multiple tasks concurrently with enriched context.
+
+        Args:
+            tasks: A list of task dictionaries containing a 'description' field.
+            base_context: The shared base context to start with.
+            user_id: The ID of the user requesting the task execution.
+            use_isolation: Whether to use Git Worktree isolation for each subagent.
+
+        Returns:
+            A list of execution results corresponding to the tasks.
+        """
+        logging.info(f"ContextAwareTeamSpawner processing {len(tasks)} tasks.")
+
+        async def execute_task(task: Dict[str, Any]) -> str:
+            """Executes a single task within the isolated context."""
+            query = task.get('description', '')
+
+            # Retrieve context items specifically for this task query
+            context_items = self.context_engine.retrieve_context(
+                query=query,
+                user_id=user_id,
+                base_retrieval_func=lambda q, uid: [base_context]
+            )
+
+            # Assemble context into a single string
+            assembled_context = await self.context_engine.assemble(
+                context_items=context_items,
+                metadata={'user_id': user_id, 'task_query': query}
+            )
+
+            # Execute a single task via SubagentSpawner with the enriched context
+            results = await self.spawner.spawn_and_execute(
+                tasks=[task],
+                base_context=assembled_context,
+                use_isolation=use_isolation
+            )
+            return results[0] if results else ""
+
+        # Execute all tasks concurrently
+        results = await asyncio.gather(*(execute_task(t) for t in tasks))
+        return list(results)

--- a/tests/test_team_spawning.py
+++ b/tests/test_team_spawning.py
@@ -1,0 +1,31 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.team_spawning import ContextAwareTeamSpawner
+from magda_agent.memory.context_engine import ContextEngine
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_context_aware_team_spawner():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_context_engine = MagicMock(spec=ContextEngine)
+
+    mock_context_engine.retrieve_context.return_value = ["base_context_item"]
+    mock_context_engine.assemble = AsyncMock(return_value="assembled_context")
+
+    spawner = ContextAwareTeamSpawner(llm=mock_llm, context_engine=mock_context_engine)
+
+    # Mocking the internal SubagentSpawner logic
+    spawner.spawner = MagicMock()
+    spawner.spawner.spawn_and_execute = AsyncMock(return_value=["mocked_result"])
+
+    tasks = [{"description": "test task"}]
+    results = await spawner.spawn_and_execute(tasks=tasks, base_context="base", user_id=1)
+
+    assert results == ["mocked_result"]
+    mock_context_engine.retrieve_context.assert_called_once()
+    mock_context_engine.assemble.assert_called_once()
+    spawner.spawner.spawn_and_execute.assert_called_once_with(
+        tasks=[{"description": "test task"}],
+        base_context="assembled_context",
+        use_isolation=True
+    )


### PR DESCRIPTION
This PR implements the subagent spawning task using OpenClaw patterns:
- Created `ContextAwareTeamSpawner` in `magda_agent/agents/team_spawning.py`.
- Added complete test coverage in `tests/test_team_spawning.py`.
- Marked task as done and injected 3 new multi-agent/safety trend tasks.

---
*PR created automatically by Jules for task [15471022543205009896](https://jules.google.com/task/15471022543205009896) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ContextAwareTeamSpawner` to spawn subagents with context-enriched tasks
> - Introduces [`ContextAwareTeamSpawner`](https://github.com/kazah4359-lgtm/Magda-agent/pull/233/files#diff-ca9dec8c41780efec2e94f7b96454cfdb0d6ff482d117603d44c1bea92fd3518) which wraps `SubagentSpawner` and enriches each task with context from `ContextEngine` before delegation.
> - Per-task context is retrieved and assembled via `ContextEngine.retrieve_context` and `ContextEngine.assemble`, then passed to `SubagentSpawner.spawn_and_execute`.
> - All tasks run concurrently via `asyncio.gather`, returning a list of result strings.
> - Adds async pytest coverage in [`test_team_spawning.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/233/files#diff-aa3cd8e99e736a041ac4a1ee6fbfa26df3aa53cca9122f87deff63cda336367a) with mocked LLM, context engine, and spawner.
> - Adds three new task entries to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/233/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) for A2A streaming, MCP taint tracking, and interactive feedback formatting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87a3161.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->