### PR TITLE
feat: openclaw local-first gateway implementation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4685,7 +4685,7 @@
     },
     {
       "id": "openclaw-local-first-gateway",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "high",
       "title": "OpenClaw Local-First Gateway",
@@ -8424,6 +8424,57 @@
       "acceptance": [
         "Magda can fetch and parse Agent Cards from an A2A discovery endpoint.",
         "Tests verify Agent Card parsing logic."
+      ]
+    },
+    {
+      "id": "agent-teams-git-worktree-v5-new-1111",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Agent Teams Git Worktree Isolation v5",
+      "description": "Inspired by Claude Agent SDK trend: Implement a robust git worktree per agent system to isolate sub-agent execution.",
+      "allowed_paths": [
+        "magda_agent/multi_agent/worktree_v5.py",
+        "tests/test_worktree_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agents execute in isolated git worktrees.",
+        "Tests verify worktree creation and cleanup."
+      ]
+    },
+    {
+      "id": "hermes-cron-daily-reports-new-2222",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Hermes Cron Daily Reports",
+      "description": "Inspired by Hermes agent trend: Add a scheduled daily report that summarizes agent activity and quality metrics.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_reports.py",
+        "tests/test_cron_reports.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A cron task is implemented for daily reports.",
+        "Tests verify the report generation logic."
+      ]
+    },
+    {
+      "id": "acs-guardrails-policy-layer-new-3333",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Guardrails Policy Layer",
+      "description": "Inspired by ACS Specification trend: Implement 5 validation checkpoints for tool execution safety.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guardrails.py",
+        "tests/test_acs_guardrails.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy layer enforces 5 validation checkpoints.",
+        "Tests verify that unsafe tools are blocked."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -213,3 +213,4 @@
   Implemented SubAgent isolation using GitWorktreeManager.
 * [x] FEATURE: MCPKernel: Taint Tracking and Sandboxed Execution (mcpkernel-sandboxed-execution)
 * [x] FEATURE: Cross-platform reach channels v2
+* [x] FEATURE: OpenClaw Local-First Gateway

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from magda_agent.visualization.server import CanvasServer
+from magda_agent.architecture.gateway import LocalFirstGateway
 from magda_agent.visualization.canvas_api_v2 import get_canvas_v2_router
 from pydantic import BaseModel
 
@@ -53,6 +54,7 @@ from magda_agent.emotions.insula import Insula
 from magda_agent.rhythms.pineal_gland import PinealGland
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
 from magda_agent.attention.salience import SalienceNetwork
+from magda_agent.gateway.router import GatewayRouter
 from magda_agent.attention.workspace import GlobalWorkspace
 from magda_agent.safety.guardrails import RealtimeGuardrail
 from magda_agent.memory.context_engine import ContextEngine
@@ -203,6 +205,8 @@ canvas_server = CanvasServer(consciousness=consciousness)
 a2a_server = A2AServer(planner=planner)
 rpc_manager = SubAgentRPCManager(llm=llm_client)
 cross_platform_dispatcher = CrossPlatformDispatcher()
+local_first_gateway = LocalFirstGateway()
+local_first_gateway.set_message_handler(consciousness.process_input)
 
 discord_bridge = DiscordBridge(token=os.getenv("DISCORD_BOT_TOKEN", "dummy"), agent_callback=consciousness.process_input)
 cross_platform_dispatcher.register_platform("discord", discord_bridge)

--- a/magda_agent/architecture/gateway.py
+++ b/magda_agent/architecture/gateway.py
@@ -1,0 +1,32 @@
+from typing import Any, Callable, Dict, Optional
+import asyncio
+from magda_agent.gateway.router import UnifiedMessage
+
+class LocalFirstGateway:
+    """
+    Local-first gateway as a control plane for channel routing.
+    Routes incoming channel messages to the agent core safely.
+    """
+    def __init__(self) -> None:
+        self._channels: Dict[str, Any] = {}
+        self._message_handler: Optional[Callable[[UnifiedMessage], Any]] = None
+
+    def register_channel(self, channel_id: str, channel: Any) -> None:
+        """Register a channel with the gateway control plane."""
+        self._channels[channel_id] = channel
+
+    def get_channel(self, channel_id: str) -> Any:
+        """Retrieve a registered channel by its ID."""
+        return self._channels.get(channel_id)
+
+    def set_message_handler(self, handler: Callable[[UnifiedMessage], Any]) -> None:
+        """Set the main handler that processes unified messages."""
+        self._message_handler = handler
+
+    async def route_message(self, message: UnifiedMessage) -> Any:
+        """Route an incoming message to the registered handler safely."""
+        if self._message_handler is None:
+            raise RuntimeError("No message handler registered with LocalFirstGateway")
+        if asyncio.iscoroutinefunction(self._message_handler):
+            return await self._message_handler(message)
+        return self._message_handler(message)

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -87,3 +87,33 @@ async def test_missing_handler():
 
     with pytest.raises(RuntimeError, match="No message handler registered with GatewayRouter"):
         await channel.receive(raw_telegram_msg)
+
+from magda_agent.architecture.gateway import LocalFirstGateway
+
+@pytest.mark.asyncio
+async def test_local_first_gateway_routing_safely():
+    gateway = LocalFirstGateway()
+    agent = MockAgentCore()
+    gateway.set_message_handler(agent.handle_message)
+
+    msg = UnifiedMessage(channel="local", text="Hello Control Plane", user_id="123")
+    response = await gateway.route_message(msg)
+
+    assert response == "Processed: Hello Control Plane"
+    assert len(agent.received_messages) == 1
+    assert agent.received_messages[0].channel == "local"
+    assert agent.received_messages[0].text == "Hello Control Plane"
+
+@pytest.mark.asyncio
+async def test_local_first_gateway_missing_handler():
+    gateway = LocalFirstGateway()
+    msg = UnifiedMessage(channel="local", text="Fail", user_id="123")
+
+    with pytest.raises(RuntimeError, match="No message handler registered with LocalFirstGateway"):
+        await gateway.route_message(msg)
+
+def test_local_first_gateway_channel_registration():
+    gateway = LocalFirstGateway()
+    gateway.register_channel("telegram", "TelegramAdapter")
+    assert gateway.get_channel("telegram") == "TelegramAdapter"
+    assert gateway.get_channel("discord") is None


### PR DESCRIPTION
Implemented the LocalFirstGateway module for safe channel routing as a control plane. Integrated it into magda_agent/api.py. Updated agent_tasks.json and backlog.md appropriately.

---
*PR created automatically by Jules for task [14059161150556996126](https://jules.google.com/task/14059161150556996126) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `LocalFirstGateway` for routing unified messages to agent core
> - Introduces [`LocalFirstGateway`](https://github.com/kazah4359-lgtm/Magda-agent/pull/252/files#diff-3295bd5fd4a89c923aa75ceb4dea4b7ec655d0b93354870a2cb3a39ac61b0894) with an internal channel registry and a configurable message handler, supporting both async and sync callables via `route_message`.
> - Wires the gateway into the app bootstrap in [`api.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/252/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d), routing incoming messages to `consciousness.process_input`.
> - Raises `RuntimeError` if `route_message` is called before a handler is registered.
> - Adds tests in [`tests/test_gateway.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/252/files#diff-4f0390209d7648ae2dbda296ebe43dc6e901a046b178a4e0aff1d78752ee65b7) covering routing, error handling, and channel registration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b5f50f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->