### PR TITLE
Implement Online learning from dialogue v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4583,7 +4583,7 @@
     },
     {
       "id": "online-learning-from-dialogue-v3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from dialogue v3",
@@ -8169,6 +8169,57 @@
       "acceptance": [
         "Policy layer correctly evaluates dynamic rules and allows/blocks calls.",
         "Tests verify dynamic policy blocking capability."
+      ]
+    },
+    {
+      "id": "context-engine-plugin-v5-48fa1bc2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Plugin v5",
+      "description": "Inspired by Context Engine trend: Implement a newer version of the Context Engine plugin architecture allowing dynamic unregistering of hooks at runtime.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_v5.py",
+        "tests/test_context_engine_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine allows dynamic unregistering of hooks.",
+        "Tests verify runtime addition and removal of context hooks."
+      ]
+    },
+    {
+      "id": "claude-multi-agent-v2-38d01b1a",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude Multi Agent Teams v2",
+      "description": "Inspired by Claude Agent Teams trend: Update the multi-agent task execution planner to handle dependency graphs internally instead of sequentially processing sub-agents.",
+      "allowed_paths": [
+        "magda_agent/agents/multi_agent_v2.py",
+        "tests/test_multi_agent_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner correctly builds and processes a DAG of sub-agent dependencies.",
+        "Tests verify parallel execution of non-dependent tasks."
+      ]
+    },
+    {
+      "id": "mcp-server-prefixed-tools-v3-8d19abf1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Server-Prefixed Tools v3",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement tool namespacing where MCP action tools are prefixed with the server ID automatically.",
+      "allowed_paths": [
+        "magda_agent/mcp/prefixed_tools_v3.py",
+        "tests/test_prefixed_tools_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP tools are automatically registered with server-id prefixing.",
+        "Tests verify correct invocation by namespace."
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -40,6 +40,7 @@ from magda_agent.metacognition.confidence import ConfidenceCalibrator
 from magda_agent.metacognition.tracker import QualityTracker
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.learning.online import OnlineLearner
+from magda_agent.learning.dialogue_v3 import DialogueOnlineLearnerV3
 from magda_agent.learning.online_rl import OnlineRLIntegrator
 from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
 from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
@@ -91,6 +92,8 @@ online_rl_integrator = OnlineRLIntegrator(
     habit_tracker=habit_tracker,
     mirror_neurons=mirror_neurons
 )
+
+dialogue_online_learner_v3 = DialogueOnlineLearnerV3()
 
 online_rl_v6 = OnlineRLFeedbackLoopV6(
     habit_tracker=habit_tracker,
@@ -152,6 +155,7 @@ consciousness = Consciousness(
     online_learner=online_learner,
     online_rl_integrator=online_rl_integrator,
     online_rl_v6=online_rl_v6,
+    dialogue_online_learner_v3=dialogue_online_learner_v3,
     openclaw_rl=openclaw_rl,
     feedback_loop=feedback_loop,
     guardrail=guardrail,

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -26,6 +26,7 @@ from magda_agent.emotions.mirror_neurons import MirrorNeurons
 from magda_agent.emotions.style_adapter import StyleAdapter
 from magda_agent.user_model.model import UserModel
 from magda_agent.learning.online import OnlineLearner
+from magda_agent.learning.dialogue_v3 import DialogueOnlineLearnerV3
 from magda_agent.learning.online_rl import OnlineRLIntegrator
 from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
 from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
@@ -69,6 +70,7 @@ class Consciousness:
         online_learner: Optional[OnlineLearner] = None,
         online_rl_integrator: Optional[OnlineRLIntegrator] = None,
         online_rl_v6: Optional[OnlineRLFeedbackLoopV6] = None,
+        dialogue_online_learner_v3: Optional[DialogueOnlineLearnerV3] = None,
         openclaw_rl: Optional[OpenClawInteractiveLearner] = None,
         feedback_loop: Optional[FeedbackLoop] = None,
         guardrail: Optional[RealtimeGuardrail] = None,
@@ -103,6 +105,7 @@ class Consciousness:
         self.online_learner = online_learner
         self.online_rl_integrator = online_rl_integrator
         self.online_rl_v6 = online_rl_v6
+        self.dialogue_online_learner_v3 = dialogue_online_learner_v3
         self.openclaw_rl = openclaw_rl
         self.feedback_loop = feedback_loop
         self.guardrail = guardrail
@@ -163,6 +166,8 @@ class Consciousness:
             )
         if self.online_rl_v6:
             await self.online_rl_v6.adjust_behavior(user_input, last_context, user_id)
+        if getattr(self, 'dialogue_online_learner_v3', None):
+            self.dialogue_online_learner_v3.process_turn(user_input, None)
 
 
         if self.thalamus and not self.thalamus.filter_input(user_input):
@@ -328,6 +333,11 @@ class Consciousness:
                 style_modifier = self.style_adapter.get_style_prompt(pad_state, um)
                 if style_modifier:
                     system_prompt += f"\n\n{style_modifier}"
+
+            if getattr(self, 'dialogue_online_learner_v3', None):
+                v3_mods = self.dialogue_online_learner_v3.get_context_modifiers()
+                if v3_mods:
+                    system_prompt += f"\n\n{v3_mods}"
 
             if plan_str:
                 system_prompt += f"\n\n{plan_str}\nUse the plan results to generate the final response."

--- a/magda_agent/learning/dialogue_v3.py
+++ b/magda_agent/learning/dialogue_v3.py
@@ -1,0 +1,56 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+class DialogueOnlineLearnerV3:
+    """
+    Online learning from dialogue v3.
+    Extracts immediate context from conversation and dynamically adjusts agent behavior.
+    """
+    def __init__(self) -> None:
+        self.active_modifiers: List[Dict[str, Any]] = []
+
+    def process_turn(self, user_message: str, agent_response: Optional[str] = None) -> None:
+        """
+        Analyzes user message to extract immediate learning insights (preferences/constraints).
+        """
+        msg_lower = user_message.lower()
+
+        # Very basic keyword heuristics to immediately adjust context
+        if "always" in msg_lower or "must" in msg_lower:
+            insight = {
+                "type": "preference",
+                "trigger": user_message,
+                "effect": f"The user strongly prefers: '{user_message}'"
+            }
+            self.active_modifiers.append(insight)
+            logger.info(f"Learned preference from dialogue: {insight['effect']}")
+
+        elif "never" in msg_lower or "don't" in msg_lower or "do not" in msg_lower:
+            insight = {
+                "type": "constraint",
+                "trigger": user_message,
+                "effect": f"Constraint established: '{user_message}'"
+            }
+            self.active_modifiers.append(insight)
+            logger.info(f"Learned constraint from dialogue: {insight['effect']}")
+
+    def get_context_modifiers(self) -> str:
+        """
+        Returns a formatted string of active behavioral modifiers to be injected into prompts.
+        """
+        if not self.active_modifiers:
+            return ""
+
+        lines = ["--- Immediate Context Modifications ---"]
+        for mod in self.active_modifiers:
+            lines.append(f"- {mod['effect']}")
+        return "\n".join(lines)
+
+    def clear_session(self) -> None:
+        """
+        Clears the current dialogue modifiers for a new session.
+        """
+        self.active_modifiers.clear()
+        logger.info("DialogueOnlineLearnerV3 session cleared.")

--- a/tests/test_dialogue_v3.py
+++ b/tests/test_dialogue_v3.py
@@ -1,0 +1,41 @@
+import pytest
+from magda_agent.learning.dialogue_v3 import DialogueOnlineLearnerV3
+
+def test_process_turn_preference() -> None:
+    """Test extracting a preference from dialogue turn."""
+    learner = DialogueOnlineLearnerV3()
+    learner.process_turn("You must always reply in JSON format.")
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Immediate Context Modifications ---" in modifiers
+    assert "The user strongly prefers" in modifiers
+    assert "always reply in JSON format" in modifiers
+
+def test_process_turn_constraint() -> None:
+    """Test extracting a constraint from dialogue turn."""
+    learner = DialogueOnlineLearnerV3()
+    learner.process_turn("Please never use emojis.")
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Immediate Context Modifications ---" in modifiers
+    assert "Constraint established" in modifiers
+    assert "never use emojis" in modifiers
+
+def test_process_turn_no_insight() -> None:
+    """Test when no learning insight is extracted."""
+    learner = DialogueOnlineLearnerV3()
+    learner.process_turn("Hello, how are you?")
+
+    modifiers = learner.get_context_modifiers()
+    assert modifiers == ""
+    assert len(learner.active_modifiers) == 0
+
+def test_clear_session() -> None:
+    """Test clearing the active modifiers session."""
+    learner = DialogueOnlineLearnerV3()
+    learner.process_turn("You must always reply in JSON format.")
+    assert len(learner.active_modifiers) == 1
+
+    learner.clear_session()
+    assert len(learner.active_modifiers) == 0
+    assert learner.get_context_modifiers() == ""


### PR DESCRIPTION
Closes `online-learning-from-dialogue-v3` from `agent_tasks.json` backlog.
Implements dynamic context updates using immediate conversational signals (heuristics like "always", "never", etc.). Wiring to the main API and core architecture was completed securely with getattr fallbacks. All tests pass and adhere to rules against making real API calls.

---
*PR created automatically by Jules for task [15701324337504301715](https://jules.google.com/task/15701324337504301715) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyword-heuristic online learning from dialogue to inject context modifiers into system prompts
> - Adds [`DialogueOnlineLearnerV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/246/files#diff-62138c8e2b87787375791bc2292604a90b1bcd17c289e0758f4774549bb22345) which scans each user message for strong-preference cues (`always`, `must`) or constraint cues (`never`, `don't`, `do not`) and accumulates matching modifiers in memory.
> - On each turn, [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/246/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) calls `process_turn()` then prepends any modifiers to the system prompt via `get_context_modifiers()`.
> - Modifier extraction is purely keyword-based with no ML model; heuristic accuracy depends heavily on exact phrasing.
> - Risk: modifiers accumulate across turns with no automatic expiry, so early false-positive matches persist for the entire session until `clear_session()` is called.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49fa677.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->