### PR TITLE
Implement A2A sub-plan delegator and append trend tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4872,7 +4872,7 @@
     },
     {
       "id": "implement-a2a-delegator-0c1de20a",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "Implement A2A sub-plan delegator",
@@ -8917,6 +8917,57 @@
       "acceptance": [
         "The ACS checkpoint pattern is implemented cleanly",
         "Integration tests confirm all policies pass or block correctly"
+      ]
+    },
+    {
+      "id": "implement-mcp-tool-export-2b9c3e4d",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Export Skills to MCP Tool Server",
+      "description": "Inspired by trend: MCP (Model Context Protocol). Create a module to export Magda skills as MCP-compatible tools.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_export.py",
+        "tests/test_mcp_export*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module successfully generates MCP tool schemas for registered skills",
+        "Tests mock JSON-RPC endpoints and verify schema output"
+      ]
+    },
+    {
+      "id": "implement-openclaw-rl-canvas-1d8f5a6b",
+      "status": "todo",
+      "area": "UI",
+      "risk": "low",
+      "title": "OpenClaw RL Canvas Visualization Module",
+      "description": "Inspired by trend: OpenClaw Canvas. Implement a backend module to structure RL learning state for Canvas UI.",
+      "allowed_paths": [
+        "magda_agent/learning/canvas_sync.py",
+        "tests/test_canvas_sync*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module tracks current goal, state, and next-state signals cleanly",
+        "Test suite verifies the JSON output structure"
+      ]
+    },
+    {
+      "id": "implement-acs-guard-refactor-9f3e2a1b",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Guardrail Checkpoint Refactor",
+      "description": "Inspired by trend: Agent Control Specification (ACS). Refactor the existing safety checks into 5 distinct ACS checkpoints.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_v2.py",
+        "tests/test_acs_guard_v2*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "5 validation checkpoints are defined in the pipeline",
+        "Policy-driven tests are verified without hitting real models"
       ]
     }
   ]

--- a/magda_agent/integration/a2a_delegation.py
+++ b/magda_agent/integration/a2a_delegation.py
@@ -16,6 +16,68 @@ class A2ADelegator:
         self.security_context = getattr(discovery, 'security_context', None)
 
 
+
+
+    def split_plan(self, plan: list[Dict[str, Any]]) -> list[Dict[str, Any]]:
+        """
+        Extracts sub-plans while preserving chronological order.
+        Groups contiguous delegation steps for the same capability into sub-plans.
+
+        Args:
+            plan: The full execution plan.
+
+        Returns:
+            A list of sub-plans (where each sub-plan is a dict containing capability and steps).
+        """
+        sub_plans = []
+        current_capability = None
+        current_steps = []
+
+        for step in plan:
+            if step.get("skill") == "delegate_to_agent":
+                capability = step.get("skill_kwargs", {}).get("capability")
+                if capability:
+                    if capability == current_capability:
+                        current_steps.append(step)
+                    else:
+                        if current_capability is not None:
+                            sub_plans.append({"capability": current_capability, "steps": current_steps})
+                        current_capability = capability
+                        current_steps = [step]
+            else:
+                if current_capability is not None:
+                    sub_plans.append({"capability": current_capability, "steps": current_steps})
+                    current_capability = None
+                    current_steps = []
+
+        if current_capability is not None:
+            sub_plans.append({"capability": current_capability, "steps": current_steps})
+
+        return sub_plans
+
+    async def execute_plan(self, plan: list[Dict[str, Any]]) -> Dict[str, str]:
+        """
+        Extracts sub-plans chronologically and delegates them sequentially.
+
+        Args:
+            plan: The full execution plan.
+
+        Returns:
+            A dictionary mapping step IDs to their delegation result.
+        """
+        results = {}
+        sub_plans = self.split_plan(plan)
+
+        for sub_plan in sub_plans:
+            capability = sub_plan["capability"]
+            for step in sub_plan["steps"]:
+                step_id = step.get("id")
+                result = await self.delegate_subplan(capability, step)
+                if step_id:
+                    results[step_id] = result
+
+        return results
+
     async def delegate_subplan(self, capability: str, plan_context: Dict[str, Any]) -> str:
         """
         Finds an agent capable of executing the requested capability and delegates

--- a/tests/test_a2a_delegation.py
+++ b/tests/test_a2a_delegation.py
@@ -87,3 +87,37 @@ async def test_planner_agent_plan_delegation(mock_post, a2a_delegator):
 
     plan = await planner_agent.plan("do coding task")
     assert plan[0]["result"] == "Delegated to Agent TestAgent: Success"
+
+
+@pytest.mark.asyncio
+async def test_a2a_delegator_split_plan(a2a_delegator):
+    plan = [
+        {"id": "1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"},
+        {"id": "2", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "analysis"}, "description": "analyze it"},
+        {"id": "3", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code again"},
+        {"id": "4", "skill": "some_other_skill", "description": "do something else"}
+    ]
+    split = a2a_delegator.split_plan(plan)
+    assert len(split) == 3
+    assert split[0]["capability"] == "coding"
+    assert split[1]["capability"] == "analysis"
+    assert split[2]["capability"] == "coding"
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_a2a_delegator_execute_plan(mock_post, a2a_delegator):
+    plan = [
+        {"id": "1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"},
+        {"id": "2", "skill": "some_other_skill", "description": "do something else"}
+    ]
+
+    from unittest.mock import MagicMock
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": {"status": "Success"}}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    results = await a2a_delegator.execute_plan(plan)
+    assert "1" in results
+    assert "2" not in results
+    assert results["1"] == "Delegated to Agent TestAgent: Success"


### PR DESCRIPTION
Implemented A2A chronological sequential sub-plan delegator, marked task 'implement-a2a-delegator-0c1de20a' as done, and added 3 new medium-low risk trending tasks targeting OpenClaw RL, MCP, and ACS standard specs.

---
*PR created automatically by Jules for task [15655753102514271875](https://jules.google.com/task/15655753102514271875) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `split_plan` and `execute_plan` to `A2ADelegator` for sub-plan delegation
> - Adds `split_plan(plan)` to [a2a_delegation.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/263/files#diff-63653ef42d92af90747a5f5e269f1df0011e8545b185e8e30afd28662f2c1eb1) which groups contiguous `delegate_to_agent` steps by capability while preserving order.
> - Adds async `execute_plan(plan)` which sequentially delegates each sub-plan group via the existing `delegate_subplan`, returning a dict of step IDs to result strings; non-delegation steps are skipped.
> - Adds tests in [test_a2a_delegation.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/263/files#diff-aaef19c58ed00f96582ff19c938d1502ef202197388b383adaa5e8664e4d131d) covering both grouping order and selective delegation behavior.
> - Appends three new task entries to [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/263/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205): MCP tool export, OpenClaw RL canvas UI, and ACS guard refactor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbb4ad8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->