### PR TITLE
Virtual Context Management Implementation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4923,7 +4923,7 @@
     },
     {
       "id": "virtual-context-management-v2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "high",
       "title": "Virtual Context Management",

--- a/magda_agent/memory/virtual_context.py
+++ b/magda_agent/memory/virtual_context.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Dict, Any
 from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import PADState
 from magda_agent.memory.working import MemoryEntry
@@ -8,14 +8,100 @@ if TYPE_CHECKING:
     from magda_agent.memory.working import WorkingMemory
     from magda_agent.memory.episodic import EpisodicMemory
 
+class CoreMemory:
+    """
+    Explicit, multi-layered core memory context inspired by MemGPT.
+    Contains persona (agent's identity), human (facts about the user),
+    and task (current high-level goals).
+    """
+    def __init__(self, persona: str = "", human: str = "", task: str = ""):
+        self.persona = persona
+        self.human = human
+        self.task = task
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "persona": self.persona,
+            "human": self.human,
+            "task": self.task
+        }
+
+    def assemble(self) -> str:
+        """Assembles the core memory into a single formatted string."""
+        parts = []
+        if self.persona:
+            parts.append(f"CORE MEMORY (PERSONA):\n{self.persona}")
+        if self.human:
+            parts.append(f"CORE MEMORY (HUMAN):\n{self.human}")
+        if self.task:
+            parts.append(f"CORE MEMORY (TASK):\n{self.task}")
+        return "\n\n".join(parts)
+
 class VirtualContextManager:
     """
-    VirtualContextManager handles paging out old short-term memory (WorkingMemory)
-    into EpisodicMemory, and paging it back in when requested via semantic search.
+    VirtualContextManager handles multi-layered core memory and paging out
+    old short-term memory (WorkingMemory) into EpisodicMemory.
     """
-    def __init__(self, llm_client: Optional['LLMClient'] = None) -> None:
-        """Initializes the VirtualContextManager with an optional LLM client."""
+    def __init__(self, llm_client: Optional['LLMClient'] = None, section_limit: int = 1000) -> None:
+        """
+        Initializes the VirtualContextManager.
+
+        Args:
+            llm_client: Optional LLM client for summarization.
+            section_limit: Heuristic word limit for core memory sections.
+        """
         self.llm_client = llm_client
+        self.core_memories: Dict[int, CoreMemory] = {}
+        self.section_limit = section_limit
+
+    def get_core_memory(self, user_id: int) -> CoreMemory:
+        """Retrieves or creates the core memory for a specific user."""
+        u_id = user_id if user_id is not None else -1
+        if u_id not in self.core_memories:
+            self.core_memories[u_id] = CoreMemory()
+        return self.core_memories[u_id]
+
+    async def update_core_section(self, user_id: int, section: str, content: str) -> None:
+        """
+        Updates a specific section of the core memory and enforces size limits.
+
+        Args:
+            user_id: The ID of the user.
+            section: One of 'persona', 'human', 'task'.
+            content: The new content for the section.
+        """
+        core = self.get_core_memory(user_id)
+        if section == "persona":
+            core.persona = content
+        elif section == "human":
+            core.human = content
+        elif section == "task":
+            core.task = content
+        else:
+            raise ValueError(f"Unknown core memory section: {section}")
+
+        await self._maintain_core_size(user_id, section)
+
+    async def _maintain_core_size(self, user_id: int, section: str) -> None:
+        """Maintains the size of a core memory section to prevent overflow."""
+        core = self.get_core_memory(user_id)
+        content = getattr(core, section)
+        if not content:
+            return
+
+        words = content.split()
+        if len(words) > self.section_limit:
+            logging.info(f"Core memory section '{section}' for user {user_id} exceeded limit ({len(words)} words). Compressing...")
+            if self.llm_client:
+                prompt = [
+                    {"role": "system", "content": f"You are a context manager. Summarize the following '{section}' memory section to stay under {self.section_limit} words while preserving essential facts."},
+                    {"role": "user", "content": content}
+                ]
+                summary = await self.llm_client.chat_completion(prompt)
+                setattr(core, section, summary.strip())
+            else:
+                # Fallback: simple truncation
+                setattr(core, section, " ".join(words[:self.section_limit]) + "...")
 
     async def compress_context(self, entries: List['MemoryEntry']) -> 'MemoryEntry':
         """
@@ -47,7 +133,8 @@ class VirtualContextManager:
         """
         Move the oldest `count` entries from WorkingMemory to EpisodicMemory.
         """
-        entries = working_memory.get_entries(user_id=user_id)
+        u_id = user_id if user_id is not None else -1
+        entries = working_memory.get_entries(user_id=u_id)
         if not entries:
             return
 
@@ -59,6 +146,9 @@ class VirtualContextManager:
                 to_remove = [compressed_entry]
             except Exception as e:
                 logging.error(f"Context compression failed during page_out: {e}")
+
+        # Keep track of IDs to remove from working memory
+        original_ids = [e.id for e in entries[:count]]
 
         for entry in to_remove:
             metadata = {
@@ -74,28 +164,30 @@ class VirtualContextManager:
             episodic_memory.store_event(
                 text=entry.content,
                 metadata=metadata,
-                user_id=user_id
+                user_id=u_id
             )
-            working_memory.remove(entry.id, user_id=user_id)
-            logging.debug(f"Paged out memory entry {entry.id} for user {user_id}")
+            logging.debug(f"Paged out memory entry {entry.id} for user {u_id}")
+
+        for eid in original_ids:
+            working_memory.remove(eid, user_id=u_id)
 
 
     async def page_in(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, query: str) -> None:
         """
         Recall relevant events from EpisodicMemory and load them into WorkingMemory.
         """
-        events = episodic_memory.recall_events(query=query, top_k=5, user_id=user_id)
+        u_id = user_id if user_id is not None else -1
+        events = episodic_memory.recall_events(query=query, top_k=5, user_id=u_id)
         for event_text in events:
-            # We recreate a MemoryEntry. For a more sophisticated system, we would retrieve
-            # the exact original metadata. But as per acceptance criteria, we restore the content.
+            # We recreate a MemoryEntry.
             entry = MemoryEntry(
                 content=event_text,
                 importance=0.5,
                 emotional_state=PADState(0, 0, 0),
-                user_id=user_id
+                user_id=u_id
             )
             # Add to working memory. Note: this might trigger another page_out if limit is exceeded!
             await working_memory.add(entry)
-            logging.debug(f"Paged in memory entry for user {user_id}: {event_text[:30]}...")
+            logging.debug(f"Paged in memory entry for user {u_id}: {event_text[:30]}...")
 
-# Implemented virtual context management
+# Implemented multi-layered core memory and virtual context management

--- a/tests/test_virtual_context.py
+++ b/tests/test_virtual_context.py
@@ -1,6 +1,6 @@
 from unittest.mock import AsyncMock
 import pytest
-from magda_agent.memory.virtual_context import VirtualContextManager
+from magda_agent.memory.virtual_context import VirtualContextManager, CoreMemory
 from magda_agent.memory.working import WorkingMemory, MemoryEntry
 from magda_agent.memory.episodic import EpisodicMemory
 from magda_agent.emotions.engine import PADState
@@ -86,4 +86,53 @@ async def test_virtual_context_compress_with_llm() -> None:
     assert summary.importance == 0.5
     assert summary.user_id == 1
 
-# Added tests for virtual context management
+@pytest.mark.asyncio
+async def test_core_memory_management():
+    vcm = VirtualContextManager()
+    user_id = 42
+
+    await vcm.update_core_section(user_id, "persona", "I am a helpful assistant.")
+    await vcm.update_core_section(user_id, "human", "The user is an engineer.")
+    await vcm.update_core_section(user_id, "task", "Implement context management.")
+
+    core = vcm.get_core_memory(user_id)
+    assert core.persona == "I am a helpful assistant."
+    assert core.human == "The user is an engineer."
+    assert core.task == "Implement context management."
+
+    assembled = core.assemble()
+    assert "CORE MEMORY (PERSONA):" in assembled
+    assert "I am a helpful assistant." in assembled
+    assert "CORE MEMORY (HUMAN):" in assembled
+    assert "The user is an engineer." in assembled
+    assert "CORE MEMORY (TASK):" in assembled
+    assert "Implement context management." in assembled
+
+@pytest.mark.asyncio
+async def test_core_memory_overflow_truncation():
+    # Set a small limit for testing truncation
+    vcm = VirtualContextManager(section_limit=5)
+    user_id = 123
+
+    long_content = "This is a very long string that will definitely exceed the five word limit."
+    await vcm.update_core_section(user_id, "persona", long_content)
+
+    core = vcm.get_core_memory(user_id)
+    # Heuristic limit is 5 words
+    words = core.persona.split()
+    assert len(words) == 5 # limit (last word includes "...")
+    assert core.persona.endswith("...")
+
+@pytest.mark.asyncio
+async def test_core_memory_overflow_llm_summarization():
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "Summarized Persona"
+    vcm = VirtualContextManager(llm_client=mock_llm, section_limit=5)
+    user_id = 123
+
+    long_content = "This is a very long string that will definitely exceed the five word limit."
+    await vcm.update_core_section(user_id, "persona", long_content)
+
+    core = vcm.get_core_memory(user_id)
+    assert core.persona == "Summarized Persona"
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Implemented the MemGPT-inspired multi-layered virtual context management system. 

Key changes:
1.  **Core Memory Support**: Introduced a `CoreMemory` class and updated `VirtualContextManager` to manage explicit context layers (`persona`, `human`, `task`) per user. This allows the agent to maintain stable identity and user facts across interactions.
2.  **Dynamic Maintenance**: Implemented automatic size enforcement for these sections. If a section exceeds the word limit, it's either summarized via LLM (if available) or truncated, preventing context overflow.
3.  **Refined Paging**: Corrected the `page_out` logic to properly handle entry removal when multiple items are compressed into one before being moved to episodic memory.
4.  **Verification**: Added new tests covering these features and verified that all existing virtual context tests pass.
5.  **Task Tracking**: Updated the internal task manifest to reflect completion.

---
*PR created automatically by Jules for task [1433240798648319258](https://jules.google.com/task/1433240798648319258) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-user core memory management to `VirtualContextManager`
> - Introduces a `CoreMemory` class in [`virtual_context.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/266/files#diff-753a92d4a4e6dcaa5f5c6ace96f8edce760eaac00102b309d237867b619b5e3e) with `persona`, `human`, and `task` fields, plus an `assemble()` method that formats all three sections into a single string.
> - Adds `get_core_memory` and `update_core_section` methods to `VirtualContextManager` for per-user retrieval and mutation of core memory sections.
> - Adds `_maintain_core_size` to enforce a configurable `section_limit` (default 1000 words) by summarizing via LLM or truncating with an ellipsis when a section exceeds the limit.
> - Fixes `page_out` and `page_in` to correctly remove all original working-memory entries after compression and to consistently map `None` user IDs to `-1`.
> - Behavioral Change: oversized core memory sections are now automatically mutated at runtime — either summarized via LLM or truncated — which permanently alters stored section content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13417c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->