### PR TITLE
Implement A2A Agent Discovery v2 via Cards

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4821,7 +4821,7 @@
     },
     {
       "id": "a2a-agent-discovery-cards-v2",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "high",
       "title": "A2A Agent Discovery via Cards v2",
@@ -8781,6 +8781,40 @@
       "acceptance": [
         "Multiple git worktrees are spun up concurrently for team agents",
         "Test checks environment path isolation"
+      ]
+    },
+    {
+      "id": "context-engine-selective-retrieval-v3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Selective Retrieval v3",
+      "description": "Inspired by trend: Context compression + selective retrieval. Enhance the Context Engine to intelligently prune context windows based on token limits dynamically.",
+      "allowed_paths": [
+        "magda_agent/memory/context_selective_retrieval_v3.py",
+        "tests/test_context_selective_retrieval_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine truncates and prioritizes tokens successfully",
+        "Tests verify limit enforcement"
+      ]
+    },
+    {
+      "id": "agent-guard-taint-tracking-v2",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Agent Guard Taint Tracking v2",
+      "description": "Inspired by trend: MCPKernel taint tracking + sandboxed execution. Implement taint tracking for external data traversing the Agent Guard policy layer.",
+      "allowed_paths": [
+        "magda_agent/safety/taint_tracking_v2.py",
+        "tests/test_taint_tracking_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "External inputs are flagged with taints when entering context",
+        "Tests verify taint propagation"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -214,3 +214,4 @@
 * [x] FEATURE: MCPKernel: Taint Tracking and Sandboxed Execution (mcpkernel-sandboxed-execution)
 * [x] FEATURE: Cross-platform reach channels v2
 * [x] FEATURE: OpenClaw Local-First Gateway
+* [x] FEATURE: A2A Agent Discovery via Cards v2 (a2a-agent-discovery-cards-v2)

--- a/magda_agent/integration/a2a_discovery_v2.py
+++ b/magda_agent/integration/a2a_discovery_v2.py
@@ -1,0 +1,113 @@
+from typing import Dict, List, Optional
+import json
+import logging
+from dataclasses import dataclass, asdict
+from magda_agent.integration.a2a_security import A2ASecurityContext
+
+
+@dataclass
+class AgentCardV2:
+    """
+    Represents the capabilities and identity of an agent in the network, version 2.
+    Inspired by Google/Linux Foundation A2A Standard, June 2026 trends.
+    """
+    agent_id: str
+    name: str
+    description: str
+    capabilities: List[str]
+    endpoints: Dict[str, str]
+    protocol_version: str = "v2"
+
+    def to_json(self) -> str:
+        """
+        Serializes the AgentCardV2 to a JSON string.
+        """
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "AgentCardV2":
+        """
+        Deserializes an AgentCardV2 from a JSON string.
+        """
+        data = json.loads(json_str)
+        return cls(**data)
+
+
+class A2ADiscoveryV2:
+    """
+    Handles discovery of other agents in the network and broadcasting
+    the local agent's capabilities using the v2 protocol.
+    """
+    def __init__(self, local_card: AgentCardV2, security_context: Optional[A2ASecurityContext] = None) -> None:
+        """
+        Initializes the discovery module with the local agent's card.
+        """
+        self.local_card = local_card
+        self.security_context = security_context or A2ASecurityContext()
+        self._discovered_agents: Dict[str, AgentCardV2] = {}
+        self._capability_index: Dict[str, List[str]] = {}
+
+    async def broadcast_card(self) -> str:
+        """
+        Broadcasts the local agent's card to the network in an envelope format.
+        """
+        logging.info(f"Broadcasting Agent Card V2: {self.local_card.name}")
+
+        # In a real system, this would be an actual network broadcast
+        envelope = {
+            "type": "a2a_discovery_broadcast",
+            "version": "2.0",
+            "payload": self.local_card.to_json()
+        }
+        return json.dumps(envelope)
+
+    async def fetch_cards(self, network_envelopes: Optional[List[str]] = None, auth_token: Optional[str] = None) -> None:
+        """
+        Fetches Agent Cards from the network envelopes and indexes them.
+        Requires an auth_token for secure discovery.
+        """
+        if auth_token and not self.security_context.validate_token(auth_token):
+            logging.error("Invalid auth token for fetch_cards")
+            raise ValueError("Invalid authentication token")
+
+        self.security_context.trace_action("fetch_cards_v2", {"count": len(network_envelopes) if network_envelopes else 0})
+
+        if network_envelopes is None:
+            network_envelopes = []
+
+        for envelope_json in network_envelopes:
+            try:
+                envelope = json.loads(envelope_json)
+                if envelope.get("type") == "a2a_discovery_broadcast" and envelope.get("version") == "2.0":
+                    payload = envelope.get("payload", "{}")
+                    if isinstance(payload, dict):
+                        payload = json.dumps(payload)
+                    card = AgentCardV2.from_json(payload)
+                    self._register_agent(card)
+            except Exception as e:
+                logging.error(f"Failed to parse Agent Card Envelope V2: {e}")
+
+    def _register_agent(self, card: AgentCardV2) -> None:
+        """
+        Registers a discovered agent internally and updates the capability index.
+        """
+        self._discovered_agents[card.agent_id] = card
+        for capability in card.capabilities:
+            if capability not in self._capability_index:
+                self._capability_index[capability] = []
+            if card.agent_id not in self._capability_index[capability]:
+                self._capability_index[capability].append(card.agent_id)
+        logging.info(f"Discovered Agent V2: {card.name} with capabilities {card.capabilities}")
+
+    def get_agent_by_id(self, agent_id: str) -> Optional[AgentCardV2]:
+        """
+        Retrieves a discovered agent's card by its ID.
+        """
+        return self._discovered_agents.get(agent_id)
+
+    def find_agents_by_capability(self, capability: str) -> List[AgentCardV2]:
+        """
+        Returns a list of Agent Cards that support the given capability.
+        """
+        agent_ids = self._capability_index.get(capability, [])
+        return [self._discovered_agents[aid] for aid in agent_ids]

--- a/tests/test_a2a_discovery_v2.py
+++ b/tests/test_a2a_discovery_v2.py
@@ -1,0 +1,95 @@
+import pytest
+import json
+from magda_agent.integration.a2a_discovery_v2 import AgentCardV2, A2ADiscoveryV2
+
+@pytest.fixture
+def local_card_v2() -> AgentCardV2:
+    return AgentCardV2(
+        agent_id="agent-v2-001",
+        name="MagdaLocalV2",
+        description="Local agent for testing v2",
+        capabilities=["chat", "code_execution"],
+        endpoints={"rpc": "http://localhost:8080/rpc"}
+    )
+
+@pytest.fixture
+def remote_card_1_v2() -> AgentCardV2:
+    return AgentCardV2(
+        agent_id="agent-remote-v2-001",
+        name="RemoteWorker1V2",
+        description="Worker node v2",
+        capabilities=["image_generation", "chat"],
+        endpoints={"rpc": "http://192.168.1.10:8080/rpc"}
+    )
+
+@pytest.fixture
+def remote_card_2_v2() -> AgentCardV2:
+    return AgentCardV2(
+        agent_id="agent-remote-v2-002",
+        name="RemoteWorker2V2",
+        description="Code worker node v2",
+        capabilities=["code_execution", "linting"],
+        endpoints={"rpc": "http://192.168.1.11:8080/rpc"}
+    )
+
+@pytest.mark.asyncio
+async def test_broadcast_card_v2(local_card_v2: AgentCardV2) -> None:
+    discovery = A2ADiscoveryV2(local_card=local_card_v2)
+    broadcasted_json = await discovery.broadcast_card()
+
+    envelope = json.loads(broadcasted_json)
+    assert envelope["type"] == "a2a_discovery_broadcast"
+    assert envelope["version"] == "2.0"
+
+    payload = json.loads(envelope["payload"])
+    assert payload["agent_id"] == "agent-v2-001"
+    assert payload["name"] == "MagdaLocalV2"
+    assert "chat" in payload["capabilities"]
+    assert payload["protocol_version"] == "v2"
+
+@pytest.mark.asyncio
+async def test_fetch_and_index_cards_v2(local_card_v2: AgentCardV2, remote_card_1_v2: AgentCardV2, remote_card_2_v2: AgentCardV2) -> None:
+    discovery = A2ADiscoveryV2(local_card=local_card_v2)
+
+    network_envelopes = [
+        json.dumps({"type": "a2a_discovery_broadcast", "version": "2.0", "payload": remote_card_1_v2.to_json()}),
+        json.dumps({"type": "a2a_discovery_broadcast", "version": "2.0", "payload": remote_card_2_v2.to_json()})
+    ]
+
+    await discovery.fetch_cards(network_envelopes=network_envelopes)
+
+    # Test getting by id
+    fetched_agent = discovery.get_agent_by_id("agent-remote-v2-001")
+    assert fetched_agent is not None
+    assert fetched_agent.name == "RemoteWorker1V2"
+
+    # Test indexing by capability (chat)
+    chat_agents = discovery.find_agents_by_capability("chat")
+    assert len(chat_agents) == 1
+    assert chat_agents[0].agent_id == "agent-remote-v2-001"
+
+    # Test indexing by capability (code_execution)
+    code_agents = discovery.find_agents_by_capability("code_execution")
+    assert len(code_agents) == 1
+    assert code_agents[0].agent_id == "agent-remote-v2-002"
+
+    # Test missing capability
+    missing_agents = discovery.find_agents_by_capability("unknown_cap")
+    assert len(missing_agents) == 0
+
+@pytest.mark.asyncio
+async def test_fetch_invalid_card_json_v2(local_card_v2: AgentCardV2) -> None:
+    discovery = A2ADiscoveryV2(local_card=local_card_v2)
+
+    # Passing invalid JSON should be caught and not crash
+    network_envelopes = [
+        '{"invalid": "json"',
+        json.dumps({"type": "wrong_type", "version": "2.0", "payload": "{}"}),
+        json.dumps({"type": "a2a_discovery_broadcast", "version": "1.0", "payload": "{}"}),
+        json.dumps({"type": "a2a_discovery_broadcast", "version": "2.0", "payload": '{"agent_id": "missing_fields"}'})
+    ]
+
+    await discovery.fetch_cards(network_envelopes=network_envelopes)
+
+    # No agents should be discovered
+    assert len(discovery._discovered_agents) == 0


### PR DESCRIPTION
This PR implements the new A2A Agent Discovery module via Agent Cards (v2). It introduces the `AgentCardV2` and `A2ADiscoveryV2` components, which allow broadcasting and fetching of capabilities. `agent_tasks.json` has been updated with new tasks inspired by trends and the backlog has been updated as well.

---
*PR created automatically by Jules for task [1424645517719601340](https://jules.google.com/task/1424645517719601340) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A Agent Discovery v2 via `AgentCardV2` and `A2ADiscoveryV2`
> - Introduces [`a2a_discovery_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/260/files#diff-467f86a5d1607032f01e04ee559494e2ad2fd134b1484f04c1842297c6018f0e) with an `AgentCardV2` dataclass (JSON serialization, protocol version `v2`) and an `A2ADiscoveryV2` class for broadcasting and ingesting agent capability cards.
> - `broadcast_card` produces a versioned discovery envelope; `fetch_cards` parses incoming envelopes, validates auth tokens via `A2ASecurityContext`, and indexes agents by ID and capability.
> - Lookup is exposed via `get_agent_by_id` and `find_agents_by_capability`; malformed envelopes are skipped without raising.
> - Adds async pytest coverage in [`tests/test_a2a_discovery_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/260/files#diff-400cde35e08362e4334ac419a063ed3e6033a13bfcdec0d447c5b0d517a797e4) for broadcast correctness, multi-card ingestion, and robustness against invalid envelopes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79f036c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->