### PR TITLE
Implement memory context compression

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4855,7 +4855,7 @@
     },
     {
       "id": "implement-memory-context-compression-1aa5e465",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Implement memory context compression",
@@ -8866,6 +8866,57 @@
       "acceptance": [
         "Evaluator parses subagent logs and generates reflection metrics",
         "Tests cover reflection logic on simulated team traces"
+      ]
+    },
+    {
+      "id": "mcp-kernel-taint-tracking-v3-fe34585d",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCPKernel Taint Tracking Extension V3",
+      "description": "Inspired by trend: MCPKernel taint tracking + sandboxed execution. Extend the taint tracking system to trace data provenance across memory blocks explicitly.",
+      "allowed_paths": [
+        "magda_agent/safety/taint_tracking_v3.py",
+        "tests/test_taint_tracking_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tracks are maintained when data moves to episodic memory",
+        "Tests verify taint propagation"
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-d42db27e",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Canvas Visualization Module",
+      "description": "Inspired by trend: OpenClaw Canvas Live Visualization. Create a module to export real-time metrics for Q-value updates to a structured format for UI ingestion.",
+      "allowed_paths": [
+        "magda_agent/learning/canvas_metrics.py",
+        "tests/test_canvas_metrics.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Metrics are formatted correctly for Canvas UI consumption",
+        "Tests cover metric transformations"
+      ]
+    },
+    {
+      "id": "acs-guardrail-runtime-governance-621d3b4e",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Guardrail Checkpoint Refactor",
+      "description": "Inspired by trend: ACS (Agent Control Specification). Refactor existing guardrails into a formal pipeline of discrete checkpoints (Input, Execution, Output).",
+      "allowed_paths": [
+        "magda_agent/safety/acs_checkpoints.py",
+        "tests/test_acs_checkpoints.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The ACS checkpoint pattern is implemented cleanly",
+        "Integration tests confirm all policies pass or block correctly"
       ]
     }
   ]

--- a/magda_agent/memory/compression.py
+++ b/magda_agent/memory/compression.py
@@ -62,6 +62,41 @@ class ContextCompressorSelective:
             user_id=first.user_id
         )
 
+
+    async def compress_workflow(self, workflow_context: str, token_limit: int) -> str:
+        """
+        Compresses a long-running workflow context to fit within a specified token limit.
+        Uses a heuristic of 4 characters per token if an exact tokenizer is unavailable.
+
+        Args:
+            workflow_context: The text of the workflow context.
+            token_limit: The maximum allowed tokens.
+
+        Returns:
+            The original string if within limits, or a compressed summary.
+        """
+        char_limit = token_limit * 4
+        if len(workflow_context) <= char_limit:
+            return workflow_context
+
+        if self.llm:
+            try:
+                logging.info(f"Compressing workflow context exceeding {token_limit} tokens.")
+                prompt = f"Summarize the following workflow context to fit within {token_limit} tokens, retaining critical state and paths:\n\n{workflow_context}"
+                messages = [
+                    {"role": "system", "content": "You compress workflow context. Return only the summary text."},
+                    {"role": "user", "content": prompt}
+                ]
+                compressed_text = await self.llm.chat_completion(messages, temperature=0.3)
+                return compressed_text.strip()
+            except Exception as e:
+                logging.error(f"Workflow compression failed: {e}")
+                # Fallback to simple truncation
+                return workflow_context[:char_limit] + "... [TRUNCATED]"
+        else:
+            logging.warning("No LLM available for workflow compression, falling back to truncation.")
+            return workflow_context[:char_limit] + "... [TRUNCATED]"
+
     def selective_retrieval(self, entries: List[MemoryEntry], query: str) -> List[MemoryEntry]:
         """
         Retrieves relevant entries based on a keyword match, to handle compressed blocks effectively.

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -42,3 +42,26 @@ def test_selective_retrieval() -> None:
 
     results_empty = compressor.selective_retrieval([e1, e2], "bananas")
     assert len(results_empty) == 0
+
+
+@pytest.mark.asyncio
+async def test_compress_workflow() -> None:
+    """Tests that compress_workflow respects token limits and falls back correctly if needed."""
+    llm = MockLLMClient()
+    compressor = ContextCompressorSelective(llm_client=llm)
+
+    # Test within limit
+    short_context = "This is a short context."
+    result = await compressor.compress_workflow(short_context, 100)
+    assert result == short_context
+
+    # Test exceeding limit with LLM
+    long_context = "A" * 500  # 500 characters
+    result_llm = await compressor.compress_workflow(long_context, 10) # 10 tokens * 4 = 40 chars limit
+    assert result_llm == "Compressed summary."
+
+    # Test exceeding limit without LLM (fallback to truncation)
+    compressor_no_llm = ContextCompressorSelective(llm_client=None)
+    result_no_llm = await compressor_no_llm.compress_workflow(long_context, 10)
+    assert result_no_llm.endswith("... [TRUNCATED]")
+    assert len(result_no_llm) == 40 + len("... [TRUNCATED]")


### PR DESCRIPTION
- Implemented `compress_workflow` method in `magda_agent/memory/compression.py` to handle context truncation and compression via mockable LLM logic for long-running workflows.
- Appended `test_compress_workflow` to `tests/test_compression.py` which mocks an LLM client and asserts the logic is correct.
- Set the status of `implement-memory-context-compression-1aa5e465` to `"done"` in `agent_tasks.json`.
- Added 3 new `"todo"` tasks inspired by `docs/trends.md` with proper uniqueness on ids.

---
*PR created automatically by Jules for task [719129944957199857](https://jules.google.com/task/719129944957199857) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `compress_workflow` method to `ContextCompressorSelective` for memory context compression
> - Adds `compress_workflow(workflow_context, token_limit)` to [`ContextCompressorSelective`](https://github.com/kazah4359-lgtm/Magda-agent/pull/262/files#diff-868363e9f1fb8adb0fb9efde1b73732484727ddcc8030a66c579a2ce7a727eaf), which compresses workflow context strings that exceed a token-derived character limit (`token_limit * 4`).
> - When over the limit, uses LLM chat completion (temperature=0.3) to generate a summary; falls back to truncation with `... [TRUNCATED]` suffix if no LLM client is present or if the LLM call fails.
> - Adds async tests in [`tests/test_compression.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/262/files#diff-250dce35a951730b03479b4f93c671f16077295464c7902c7048275c8556afb3) covering the within-limit, LLM, and no-LLM fallback paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec5ac22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->