### PR TITLE
feat: implement falco prempti tool interception and update tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4753,7 +4753,7 @@
     },
     {
       "id": "falco-prempti-interception",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Falco Prempti Tool Interception",
@@ -8628,6 +8628,57 @@
       "acceptance": [
         "A cron task is implemented for nightly backups.",
         "Tests verify backup routines and mock the storage layer."
+      ]
+    },
+    {
+      "id": "mcp-tool-export-skills",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Export Skills to MCP Tool Server",
+      "description": "Inspired by trend: MCP (Model Context Protocol) is the de-facto standard. Update Magda to export skills as MCP server-prefixed tools to support compatibility with OpenAI Agents SDK.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_server.py",
+        "tests/test_mcp_server.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills are successfully exposed via JSON-RPC compatible MCP prefix",
+        "Tests cover MCP execution"
+      ]
+    },
+    {
+      "id": "agent-to-agent-delegation",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "A2A Protocol Discovery and Delegation",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol). Implement agent discovery via Agent Cards and peer-to-peer task delegation mechanism to external LangGraph/CrewAI agents.",
+      "allowed_paths": [
+        "magda_agent/agents/a2a_discovery.py",
+        "tests/test_a2a_discovery.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent Cards can be generated and parsed",
+        "Tasks can be delegated via A2A messaging interface"
+      ]
+    },
+    {
+      "id": "acs-guardrail-persistence",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Control Specification Persistence",
+      "description": "Inspired by trend: ACS (Agent Control Specification) standardization. Persist the 5 validation checkpoints state to SQLite to allow audit trails and runtime policy adjustments.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_persistence.py",
+        "tests/test_acs_persistence.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS validation checkpoints are recorded in SQLite",
+        "Tests ensure correct schema and writes"
       ]
     }
   ]

--- a/magda_agent/safety/audit.py
+++ b/magda_agent/safety/audit.py
@@ -1,0 +1,192 @@
+import time
+import inspect
+from functools import wraps
+from typing import Any, Callable, Dict, Optional, TypeVar, cast
+from magda_agent.safety.audit_trail import AuditTrail
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+class ToolInterceptor:
+    """
+    A decorator and wrapper class that intercepts tool calls to provide
+    an audit trail of invocations, arguments, and results.
+    Inspired by Prempti (Falco).
+    """
+
+    def __init__(self, audit_trail: AuditTrail) -> None:
+        """
+        Initializes the ToolInterceptor with an underlying AuditTrail instance.
+
+        Args:
+            audit_trail (AuditTrail): The audit trail instance to log events into.
+        """
+        self.audit_trail = audit_trail
+
+    def intercept(self, tool_name: Optional[str] = None, why: str = "intercepted call") -> Callable[[F], F]:
+        """
+        A decorator to intercept a function/tool call.
+
+        Args:
+            tool_name (Optional[str]): The name of the tool. If not provided,
+                                       the function's __name__ is used.
+            why (str): The default reason or context for the call.
+
+        Returns:
+            Callable[[F], F]: The decorated function.
+        """
+        def decorator(func: F) -> F:
+            name_to_use = tool_name if tool_name else func.__name__
+
+            if inspect.iscoroutinefunction(func):
+                @wraps(func)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    start_time = time.time()
+                    all_args = self._extract_args(func, args, kwargs)
+                    try:
+                        result = await func(*args, **kwargs)
+                        duration = time.time() - start_time
+                        self.audit_trail.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=why,
+                            result=result,
+                            duration=duration
+                        )
+                        return result
+                    except Exception as e:
+                        duration = time.time() - start_time
+                        self.audit_trail.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=f"{why} (failed)",
+                            result=str(e),
+                            duration=duration
+                        )
+                        raise
+                return cast(F, async_wrapper)
+            else:
+                @wraps(func)
+                def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    start_time = time.time()
+                    all_args = self._extract_args(func, args, kwargs)
+                    try:
+                        result = func(*args, **kwargs)
+                        duration = time.time() - start_time
+                        self.audit_trail.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=why,
+                            result=result,
+                            duration=duration
+                        )
+                        return result
+                    except Exception as e:
+                        duration = time.time() - start_time
+                        self.audit_trail.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=f"{why} (failed)",
+                            result=str(e),
+                            duration=duration
+                        )
+                        raise
+                return cast(F, sync_wrapper)
+
+        return decorator
+
+    def _extract_args(self, func: Callable[..., Any], args: Any, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Extracts and normalizes arguments passed to a function based on its signature.
+
+        Args:
+            func (Callable): The function being called.
+            args (tuple): Positional arguments.
+            kwargs (dict): Keyword arguments.
+
+        Returns:
+            Dict[str, Any]: A dictionary of all arguments bound to their names.
+        """
+        try:
+            sig = inspect.signature(func)
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            return dict(bound.arguments)
+        except Exception:
+            # Fallback if signature parsing fails
+            return {"args": list(args), "kwargs": kwargs}
+
+    async def execute_async(self, func: Callable[..., Any], tool_name: str, why: str, *args: Any, **kwargs: Any) -> Any:
+        """
+        Explicitly executes and intercepts an async function without decorators.
+
+        Args:
+            func (Callable): The async function to execute.
+            tool_name (str): The name of the tool.
+            why (str): Context for the call.
+            *args: Positional arguments for the function.
+            **kwargs: Keyword arguments for the function.
+
+        Returns:
+            Any: The function's result.
+        """
+        start_time = time.time()
+        all_args = self._extract_args(func, args, kwargs)
+        try:
+            result = await func(*args, **kwargs)
+            duration = time.time() - start_time
+            self.audit_trail.log_call(
+                tool_name=tool_name,
+                kwargs=all_args,
+                why=why,
+                result=result,
+                duration=duration
+            )
+            return result
+        except Exception as e:
+            duration = time.time() - start_time
+            self.audit_trail.log_call(
+                tool_name=tool_name,
+                kwargs=all_args,
+                why=f"{why} (failed)",
+                result=str(e),
+                duration=duration
+            )
+            raise
+
+    def execute_sync(self, func: Callable[..., Any], tool_name: str, why: str, *args: Any, **kwargs: Any) -> Any:
+        """
+        Explicitly executes and intercepts a sync function without decorators.
+
+        Args:
+            func (Callable): The sync function to execute.
+            tool_name (str): The name of the tool.
+            why (str): Context for the call.
+            *args: Positional arguments for the function.
+            **kwargs: Keyword arguments for the function.
+
+        Returns:
+            Any: The function's result.
+        """
+        start_time = time.time()
+        all_args = self._extract_args(func, args, kwargs)
+        try:
+            result = func(*args, **kwargs)
+            duration = time.time() - start_time
+            self.audit_trail.log_call(
+                tool_name=tool_name,
+                kwargs=all_args,
+                why=why,
+                result=result,
+                duration=duration
+            )
+            return result
+        except Exception as e:
+            duration = time.time() - start_time
+            self.audit_trail.log_call(
+                tool_name=tool_name,
+                kwargs=all_args,
+                why=f"{why} (failed)",
+                result=str(e),
+                duration=duration
+            )
+            raise

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,102 @@
+import pytest
+import asyncio
+from magda_agent.safety.audit_trail import AuditTrail
+from magda_agent.safety.audit import ToolInterceptor
+
+@pytest.fixture
+def audit_trail():
+    return AuditTrail(max_capacity=10)
+
+@pytest.fixture
+def interceptor(audit_trail):
+    return ToolInterceptor(audit_trail)
+
+def test_intercept_sync_success(interceptor, audit_trail):
+    @interceptor.intercept(tool_name="sync_tool", why="testing sync success")
+    def sync_tool(x: int, y: int = 5) -> int:
+        return x + y
+
+    result = sync_tool(10)
+    assert result == 15
+
+    logs = audit_trail.query(tool_name="sync_tool")
+    assert len(logs) == 1
+    log = logs[0]
+    assert log["kwargs"]["x"] == 10
+    assert log["kwargs"]["y"] == 5
+    assert log["why"] == "testing sync success"
+    assert log["result"] == 15
+    assert log["duration"] >= 0
+
+def test_intercept_sync_exception(interceptor, audit_trail):
+    @interceptor.intercept(tool_name="sync_tool_fail", why="testing sync fail")
+    def sync_tool_fail(val: str) -> None:
+        raise ValueError("Failed intentionally")
+
+    with pytest.raises(ValueError):
+        sync_tool_fail("hello")
+
+    logs = audit_trail.query(tool_name="sync_tool_fail")
+    assert len(logs) == 1
+    log = logs[0]
+    assert log["kwargs"]["val"] == "hello"
+    assert "testing sync fail (failed)" in log["why"]
+    assert log["result"] == "Failed intentionally"
+
+@pytest.mark.asyncio
+async def test_intercept_async_success(interceptor, audit_trail):
+    @interceptor.intercept(tool_name="async_tool", why="testing async success")
+    async def async_tool(a: str, b: str) -> str:
+        await asyncio.sleep(0.01)
+        return a + b
+
+    result = await async_tool("foo", b="bar")
+    assert result == "foobar"
+
+    logs = audit_trail.query(tool_name="async_tool")
+    assert len(logs) == 1
+    log = logs[0]
+    assert log["kwargs"]["a"] == "foo"
+    assert log["kwargs"]["b"] == "bar"
+    assert log["result"] == "foobar"
+    assert log["duration"] > 0
+
+@pytest.mark.asyncio
+async def test_intercept_async_exception(interceptor, audit_trail):
+    @interceptor.intercept(tool_name="async_tool_fail", why="testing async fail")
+    async def async_tool_fail() -> None:
+        raise RuntimeError("Async error")
+
+    with pytest.raises(RuntimeError):
+        await async_tool_fail()
+
+    logs = audit_trail.query(tool_name="async_tool_fail")
+    assert len(logs) == 1
+    log = logs[0]
+    assert "testing async fail (failed)" in log["why"]
+    assert log["result"] == "Async error"
+
+def test_execute_sync_success(interceptor, audit_trail):
+    def raw_tool(x: int) -> int:
+        return x * 2
+
+    result = interceptor.execute_sync(raw_tool, "raw_sync", "testing execute_sync", 20)
+    assert result == 40
+
+    logs = audit_trail.query(tool_name="raw_sync")
+    assert len(logs) == 1
+    assert logs[0]["kwargs"]["x"] == 20
+    assert logs[0]["result"] == 40
+
+@pytest.mark.asyncio
+async def test_execute_async_success(interceptor, audit_trail):
+    async def raw_async_tool(y: int) -> int:
+        return y * 3
+
+    result = await interceptor.execute_async(raw_async_tool, "raw_async", "testing execute_async", 10)
+    assert result == 30
+
+    logs = audit_trail.query(tool_name="raw_async")
+    assert len(logs) == 1
+    assert logs[0]["kwargs"]["y"] == 10
+    assert logs[0]["result"] == 30


### PR DESCRIPTION
Implemented `ToolInterceptor` in `magda_agent/safety/audit.py` to wrap tool calls and generate audit trails. Included exhaustive tests in `tests/test_audit.py` for sync and async flows. Marked `falco-prempti-interception` as done in `agent_tasks.json` and generated 3 new tasks based on trends.

---
*PR created automatically by Jules for task [9820775217202138920](https://jules.google.com/task/9820775217202138920) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ToolInterceptor` class to log tool invocations and failures to `AuditTrail`
> - Adds [`ToolInterceptor`](https://github.com/kazah4359-lgtm/Magda-agent/pull/256/files#diff-61cd206d2a82d4f1e12ed447594460193f6e3e415766f9bb23fcd97a9a3a2bb1) to [safety/audit.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/256/files#diff-61cd206d2a82d4f1e12ed447594460193f6e3e415766f9bb23fcd97a9a3a2bb1), providing a decorator (`intercept`) and direct wrappers (`execute_sync`, `execute_async`) for capturing tool call audit trails.
> - Binds arguments via `inspect.signature` (including defaults), measures duration, and logs each call with tool name, args, result, and duration via `AuditTrail.log_call`.
> - On exception, logs with a `(failed)` suffix and re-raises the original exception, preserving normal error propagation.
> - Adds unit tests in [`tests/test_audit.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/256/files#diff-4ad97cb6979c3b53c7c696c8c048d67b5a96023a07519692e05ddbc5a12a3417) covering sync/async success, failure logging, and direct execution wrappers.
> - Updates [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/256/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) to mark a task done and add three new tasks for MCP tool export, agent-to-agent delegation, and ACS guardrail persistence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62eb206.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->