### PR TITLE
Feature: Implement OpenClaw-RL Online Reinforcement Learning v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4804,7 +4804,7 @@
     },
     {
       "id": "openclaw-rl-online-learning-v2",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Online Reinforcement Learning v2",
@@ -8730,6 +8730,57 @@
       "acceptance": [
         "A daily cron task is defined for generating reports.",
         "Tests verify the output schema of the daily summary."
+      ]
+    },
+    {
+      "id": "openclaw-rl-metrics-v3-unique",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Metrics and Visualization v3",
+      "description": "Inspired by OpenClaw Canvas Live Visualization: Add visual metrics for Q-value updates and rewards from the RL system to track improvement visually.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_metrics.py",
+        "tests/test_openclaw_rl_metrics.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL Metrics visually represented in canvas context",
+        "Tests verify metric computations"
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-export-v3",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Hermes Skill Marketplace Export V3",
+      "description": "Inspired by Hermes Agent trend (June 2026): Create an explicit module to package procedural skills learned via the RL and Experience loops into the open agentskills.io format for marketplace publishing.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_export.py",
+        "tests/test_marketplace_export.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills export to valid agentskills.io format",
+        "Integration test generates a payload matching schema"
+      ]
+    },
+    {
+      "id": "claude-git-worktree-team-isolation-v4",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude Git Worktree Team Isolation v4",
+      "description": "Inspired by Claude Agent SDK Agent Teams trend: Upgrade the worktree manager to run multi-agent subtasks concurrently with total context isolation in separate git worktrees, preventing state bleeding.",
+      "allowed_paths": [
+        "magda_agent/isolation/git_worktree_multi.py",
+        "tests/test_git_worktree_multi.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Multiple git worktrees are spun up concurrently for team agents",
+        "Test checks environment path isolation"
       ]
     }
   ]

--- a/magda_agent/learning/openclaw_rl_v2.py
+++ b/magda_agent/learning/openclaw_rl_v2.py
@@ -1,0 +1,102 @@
+import logging
+from typing import Optional, List
+
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+from magda_agent.user_model.model import UserModel
+
+class OpenClawRLOnlineLearnerV2:
+    """
+    OpenClaw-RL Online Reinforcement Learning v2.
+    Implements online learning from next-state signals, including user replies and tool outputs.
+    """
+
+    def __init__(
+        self,
+        habit_tracker: HabitTracker,
+        mirror_neurons: MirrorNeurons,
+        user_model: UserModel,
+    ) -> None:
+        """
+        Initializes the learner with its dependencies.
+
+        Args:
+            habit_tracker: The system for tracking habit/skill usage.
+            mirror_neurons: The sentiment and empathy processor for implicit feedback.
+            user_model: The user model to maintain user-specific preferences.
+        """
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+        self.user_model = user_model
+
+    async def process_next_state_signal(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: int,
+        tool_output: Optional[str] = None,
+        skills_used: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Analyzes the subsequent state (user reply and tool output) and updates Q-values/weights dynamically.
+
+        Args:
+            user_reply (str): The user's reply string.
+            action_context (str): A description of the action taken.
+            user_id (int): The ID of the current user.
+            tool_output (Optional[str], optional): The output from the executed tool. Defaults to None.
+            skills_used (Optional[List[str]], optional): A list of skill names used. Defaults to None.
+        """
+        if not user_reply or not action_context:
+            return
+
+        signal_text = user_reply
+        if tool_output:
+            signal_text += f" [Tool Output: {tool_output}]"
+
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(signal_text)
+
+        skills = skills_used or ["rl_skill_v2"]
+
+        # Dynamic Q-Value calculation inspired by RL
+        # p_shift ranges between -1.0 to 1.0 (approximate).
+        # We transform this into a score between 0.0 and 10.0
+        base_reward = (p_shift + 1.0) * 5.0
+
+        # Give bonus if there's a valid tool output and positive empathy shift
+        if tool_output and p_shift > 0.0:
+            base_reward += 2.0
+
+        reward = max(0.0, min(10.0, base_reward))
+
+        # Retrieve user model
+        model_data = self.user_model.get_model(user_id)
+
+        if reward > 5.0:
+            # Positive signal, reinforce habits
+            for skill in skills:
+                self.habit_tracker.record_usage(
+                    input_text=action_context,
+                    skill_used=skill,
+                    evaluation_score=reward,
+                    user_id=user_id
+                )
+            logging.info(f"OpenClawRLV2: Positive signal received (reward={reward:.2f}). Reinforced skills: {skills}")
+
+            if "(confident)" not in model_data.get("communication_style", ""):
+                model_data["communication_style"] = f"{model_data.get('communication_style', 'default')} (confident)"
+        else:
+            # Negative or low neutral signal
+            logging.info(f"OpenClawRLV2: Low/Negative signal (reward={reward:.2f}). No usage recorded.")
+
+            if "(attentive)" not in model_data.get("communication_style", ""):
+                model_data["communication_style"] = f"{model_data.get('communication_style', 'default')} (attentive)"
+
+        # Save preferences state dynamically
+        if "rl_v2_preferences" not in model_data:
+            model_data["rl_v2_preferences"] = {}
+        model_data["rl_v2_preferences"]["last_reward"] = reward
+
+        # Save the model
+        self.user_model.save_model(user_id, model_data)
+        logging.info(f"OpenClawRLV2: Updated user model for user {user_id} with next-state feedback.")

--- a/tests/test_openclaw_rl_v2.py
+++ b/tests/test_openclaw_rl_v2.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest.mock import MagicMock
+
+from magda_agent.learning.openclaw_rl_v2 import OpenClawRLOnlineLearnerV2
+
+@pytest.fixture
+def mock_habit_tracker() -> MagicMock:
+    """Mocks the HabitTracker."""
+    return MagicMock()
+
+@pytest.fixture
+def mock_mirror_neurons() -> MagicMock:
+    """Mocks the MirrorNeurons."""
+    return MagicMock()
+
+@pytest.fixture
+def mock_user_model() -> MagicMock:
+    """Mocks the UserModel."""
+    return MagicMock()
+
+@pytest.fixture
+def learner(mock_habit_tracker: MagicMock, mock_mirror_neurons: MagicMock, mock_user_model: MagicMock) -> OpenClawRLOnlineLearnerV2:
+    """Provides a fresh OpenClawRLOnlineLearnerV2 instance."""
+    return OpenClawRLOnlineLearnerV2(
+        habit_tracker=mock_habit_tracker,
+        mirror_neurons=mock_mirror_neurons,
+        user_model=mock_user_model
+    )
+
+@pytest.mark.asyncio
+async def test_process_positive_signal(
+
+    learner: OpenClawRLOnlineLearnerV2,
+    mock_habit_tracker: MagicMock,
+    mock_mirror_neurons: MagicMock,
+    mock_user_model: MagicMock
+) -> None:
+    """Tests positive signal."""
+    # Arrange
+    user_id = 42
+    user_reply = "That was very helpful!"
+    action_context = "Completed task XYZ"
+    tool_output = "Task XYZ completed successfully"
+
+    mock_mirror_neurons.empathize.return_value = (0.5, 0.1, 0.0) # p_shift = 0.5
+    mock_user_model.get_model.return_value = {"communication_style": "default"}
+
+    # Act
+    await learner.process_next_state_signal(
+        user_reply=user_reply,
+        action_context=action_context,
+        user_id=user_id,
+        tool_output=tool_output
+    )
+
+    # Assert
+    # Base reward = (0.5 + 1.0) * 5.0 = 7.5
+    # Bonus = +2.0 (since tool_output is present and p_shift > 0)
+    # Total reward = 9.5
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text=action_context,
+        skill_used="rl_skill_v2",
+        evaluation_score=9.5,
+        user_id=user_id
+    )
+
+    saved_model = mock_user_model.save_model.call_args[0][1]
+    assert "(confident)" in saved_model["communication_style"]
+    assert saved_model["rl_v2_preferences"]["last_reward"] == 9.5
+
+@pytest.mark.asyncio
+async def test_process_negative_signal(
+
+    learner: OpenClawRLOnlineLearnerV2,
+    mock_habit_tracker: MagicMock,
+    mock_mirror_neurons: MagicMock,
+    mock_user_model: MagicMock
+) -> None:
+    """Tests positive signal."""
+    # Arrange
+    user_id = 42
+    user_reply = "This didn't work at all"
+    action_context = "Failed attempt at XYZ"
+
+    mock_mirror_neurons.empathize.return_value = (-0.8, -0.2, 0.0) # p_shift = -0.8
+    mock_user_model.get_model.return_value = {"communication_style": "default"}
+
+    # Act
+    await learner.process_next_state_signal(
+        user_reply=user_reply,
+        action_context=action_context,
+        user_id=user_id,
+        tool_output=None
+    )
+
+    # Assert
+    # Base reward = (-0.8 + 1.0) * 5.0 = 1.0
+    # No bonus since tool output is None
+    # Total reward = 1.0
+    mock_habit_tracker.record_usage.assert_not_called()
+
+    saved_model = mock_user_model.save_model.call_args[0][1]
+    assert "(attentive)" in saved_model["communication_style"]
+    assert abs(saved_model["rl_v2_preferences"]["last_reward"] - 1.0) < 1e-5
+
+@pytest.mark.asyncio
+async def test_empty_signals(
+
+    learner: OpenClawRLOnlineLearnerV2,
+    mock_habit_tracker: MagicMock,
+    mock_mirror_neurons: MagicMock,
+    mock_user_model: MagicMock
+) -> None:
+    """Tests empty signals do not process anything."""
+    # Act
+    await learner.process_next_state_signal(
+        user_reply="",
+        action_context="Something",
+        user_id=1
+    )
+
+    # Assert
+    mock_mirror_neurons.empathize.assert_not_called()
+    mock_user_model.get_model.assert_not_called()
+    mock_habit_tracker.record_usage.assert_not_called()
+    mock_user_model.save_model.assert_not_called()


### PR DESCRIPTION
Implements the first "todo" task `openclaw-rl-online-learning-v2`. This adds an online RL pipeline that learns directly from next-state signals like user replies and tool outputs.

Also completed the mandatory task of updating `agent_tasks.json` with new AI agent trends.

---
*PR created automatically by Jules for task [14049269640258097191](https://jules.google.com/task/14049269640258097191) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add online reinforcement learning class `OpenClawRLOnlineLearnerV2` for user reply scoring
> - Introduces [`openclaw_rl_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/259/files#diff-8644e21ce522fa4d8ecaada3d9bc3487e69b2afbb97d7590de14bd216055b5a1) with `OpenClawRLOnlineLearnerV2`, which processes next-state signals (user replies and tool outputs) to compute a reward via `MirrorNeurons.empathize` and persist updates to the user model.
> - Reward is computed as `(p_shift + 1.0) * 5.0`, with a +2.0 bonus when tool output is present and sentiment is positive, clamped to [0.0, 10.0].
> - For rewards above 5.0, `HabitTracker.record_usage` is called per skill and `"(confident)"` is appended to `communication_style`; otherwise `"(attentive)"` is appended.
> - Adds tests covering positive signals, negative signals, and empty input early-exit behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0eca7a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->