### PR TITLE
Recursive Taint Tracking and Propagation for MCPKernel

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4787,7 +4787,7 @@
     },
     {
       "id": "mcpkernel-taint-tracking-v3",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCPKernel Taint Tracking",

--- a/magda_agent/safety/taint.py
+++ b/magda_agent/safety/taint.py
@@ -2,7 +2,7 @@
 
 Provides taint tracking and sandboxing for tool execution.
 """
-from typing import Any, Callable, Dict, Set
+from typing import Any, Callable, Dict, List
 
 
 class PolicyViolationError(Exception):
@@ -10,41 +10,69 @@ class PolicyViolationError(Exception):
     pass
 
 
-class TaintedString(str):
+class TaintedData:
+    """Base class for tainted data wrappers."""
+    def __init__(self, value: Any):
+        self.value = value
+
+
+class TaintedString(TaintedData, str):
     """A string subclass that marks data as tainted."""
-    pass
+    def __new__(cls, value: str):
+        obj = str.__new__(cls, value)
+        return obj
 
 
-def mark_tainted(s: str) -> TaintedString:
-    """Marks a string as tainted."""
-    return TaintedString(s)
+def mark_tainted(s: Any) -> Any:
+    """Marks a string, list, or dict as tainted recursively."""
+    if isinstance(s, str) and not isinstance(s, TaintedString):
+        return TaintedString(s)
+    elif isinstance(s, list):
+        return [mark_tainted(item) for item in s]
+    elif isinstance(s, dict):
+        return {mark_tainted(k): mark_tainted(v) for k, v in s.items()}
+    return s
 
 
 def is_tainted(s: Any) -> bool:
-    """Checks if a string is tainted."""
-    return isinstance(s, TaintedString)
+    """Checks if an object or any of its nested structures is tainted."""
+    if isinstance(s, TaintedData):
+        return True
+    if isinstance(s, list):
+        return any(is_tainted(item) for item in s)
+    if isinstance(s, dict):
+        return any(is_tainted(k) or is_tainted(v) for k, v in s.items())
+    return False
 
 
-def sanitize(s: Any) -> str:
-    """Sanitizes a tainted string, returning a regular string."""
-    return str(s)
+def sanitize(s: Any) -> Any:
+    """Sanitizes tainted data, returning regular primitives recursively."""
+    if isinstance(s, TaintedData):
+        return sanitize(s.value)
+    elif isinstance(s, list):
+        return [sanitize(item) for item in s]
+    elif isinstance(s, dict):
+        return {sanitize(k): sanitize(v) for k, v in s.items()}
+    return s
 
 
 class TaintTracker:
-    """Tracks tainted objects. In this implementation, it relies on TaintedString."""
+    """Tracks tainted objects."""
     def __init__(self) -> None:
         """Initialize the TaintTracker."""
         pass
 
     def taint(self, obj: Any) -> Any:
-        """Mark an object as tainted. For strings, returns a TaintedString."""
-        if isinstance(obj, str):
-            return mark_tainted(obj)
-        return obj
+        """Mark an object as tainted recursively."""
+        return mark_tainted(obj)
 
     def is_tainted(self, obj: Any) -> bool:
-        """Check if an object is tainted."""
+        """Check if an object or its contents are tainted."""
         return is_tainted(obj)
+
+    def sanitize(self, obj: Any) -> Any:
+        """Sanitize an object recursively."""
+        return sanitize(obj)
 
     def clear(self) -> None:
         """Clear tracked objects. (No-op in this implementation)."""
@@ -52,14 +80,24 @@ class TaintTracker:
 
 
 class SandboxExecutionEnvironment:
-    """A sandbox for executing tools."""
+    """A sandbox for executing tools with taint propagation."""
     def __init__(self, tracker: TaintTracker) -> None:
         """Initialize the sandbox execution environment."""
         self.tracker = tracker
 
     def execute(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        """Execute a function in the sandbox. Tainted inputs must be handled by the caller."""
-        return func(*args, **kwargs)
+        """
+        Execute a function in the sandbox.
+        Automatically propagates taint from inputs to output.
+        """
+        any_input_tainted = any(self.tracker.is_tainted(arg) for arg in args) or \
+                           any(self.tracker.is_tainted(val) for val in kwargs.values())
+
+        result = func(*args, **kwargs)
+
+        if any_input_tainted:
+            return self.tracker.taint(result)
+        return result
 
 
 class MCPKernel:
@@ -72,14 +110,13 @@ class MCPKernel:
     def execute_tool(self, tool_func: Callable[..., Any], inputs: Dict[str, Any], is_sensitive: bool = False) -> Any:
         """Executes a tool within the kernel. If is_sensitive is True, tainted inputs will fail."""
         if is_sensitive:
-            for k, v in inputs.items():
-                if self.tracker.is_tainted(v):
-                     raise PolicyViolationError(f"Tainted input to sensitive tool call: {k}={v}")
+            if self.tracker.is_tainted(inputs):
+                raise PolicyViolationError(f"Tainted input to sensitive tool call: {inputs}")
 
         try:
-             result = self.sandbox.execute(tool_func, **inputs)
-             return result
+            result = self.sandbox.execute(tool_func, **inputs)
+            return result
         except Exception as e:
-             if isinstance(e, PolicyViolationError):
-                 raise
-             raise RuntimeError(f"Tool execution failed: {str(e)}")
+            if isinstance(e, PolicyViolationError):
+                raise
+            raise RuntimeError(f"Tool execution failed: {str(e)}")

--- a/tests/test_taint.py
+++ b/tests/test_taint.py
@@ -1,13 +1,13 @@
 """Tests for the MCPKernel Taint Tracking Sandbox."""
 import pytest
-from typing import Dict, Any
-from magda_agent.safety.taint import MCPKernel, PolicyViolationError
+from typing import Dict, Any, List
+from magda_agent.safety.taint import MCPKernel, PolicyViolationError, mark_tainted, is_tainted, sanitize
 
-def sample_sensitive_tool(data: Dict[str, Any]) -> str:
+def sample_sensitive_tool(data: Any) -> str:
     """A sample sensitive tool that returns processed data."""
     return f"Processed {data}"
 
-def sample_safe_tool(data: Dict[str, Any]) -> str:
+def sample_safe_tool(data: Any) -> str:
     """A sample safe tool that returns data."""
     return f"Safe {data}"
 
@@ -22,20 +22,91 @@ def test_mcp_kernel_taint_tracking() -> None:
 
     assert kernel.tracker.is_tainted(tainted_string) == True
     assert kernel.tracker.is_tainted(safe_data) == False
+    assert kernel.tracker.is_tainted(tainted_data) == True
 
     # Safe tool should accept untainted
     res = kernel.execute_tool(sample_safe_tool, {"data": safe_data}, is_sensitive=False)
     assert "Safe" in res
+    assert not kernel.tracker.is_tainted(res)
 
     # Safe tool should accept tainted (not sensitive)
     res = kernel.execute_tool(sample_safe_tool, {"data": tainted_data}, is_sensitive=False)
     assert "Safe" in res
+    assert kernel.tracker.is_tainted(res) # Taint propagation
 
     # Sensitive tool should reject tainted
     with pytest.raises(PolicyViolationError) as exc_info:
         kernel.execute_tool(sample_sensitive_tool, {"data": tainted_string}, is_sensitive=True)
     assert "Tainted input to sensitive tool call" in str(exc_info.value)
 
+    # Sensitive tool should reject nested tainted data
+    with pytest.raises(PolicyViolationError) as exc_info:
+        kernel.execute_tool(sample_sensitive_tool, {"data": tainted_data}, is_sensitive=True)
+    assert "Tainted input to sensitive tool call" in str(exc_info.value)
+
     # Sensitive tool should accept safe data
     res = kernel.execute_tool(sample_sensitive_tool, {"data": safe_data}, is_sensitive=True)
     assert "Processed" in res
+    assert not kernel.tracker.is_tainted(res)
+
+def test_recursive_taint_tracking():
+    """Test recursive marking and checking of tainted data."""
+    data = {
+        "users": ["alice", "bob"],
+        "metadata": {
+            "query": "SELECT * FROM users"
+        }
+    }
+
+    # Mark specific part tainted
+    data["metadata"]["query"] = mark_tainted(data["metadata"]["query"])
+    assert is_tainted(data) == True
+    assert is_tainted(data["metadata"]) == True
+    assert is_tainted(data["users"]) == False
+
+    # mark_tainted on entire structure
+    tainted_struct = mark_tainted({
+        "a": [1, "unsafe"],
+        "b": {"c": "dangerous"}
+    })
+    assert is_tainted(tainted_struct) == True
+    assert is_tainted(tainted_struct["a"][1]) == True
+    assert is_tainted(tainted_struct["b"]["c"]) == True
+
+def test_sanitize():
+    """Test recursive sanitization."""
+    tainted_struct = mark_tainted({
+        "a": [1, "unsafe"],
+        "b": {"c": "dangerous"}
+    })
+    assert is_tainted(tainted_struct) == True
+
+    clean_struct = sanitize(tainted_struct)
+    assert is_tainted(clean_struct) == False
+    assert clean_struct == {"a": [1, "unsafe"], "b": {"c": "dangerous"}}
+    assert isinstance(clean_struct["a"][1], str)
+    assert not isinstance(clean_struct["a"][1], str.__subclasses__()[0] if str.__subclasses__() else object) # Should be regular str
+
+def test_taint_propagation_in_sandbox():
+    """Test that taint propagates through function execution in sandbox."""
+    kernel = MCPKernel()
+
+    def identity(x):
+        return x
+
+    def join_strings(a, b):
+        return f"{a} and {b}"
+
+    tainted_val = mark_tainted("tainted")
+    safe_val = "safe"
+
+    # Propagate through identity
+    res1 = kernel.sandbox.execute(identity, tainted_val)
+    assert is_tainted(res1)
+
+    # Propagate through join
+    res2 = kernel.sandbox.execute(join_strings, safe_val, tainted_val)
+    assert is_tainted(res2)
+
+    res3 = kernel.sandbox.execute(join_strings, safe_val, safe_val)
+    assert not is_tainted(res3)


### PR DESCRIPTION
This PR enhances the `MCPKernel` taint tracking system to support recursive tracking of nested data structures (lists and dicts) and automatic propagation of taint from function inputs to outputs within the sandbox. This ensures that any data derived from untrusted sources remains marked as tainted and cannot be passed to sensitive tools without explicit sanitization.

Key changes:
- Refactored `magda_agent/safety/taint.py` to support recursive operations.
- Updated `SandboxExecutionEnvironment` to handle automatic taint propagation.
- Added comprehensive unit tests in `tests/test_taint.py`.
- Updated `agent_tasks.json` manifest.

---
*PR created automatically by Jules for task [3659263079267727081](https://jules.google.com/task/3659263079267727081) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add recursive taint tracking and propagation to `MCPKernel` and `SandboxExecutionEnvironment`
> - Introduces `TaintedData` as a base class for tainted values; refactors `TaintedString` to inherit from it, and extends `mark_tainted`, `is_tainted`, and `sanitize` to recurse into nested lists and dicts in [taint.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/258/files#diff-ba804a6ebe982c78651653e066e5ae57c05788df60af71d2472e9e85537cd44c).
> - `SandboxExecutionEnvironment.execute` now taints its return value when any input argument is tainted, propagating taint through sandbox-executed functions.
> - `MCPKernel.execute_tool` now calls `is_tainted` on the full inputs dict (including nested structures) rather than a single key, and reports the entire dict in the rejection error.
> - New tests in [test_taint.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/258/files#diff-7e3ec7cf83e488baf52e8bda514da913c8e89fd2886d14cb64dcdc52de3fcad4) cover recursive taint detection, sanitization of nested structures, and sandbox taint propagation.
> - Risk: `sanitize` on a `TaintedString` will raise `AttributeError` because `TaintedString` does not define a `.value` attribute, despite `sanitize` calling `sanitize(s.value)` for any `TaintedData` instance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0351443.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->