### PR TITLE
Implement Magentic-One Multi-Agent Orchestration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4736,7 +4736,7 @@
     },
     {
       "id": "magentic-one-orchestration-v2",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "high",
       "title": "Magentic-One Multi-Agent Orchestration",
@@ -8577,6 +8577,57 @@
       "acceptance": [
         "Subagents spawn in isolated worktrees",
         "Tests mock git and verify isolation"
+      ]
+    },
+    {
+      "id": "openclaw-online-rl-state-v5-1f0a1eb3",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw Online RL Next-State Signals v5",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Expand the RL pipeline to handle next-state signals dynamically and update Q-values using the new RLMetricsTracker.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_next_state_v5.py",
+        "tests/test_rl_next_state_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL pipeline consumes next-state signals dynamically.",
+        "Test verifies Q-value updates."
+      ]
+    },
+    {
+      "id": "claude-evaluator-dependency-graph-v3-3910b122",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Claude Evaluator Dependency Graph v3",
+      "description": "Inspired by Claude Agent Teams trend (June 2026): Update the Evaluator to understand and process task dependency graphs when scoring Planner outputs.",
+      "allowed_paths": [
+        "magda_agent/evaluation/evaluator_dependency_v3.py",
+        "tests/test_evaluator_dependency_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator processes dependency graphs.",
+        "Tests verify graph evaluation metrics."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backups-v2-03b0cbbd",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Hermes Cron Nightly Backups",
+      "description": "Inspired by Hermes agent trend (June 2026): Add a scheduled nightly backup task that persists all episodic and semantic memory to encrypted storage.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_backups.py",
+        "tests/test_cron_backups.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A cron task is implemented for nightly backups.",
+        "Tests verify backup routines and mock the storage layer."
       ]
     }
   ]

--- a/magda_agent/agents/magentic.py
+++ b/magda_agent/agents/magentic.py
@@ -1,0 +1,136 @@
+import asyncio
+import json
+import logging
+from typing import List, Dict, Any, Optional
+from magda_agent.llm_client import LLMClient
+
+class Worker:
+    """
+    A specialized agent worker in the Magentic-One orchestration pattern.
+    """
+
+    def __init__(self, name: str, description: str, llm: Optional[LLMClient] = None):
+        """
+        Initializes the Worker.
+
+        Args:
+            name (str): The identifier for this worker.
+            description (str): Description of the worker's capabilities.
+            llm (Optional[LLMClient]): The language model client for the worker.
+        """
+        self.name = name
+        self.description = description
+        self.llm = llm
+
+    async def execute_task(self, task: str) -> str:
+        """
+        Executes a given task.
+
+        Args:
+            task (str): The task to execute.
+
+        Returns:
+            str: The result of the execution.
+        """
+        if self.llm:
+            prompt = f"You are {self.name}. Your role: {self.description}. Execute this task: {task}"
+            try:
+                response = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+                return response
+            except Exception as e:
+                logging.error(f"Worker {self.name} failed to execute task: {e}")
+                return f"Worker {self.name} encountered an error: {e}"
+        else:
+            return f"Worker {self.name} executed task: {task} (No LLM configured)"
+
+class Director:
+    """
+    The Director agent in the Magentic-One orchestration pattern.
+    Delegates tasks to a team of Workers.
+    """
+
+    def __init__(self, llm: LLMClient, workers: List[Worker]):
+        """
+        Initializes the Director.
+
+        Args:
+            llm (LLMClient): The language model client for the director.
+            workers (List[Worker]): A list of available worker agents.
+        """
+        self.llm = llm
+        self.workers = workers
+
+    async def delegate(self, task: str) -> str:
+        """
+        Analyzes a task, breaks it down, and delegates it to appropriate workers.
+
+        Args:
+            task (str): The main task to accomplish.
+
+        Returns:
+            str: The final aggregated result.
+        """
+        worker_profiles = "\n".join([f"- {w.name}: {w.description}" for w in self.workers])
+
+        prompt = (
+            f"You are the Director. Main task: {task}\n"
+            f"Available workers:\n{worker_profiles}\n\n"
+            "Break down the main task and assign subtasks to the most appropriate workers. "
+            "Return ONLY a valid JSON list of dictionaries. Each dictionary must have 'worker_name' and 'subtask' keys."
+        )
+
+        try:
+            response = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+
+            clean_response = response.strip()
+            if clean_response.startswith("```json"):
+                clean_response = clean_response[7:-3].strip()
+            elif clean_response.startswith("```"):
+                clean_response = clean_response[3:-3].strip()
+
+            assignments = json.loads(clean_response)
+        except Exception as e:
+            logging.error(f"Director failed to parse assignments JSON: {e}. Raw response: {response if 'response' in locals() else 'None'}")
+            return f"Delegation failed: Could not create assignments."
+
+        results = []
+
+        # Parallel execution of subtasks
+        tasks = []
+        for assignment in assignments:
+            worker_name = assignment.get('worker_name')
+            subtask = assignment.get('subtask')
+
+            worker = next((w for w in self.workers if w.name == worker_name), None)
+
+            if worker:
+                tasks.append(self._run_worker_task(worker, subtask))
+            else:
+                results.append(f"Worker {worker_name} not found for subtask: {subtask}")
+
+        if tasks:
+            completed_tasks = await asyncio.gather(*tasks, return_exceptions=True)
+            for res in completed_tasks:
+                if isinstance(res, Exception):
+                    results.append(f"Error during execution: {res}")
+                else:
+                    results.append(res)
+
+        # Final synthesis
+        synthesis_prompt = (
+            f"Main task: {task}\n"
+            f"Subtask results:\n" + "\n".join(results) + "\n\n"
+            "Synthesize these results into a final coherent response to the main task."
+        )
+
+        try:
+            final_response = await self.llm.chat_completion([{"role": "user", "content": synthesis_prompt}])
+            return final_response
+        except Exception as e:
+            logging.error(f"Director failed to synthesize results: {e}")
+            return f"Synthesis failed. Raw results: {results}"
+
+    async def _run_worker_task(self, worker: Worker, subtask: str) -> str:
+        """Helper method to execute a task on a worker and format the result."""
+        res = await worker.execute_task(subtask)
+        return f"[{worker.name}]: {res}"

--- a/tests/test_magentic.py
+++ b/tests/test_magentic.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.magentic import Worker, Director
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_worker_execution_with_llm():
+    mock_llm = AsyncMock(spec=LLMClient)
+    mock_llm.chat_completion.return_value = "Worker result"
+
+    worker = Worker("Coder", "Writes code", llm=mock_llm)
+    result = await worker.execute_task("Write a function")
+
+    assert result == "Worker result"
+    mock_llm.chat_completion.assert_called_once()
+    args, kwargs = mock_llm.chat_completion.call_args
+    assert "You are Coder" in args[0][0]["content"]
+
+@pytest.mark.asyncio
+async def test_worker_execution_no_llm():
+    worker = Worker("MockWorker", "Mocks things", llm=None)
+    result = await worker.execute_task("Do a mock task")
+
+    assert "executed task: Do a mock task" in result
+
+@pytest.mark.asyncio
+async def test_director_delegation():
+    mock_llm = AsyncMock(spec=LLMClient)
+
+    # Mock sequence:
+    # 1. Assignment JSON
+    # 2. Final synthesis
+    mock_llm.chat_completion.side_effect = [
+        '[{"worker_name": "Coder", "subtask": "write code"}, {"worker_name": "Reviewer", "subtask": "review code"}]',
+        "Final synthesis result"
+    ]
+
+    mock_worker_1 = AsyncMock(spec=Worker)
+    mock_worker_1.name = "Coder"
+    mock_worker_1.description = "Writes code"
+    mock_worker_1.execute_task.return_value = "Code written"
+
+    mock_worker_2 = AsyncMock(spec=Worker)
+    mock_worker_2.name = "Reviewer"
+    mock_worker_2.description = "Reviews code"
+    mock_worker_2.execute_task.return_value = "Code reviewed"
+
+    director = Director(llm=mock_llm, workers=[mock_worker_1, mock_worker_2])
+
+    result = await director.delegate("Write and review code")
+
+    assert result == "Final synthesis result"
+    assert mock_llm.chat_completion.call_count == 2
+
+    # Verify workers were called
+    mock_worker_1.execute_task.assert_called_once_with("write code")
+    mock_worker_2.execute_task.assert_called_once_with("review code")
+
+@pytest.mark.asyncio
+async def test_director_delegation_parsing_error():
+    mock_llm = AsyncMock(spec=LLMClient)
+    mock_llm.chat_completion.return_value = "I am not returning JSON today."
+
+    director = Director(llm=mock_llm, workers=[])
+    result = await director.delegate("Task")
+
+    assert result == "Delegation failed: Could not create assignments."


### PR DESCRIPTION
Implements the `magentic-one-orchestration-v2` task from `agent_tasks.json`.

This PR includes:
- The creation of `magda_agent/agents/magentic.py`, containing the `Worker` and `Director` classes to support the Magentic-One style multi-agent orchestration pattern using async LLM calls.
- Full pytest coverage in `tests/test_magentic.py` using `AsyncMock` to ensure the logic runs reliably without reaching out to external real-world LLM APIs.
- Updates to `agent_tasks.json`: 
  - Status updated to "done" for `magentic-one-orchestration-v2`.
  - Added 3 new tasks (`openclaw-online-rl-state-v5`, `claude-evaluator-dependency-graph-v3`, `hermes-cron-nightly-backups-v2`) inspired by June 2026 AI agent trends.
  - JSON structurally validated through `validate_agent_tasks.py`.

No side-effects are introduced outside of the allowed paths. Pull request created directly from the branch.

---
*PR created automatically by Jules for task [8591790590627156458](https://jules.google.com/task/8591790590627156458) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement Magentic-One multi-agent orchestration with `Director` and `Worker` classes
> - Adds [magda_agent/agents/magentic.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/255/files#diff-f4de397c196ca95eeeb65cf61f7447c737edc1a77df46a4265ad3a914fcc1f5a) with a `Worker` class that executes tasks via an LLM client or returns a fallback string when no LLM is configured.
> - Adds a `Director` class that uses an LLM to decompose a task into subtasks, dispatches them to workers concurrently via `asyncio.gather`, then synthesizes a final response with a second LLM call.
> - `Director.delegate` handles JSON parsing failures (returns a fixed error string) and synthesis failures (returns raw aggregated results with an error message).
> - Adds async unit tests in [tests/test_magentic.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/255/files#diff-4b581ab3becd7198d8dfb1b67b9085cc17a3c7ff6a44c0f115d83b521e5ce4ff) covering worker behavior with and without an LLM, the delegation happy path, and non-JSON planning responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0082573.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->