### PR TITLE
feat(safety): Implement formal ACS Checkpoint interface

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4426,7 +4426,7 @@
     },
     {
       "id": "acs-guardrails-checkpoint-interface",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "ACS Control Checkpoints Interface",
@@ -7757,6 +7757,57 @@
       "acceptance": [
         "MCP Kernel properly intercepts and enforces taint tracking.",
         "Tests mock the runtime proxy accurately."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-memory-visualization-59894892",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Memory Visualization",
+      "description": "Inspired by the OpenClaw Canvas trend: Implement a Memory Visualizer component that streams memory structures to the Canvas for live visualization.",
+      "allowed_paths": [
+        "magda_agent/visualization/memory_canvas.py",
+        "tests/test_memory_canvas.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory visualizer correctly formats memory blocks for Canvas consumption.",
+        "Tests mock Canvas and verify data structure."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backups-v2-6aeef707",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Hermes Cron Nightly Backups v2",
+      "description": "Inspired by Hermes Cron scheduler trend: Implement a nightly backup scheduler to snapshot ChromaDB and working memory, expanding on operations cron capabilities.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_backups.py",
+        "tests/test_cron_backups.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron backups scheduler correctly triggers database snapshots.",
+        "Tests mock time and file system to verify backup execution."
+      ]
+    },
+    {
+      "id": "claude-evaluator-critic-agent-a8bc4909",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Claude Evaluator Critic Agent",
+      "description": "Inspired by Claude Agent Teams trend: Implement the Evaluator (Critic) agent in the Triad Architecture to rigorously evaluate generator output.",
+      "allowed_paths": [
+        "magda_agent/agents/critic_evaluator.py",
+        "tests/test_critic_evaluator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Critic evaluator correctly assigns scores and provides feedback on generator outputs.",
+        "Tests mock LLM calls to verify critic decision logic."
       ]
     }
   ]

--- a/magda_agent/safety/acs_guard.py
+++ b/magda_agent/safety/acs_guard.py
@@ -4,12 +4,97 @@ Implements 5 validation checkpoints for agent workflows to standardize runtime g
 """
 
 import logging
-from typing import Dict, Any, Tuple, Optional
+from abc import ABC, abstractmethod
+from typing import Dict, Any, Tuple, Optional, List
 
 
 class SecurityViolationError(Exception):
     """Exception raised when an action is blocked by the ACS Guard."""
     pass
+
+
+class ACSCheckpoint(ABC):
+    """Abstract base class for ACS validation checkpoints."""
+
+    @abstractmethod
+    def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Validates the workflow data against this checkpoint.
+
+        Args:
+            workflow_data: The workflow context data.
+
+        Returns:
+            A tuple (passed, reason).
+        """
+        pass
+
+
+class InputValidationCheckpoint(ACSCheckpoint):
+    """
+    Checkpoint 1: Input Validation.
+    Validates the raw input data.
+    """
+
+    def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        if not workflow_data:
+            return False, "Input validation failed: workflow data is empty."
+        if "action" not in workflow_data:
+            return False, "Input validation failed: missing 'action' field."
+        return True, "Input validation passed."
+
+
+class IntentAuthorizationCheckpoint(ACSCheckpoint):
+    """
+    Checkpoint 2: Intent Authorization.
+    Verifies if the agent's intent is authorized.
+    """
+
+    def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        action = workflow_data.get("action")
+        if action == "unauthorized_action":
+            return False, f"Intent authorization failed: action '{action}' is not allowed."
+        return True, "Intent authorization passed."
+
+
+class ToolPolicyCheckpoint(ACSCheckpoint):
+    """
+    Checkpoint 3: Tool Policy.
+    Checks if the tool complies with defined policies.
+    """
+
+    def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        tool = workflow_data.get("tool")
+        if tool == "forbidden_tool":
+            return False, f"Tool policy failed: tool '{tool}' is forbidden."
+        return True, "Tool policy passed."
+
+
+class StateTransitionCheckpoint(ACSCheckpoint):
+    """
+    Checkpoint 4: State Transition.
+    Ensures the proposed state transition is valid.
+    """
+
+    def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        current_state = workflow_data.get("current_state")
+        next_state = workflow_data.get("next_state")
+        if current_state == "error" and next_state == "executing":
+            return False, f"State transition failed: cannot transition from '{current_state}' to '{next_state}'."
+        return True, "State transition passed."
+
+
+class OutputSanitizationCheckpoint(ACSCheckpoint):
+    """
+    Checkpoint 5: Output Sanitization.
+    Sanitizes the final output.
+    """
+
+    def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        output = workflow_data.get("output", "")
+        if "secret_key" in str(output):
+            return False, "Output sanitization failed: sensitive data detected in output."
+        return True, "Output sanitization passed."
 
 
 class ACSGuard:
@@ -21,88 +106,13 @@ class ACSGuard:
     def __init__(self) -> None:
         """Initializes the ACS Guard."""
         self.logger = logging.getLogger(__name__)
-
-    def checkpoint_1_input_validation(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """
-        Checkpoint 1: Input Validation.
-        Validates the raw input data.
-
-        Args:
-            workflow_data: The workflow context data.
-
-        Returns:
-            A tuple (passed, reason).
-        """
-        if not workflow_data:
-            return False, "Input validation failed: workflow data is empty."
-        if "action" not in workflow_data:
-            return False, "Input validation failed: missing 'action' field."
-        return True, "Input validation passed."
-
-    def checkpoint_2_intent_authorization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """
-        Checkpoint 2: Intent Authorization.
-        Verifies if the agent's intent is authorized.
-
-        Args:
-            workflow_data: The workflow context data.
-
-        Returns:
-            A tuple (passed, reason).
-        """
-        action = workflow_data.get("action")
-        if action == "unauthorized_action":
-            return False, f"Intent authorization failed: action '{action}' is not allowed."
-        return True, "Intent authorization passed."
-
-    def checkpoint_3_tool_policy(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """
-        Checkpoint 3: Tool Policy.
-        Checks if the tool complies with defined policies.
-
-        Args:
-            workflow_data: The workflow context data.
-
-        Returns:
-            A tuple (passed, reason).
-        """
-        tool = workflow_data.get("tool")
-        if tool == "forbidden_tool":
-            return False, f"Tool policy failed: tool '{tool}' is forbidden."
-        return True, "Tool policy passed."
-
-    def checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """
-        Checkpoint 4: State Transition.
-        Ensures the proposed state transition is valid.
-
-        Args:
-            workflow_data: The workflow context data.
-
-        Returns:
-            A tuple (passed, reason).
-        """
-        current_state = workflow_data.get("current_state")
-        next_state = workflow_data.get("next_state")
-        if current_state == "error" and next_state == "executing":
-            return False, f"State transition failed: cannot transition from '{current_state}' to '{next_state}'."
-        return True, "State transition passed."
-
-    def checkpoint_5_output_sanitization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """
-        Checkpoint 5: Output Sanitization.
-        Sanitizes the final output.
-
-        Args:
-            workflow_data: The workflow context data.
-
-        Returns:
-            A tuple (passed, reason).
-        """
-        output = workflow_data.get("output", "")
-        if "secret_key" in str(output):
-            return False, "Output sanitization failed: sensitive data detected in output."
-        return True, "Output sanitization passed."
+        self.checkpoints: List[ACSCheckpoint] = [
+            InputValidationCheckpoint(),
+            IntentAuthorizationCheckpoint(),
+            ToolPolicyCheckpoint(),
+            StateTransitionCheckpoint(),
+            OutputSanitizationCheckpoint()
+        ]
 
     def validate_workflow(self, workflow_data: Dict[str, Any]) -> bool:
         """
@@ -114,16 +124,8 @@ class ACSGuard:
         Returns:
             True if passed, False otherwise.
         """
-        checkpoints = [
-            self.checkpoint_1_input_validation,
-            self.checkpoint_2_intent_authorization,
-            self.checkpoint_3_tool_policy,
-            self.checkpoint_4_state_transition,
-            self.checkpoint_5_output_sanitization
-        ]
-
-        for i, checkpoint in enumerate(checkpoints, 1):
-            passed, reason = checkpoint(workflow_data)
+        for i, checkpoint in enumerate(self.checkpoints, 1):
+            passed, reason = checkpoint.validate(workflow_data)
             if not passed:
                 self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
                 return False
@@ -144,16 +146,8 @@ class ACSGuard:
         Raises:
             SecurityViolationError: If validation fails at any checkpoint.
         """
-        checkpoints = [
-            self.checkpoint_1_input_validation,
-            self.checkpoint_2_intent_authorization,
-            self.checkpoint_3_tool_policy,
-            self.checkpoint_4_state_transition,
-            self.checkpoint_5_output_sanitization
-        ]
-
-        for i, checkpoint in enumerate(checkpoints, 1):
-            passed, reason = checkpoint(workflow_data)
+        for i, checkpoint in enumerate(self.checkpoints, 1):
+            passed, reason = checkpoint.validate(workflow_data)
             if not passed:
                 self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
                 raise SecurityViolationError(f"Action blocked by ACS checkpoint {i}: {reason}")

--- a/tests/test_acs_guard.py
+++ b/tests/test_acs_guard.py
@@ -1,6 +1,14 @@
 """Tests for the ACS Runtime Safety Guard."""
 import pytest
-from magda_agent.safety.acs_guard import ACSGuard, SecurityViolationError
+from magda_agent.safety.acs_guard import (
+    ACSGuard,
+    SecurityViolationError,
+    InputValidationCheckpoint,
+    IntentAuthorizationCheckpoint,
+    ToolPolicyCheckpoint,
+    StateTransitionCheckpoint,
+    OutputSanitizationCheckpoint
+)
 
 def test_acs_guard_valid_payload():
     guard = ACSGuard()
@@ -60,3 +68,58 @@ def test_acs_guard_checkpoint_5_secret_leak():
     }
     with pytest.raises(SecurityViolationError, match="Action blocked by ACS checkpoint 5: Output sanitization failed: sensitive data detected in output."):
         guard.intercept_action(payload)
+
+# Individual Checkpoint Tests
+def test_input_validation_checkpoint():
+    checkpoint = InputValidationCheckpoint()
+    passed, reason = checkpoint.validate({"action": "run"})
+    assert passed
+    assert reason == "Input validation passed."
+
+    passed, reason = checkpoint.validate({})
+    assert not passed
+    assert reason == "Input validation failed: workflow data is empty."
+
+    passed, reason = checkpoint.validate({"tool": "ls"})
+    assert not passed
+    assert reason == "Input validation failed: missing 'action' field."
+
+def test_intent_authorization_checkpoint():
+    checkpoint = IntentAuthorizationCheckpoint()
+    passed, reason = checkpoint.validate({"action": "run"})
+    assert passed
+    assert reason == "Intent authorization passed."
+
+    passed, reason = checkpoint.validate({"action": "unauthorized_action"})
+    assert not passed
+    assert reason == "Intent authorization failed: action 'unauthorized_action' is not allowed."
+
+def test_tool_policy_checkpoint():
+    checkpoint = ToolPolicyCheckpoint()
+    passed, reason = checkpoint.validate({"tool": "ls"})
+    assert passed
+    assert reason == "Tool policy passed."
+
+    passed, reason = checkpoint.validate({"tool": "forbidden_tool"})
+    assert not passed
+    assert reason == "Tool policy failed: tool 'forbidden_tool' is forbidden."
+
+def test_state_transition_checkpoint():
+    checkpoint = StateTransitionCheckpoint()
+    passed, reason = checkpoint.validate({"current_state": "idle", "next_state": "executing"})
+    assert passed
+    assert reason == "State transition passed."
+
+    passed, reason = checkpoint.validate({"current_state": "error", "next_state": "executing"})
+    assert not passed
+    assert reason == "State transition failed: cannot transition from 'error' to 'executing'."
+
+def test_output_sanitization_checkpoint():
+    checkpoint = OutputSanitizationCheckpoint()
+    passed, reason = checkpoint.validate({"output": "safe output"})
+    assert passed
+    assert reason == "Output sanitization passed."
+
+    passed, reason = checkpoint.validate({"output": "This is a secret_key value"})
+    assert not passed
+    assert reason == "Output sanitization failed: sensitive data detected in output."


### PR DESCRIPTION
This pull request completes the `acs-guardrails-checkpoint-interface` task from the backlog.

### Changes:
- **`magda_agent/safety/acs_guard.py`**: Introduced `ACSCheckpoint` abstract base class. Refactored the 5 internal checkpoint methods (`checkpoint_1_input_validation`, etc.) into 5 concrete classes (`InputValidationCheckpoint`, `IntentAuthorizationCheckpoint`, `ToolPolicyCheckpoint`, `StateTransitionCheckpoint`, `OutputSanitizationCheckpoint`). Updated `ACSGuard` to initialize and iterate over these instantiated classes.
- **`tests/test_acs_guard.py`**: Preserved the original integration tests for `ACSGuard`. Added specific unit tests for each of the 5 new Checkpoint classes.
- **`agent_tasks.json`**: Marked the current task as `"done"`. Appended 3 new trend-inspired tasks (`openclaw-canvas-memory-visualization`, `hermes-cron-nightly-backups-v2`, `claude-evaluator-critic-agent`). All formatting constraints were respected.

---
*PR created automatically by Jules for task [6275537378387774455](https://jules.google.com/task/6275537378387774455) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce formal `ACSCheckpoint` abstract interface for ACS safety validation
> - Defines an `ACSCheckpoint` abstract base class in [acs_guard.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/237/files#diff-8d12ccdddf0184d11805240080a4e62da30ab6a1347a04413035f5a25ed89d76) with a `validate(workflow_data) -> (bool, str)` contract.
> - Extracts five existing inline validation checks (input validation, intent authorization, tool policy, state transition, output sanitization) into concrete `ACSCheckpoint` subclasses.
> - Refactors `ACSGuard.validate_workflow` and `ACSGuard.intercept_action` to iterate over a list of checkpoint instances, preserving existing logging and error-raising behavior.
> - Adds unit tests for each checkpoint class directly in [test_acs_guard.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/237/files#diff-113254d57e7b197af78eff676d430568b29db195ababf0581e7139ab1edf675a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b24734.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->