### PR TITLE
Complete longitudinal quality metrics task

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4515,7 +4515,7 @@
     },
     {
       "id": "longitudinal-quality-metrics-v3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Longitudinal quality metrics v3",
@@ -7965,6 +7965,57 @@
       "acceptance": [
         "Agent adjusts policies based on conversation PAD shifts.",
         "Tests verify that positive feedback reinforces recent habits."
+      ]
+    },
+    {
+      "id": "a2a-workflow-chaining-b3c1a29f",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Workflow Chaining",
+      "description": "Inspired by A2A open standard trend: Implement an A2A workflow manager that allows peer-to-peer chaining of agent tasks natively without a central coordinator.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_workflow.py",
+        "tests/test_a2a_workflow.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A Workflow manager orchestrates sequential task handoffs correctly.",
+        "Tests verify that context is passed accurately between chained steps."
+      ]
+    },
+    {
+      "id": "context-eviction-policy-v1-987a1f5c",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Eviction Policy v1",
+      "description": "Inspired by Context Engine trends: Implement an explicit, priority-based context eviction policy module to gracefully discard low-priority items from working memory when approaching 1M token limits.",
+      "allowed_paths": [
+        "magda_agent/memory/eviction.py",
+        "tests/test_eviction.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Eviction module correctly filters and removes low-priority context items.",
+        "Tests verify prioritization logic handles edge cases appropriately."
+      ]
+    },
+    {
+      "id": "subagent-heartbeat-monitor-74d1a2f1",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Subagent Heartbeat Monitor",
+      "description": "Inspired by Agent Teams isolation trend: Implement a monitor in SubagentSpawner to track heartbeat signals from Git worktree-isolated subagents to detect deadlocks.",
+      "allowed_paths": [
+        "magda_agent/agents/heartbeat.py",
+        "tests/test_heartbeat.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Monitor triggers an alert when a subagent fails to send a heartbeat within the timeout window.",
+        "Tests mock processes to ensure deadlock detection behaves correctly."
       ]
     }
   ]

--- a/magda_agent/metacognition/__init__.py
+++ b/magda_agent/metacognition/__init__.py
@@ -4,7 +4,10 @@ from magda_agent.metacognition.confidence import ConfidenceCalibrator
 from magda_agent.metacognition.tracker import QualityTracker
 from magda_agent.metacognition.failure_patterns import FailurePatternTracker
 
+from magda_agent.metacognition.metrics import LongitudinalMetrics
+
 # Global instance for tracking continuous improvement metrics
 quality_tracker = QualityTracker()
+longitudinal_metrics = LongitudinalMetrics()
 
-__all__ = ["AssertEvaluator", "Evaluator", "QualityTracker", "quality_tracker", "FailurePatternTracker", "ConfidenceCalibrator"]
+__all__ = ["AssertEvaluator", "Evaluator", "QualityTracker", "quality_tracker", "FailurePatternTracker", "ConfidenceCalibrator", "LongitudinalMetrics", "longitudinal_metrics"]

--- a/magda_agent/metacognition/metrics.py
+++ b/magda_agent/metacognition/metrics.py
@@ -1,0 +1,122 @@
+import sqlite3
+import logging
+from typing import Optional, List, Dict, Any
+
+class LongitudinalMetrics:
+    """
+    LongitudinalMetrics logs continuous improvement metrics specifically for
+    test success rates over time.
+    It stores these metrics persistently in a SQLite database.
+    """
+    def __init__(self, db_path: str = "./metrics_db.sqlite3") -> None:
+        """
+        Initialize the LongitudinalMetrics with a SQLite database.
+
+        Args:
+            db_path (str): Path to store the DB, or ':memory:' for an ephemeral database.
+        """
+        self.db_path = db_path
+        # If it's an in-memory DB, we must keep the connection open to retain data
+        self._memory_conn = sqlite3.connect(':memory:') if self.db_path == ':memory:' else None
+        self._init_db()
+        logging.info(f"Initialized LongitudinalMetrics with database: {db_path}")
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Returns a connection to the database."""
+        if self._memory_conn:
+            return self._memory_conn
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self) -> None:
+        """Initializes the database schema for longitudinal tracking."""
+        conn = self._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS test_success_rates (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    test_suite TEXT NOT NULL,
+                    success_rate REAL NOT NULL,
+                    total_tests INTEGER NOT NULL,
+                    passed_tests INTEGER NOT NULL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+            conn.commit()
+        finally:
+            if not self._memory_conn:
+                conn.close()
+
+    def log_test_success_rate(self, test_suite: str, total_tests: int, passed_tests: int) -> None:
+        """
+        Logs the test success rate for a given test suite execution.
+
+        Args:
+            test_suite (str): The name or identifier of the test suite.
+            total_tests (int): The total number of tests executed.
+            passed_tests (int): The number of tests that passed.
+        """
+        if total_tests <= 0:
+            logging.warning("Cannot log success rate with total_tests <= 0")
+            return
+
+        success_rate = (passed_tests / total_tests) * 100.0
+
+        try:
+            conn = self._get_connection()
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''INSERT INTO test_success_rates
+                       (test_suite, success_rate, total_tests, passed_tests)
+                       VALUES (?, ?, ?, ?)''',
+                    (test_suite, success_rate, total_tests, passed_tests)
+                )
+                conn.commit()
+            finally:
+                if not self._memory_conn:
+                    conn.close()
+            logging.debug(f"Logged test success rate for '{test_suite}': {success_rate:.2f}%")
+        except Exception as e:
+            logging.error(f"Failed to log test success rate for '{test_suite}': {e}")
+
+    def get_success_rates(self, test_suite: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """
+        Retrieves recent success rates for a specific test suite.
+
+        Args:
+            test_suite (str): The name of the test suite to retrieve.
+            limit (int): The maximum number of entries to return.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries containing success rate data.
+        """
+        try:
+            conn = self._get_connection()
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''SELECT success_rate, total_tests, passed_tests, timestamp
+                       FROM test_success_rates
+                       WHERE test_suite = ?
+                       ORDER BY timestamp DESC LIMIT ?''',
+                    (test_suite, limit)
+                )
+                rows = cursor.fetchall()
+            finally:
+                if not self._memory_conn:
+                    conn.close()
+
+            results = []
+            for row in rows:
+                success_rate, total_tests, passed_tests, timestamp = row
+                results.append({
+                    'success_rate': success_rate,
+                    'total_tests': total_tests,
+                    'passed_tests': passed_tests,
+                    'timestamp': timestamp
+                })
+            return results
+        except Exception as e:
+            logging.error(f"Failed to retrieve success rates for '{test_suite}': {e}")
+            return []

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,4 @@
+from magda_agent.metacognition.metrics import LongitudinalMetrics
 import pytest
 import sys
 import io
@@ -116,3 +117,39 @@ def test_metrics_cli_list_empty(capsys: pytest.CaptureFixture[str]) -> None:
     finally:
         if os.path.exists(db_path):
             os.remove(db_path)
+
+
+
+@pytest.fixture
+def longitudinal_metrics():
+    """Provides a LongitudinalMetrics instance using an ephemeral SQLite database for testing."""
+    return LongitudinalMetrics(db_path=":memory:")
+
+def test_longitudinal_metrics_log_and_get(longitudinal_metrics):
+    """Test logging and retrieving test success rates."""
+    longitudinal_metrics.log_test_success_rate("core_suite", 100, 95)
+    longitudinal_metrics.log_test_success_rate("core_suite", 50, 50)
+
+    rates = longitudinal_metrics.get_success_rates("core_suite")
+    assert len(rates) == 2
+
+    # The rates should have both 100.0 and 95.0
+    success_rates = [r['success_rate'] for r in rates]
+    assert 100.0 in success_rates
+    assert 95.0 in success_rates
+
+def test_longitudinal_metrics_log_zero_total(longitudinal_metrics, caplog):
+    """Test logging test success rate with zero total tests."""
+    longitudinal_metrics.log_test_success_rate("empty_suite", 0, 0)
+
+    rates = longitudinal_metrics.get_success_rates("empty_suite")
+    assert len(rates) == 0
+    assert "Cannot log success rate with total_tests <= 0" in caplog.text
+
+def test_longitudinal_metrics_limit(longitudinal_metrics):
+    """Test that retrieval respects the limit parameter."""
+    for i in range(15):
+        longitudinal_metrics.log_test_success_rate("loop_suite", 10, i % 10)
+
+    rates = longitudinal_metrics.get_success_rates("loop_suite", limit=5)
+    assert len(rates) == 5


### PR DESCRIPTION
Implemented the LongitudinalMetrics tracking class with sqlite persistence, added 3 new todo tasks based on trends, updated agent_tasks.json, and added test cases.

---
*PR created automatically by Jules for task [1500850180147926802](https://jules.google.com/task/1500850180147926802) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add longitudinal test success rate tracking with SQLite persistence
> - Adds a new `LongitudinalMetrics` class in [`magda_agent/metacognition/metrics.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/242/files#diff-8ff4977d080a8ee18e723b831ff21e188070a37c738b38f03cd69b874f88aa5e) that logs and retrieves per-suite test success rates using SQLite.
> - Exposes `LongitudinalMetrics` and a pre-instantiated `longitudinal_metrics` singleton from the `magda_agent.metacognition` module.
> - Adds tests in [`tests/test_metrics.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/242/files#diff-c013839ae9f8d11da7ba9ed964de9d4b9ef733c1dd3d1a5487f32a5b2062e1cf) covering logging, retrieval, zero-total handling, and limit enforcement using an in-memory DB.
> - Risk: importing `magda_agent.metacognition` now creates `./metrics_db.sqlite3` on disk if it does not already exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5eb7805.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->