### PR TITLE
Implement ACS Workflow Guard Checkpoints & Expand Trend-Inspired Agent Tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4889,7 +4889,7 @@
     },
     {
       "id": "implement-acs-guard-881e0e4c",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Implement ACS Workflow Guard",
@@ -8968,6 +8968,57 @@
       "acceptance": [
         "5 validation checkpoints are defined in the pipeline",
         "Policy-driven tests are verified without hitting real models"
+      ]
+    },
+    {
+      "id": "mcp-action-tools-preflight-v4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Action Tools Pre-flight Validation",
+      "description": "Inspired by trend: MCP (Model Context Protocol). Create a pre-flight validation mechanism for all MCP action tools before invoking JSON-RPC.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_preflight.py",
+        "tests/test_mcp_preflight.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pre-flight validator intercepts invalid requests",
+        "Tests mock MCP clients to verify blocking behavior"
+      ]
+    },
+    {
+      "id": "a2a-delegation-circuit-breaker-v5",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Delegation Circuit Breaker",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol). Implement a circuit breaker pattern to prevent continuous task delegation failures to unresponsive peer agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_circuit_breaker.py",
+        "tests/test_a2a_circuit_breaker.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Circuit breaker trips after consecutive failures",
+        "System degrades gracefully to local execution or error state"
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-rollout-v6",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw-RL Multi-turn Trajectory Rollout",
+      "description": "Inspired by trend: OpenClaw-RL. Expand online reinforcement learning to buffer and rollout multi-turn conversational trajectories for delayed reward signals.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_rollout.py",
+        "tests/test_openclaw_rl_rollout.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory buffers persist across turns",
+        "Delayed reward is properly backpropagated to previous steps"
       ]
     }
   ]

--- a/magda_agent/safety/acs_guard.py
+++ b/magda_agent/safety/acs_guard.py
@@ -6,6 +6,8 @@ Implements 5 validation checkpoints for agent workflows to standardize runtime g
 import logging
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Tuple, Optional, List
+import re
+from magda_agent.safety.policy import PolicyLayer
 
 
 class SecurityViolationError(Exception):
@@ -63,10 +65,25 @@ class ToolPolicyCheckpoint(ACSCheckpoint):
     Checks if the tool complies with defined policies.
     """
 
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None) -> None:
+        """
+        Initializes the ToolPolicyCheckpoint.
+
+        Args:
+            policy_layer: An optional policy layer for evaluating tool usage.
+        """
+        self.policy_layer = policy_layer
+
     def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
         tool = workflow_data.get("tool")
         if tool == "forbidden_tool":
             return False, f"Tool policy failed: tool '{tool}' is forbidden."
+
+        if self.policy_layer and tool:
+            kwargs = workflow_data.get("kwargs", {})
+            allow, explanation = self.policy_layer.evaluate(tool, **kwargs)
+            if not allow:
+                return False, f"Tool policy failed: {explanation}"
         return True, "Tool policy passed."
 
 
@@ -84,6 +101,11 @@ class StateTransitionCheckpoint(ACSCheckpoint):
         return True, "State transition passed."
 
 
+_SENSITIVE_PATTERNS = (
+    re.compile(r"api[_-]?key|token|password|private[_-]?key", re.IGNORECASE),
+    re.compile(r"-----BEGIN [A-Z ]+ PRIVATE KEY-----"),
+)
+
 class OutputSanitizationCheckpoint(ACSCheckpoint):
     """
     Checkpoint 5: Output Sanitization.
@@ -92,8 +114,14 @@ class OutputSanitizationCheckpoint(ACSCheckpoint):
 
     def validate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
         output = workflow_data.get("output", "")
-        if "secret_key" in str(output):
+        output_str = str(output)
+        if "secret_key" in output_str:
             return False, "Output sanitization failed: sensitive data detected in output."
+
+        for pattern in _SENSITIVE_PATTERNS:
+            if pattern.search(output_str):
+                return False, f"Output sanitization failed: sensitive pattern '{pattern.pattern}' detected."
+
         return True, "Output sanitization passed."
 
 
@@ -103,13 +131,14 @@ class ACSGuard:
     and evaluates them through 5 ACS checkpoints before execution.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None) -> None:
         """Initializes the ACS Guard."""
         self.logger = logging.getLogger(__name__)
+        self.policy_layer = policy_layer
         self.checkpoints: List[ACSCheckpoint] = [
             InputValidationCheckpoint(),
             IntentAuthorizationCheckpoint(),
-            ToolPolicyCheckpoint(),
+            ToolPolicyCheckpoint(policy_layer=self.policy_layer),
             StateTransitionCheckpoint(),
             OutputSanitizationCheckpoint()
         ]

--- a/tests/test_acs_guard.py
+++ b/tests/test_acs_guard.py
@@ -1,5 +1,7 @@
 """Tests for the ACS Runtime Safety Guard."""
 import pytest
+from typing import Tuple
+from magda_agent.safety.policy import PolicyLayer
 from magda_agent.safety.acs_guard import (
     ACSGuard,
     SecurityViolationError,
@@ -9,6 +11,15 @@ from magda_agent.safety.acs_guard import (
     StateTransitionCheckpoint,
     OutputSanitizationCheckpoint
 )
+
+class MockPolicyLayer(PolicyLayer):
+    """Mock policy layer for testing."""
+    def evaluate(self, tool_name: str, **kwargs) -> Tuple[bool, str]:
+        """Evaluates if a tool is allowed."""
+        if tool_name == "blocked_by_policy":
+            return False, "Action denied: mock policy blocked this tool."
+        return True, "Action allowed."
+
 
 def test_acs_guard_valid_payload():
     guard = ACSGuard()
@@ -103,6 +114,46 @@ def test_tool_policy_checkpoint():
     passed, reason = checkpoint.validate({"tool": "forbidden_tool"})
     assert not passed
     assert reason == "Tool policy failed: tool 'forbidden_tool' is forbidden."
+
+def test_acs_guard_checkpoint_3_policy_layer_block() -> None:
+    """Tests that checkpoint 3 blocks execution if the policy layer denies the action."""
+    policy = MockPolicyLayer()
+    guard = ACSGuard(policy_layer=policy)
+    payload = {"action": "some_action", "tool": "blocked_by_policy", "kwargs": {"code": "some code"}}
+    with pytest.raises(SecurityViolationError, match="Action blocked by ACS checkpoint 3: Tool policy failed: Action denied: mock policy blocked this tool."):
+        guard.intercept_action(payload)
+
+def test_acs_guard_checkpoint_5_regex_leak() -> None:
+    """Tests that checkpoint 5 blocks execution if the output matches a sensitive regex pattern."""
+    guard = ACSGuard()
+    payload = {
+        "action": "some_action",
+        "tool": "some_tool",
+        "current_state": "idle",
+        "next_state": "executing",
+        "output": "here is my API_KEY: 12345"
+    }
+    with pytest.raises(SecurityViolationError, match="Action blocked by ACS checkpoint 5: Output sanitization failed: sensitive pattern .* detected."):
+        guard.intercept_action(payload)
+
+def test_tool_policy_checkpoint_with_policy() -> None:
+    """Tests the ToolPolicyCheckpoint with a mocked policy layer."""
+    policy = MockPolicyLayer()
+    checkpoint = ToolPolicyCheckpoint(policy_layer=policy)
+    passed, reason = checkpoint.validate({"tool": "ls"})
+    assert passed
+    assert reason == "Tool policy passed."
+
+    passed, reason = checkpoint.validate({"tool": "blocked_by_policy"})
+    assert not passed
+    assert reason == "Tool policy failed: Action denied: mock policy blocked this tool."
+
+def test_output_sanitization_checkpoint_regex() -> None:
+    """Tests the OutputSanitizationCheckpoint regex validation."""
+    checkpoint = OutputSanitizationCheckpoint()
+    passed, reason = checkpoint.validate({"output": "This has a PRIVATE_KEY included"})
+    assert not passed
+    assert "Output sanitization failed: sensitive pattern" in reason
 
 def test_state_transition_checkpoint():
     checkpoint = StateTransitionCheckpoint()


### PR DESCRIPTION
Implements the ACS Workflow Guard validation pipeline, specifically integrating an injected `PolicyLayer` for dynamic tool-level policy checks within `ToolPolicyCheckpoint`, and strengthening the `OutputSanitizationCheckpoint` using compiled regular expressions to rigorously block leakages of sensitive secrets (e.g. keys, tokens, passwords). Additionally marks the target implementation task as done in `agent_tasks.json` and seeds the backlog with three new actionable tasks inspired by June 2026 AI Agent trends: "MCP Action Tools Pre-flight Validation", "A2A Delegation Circuit Breaker", and "OpenClaw-RL Multi-turn Trajectory Rollout". Full test coverage has been added using a mock policy layer, and the workspace remains strictly clean.

---
*PR created automatically by Jules for task [6185746562005846944](https://jules.google.com/task/6185746562005846944) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add policy layer integration and regex-based sensitive pattern detection to ACS guard checkpoints
> - `ToolPolicyCheckpoint` in [acs_guard.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/264/files#diff-8d12ccdddf0184d11805240080a4e62da30ab6a1347a04413035f5a25ed89d76) now accepts an injected `PolicyLayer` and calls `policy_layer.evaluate(tool, **kwargs)` during validation, blocking tool executions the policy denies.
> - `OutputSanitizationCheckpoint` adds regex-based detection of common sensitive patterns (API keys, tokens, passwords, PEM private key headers) in addition to the existing `secret_key` literal check.
> - `ACSGuard.__init__` accepts an optional `PolicyLayer` and passes it to `ToolPolicyCheckpoint` at construction time.
> - New tests in [test_acs_guard.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/264/files#diff-113254d57e7b197af78eff676d430568b29db195ababf0581e7139ab1edf675a) cover policy-blocked tools at checkpoint 3 and regex-triggered failures at checkpoint 5.
> - Three new agent task entries are added to [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/264/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69cce74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->