### PR TITLE
feat(skills): implement Hermes skill creation from experience

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4770,7 +4770,7 @@
     },
     {
       "id": "hermes-skill-experience",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Hermes Skill Creation from Experience",
@@ -8679,6 +8679,57 @@
       "acceptance": [
         "ACS validation checkpoints are recorded in SQLite",
         "Tests ensure correct schema and writes"
+      ]
+    },
+    {
+      "id": "openclaw-local-first-gateway-v4",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "OpenClaw Local-First Gateway V4",
+      "description": "Inspired by OpenClaw architecture trend (June 2026): Create a local-first gateway as the control plane that supports routing events from multiple channels (Telegram, Discord, Slack, CLI) via a new unified routing layer.",
+      "allowed_paths": [
+        "magda_agent/architecture/gateway_v4.py",
+        "tests/test_gateway_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A local-first gateway handles routing for at least two channels.",
+        "Integration tests verify message routing."
+      ]
+    },
+    {
+      "id": "claude-evaluator-multi-agent-teams-v2",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude SDK Teams Orchestration Evaluator",
+      "description": "Inspired by Claude Agent SDK Agent Teams trend: Update the Evaluator agent to evaluate the execution of subagents operating in isolated git worktrees, providing feedback across the dependency graph of spawned tasks.",
+      "allowed_paths": [
+        "magda_agent/evaluation/team_evaluator_v2.py",
+        "tests/test_team_evaluator_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator processes team-based subagent outputs correctly.",
+        "Tests verify multi-agent evaluation logic."
+      ]
+    },
+    {
+      "id": "hermes-cron-daily-reports-export-v3",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Hermes Cron Daily Reports Export V3",
+      "description": "Inspired by Hermes Agent trend (June 2026): Implement an explicit scheduled cron job that compiles daily reports summarizing memory usage and procedural learnings into an accessible summary document.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_reports_v3.py",
+        "tests/test_cron_reports_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A daily cron task is defined for generating reports.",
+        "Tests verify the output schema of the daily summary."
       ]
     }
   ]

--- a/magda_agent/learning/__init__.py
+++ b/magda_agent/learning/__init__.py
@@ -2,3 +2,4 @@ from .skill_versioning import SkillVersioning
 from .openclaw_rl import OpenClawInteractiveLearner
 from .skill_extraction import SkillExtractor
 from .online_rl_v6 import OnlineRLFeedbackLoopV6
+from .experience import ExperienceToSkillCreator

--- a/magda_agent/learning/experience.py
+++ b/magda_agent/learning/experience.py
@@ -1,0 +1,65 @@
+import logging
+from typing import List, Dict, Optional, Any
+import re
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.procedural import ProceduralMemory
+
+class ExperienceToSkillCreator:
+    """
+    Creates reusable skills from experience, inspired by Hermes.
+    """
+    def __init__(self, procedural_memory: ProceduralMemory, llm: LLMClient) -> None:
+        self.procedural_memory = procedural_memory
+        self.llm = llm
+
+    async def create_skill_from_experience(
+        self,
+        task_description: str,
+        execution_trace: List[Dict[str, Any]],
+        user_id: Optional[int] = None
+    ) -> Optional[str]:
+        """
+        Analyzes an execution trace and generates a Python skill.
+        Returns the skill code if successful, else None.
+        """
+        trace_text = ""
+        for i, step in enumerate(execution_trace):
+            action = step.get("action", "unknown action")
+            outcome = step.get("outcome", "unknown outcome")
+            trace_text += f"Step {i+1}: {action} -> {outcome}\n"
+
+        prompt = f"""
+        Analyze the following execution trace of a successful task.
+        If the steps represent a highly reusable procedure, generate a Python function (a 'skill') that encapsulates this logic.
+        Return ONLY valid Python code starting with 'def '. Do not include markdown formatting or explanations.
+        If it's not suitable for a skill, return exactly 'NOT_REUSABLE'.
+
+        Task: {task_description}
+
+        Execution Trace:
+        {trace_text}
+        """
+
+        try:
+            response = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+            code = response.strip()
+
+            if code and code != "NOT_REUSABLE" and code.startswith("def "):
+                match = re.search(r"def\s+([a-zA-Z0-9_]+)\(", code)
+                skill_name = match.group(1) if match else "generated_skill"
+
+                self.procedural_memory.store_procedure(
+                    name=skill_name,
+                    procedure=code,
+                    user_id=user_id,
+                    metadata={"source_task": task_description, "type": "python_skill_experience"}
+                )
+                logging.info(f"Dynamically generated and stored new Python skill from experience: {skill_name}")
+                return code
+            else:
+                logging.info("Experience not suitable for skill generation.")
+                return None
+        except Exception as e:
+            logging.error(f"Failed to create skill from experience: {e}")
+            return None

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.learning.experience import ExperienceToSkillCreator
+
+@pytest.mark.asyncio
+async def test_create_skill_from_experience_success() -> None:
+    mock_memory = MagicMock()
+    mock_llm = AsyncMock()
+
+    mock_code = "def sample_skill(x):\n    return x + 1"
+    mock_llm.chat_completion.return_value = mock_code
+
+    creator = ExperienceToSkillCreator(procedural_memory=mock_memory, llm=mock_llm)
+
+    trace = [{"action": "add 1", "outcome": "success"}]
+
+    result = await creator.create_skill_from_experience("add one to number", trace)
+
+    assert result == mock_code
+    mock_memory.store_procedure.assert_called_once()
+    args, kwargs = mock_memory.store_procedure.call_args
+    assert kwargs["name"] == "sample_skill"
+    assert kwargs["procedure"] == mock_code
+
+@pytest.mark.asyncio
+async def test_create_skill_from_experience_not_reusable() -> None:
+    mock_memory = MagicMock()
+    mock_llm = AsyncMock()
+
+    mock_llm.chat_completion.return_value = "NOT_REUSABLE"
+
+    creator = ExperienceToSkillCreator(procedural_memory=mock_memory, llm=mock_llm)
+
+    trace = [{"action": "random action", "outcome": "failure"}]
+
+    result = await creator.create_skill_from_experience("random task", trace)
+
+    assert result is None
+    mock_memory.store_procedure.assert_not_called()


### PR DESCRIPTION
- Added `ExperienceToSkillCreator` in `magda_agent/learning/experience.py` to convert execution traces into reusable Python skills using LLM.
- Added corresponding robust pytest suite in `tests/test_experience.py` with full mock coverage for LLM endpoints.
- Exposed the new module in `magda_agent/learning/__init__.py`.
- Updated `agent_tasks.json` by marking the task as done and appending 3 new future trend tasks related to OpenClaw Local-First Gateway, Claude SDK Teams Orchestrator, and Hermes Cron Reports Export.

---
*PR created automatically by Jules for task [10502293188926282034](https://jules.google.com/task/10502293188926282034) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ExperienceToSkillCreator` class to synthesize reusable skills from execution traces
> - Introduces [`ExperienceToSkillCreator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/257/files#diff-29b4579b586ba43c264010cdfda0327282d51d786a86b7af96d0af7ec22e70d2) with an async `create_skill_from_experience` method that builds a trace summary, prompts an LLM for Python code, and persists the result via `ProceduralMemory.store_procedure`.
> - Returns the generated function code on success, or `None` if the LLM deems the trace `NOT_REUSABLE` or an error occurs (errors are swallowed and logged).
> - Exports `ExperienceToSkillCreator` from the `magda_agent.learning` package and covers both success and non-reusable paths with async pytest tests.
> - Risk: exceptions in skill creation are silently swallowed, making failures invisible without log monitoring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8073b71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->