### PR TITLE
feat: implement task dependency graph planner

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4702,7 +4702,7 @@
     },
     {
       "id": "task-system-dependency-graphs",
-      "status": "todo",
+      "status": "done",
       "area": "core",
       "risk": "high",
       "title": "Task System with Dependency Graphs",
@@ -8475,6 +8475,57 @@
       "acceptance": [
         "Policy layer enforces 5 validation checkpoints.",
         "Tests verify that unsafe tools are blocked."
+      ]
+    },
+    {
+      "id": "mcp-export-skills-trend-june-2026",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Export Skills as MCP Tools",
+      "description": "Inspired by MCP trend (June 2026): Magda should be able to export its skills as MCP tools. Implement a generic wrapper to expose SkillRegistry capabilities via the MCP json-rpc server.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_export.py",
+        "tests/test_mcp_export.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be exported and called via MCP protocol.",
+        "Tests verify that MCP method calls route to the corresponding skill."
+      ]
+    },
+    {
+      "id": "online-learning-interaction-loop-june-2026",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "Online Learning from Dialog Interactions",
+      "description": "Inspired by OpenClaw-RL trend (June 2026): Learn from next-state signals like user replies to dynamically adjust agent behavior, without relying on separate reflection tasks.",
+      "allowed_paths": [
+        "magda_agent/learning/dialogue_v3.py",
+        "tests/test_dialogue_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Online RL pipeline consumes user reply signals.",
+        "Test verifies weight updates or memory writes triggered by the interaction loop."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-discovery-june-2026",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Task Delegation and Discovery",
+      "description": "Inspired by A2A Protocol trend (June 2026): Implement the ability to delegate subtasks to other agents via Agent Cards discovery.",
+      "allowed_paths": [
+        "magda_agent/agents/a2a_delegation.py",
+        "tests/test_a2a_delegation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can discover and dispatch tasks to A2A compliant peers.",
+        "Unit tests verify the A2A delegation payload format."
       ]
     }
   ]

--- a/magda_agent/core/task_graph.py
+++ b/magda_agent/core/task_graph.py
@@ -1,0 +1,79 @@
+import logging
+from typing import List, Dict, Any, Set
+
+class DependencyGraph:
+    """
+    Utility class for resolving task dependencies and computing topological sorts
+    for execution plans. Implements the dependency graph task system for Claude multi-agent orchestration.
+    """
+
+    @staticmethod
+    def get_executable_steps(plan_steps: List[Dict[str, Any]], completed_step_ids: Set[str]) -> List[Dict[str, Any]]:
+        """
+        Returns a list of steps that have all their dependencies met and are not yet completed.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries. Each should have 'id' and 'dependencies'.
+            completed_step_ids (Set[str]): A set of IDs of steps that have already been completed.
+
+        Returns:
+            List[Dict[str, Any]]: A list of steps ready for execution.
+        """
+        executable_steps = []
+        for step in plan_steps:
+            step_id = step.get("id")
+            if not step_id or step_id in completed_step_ids:
+                continue
+
+            dependencies = step.get("dependencies", [])
+            # A step is executable if all its dependencies are in completed_step_ids
+            if all(dep in completed_step_ids for dep in dependencies):
+                executable_steps.append(step)
+
+        return executable_steps
+
+    @staticmethod
+    def topological_sort(plan_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Returns a topologically sorted list of steps using Kahn's algorithm.
+        Raises ValueError if a cycle is detected.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries.
+
+        Returns:
+            List[Dict[str, Any]]: The sorted steps.
+        """
+        # Build adjacency list
+        adj: Dict[str, List[str]] = {step.get("id", ""): [] for step in plan_steps if step.get("id")}
+        in_degree: Dict[str, int] = {step.get("id", ""): 0 for step in plan_steps if step.get("id")}
+
+        step_map = {step.get("id"): step for step in plan_steps if step.get("id")}
+
+        for step in plan_steps:
+            step_id = step.get("id")
+            if not step_id:
+                continue
+            for dep in step.get("dependencies", []):
+                if dep in adj:
+                    adj[dep].append(step_id)
+                    in_degree[step_id] += 1
+                else:
+                    logging.warning(f"Dependency {dep} for step {step_id} not found in plan steps.")
+
+        # Kahn's algorithm
+        queue = [node for node, deg in in_degree.items() if deg == 0]
+        sorted_ids = []
+
+        while queue:
+            node = queue.pop(0)
+            sorted_ids.append(node)
+            for neighbor in adj.get(node, []):
+                in_degree[neighbor] -= 1
+                if in_degree[neighbor] == 0:
+                    queue.append(neighbor)
+
+        if len(sorted_ids) != len(adj):
+            raise ValueError("Cycle detected in plan dependencies")
+
+        return [step_map[node] for node in sorted_ids]

--- a/tests/test_task_graph.py
+++ b/tests/test_task_graph.py
@@ -1,5 +1,5 @@
 import pytest
-from magda_agent.planning.dependency_graph import DependencyGraph
+from magda_agent.core.task_graph import DependencyGraph
 
 def test_dag_planner_topological_sort_linear():
     plan_steps = [


### PR DESCRIPTION
Implement task dependency graph planner using Kahn's algorithm for multi-agent task execution. Resolves task 'task-system-dependency-graphs', updates agent_tasks.json, and adds three new todo tasks based on current June 2026 AI trends.

---
*PR created automatically by Jules for task [13833449988878864315](https://jules.google.com/task/13833449988878864315) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `DependencyGraph` task planner with topological sort and cycle detection
> - Adds [`magda_agent/core/task_graph.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/253/files#diff-0ba969528d9697e4578272be5ea72b04a7fe062f78f6101efc68fd7895c75369) with a `DependencyGraph` class implementing Kahn's algorithm for topological sorting and a `get_executable_steps` method that returns steps ready to run given a set of completed step IDs.
> - Creates [`magda_agent/core/__init__.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/253/files#diff-ea3b4fd8a41d6059d957c66cdb443b5eef8b45c573cf804a310a8c990b43da50) to make `magda_agent.core` an importable package.
> - Updates [`tests/test_task_graph.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/253/files#diff-3eeb88d774e119f8e95a7d1e0abf2ccfc1bac0f777f1a72882d61892fa046192) to import from `magda_agent.core.task_graph` instead of the old `magda_agent.planning.dependency_graph` path.
> - Raises `ValueError` on cyclic dependencies and logs warnings for dependency references missing from the plan.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28c0f6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->