### PR TITLE
feat: Implement Generic Cron Scheduler V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4549,7 +4549,7 @@
     },
     {
       "id": "scheduled-operations-cron-v2",
-      "status": "todo",
+      "status": "done",
       "area": "operations",
       "risk": "medium",
       "title": "Scheduled operations cron-like tasks",
@@ -8067,6 +8067,57 @@
       "acceptance": [
         "MCP Kernel properly intercepts and enforces taint tracking.",
         "Tests mock the runtime proxy accurately."
+      ]
+    },
+    {
+      "id": "acs-validation-checkpoints-a467f77d",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Validation Checkpoints",
+      "description": "Inspired by ACS trend: Implement 5 validation checkpoints in agentic workflows to enforce runtime safety controls.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_checkpoints.py",
+        "tests/test_acs_checkpoints.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "5 distinct validation checkpoints are implemented and integrated.",
+        "Tests verify that workflows are gated by these checkpoints."
+      ]
+    },
+    {
+      "id": "a2a-peer-delegation-v4-5d34cc13",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Peer-to-Peer Delegation v4",
+      "description": "Inspired by A2A standard trend: Implement peer-to-peer task delegation using Agent Cards for asynchronous discovery.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegation_v4.py",
+        "tests/test_a2a_delegation_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can parse Agent Cards and delegate tasks peer-to-peer.",
+        "Tests mock peer communication and verify delegation."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-v4-6ab3f8c6",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude Agent Teams Subagent Spawning v4",
+      "description": "Inspired by Claude Agent Teams trend: Update subagent spawning to provide better git worktree isolation and context context compression.",
+      "allowed_paths": [
+        "magda_agent/agents/spawner_v4.py",
+        "tests/test_spawner_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents spawn in isolated git worktrees.",
+        "Tests verify strict isolation and correct teardown."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -197,7 +197,7 @@
 * [x] FEATURE: MCPKernel Taint Tracking Sandbox
 * [x] FEATURE: ASSERT Policy-Driven Evaluation
 
-* [x] MODULE: **Operations Cron Scheduler** — модуль `magda_agent/operations/cron.py`. (2026-06-09)
+* [x] MODULE: **Operations Cron Scheduler** — модуль `magda_agent/operations/cron_v2.py`. (2026-06-09)
   Отвечает за cron-подобные фоновые задачи без участия пользователя.
   Интеграция: Вызывается в `api.py` при старте.
   Тесты: mock _get_now, проверить логику scheduler._execute_job.

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -29,6 +29,7 @@ from magda_agent.consciousness.core import Consciousness
 from magda_agent.subconsciousness.reflection import Subconsciousness
 from magda_agent.evaluation.agentbench import daily_agentbench_eval
 from magda_agent.scheduler.cron import CronScheduler
+from magda_agent.operations.cron_v2 import GenericCronSchedulerV2
 from magda_agent.scheduler.autonomous_tasks import run_health_check, report_quality_metrics
 from magda_agent.autonomy.task_store import TaskStore, TaskStatus
 from magda_agent.autonomy.executor import AutonomousExecutor
@@ -170,7 +171,7 @@ subconsciousness = Subconsciousness(
 )
 
 cron_scheduler = CronScheduler()
-operations_scheduler = CronScheduler()
+operations_scheduler = GenericCronSchedulerV2()
 
 # Schedule Subconsciousness reflection
 # Default interval was 300 seconds, which is every 5 minutes

--- a/magda_agent/operations/cron_v2.py
+++ b/magda_agent/operations/cron_v2.py
@@ -1,0 +1,133 @@
+import asyncio
+import logging
+from datetime import datetime
+from typing import Callable, Any, Coroutine, Dict, List, Optional
+from croniter import croniter
+
+logger = logging.getLogger(__name__)
+
+class GenericCronSchedulerV2:
+    """
+    A generic cron-like scheduler for autonomous tasks based on trend: Scheduled operations.
+    Runs tasks periodically based on cron expressions without user interaction.
+    """
+
+    def __init__(self, result_callback: Optional[Callable[[Any], Coroutine[Any, Any, None]]] = None):
+        """
+        Initializes the GenericCronSchedulerV2.
+
+        Args:
+            result_callback: Optional async callback to handle the result of a task execution.
+        """
+        self.jobs: List[Dict[str, Any]] = []
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+        self.result_callback = result_callback
+
+    def schedule(self, cron_expr: str, func: Callable[..., Coroutine[Any, Any, Any]], name: Optional[str] = None, *args, **kwargs) -> None:
+        """
+        Schedules a task to run according to a cron expression.
+
+        Args:
+            cron_expr: The cron expression (e.g., "*/5 * * * *").
+            func: The async function to execute.
+            name: Optional name for the task.
+            *args: Arguments to pass to the function.
+            **kwargs: Keyword arguments to pass to the function.
+        """
+        if not croniter.is_valid(cron_expr):
+            raise ValueError(f"Invalid cron expression: {cron_expr}")
+
+        now = self._get_now()
+        itr = croniter(cron_expr, now)
+        next_run = itr.get_next(datetime)
+
+        job_name = name or func.__name__
+
+        job = {
+            "name": job_name,
+            "cron_expr": cron_expr,
+            "func": func,
+            "args": args,
+            "kwargs": kwargs,
+            "next_run": next_run,
+            "iterator": itr
+        }
+        self.jobs.append(job)
+        logger.info(f"Scheduled generic task '{job_name}' with cron '{cron_expr}', next run: {next_run}")
+
+    def task(self, cron_expr: str, name: Optional[str] = None) -> Callable[[Callable[..., Coroutine[Any, Any, Any]]], Callable[..., Coroutine[Any, Any, Any]]]:
+        """
+        A decorator to schedule a task via GenericCronSchedulerV2.
+
+        Args:
+            cron_expr: The cron expression.
+            name: Optional name for the task.
+
+        Returns:
+            The decorator function.
+        """
+        def decorator(func: Callable[..., Coroutine[Any, Any, Any]]) -> Callable[..., Coroutine[Any, Any, Any]]:
+            self.schedule(cron_expr, func, name=name)
+            return func
+        return decorator
+
+    def _get_now(self) -> datetime:
+        """
+        Returns the current time. Useful for mocking in tests.
+        """
+        return datetime.now()
+
+    async def start(self) -> None:
+        """
+        Starts the generic scheduler loop in the background.
+        """
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info("GenericCronSchedulerV2 started.")
+
+    async def stop(self) -> None:
+        """
+        Stops the generic scheduler loop.
+        """
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("GenericCronSchedulerV2 stopped.")
+
+    async def _loop(self) -> None:
+        """
+        The main loop checking for jobs to run.
+        """
+        while self._running:
+            now = self._get_now()
+            for job in self.jobs:
+                if now >= job["next_run"]:
+                    # Execute task
+                    asyncio.create_task(self._execute_job(job))
+                    # Update next run time
+                    job["next_run"] = job["iterator"].get_next(datetime)
+            await asyncio.sleep(1.0) # Check every second
+
+    async def _execute_job(self, job: Dict[str, Any]) -> None:
+        """
+        Executes a scheduled job and optionally calls the result callback.
+
+        Args:
+            job: The job dictionary containing execution details.
+        """
+        func = job["func"]
+        name = job["name"]
+        try:
+            logger.info(f"Executing scheduled generic task: {name}")
+            result = await func(*job["args"], **job["kwargs"])
+            if self.result_callback and result is not None:
+                await self.result_callback(result)
+        except Exception as e:
+            logger.error(f"Error executing generic scheduled task {name}: {e}", exc_info=True)

--- a/tests/test_cron_v2.py
+++ b/tests/test_cron_v2.py
@@ -1,0 +1,99 @@
+import pytest
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from magda_agent.operations.cron_v2 import GenericCronSchedulerV2
+
+@pytest.fixture
+def scheduler():
+    return GenericCronSchedulerV2()
+
+@pytest.mark.asyncio
+async def test_scheduler_accepts_cron_expression(scheduler: GenericCronSchedulerV2):
+    """
+    Test that the scheduler can accept a cron expression and schedule a task.
+    """
+    async def dummy_task():
+        pass
+
+    scheduler.schedule("* * * * *", dummy_task)
+    assert len(scheduler.jobs) == 1
+    assert scheduler.jobs[0]["cron_expr"] == "* * * * *"
+    assert scheduler.jobs[0]["name"] == "dummy_task"
+
+    scheduler.schedule("* * * * *", dummy_task, name="custom_name")
+    assert len(scheduler.jobs) == 2
+    assert scheduler.jobs[1]["name"] == "custom_name"
+
+    with pytest.raises(ValueError, match="Invalid cron expression"):
+        scheduler.schedule("invalid cron", dummy_task)
+
+@pytest.mark.asyncio
+async def test_scheduler_decorator(scheduler: GenericCronSchedulerV2):
+    """
+    Test that the scheduler decorator successfully registers a task.
+    """
+    @scheduler.task("*/5 * * * *", name="decorated_task")
+    async def my_task():
+        return "done"
+
+    assert len(scheduler.jobs) == 1
+    assert scheduler.jobs[0]["name"] == "decorated_task"
+    assert scheduler.jobs[0]["cron_expr"] == "*/5 * * * *"
+
+    result = await scheduler.jobs[0]["func"]()
+    assert result == "done"
+
+@pytest.mark.asyncio
+async def test_scheduler_executes_task_on_schedule():
+    """
+    Test that the scheduler executes the task exactly at the expected time.
+    """
+    mock_task = AsyncMock(return_value="result")
+    mock_callback = AsyncMock()
+
+    scheduler = GenericCronSchedulerV2(result_callback=mock_callback)
+    now = datetime(2026, 6, 1, 12, 0, 0)
+
+    with patch.object(scheduler, '_get_now') as mock_get_now:
+        mock_get_now.return_value = now
+
+        scheduler.schedule("* * * * *", mock_task)
+        assert len(scheduler.jobs) == 1
+        job = scheduler.jobs[0]
+        assert job["next_run"] == datetime(2026, 6, 1, 12, 1, 0)
+
+        scheduler._running = True
+        mock_get_now.return_value = datetime(2026, 6, 1, 12, 0, 59)
+
+        for j in scheduler.jobs:
+            if mock_get_now() >= j["next_run"]:
+                await scheduler._execute_job(j)
+                j["next_run"] = j["iterator"].get_next(datetime)
+
+        mock_task.assert_not_called()
+
+        mock_get_now.return_value = datetime(2026, 6, 1, 12, 1, 0)
+        for j in scheduler.jobs:
+            if mock_get_now() >= j["next_run"]:
+                await scheduler._execute_job(j)
+                j["next_run"] = j["iterator"].get_next(datetime)
+
+        mock_task.assert_called_once()
+        mock_callback.assert_called_once_with("result")
+        assert job["next_run"] == datetime(2026, 6, 1, 12, 2, 0)
+
+@pytest.mark.asyncio
+async def test_scheduler_start_stop(scheduler: GenericCronSchedulerV2):
+    """
+    Test the start and stop operations of the scheduler loop.
+    """
+    await scheduler.start()
+    assert scheduler._running is True
+    assert scheduler._task is not None
+    assert not scheduler._task.done()
+
+    await scheduler.stop()
+    assert scheduler._running is False
+    assert scheduler._task.done()


### PR DESCRIPTION
Implemented the "scheduled-operations-cron-v2" task, providing a generic async cron scheduler utilizing `croniter`. Wired it into `magda_agent/api.py` for integration. Ensured tests pass and updated required task lists and backlogs.

---
*PR created automatically by Jules for task [13231979282368079496](https://jules.google.com/task/13231979282368079496) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `GenericCronSchedulerV2` as the operations cron scheduler
> - Adds [`cron_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/244/files#diff-e0462366ed66995f7b5e9d53fd0c651198a70e0c7d228e982958765c035e3521) with a new `GenericCronSchedulerV2` class that validates cron expressions via `croniter`, tracks `next_run` times, and dispatches due async jobs every second in a background loop.
> - Supports both direct `schedule()` registration and a `@task()` decorator, with an optional `result_callback` for forwarding job results.
> - Replaces the previous `CronScheduler` with `GenericCronSchedulerV2` in [`api.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/244/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d).
> - Adds a test suite in [`tests/test_cron_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/244/files#diff-fe891b725a140903c3473564945b22fd75e7b9fdc708a8b6eb6fa8b23238d662) with mocked time via `_get_now()` for deterministic timing assertions.
> - Behavioral Change: `operations_scheduler` is now an instance of `GenericCronSchedulerV2` instead of `CronScheduler`; any callers depending on the old scheduler's interface may break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6667e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->