### PR TITLE
Implement Context Compression and Selective Retrieval

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4719,7 +4719,7 @@
     },
     {
       "id": "context-compression-selective-retrieval-v2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Compression & Selective Retrieval",
@@ -8526,6 +8526,57 @@
       "acceptance": [
         "Agent can discover and dispatch tasks to A2A compliant peers.",
         "Unit tests verify the A2A delegation payload format."
+      ]
+    },
+    {
+      "id": "agent-guard-acs-checkpoints-v6",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Agent Guard ACS Checkpoints v6",
+      "description": "Inspired by ACS (Agent Control Specification) trend: Implement 5 validation checkpoints for agentic workflows, expanding the AgentGuard with taint tracking for all tool inputs.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_v6.py",
+        "tests/test_acs_guard_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS check points validate tool executions",
+        "Tests verify intercepts"
+      ]
+    },
+    {
+      "id": "openclaw-rl-metrics-tracker-v4",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Metrics Tracker v4",
+      "description": "Inspired by OpenClaw RL trend: Implement online reinforcement learning from user feedback (next-state signals) and track metrics longitudinally to ensure self-improvement quality.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_metrics_v4.py",
+        "tests/test_rl_metrics_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL Metrics Tracker logs longitudinal improvements",
+        "Tests verify metric aggregation"
+      ]
+    },
+    {
+      "id": "claude-team-git-worktrees-v6",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude Team Git Worktrees v6",
+      "description": "Inspired by Claude Agent Teams trend: Update the subagent dispatcher to isolate team processes using git worktrees seamlessly and handle cleanup robustly.",
+      "allowed_paths": [
+        "magda_agent/agents/worktree_dispatcher_v6.py",
+        "tests/test_worktree_dispatcher_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents spawn in isolated worktrees",
+        "Tests mock git and verify isolation"
       ]
     }
   ]

--- a/magda_agent/memory/compression.py
+++ b/magda_agent/memory/compression.py
@@ -1,0 +1,82 @@
+import logging
+from typing import List, Optional
+from magda_agent.memory.working import MemoryEntry
+
+class ContextCompressorSelective:
+    """
+    Handles compression of working memory prior to semantic conversion, and supports selective
+    retrieval from compressed blocks.
+    """
+    def __init__(self, llm_client=None) -> None:
+        """
+        Initializes the context compressor.
+
+        Args:
+            llm_client: Optional LLM client to use for summarization.
+        """
+        self.llm = llm_client
+
+    async def compress_entries(self, entries: List[MemoryEntry]) -> MemoryEntry:
+        """
+        Compresses a list of memory entries into a single entry.
+
+        Args:
+            entries: A list of MemoryEntry objects to compress.
+
+        Returns:
+            A new MemoryEntry object representing the compressed content.
+        """
+        if not entries:
+            raise ValueError("No entries to compress")
+
+        combined_text = "\n".join(e.content for e in entries)
+        compressed_text = combined_text
+
+        if self.llm:
+            try:
+                logging.info("Compressing old working memory entries.")
+                prompt = f"Summarize the following text, maintaining key facts:\n\n{combined_text}"
+                messages = [
+                    {"role": "system", "content": "You compress memory context. Return only the summary text."},
+                    {"role": "user", "content": prompt}
+                ]
+                compressed_text = await self.llm.chat_completion(messages, temperature=0.3)
+                compressed_text = compressed_text.strip()
+            except Exception as e:
+                logging.error(f"Compression failed: {e}")
+
+        avg_importance = sum(e.importance for e in entries) / len(entries)
+        first = entries[0]
+
+        # Combine tags from all entries
+        all_tags = set()
+        for e in entries:
+            if e.tags:
+                all_tags.update(e.tags)
+
+        return MemoryEntry(
+            content=compressed_text,
+            importance=avg_importance,
+            emotional_state=first.emotional_state,
+            tags=list(all_tags),
+            user_id=first.user_id
+        )
+
+    def selective_retrieval(self, entries: List[MemoryEntry], query: str) -> List[MemoryEntry]:
+        """
+        Retrieves relevant entries based on a keyword match, to handle compressed blocks effectively.
+
+        Args:
+            entries: A list of MemoryEntry objects.
+            query: The keyword query to filter by.
+
+        Returns:
+            A list of filtered MemoryEntry objects.
+        """
+        query_words = set(query.lower().split())
+        filtered = []
+        for e in entries:
+            content_lower = e.content.lower()
+            if any(word in content_lower for word in query_words):
+                filtered.append(e)
+        return filtered

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,44 @@
+import pytest
+import asyncio
+from magda_agent.memory.compression import ContextCompressorSelective
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+from typing import List, Dict, Any
+
+class MockLLMClient:
+    """Mock LLM client for testing without making real API calls."""
+    async def chat_completion(self, messages: List[Dict[str, Any]], temperature: float = 0.0) -> str:
+        """Mocks the chat completion endpoint."""
+        return "Compressed summary."
+
+@pytest.mark.asyncio
+async def test_compress_entries() -> None:
+    """Tests that entries are correctly compressed using the mock LLM."""
+    llm = MockLLMClient()
+    compressor = ContextCompressorSelective(llm_client=llm)
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("User says hello.", 0.5, state, tags=["greeting"], user_id=1)
+    e2 = MemoryEntry("User says goodbye.", 0.6, state, tags=["farewell"], user_id=1)
+
+    result = await compressor.compress_entries([e1, e2])
+    assert result.content == "Compressed summary."
+    assert result.importance == 0.55
+    assert result.user_id == 1
+    assert "greeting" in result.tags
+    assert "farewell" in result.tags
+
+def test_selective_retrieval() -> None:
+    """Tests the selective retrieval of memory entries based on keyword queries."""
+    compressor = ContextCompressorSelective()
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("This is about apples and oranges.", 0.5, state)
+    e2 = MemoryEntry("This is about cars and bikes.", 0.5, state)
+
+    results = compressor.selective_retrieval([e1, e2], "apples")
+    assert len(results) == 1
+    assert results[0].content == "This is about apples and oranges."
+
+    results_empty = compressor.selective_retrieval([e1, e2], "bananas")
+    assert len(results_empty) == 0


### PR DESCRIPTION
This implements `ContextCompressorSelective` handling compression of working memory prior to semantic conversion and supports selective retrieval from compressed blocks. Appended three new `todo` tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [4778580962269480531](https://jules.google.com/task/4778580962269480531) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context compression and selective retrieval to agent memory
> - Adds [`ContextCompressorSelective`](https://github.com/kazah4359-lgtm/Magda-agent/pull/254/files#diff-868363e9f1fb8adb0fb9efde1b73732484727ddcc8030a66c579a2ce7a727eaf) with two capabilities: compressing multiple `MemoryEntry` objects into one via LLM summarization, and filtering entries by keyword matching.
> - `compress_entries` concatenates entry contents and calls the LLM (temperature=0.3) when available; without an LLM it falls back to plain concatenation. Importance is averaged and tags are merged across entries.
> - `selective_retrieval` does case-insensitive word-level matching against entry content to return relevant entries for a query.
> - Adds tests in [`tests/test_compression.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/254/files#diff-250dce35a951730b03479b4f93c671f16077295464c7902c7048275c8556afb3) covering both methods with a mock LLM client.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c0b122.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->