### PR TITLE
Implement MCPKernel Taint Tracking and Sandboxed Execution

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4532,7 +4532,7 @@
     },
     {
       "id": "mcpkernel-sandboxed-execution",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "high",
       "title": "MCPKernel: Taint Tracking and Sandboxed Execution",
@@ -8016,6 +8016,57 @@
       "acceptance": [
         "Monitor triggers an alert when a subagent fails to send a heartbeat within the timeout window.",
         "Tests mock processes to ensure deadlock detection behaves correctly."
+      ]
+    },
+    {
+      "id": "openclaw-rl-metrics-v2-unique",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Metrics System v2",
+      "description": "Inspired by OpenClaw trend: Implement an online reinforcement learning metrics system to capture longitudinal quality updates based on next-state signals.",
+      "allowed_paths": [
+        "magda_agent/learning/metrics_v2.py",
+        "tests/test_rl_metrics_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL Metrics System correctly captures and logs next-state signals.",
+        "Tests pass correctly mocking LLM client."
+      ]
+    },
+    {
+      "id": "a2a-discovery-v3-unique",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Discovery v3 (Agent Cards)",
+      "description": "Inspired by A2A open standard trend: Implement an Agent Discovery service using Agent Cards for asynchronous peer-to-peer task delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v3_unique.py",
+        "tests/test_a2a_discovery_v3_unique.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A Discovery service properly parses Agent Cards.",
+        "Tests verify A2A protocol behavior."
+      ]
+    },
+    {
+      "id": "mcp-kernel-runtime-v4-unique",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Kernel Runtime v4",
+      "description": "Inspired by MCPKernel taint tracking trend: Implement the MCP Kernel Runtime module that acts as a runtime proxy enforcing taint policy for tool calls.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_kernel_runtime_v4.py",
+        "tests/test_mcp_kernel_runtime_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Kernel properly intercepts and enforces taint tracking.",
+        "Tests mock the runtime proxy accurately."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -211,3 +211,4 @@
 
 * [x] MODULE: **Agent Teams Worktree Isolation** — `claude-subagent-worktree`.
   Implemented SubAgent isolation using GitWorktreeManager.
+* [x] FEATURE: MCPKernel: Taint Tracking and Sandboxed Execution (mcpkernel-sandboxed-execution)

--- a/tests/test_mcp_kernel.py
+++ b/tests/test_mcp_kernel.py
@@ -50,3 +50,11 @@ print("import os; os.system('id')")
 """
     with pytest.raises(SecurityError, match="Code contains unsafe operations"):
         kernel.execute(code)
+
+def test_mcp_kernel_blocks_tainted_input() -> None:
+    """Test blocking of tainted inputs."""
+    kernel = MCPKernel()
+    from magda_agent.security.mcp_kernel_taint import mark_tainted
+    code = mark_tainted("x = 5")
+    with pytest.raises(SecurityError, match="Code is tainted and unsafe to execute."):
+        kernel.execute(code)


### PR DESCRIPTION
Completed task mcpkernel-sandboxed-execution in agent_tasks.json. I verified that the code for `magda_agent/security/mcp_kernel_taint.py` and `magda_agent/security/mcp_kernel.py` already implements the taint tracking behavior, so I added a specific test to explicitly verify it. I updated the task's status to "done" in `agent_tasks.json`, added an entry in `backlog.md`, and generated 3 new trend-inspired tasks as requested.

---
*PR created automatically by Jules for task [9705125525023809869](https://jules.google.com/task/9705125525023809869) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add taint tracking and sandboxed execution to `MCPKernel`
> - Introduces `MCPKernel.execute`, which checks for tainted code before running it, raising `SecurityError` with the message "Code is tainted and unsafe to execute."
> - Adds `mark_tainted` in `magda_agent.security.mcp_kernel_taint` to flag code strings as unsafe.
> - Adds a test in [tests/test_mcp_kernel.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/243/files#diff-35dae0f7df75c2b4c4a533daadb58bce6af7fbd6f2866e9d57af4efb14da5a7f) verifying that tainted code passed to `MCPKernel.execute` raises `SecurityError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8da866.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->