### PR TITLE
feat: implement Claude-style subagent spawning for parallel execution

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4477,7 +4477,7 @@
     },
     {
       "id": "claude-subagent-spawning-teams",
-      "status": "todo",
+      "status": "done",
       "area": "core",
       "risk": "high",
       "title": "Claude Subagent Spawning",
@@ -7910,6 +7910,57 @@
       "acceptance": [
         "Context compressor correctly reduces context size.",
         "Tests verify that critical memories are retained during compression."
+      ]
+    },
+    {
+      "id": "webarena-navigation-skills-v2-2aa4a776",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "WebArena Navigation Skill Integration v2",
+      "description": "Inspired by WebArena benchmarks. Implement an advanced proactive navigation skill that allows the agent to visually and semantically parse web pages to execute user commands directly, simulating browser interaction.",
+      "allowed_paths": [
+        "magda_agent/skills/web_navigation_v2.py",
+        "tests/test_web_navigation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill provides 'click' and 'type' action capabilities on identified elements",
+        "Tests verify skill functions with a mocked HTML structure"
+      ]
+    },
+    {
+      "id": "mcp-action-tool-concurrency-v8-a317db1a",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP action tools support with dynamic loading",
+      "description": "Inspired by MCP trend where action tools grew to 65%. Implement a robust interface in MCP compatibility layer to not just export read-only skills, but full state-mutating action tools protected by policy layer.",
+      "allowed_paths": [
+        "magda_agent/mcp/action_tools_v8.py",
+        "tests/test_mcp_action_tools_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Action tools can be registered and invoked via MCP",
+        "Tests verify invocation and policy gating"
+      ]
+    },
+    {
+      "id": "openclaw-rl-interactive-learning-v9-1d630384",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Online Reinforcement Learning",
+      "description": "Inspired by OpenClaw trend: Implement an online reinforcement learning mechanism using MirrorNeurons PAD shifts from user replies to train agent simply by talking. Extract implicit feedback as next-state signals.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v9.py",
+        "tests/test_openclaw_rl_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent adjusts policies based on conversation PAD shifts.",
+        "Tests verify that positive feedback reinforces recent habits."
       ]
     }
   ]

--- a/magda_agent/agents/subagents.py
+++ b/magda_agent/agents/subagents.py
@@ -1,0 +1,46 @@
+import asyncio
+import logging
+from typing import List, Dict, Any, Optional
+
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.llm_client import LLMClient
+
+class SubagentsManager:
+    """
+    SubagentsManager coordinates and executes parallel tasks using isolated SubAgents.
+    Inspired by Claude Agent SDK trends: subagent spawning for parallel execution
+    using git worktree isolation.
+    """
+    def __init__(self, llm: LLMClient):
+        """
+        Initializes the SubagentsManager.
+
+        Args:
+            llm: The Language Model client to be used by spawned SubAgents.
+        """
+        self.llm = llm
+
+    async def spawn_and_execute_parallel(self, tasks: List[Dict[str, Any]], context: str) -> List[str]:
+        """
+        Spawns subagents dynamically to execute multiple tasks concurrently.
+        Enforces use_isolation=True to ensure Git worktree isolation.
+
+        Args:
+            tasks: A list of task dictionaries. Each dictionary should contain a 'description' field.
+            context: The shared context passed to all subagents.
+
+        Returns:
+            A list of execution results corresponding to the order of tasks.
+        """
+        logging.info(f"SubagentsManager spawning {len(tasks)} isolated subagents for parallel execution.")
+
+        async def run_subagent(task_spec: Dict[str, Any]) -> str:
+            system_prompt: Optional[str] = task_spec.get('system_prompt', None)
+            # Spawn the SubAgent enforcing worktree isolation.
+            sub_agent = SubAgent(llm=self.llm, system_prompt=system_prompt, use_isolation=True)
+            task_description = task_spec.get('description', 'Unknown task')
+            return await sub_agent.execute(task=task_description, context=context)
+
+        # Run all subagents concurrently
+        results = await asyncio.gather(*(run_subagent(task) for task in tasks), return_exceptions=False)
+        return list(results)

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -1,0 +1,64 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from magda_agent.agents.subagents import SubagentsManager
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_subagents_manager_spawn_and_execute_parallel():
+    """
+    Tests that SubagentsManager correctly spawns sub-agents and executes them in parallel.
+    """
+    llm_mock = MagicMock(spec=LLMClient)
+    manager = SubagentsManager(llm=llm_mock)
+
+    tasks = [
+        {"description": "Task 1: Search logs", "system_prompt": "You are a log searcher."},
+        {"description": "Task 2: Analyze performance"},
+        {"description": "Task 3: Write report"}
+    ]
+
+    with patch('magda_agent.agents.subagents.SubAgent') as MockSubAgent:
+        # We need to mock the execute method of the instantiated SubAgent
+        mock_sub_agent_instance = MagicMock()
+        MockSubAgent.return_value = mock_sub_agent_instance
+
+        async def mock_execute(task, context):
+            await asyncio.sleep(0.01) # Sleep to simulate work and parallel execution
+            return f"Result for {task}"
+
+        mock_sub_agent_instance.execute = AsyncMock(side_effect=mock_execute)
+
+        results = await manager.spawn_and_execute_parallel(tasks=tasks, context="System Context")
+
+        assert len(results) == 3
+        assert results == [
+            "Result for Task 1: Search logs",
+            "Result for Task 2: Analyze performance",
+            "Result for Task 3: Write report"
+        ]
+
+        assert MockSubAgent.call_count == 3
+
+        # Verify that SubAgent was instantiated with use_isolation=True
+        # Task 1
+        MockSubAgent.assert_any_call(llm=llm_mock, system_prompt="You are a log searcher.", use_isolation=True)
+        # Task 2
+        MockSubAgent.assert_any_call(llm=llm_mock, system_prompt=None, use_isolation=True)
+
+        assert mock_sub_agent_instance.execute.call_count == 3
+        mock_sub_agent_instance.execute.assert_any_call(task="Task 1: Search logs", context="System Context")
+        mock_sub_agent_instance.execute.assert_any_call(task="Task 2: Analyze performance", context="System Context")
+        mock_sub_agent_instance.execute.assert_any_call(task="Task 3: Write report", context="System Context")
+
+@pytest.mark.asyncio
+async def test_subagents_manager_empty_tasks():
+    """
+    Tests SubagentsManager with an empty task list.
+    """
+    llm_mock = MagicMock(spec=LLMClient)
+    manager = SubagentsManager(llm=llm_mock)
+
+    results = await manager.spawn_and_execute_parallel(tasks=[], context="System Context")
+    assert results == []


### PR DESCRIPTION
This PR implements the `claude-subagent-spawning-teams` task from the backlog, which brings Claude SDK-inspired subagent spawning functionality to Magda.

Key changes:
1. Created `SubagentsManager` to dynamically instantiate isolated `SubAgent` components (`use_isolation=True`) and run them concurrently using `asyncio.gather`.
2. Created corresponding unit tests in `tests/test_subagents.py`.
3. Validated and updated `agent_tasks.json`, properly marking the current task as done and adding 3 new trend-inspired tasks (WebArena v2, MCP action tools dynamic loading, OpenClaw RL v9) to maintain minimum queue bounds.
4. Confirmed full test suite passes with 0 regressions.

---
*PR created automatically by Jules for task [17636218442679495409](https://jules.google.com/task/17636218442679495409) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SubagentsManager` to spawn and execute subagents in parallel
> - Introduces [`SubagentsManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/240/files#diff-f5c39b1db7cba8e9cedb6c5ee8d9b95de55e990e59d6ad65e3042d197d1385b2) with a `spawn_and_execute_parallel` coroutine that runs multiple task descriptions concurrently via `asyncio.gather`.
> - Each subagent is instantiated with `use_isolation=True` and an optional `system_prompt`, matching Claude-style isolated execution semantics.
> - Adds tests in [`tests/test_subagents.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/240/files#diff-5f6901392b59de6a3d0d9e6698ce8b6ce11b789efca7bdf7fb088e27d27df260) covering parallel spawning with ordered results and empty-task-list behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 629016d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->