### PR TITLE
feat(learning): OpenClaw RL Next-State Signals

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4460,7 +4460,7 @@
     },
     {
       "id": "openclaw-rl-next-state-signals",
-      "status": "todo",
+      "status": "done",
       "area": "core",
       "risk": "high",
       "title": "OpenClaw RL Next-State Signals",
@@ -7859,6 +7859,57 @@
       "acceptance": [
         "Untrusted tool outputs are correctly blocked in isolation mode.",
         "Tests ensure malicious execution is prevented."
+      ]
+    },
+    {
+      "id": "agent-teams-subagent-spawner-v2",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Agent Teams Subagent Spawner v2",
+      "description": "Inspired by Claude Agent Teams trend: Update the subagent spawner to better isolate contexts and leverage Git worktrees more dynamically.",
+      "allowed_paths": [
+        "magda_agent/agents/spawner_v2.py",
+        "tests/test_spawner_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent spawner correctly provisions isolated contexts.",
+        "Tests verify that no state leaks across spawned subagents."
+      ]
+    },
+    {
+      "id": "acs-runtime-tool-validation-v5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Runtime Tool Validation v5",
+      "description": "Inspired by ACS Guardrails trend: Implement the next iteration of runtime tool validation checks to block potentially destructive actions before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_validation_v5.py",
+        "tests/test_acs_validation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS validation correctly identifies and blocks destructive tool calls.",
+        "Tests verify successful blocking without false positives."
+      ]
+    },
+    {
+      "id": "openclaw-context-compression-v3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Compression v3",
+      "description": "Inspired by OpenClaw Context Engine trend: Implement a newer context compression algorithm using selective retrieval to maintain memory limits.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v3.py",
+        "tests/test_compression_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context compressor correctly reduces context size.",
+        "Tests verify that critical memories are retained during compression."
       ]
     }
   ]

--- a/magda_agent/learning/rl_signals.py
+++ b/magda_agent/learning/rl_signals.py
@@ -1,0 +1,64 @@
+import logging
+from typing import Optional, List
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+class RLSignalProcessor:
+    """
+    OpenClaw-RL pattern signal processor.
+    Implements online reinforcement learning from next-state signals like user replies and tool outputs.
+    """
+    def __init__(
+        self,
+        habit_tracker: HabitTracker,
+        mirror_neurons: MirrorNeurons
+    ) -> None:
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+
+    async def process_signal(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: Optional[int] = None,
+        tool_output: Optional[str] = None,
+        skills_used: Optional[List[str]] = None
+    ) -> None:
+        """
+        Analyzes the user's reply and tool output as a next-state signal,
+        and uses MirrorNeurons to evaluate it and update HabitTracker.
+
+        Args:
+            user_reply (str): The text of the user's reply.
+            action_context (str): The context of the action that was taken.
+            user_id (Optional[int]): The user's ID.
+            tool_output (Optional[str], optional): The output of the tool, if any. Defaults to None.
+            skills_used (Optional[List[str]], optional): List of skills used. Defaults to ["rl_skill"].
+        """
+        if not user_reply or not action_context:
+            return
+
+        signal_text = user_reply
+        if tool_output:
+            signal_text += f" [Tool Output: {tool_output}]"
+
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(signal_text)
+
+        if p_shift > 0.0:
+            skills = skills_used or ["rl_skill"]
+            # Convert p_shift (0 to 1) to a score out of 10.
+            score = (p_shift + 1.0) * 5.0
+            if tool_output:
+                score += 1.0
+            score = min(10.0, score)
+
+            for skill in skills:
+                self.habit_tracker.record_usage(
+                    input_text=action_context,
+                    skill_used=skill,
+                    evaluation_score=score,
+                    user_id=user_id
+                )
+            logging.info(f"RLSignalProcessor: Positive signal received (p_shift={p_shift:.2f}). Reinforced skills: {skills}")
+        elif p_shift < 0.0:
+            logging.info(f"RLSignalProcessor: Negative signal received (p_shift={p_shift:.2f}). No usage recorded.")

--- a/tests/test_rl_signals.py
+++ b/tests/test_rl_signals.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.rl_signals import RLSignalProcessor
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+@pytest.fixture
+def mock_habit_tracker():
+    return MagicMock(spec=HabitTracker)
+
+@pytest.fixture
+def mock_mirror_neurons():
+    return MagicMock(spec=MirrorNeurons)
+
+@pytest.mark.asyncio
+async def test_rl_signals_positive_feedback(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.5, 0.0, 0.0)
+    processor = RLSignalProcessor(mock_habit_tracker, mock_mirror_neurons)
+
+    await processor.process_signal("Great job", "context", user_id=1, skills_used=["test_skill"])
+
+    mock_mirror_neurons.empathize.assert_called_once_with("Great job")
+
+    # Expected score calculation:
+    # p_shift = 0.5
+    # score = (0.5 + 1.0) * 5.0 = 7.5
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="context",
+        skill_used="test_skill",
+        evaluation_score=7.5,
+        user_id=1
+    )
+
+@pytest.mark.asyncio
+async def test_rl_signals_negative_feedback(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (-0.5, 0.0, 0.0)
+    processor = RLSignalProcessor(mock_habit_tracker, mock_mirror_neurons)
+
+    await processor.process_signal("This is wrong", "context", user_id=1)
+
+    mock_mirror_neurons.empathize.assert_called_once_with("This is wrong")
+    mock_habit_tracker.record_usage.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_rl_signals_with_tool_output(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.8, 0.0, 0.0)
+    processor = RLSignalProcessor(mock_habit_tracker, mock_mirror_neurons)
+
+    await processor.process_signal("Nice", "context", user_id=2, tool_output="Tool success")
+
+    mock_mirror_neurons.empathize.assert_called_once_with("Nice [Tool Output: Tool success]")
+
+    # Expected score calculation:
+    # p_shift = 0.8
+    # score = (0.8 + 1.0) * 5.0 + 1.0 = 10.0
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="context",
+        skill_used="rl_skill",
+        evaluation_score=10.0,
+        user_id=2
+    )


### PR DESCRIPTION
This PR implements the OpenClaw-RL pattern signal processor as outlined in the `openclaw-rl-next-state-signals` task. It processes next-state signals (user replies and tool outputs) to adjust the agent's habits directly. It also adds three new trend-inspired tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [6063644893110772389](https://jules.google.com/task/6063644893110772389) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLSignalProcessor` to record habit usage from RL next-state signals
> - Adds [rl_signals.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/239/files#diff-968c7295691efd90276b254eed585dae041c91dacde2782f6b15bd489c73a413) with `RLSignalProcessor`, which combines `HabitTracker` and `MirrorNeurons` to process reinforcement signals from user replies.
> - On a positive `p_shift` from `MirrorNeurons.empathize`, computes an evaluation score via `(p_shift + 1.0) * 5.0` (capped at 10.0, +1.0 bonus if tool output is present) and calls `HabitTracker.record_usage` for each skill; negative `p_shift` results in no usage recorded.
> - When `tool_output` is provided, it is appended to the text passed to `empathize` and raises the computed score.
> - Covers the logic with three async tests in [test_rl_signals.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/239/files#diff-3e0e39bb86be2542a5cfcaad7604f59322982432e8476a5b815a30dc9285b77f) for positive feedback, negative feedback, and tool output handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6317ef2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->