### PR TITLE
MCP Action Tool Concurrency

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4373,7 +4373,7 @@
     },
     {
       "id": "mcp-action-tool-concurrency",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP server-prefixed tool names and concurrency",
@@ -7646,6 +7646,57 @@
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Interactive Feedback Formatter",
+      "description": "Inspired by trend: OpenClaw-RL interactive learning. Implement an interactive feedback formatter to capture explicit and implicit user signals during conversations.",
+      "allowed_paths": [
+        "magda_agent/learning/interactive_feedback.py",
+        "tests/test_interactive_feedback.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Feedback formatter correctly parses user corrections.",
+        "Tests ensure parsed signals are accurately extracted."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-streaming-v2-uuid",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Task Delegation Streaming Interface v2",
+      "description": "Inspired by trend: A2A open standard. Implement a streaming interface for A2A peer-to-peer task delegation to support long-horizon task coordination.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_streaming.py",
+        "tests/test_a2a_streaming.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A streaming interface supports chunked updates for task delegation.",
+        "Tests verify chunked response processing."
+      ]
+    },
+    {
+      "id": "mcp-kernel-sandbox-taint-policy-v2-uuid",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Kernel Taint Tracking Policy Engine v2",
+      "description": "Inspired by trend: MCPKernel taint tracking + sandboxed execution. Build a dynamic taint tracking policy engine to restrict untrusted tool outputs.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_taint_policy.py",
+        "tests/test_mcp_taint_policy.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint policy engine evaluates data streams before execution.",
+        "Tests ensure malicious untrusted output is blocked."
+      ]
+    },
+    {
+      "id": "openclaw-rl-interactive-feedback-v2-uuid",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Interactive Feedback Formatter v2",
       "description": "Inspired by trend: OpenClaw-RL interactive learning. Implement an interactive feedback formatter to capture explicit and implicit user signals during conversations.",
       "allowed_paths": [
         "magda_agent/learning/interactive_feedback.py",

--- a/magda_agent/integration/mcp_concurrency.py
+++ b/magda_agent/integration/mcp_concurrency.py
@@ -1,0 +1,107 @@
+import asyncio
+import json
+from typing import List, Dict, Any
+from magda_agent.integration.mcp_server import MCPServer
+
+class MCPConcurrentHandler:
+    """
+    Handles MCP server-prefixed tool names and runtime function tool concurrency.
+    Supports executing multiple MCP tools in parallel.
+    """
+    def __init__(self, server: MCPServer, server_prefix: str = "") -> None:
+        """
+        Initializes the MCPConcurrentHandler with an MCPServer and an optional prefix.
+
+        Args:
+            server: The MCPServer instance to handle execution.
+            server_prefix: Optional string prefix to namespace tools.
+        """
+        self.server = server
+        self.server_prefix = server_prefix
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists available tools, optionally prepending the server_prefix to their names.
+
+        Returns:
+            A list of dictionary definitions for MCP compatible tools.
+        """
+        tools = self.server.list_tools()
+        if not self.server_prefix:
+            return tools
+
+        prefixed_tools = []
+        for tool in tools:
+            new_tool = dict(tool)
+            new_tool["name"] = f"{self.server_prefix}__{tool['name']}"
+            prefixed_tools.append(new_tool)
+        return prefixed_tools
+
+    async def handle_request(self, payload: str) -> str:
+        """
+        Handles a JSON-RPC payload string. If the payload is a list of requests,
+        executes them concurrently.
+
+        Args:
+            payload: A raw JSON string containing a single object or an array of objects.
+
+        Returns:
+            A JSON string representing the JSON-RPC response or batch responses.
+        """
+        try:
+            request_data = json.loads(payload)
+        except json.JSONDecodeError:
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error"}
+            })
+
+        if isinstance(request_data, list):
+            if not request_data:
+                return json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32600, "message": "Invalid Request"}
+                })
+
+            tasks = []
+            for req in request_data:
+                tasks.append(self._process_single_request(req.copy()))
+
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            return json.dumps(results)
+        else:
+            result = await self._process_single_request(request_data.copy())
+            return json.dumps(result)
+
+    async def _process_single_request(self, req: dict) -> dict:
+        """
+        Processes a single JSON-RPC request dictionary, stripping the server prefix if applicable.
+
+        Args:
+            req: A dictionary representing a single JSON-RPC request.
+
+        Returns:
+            A dictionary representing the JSON-RPC response.
+        """
+        if not isinstance(req, dict):
+            return {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request"}
+            }
+
+        method = req.get("method")
+        if method and isinstance(method, str) and self.server_prefix:
+            prefix_str = f"{self.server_prefix}__"
+            if method.startswith(prefix_str):
+                req["method"] = method[len(prefix_str):]
+            else:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req.get("id"),
+                    "error": {"code": -32601, "message": f"Method not found or missing server prefix: {method}"}
+                }
+
+        return await self.server.exporter.handle_rpc_request(req)

--- a/tests/test_mcp_concurrency.py
+++ b/tests/test_mcp_concurrency.py
@@ -1,0 +1,82 @@
+import pytest
+import asyncio
+import json
+from magda_agent.integration.mcp_concurrency import MCPConcurrentHandler
+from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.integration.mcp_exporter import MCPExporter
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.fixture
+def registry():
+    reg = SkillRegistry()
+
+    async def fast_tool():
+        return "fast"
+
+    async def slow_tool():
+        await asyncio.sleep(0.1)
+        return "slow"
+
+    reg.register_skill("fast_tool", fast_tool, "fast")
+    reg.register_skill("slow_tool", slow_tool, "slow")
+    return reg
+
+@pytest.fixture
+def server(registry):
+    return MCPServer(MCPExporter(registry))
+
+@pytest.fixture
+def handler(server):
+    return MCPConcurrentHandler(server, "my_server")
+
+def test_list_tools(handler):
+    tools = handler.list_tools()
+    names = [t["name"] for t in tools]
+    assert "my_server__fast_tool" in names
+    assert "my_server__slow_tool" in names
+
+@pytest.mark.asyncio
+async def test_handle_request_single(handler):
+    req = {"jsonrpc": "2.0", "id": 1, "method": "my_server__fast_tool"}
+    res_str = await handler.handle_request(json.dumps(req))
+    res = json.loads(res_str)
+    assert res["jsonrpc"] == "2.0"
+    assert res["id"] == 1
+    assert res["result"]["content"][0]["text"] == "fast"
+
+@pytest.mark.asyncio
+async def test_handle_request_batch_concurrent(handler):
+    req1 = {"jsonrpc": "2.0", "id": 1, "method": "my_server__slow_tool"}
+    req2 = {"jsonrpc": "2.0", "id": 2, "method": "my_server__fast_tool"}
+
+    start = asyncio.get_event_loop().time()
+    res_str = await handler.handle_request(json.dumps([req1, req2]))
+    end = asyncio.get_event_loop().time()
+
+    res = json.loads(res_str)
+    assert len(res) == 2
+    # Ensure they ran concurrently, should take ~0.1s total not 0.1+
+    assert end - start < 0.15
+
+    ids = [r["id"] for r in res]
+    assert 1 in ids
+    assert 2 in ids
+
+@pytest.mark.asyncio
+async def test_handle_request_invalid_json(handler):
+    res_str = await handler.handle_request("{invalid json")
+    res = json.loads(res_str)
+    assert res["error"]["code"] == -32700
+
+@pytest.mark.asyncio
+async def test_handle_request_missing_prefix(handler):
+    req = {"jsonrpc": "2.0", "id": 1, "method": "fast_tool"}
+    res_str = await handler.handle_request(json.dumps(req))
+    res = json.loads(res_str)
+    assert res["error"]["code"] == -32601
+
+@pytest.mark.asyncio
+async def test_handle_request_empty_batch(handler):
+    res_str = await handler.handle_request("[]")
+    res = json.loads(res_str)
+    assert res["error"]["code"] == -32600


### PR DESCRIPTION
Implements runtime function tool concurrency for executing multiple tools at once without waiting for sequential completion, fixing task `mcp-action-tool-concurrency`.

---
*PR created automatically by Jules for task [14961834475915925939](https://jules.google.com/task/14961834475915925939) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add concurrent batch JSON-RPC handling to MCP action tools via `MCPConcurrentHandler`
> - Introduces [`MCPConcurrentHandler`](https://github.com/kazah4359-lgtm/Magda-agent/pull/234/files#diff-f74a96e79dd9545b357d9a11fae0a3a2d09457f7622157eac67a3ca213cdcf96) to wrap an `MCPServer` and support both single and batch JSON-RPC requests, executing batch entries concurrently via `asyncio.gather`.
> - Supports optional server-prefix namespacing: tool names are exposed as `<prefix>__<tool>` and incoming method names are validated and stripped of the prefix before being delegated to `server.exporter.handle_rpc_request`.
> - Returns JSON-RPC-compliant error codes for parse failures (-32700), invalid requests (-32600), and missing/mismatched prefixes (-32601).
> - Adds async test coverage in [`tests/test_mcp_concurrency.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/234/files#diff-5f1dc28a34199dd3dd8ae9fa6b1e30d970d82e406934628a244b7efac861ccb5) verifying prefixed listing, single/batch handling, concurrency timing, and error cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01a7ce1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->