### PR TITLE
feat: Implement ASSERT Policy-Driven Evaluator and replenish tasks queue

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4600,7 +4600,7 @@
     },
     {
       "id": "assert-policy-driven-evaluator",
-      "status": "todo",
+      "status": "done",
       "area": "evaluation",
       "risk": "medium",
       "title": "ASSERT Policy-Driven Evaluation",
@@ -8220,6 +8220,57 @@
       "acceptance": [
         "MCP tools are automatically registered with server-id prefixing.",
         "Tests verify correct invocation by namespace."
+      ]
+    },
+    {
+      "id": "mcp-kernel-sandboxed-execution-v5-new-1234",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCPKernel Sandboxed Execution v5",
+      "description": "Inspired by MCPKernel taint tracking trend: Sandbox tool execution in containers to improve security.",
+      "allowed_paths": [
+        "magda_agent/safety/sandbox_v5.py",
+        "tests/test_sandbox_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool execution is properly sandboxed.",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "memgpt-virtual-context-v3-new-5678",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "MemGPT Virtual Context Management v3",
+      "description": "Inspired by MemGPT/Letta pattern trend: Implement virtual context management for explicit memory paging.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_v3.py",
+        "tests/test_virtual_context_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Virtual context accurately pages short-term memory out/in.",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "swe-bench-verified-evaluation-suite-new-9012",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "SWE-bench Verified Evaluation Suite",
+      "description": "Inspired by SWE-bench Verified trend: Add a testing harness for evaluating the agent using SWE-bench verified tasks.",
+      "allowed_paths": [
+        "magda_agent/evals/swe_bench.py",
+        "tests/test_swe_bench.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluation suite integrates SWE-bench verified tasks.",
+        "Tests pass"
       ]
     }
   ]

--- a/magda_agent/evals/assert_policy.py
+++ b/magda_agent/evals/assert_policy.py
@@ -1,0 +1,85 @@
+import json
+import logging
+from typing import Optional, Dict, Any, List
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.emotions.engine import PADState
+
+class AssertPolicyEvaluator:
+    """
+    Metacognition: Policy-driven Evaluation framework.
+    Evaluates the agent's responses conditionally based on satisfying explicit policy documents or rules.
+    """
+    def __init__(self, llm: LLMClient, memory: MemorySystem):
+        self.llm = llm
+        self.memory = memory
+        self.last_evaluation: Optional[Dict[str, Any]] = None
+
+    async def evaluate_response_with_policy(self, user_input: str, agent_response: str, policies: List[str]) -> Optional[Dict[str, Any]]:
+        """
+        Evaluates the generated response using the LLM based on explicit policy constraints and stores the result in memory.
+        """
+        formatted_policies = "\n".join([f"- {policy}" for policy in policies])
+        prompt = (
+            "Evaluate the following response given by an AI to a user's input.\n"
+            "Score the response from 1 to 10 based on how well it adheres to the following explicit policy constraints:\n"
+            f"{formatted_policies}\n\n"
+            "Consider criteria like usefulness, accuracy, completeness, and emotional adequacy, but strictly evaluate against the provided constraints.\n\n"
+            f"User input: {user_input}\n"
+            f"AI Response: {agent_response}\n\n"
+            "Respond ONLY with a JSON object in this format:\n"
+            "{\n"
+            '  "policy_adherence_score": 8.0,\n'
+            '  "violated_policies": ["Policy description if violated, else empty"],\n'
+            '  "feedback": "A short sentence explaining the score"\n'
+            "}"
+        )
+        messages = [{"role": "system", "content": prompt}]
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.llm.chat_completion(messages, temperature=0.1)
+                # Remove any markdown formatting (e.g. ```json)
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+
+                # Store in memory
+                content = f"Policy Evaluation of response to '{user_input[:20]}...': Score: {evaluation.get('policy_adherence_score')} - {evaluation.get('feedback')}"
+                await self.memory.add_memory(
+                    content=content,
+                    importance=0.7,
+                    emotional_state=PADState(0.0, 0.0, 0.0), # Neutral PAD state for evaluation
+                    tags=["evaluation", "metacognition", "policy"]
+                )
+
+                self.last_evaluation = evaluation
+                return evaluation
+            except json.JSONDecodeError as e:
+                logging.warning(f"JSON decoding error in evaluator attempt {attempt + 1}/{max_retries}: {e}. Retrying...")
+                if attempt == max_retries - 1:
+                    logging.error("Max retries reached for evaluate_response_with_policy JSON parsing.")
+                    return None
+            except Exception as e:
+                logging.error(f"Failed to evaluate response: {e}")
+                return None
+
+    def get_feedback_for_prompt(self) -> str:
+        """
+        Returns feedback to be included in the next system prompt if the previous evaluation was low.
+        """
+        if not self.last_evaluation:
+            return ""
+
+        score = self.last_evaluation.get("policy_adherence_score", 10.0)
+        if score < 8.0:
+            feedback = self.last_evaluation.get("feedback", "Improve policy adherence.")
+            violations = self.last_evaluation.get("violated_policies", [])
+            violation_text = f" Violated policies: {', '.join(violations)}." if violations else ""
+            return f"Note: Your previous response received a low policy adherence score ({score}/10).{violation_text} Feedback: {feedback}. Please ensure strict adherence to all stated policies."
+        return ""

--- a/tests/test_assert_policy.py
+++ b/tests/test_assert_policy.py
@@ -1,0 +1,128 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.evals.assert_policy import AssertPolicyEvaluator
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+
+@pytest.fixture
+def mock_llm_client():
+    mock = AsyncMock(spec=LLMClient)
+    # Default successful mock response
+    mock_json_response = '''
+    ```json
+    {
+      "policy_adherence_score": 9.0,
+      "violated_policies": [],
+      "feedback": "Complies well with the provided policies"
+    }
+    ```
+    '''
+    mock.chat_completion.return_value = mock_json_response
+    return mock
+
+@pytest.fixture
+def mock_memory_system():
+    mock = MagicMock(spec=MemorySystem)
+    mock.add_memory = AsyncMock()
+    return mock
+
+@pytest.fixture
+def evaluator(mock_llm_client, mock_memory_system):
+    return AssertPolicyEvaluator(llm=mock_llm_client, memory=mock_memory_system)
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_success(evaluator, mock_llm_client, mock_memory_system) -> None:
+    user_input = "Hello"
+    agent_response = "Hi there!"
+    policies = ["Be polite"]
+
+    result = await evaluator.evaluate_response_with_policy(user_input, agent_response, policies)
+
+    # Assert LLM was called
+    mock_llm_client.chat_completion.assert_called_once()
+
+    # Assert policies are in the prompt
+    call_args = mock_llm_client.chat_completion.call_args[0][0]
+    assert "- Be polite" in call_args[0]["content"]
+
+    # Assert memory was added
+    mock_memory_system.add_memory.assert_called_once()
+    mem_call_args = mock_memory_system.add_memory.call_args[1]
+    assert "Score: 9.0" in mem_call_args["content"]
+    assert mem_call_args["tags"] == ["evaluation", "metacognition", "policy"]
+
+    # Assert result
+    assert result is not None
+    assert result["policy_adherence_score"] == 9.0
+    assert result["feedback"] == "Complies well with the provided policies"
+
+    # Assert state updated
+    assert evaluator.last_evaluation == result
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_no_markdown(evaluator, mock_llm_client) -> None:
+    mock_json_response = '''{
+      "policy_adherence_score": 5.0,
+      "violated_policies": ["Do not use exclamation marks"],
+      "feedback": "Failed to adhere to policy"
+    }'''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    result = await evaluator.evaluate_response_with_policy("Test", "Response!", ["Do not use exclamation marks"])
+    assert result is not None
+    assert result["policy_adherence_score"] == 5.0
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_high_score(evaluator) -> None:
+    evaluator.last_evaluation = {"policy_adherence_score": 8.5, "feedback": "Great"}
+    feedback = evaluator.get_feedback_for_prompt()
+    assert feedback == "" # Should be empty for high scores
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_low_score(evaluator) -> None:
+    evaluator.last_evaluation = {"policy_adherence_score": 4.5, "violated_policies": ["No swearing"], "feedback": "Policy violation"}
+    feedback = evaluator.get_feedback_for_prompt()
+    assert "low policy adherence score (4.5/10)" in feedback
+    assert "Violated policies: No swearing" in feedback
+    assert "Policy violation" in feedback
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_no_evaluation(evaluator) -> None:
+    feedback = evaluator.get_feedback_for_prompt()
+    assert feedback == ""
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_exception(evaluator, mock_llm_client) -> None:
+    mock_llm_client.chat_completion.side_effect = Exception("API Error")
+    result = await evaluator.evaluate_response_with_policy("Test", "Response", [])
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_retry_success(evaluator, mock_llm_client) -> None:
+    # First response is invalid JSON, second response is valid JSON
+    invalid_json_response = "this is not valid json"
+    valid_json_response = '''{
+      "policy_adherence_score": 9.0,
+      "violated_policies": [],
+      "feedback": "Retry success"
+    }'''
+    mock_llm_client.chat_completion.side_effect = [invalid_json_response, valid_json_response]
+
+    result = await evaluator.evaluate_response_with_policy("Test", "Response", [])
+
+    assert result is not None
+    assert result["policy_adherence_score"] == 9.0
+    assert result["feedback"] == "Retry success"
+    assert mock_llm_client.chat_completion.call_count == 2
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policy_retry_failure(evaluator, mock_llm_client) -> None:
+    # Always return invalid JSON
+    invalid_json_response = "still not valid json"
+    mock_llm_client.chat_completion.side_effect = [invalid_json_response, invalid_json_response, invalid_json_response]
+
+    result = await evaluator.evaluate_response_with_policy("Test", "Response", [])
+
+    assert result is None
+    assert mock_llm_client.chat_completion.call_count == 3


### PR DESCRIPTION
This PR fulfills the autonomous task to implement the ASSERT Policy-Driven Evaluator framework. 

It introduces the `AssertPolicyEvaluator` class inside `magda_agent/evals/assert_policy.py` to evaluate responses against explicit policies using the LLM. It includes full mocked test coverage for parsing and retries inside `tests/test_assert_policy.py`.

Additionally, the task has been marked complete in `agent_tasks.json`, and the `agent_tasks.json` backlog has been replenished with 3 new actionable tasks based on the latest documented AI trends.

---
*PR created automatically by Jules for task [12069356771088001939](https://jules.google.com/task/12069356771088001939) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AssertPolicyEvaluator` for LLM-driven policy assessment of agent responses
> - Introduces [`AssertPolicyEvaluator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/247/files#diff-0c8881b78ab6c55a5130317afd1b5aae481ff57b7219c0a9958c5297739a754e) which sends agent responses to an LLM for structured policy compliance scoring, returning a parsed JSON evaluation dict.
> - On success, writes a memory entry tagged `['evaluation','metacognition','policy']` with `importance=0.7` via `MemorySystem.add_memory`.
> - Retries up to 3 times on `JSONDecodeError` and returns `None` on unrecoverable failure.
> - `get_feedback_for_prompt` returns a feedback string for scores below 8.0, listing violated policies, for injection into subsequent prompts.
> - Adds a pytest suite in [`tests/test_assert_policy.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/247/files#diff-82e6b51ebb99e8d88e5ca137c08387fbdd1903d7f7bd3d9d8a3fcaf4c09ba6aa) covering success, retry, exception, and feedback paths.
> - Also replenishes [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/247/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) with three new tasks (sandboxed execution, virtual context, and evaluation suite).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ea66bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->