### PR TITLE
feat(safety): Implement RealtimeGuardrailFallback and task updates

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -4974,7 +4974,7 @@
     },
     {
       "id": "openai-realtime-guardrail-fallback-v2",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "OpenAI Realtime Guardrail Fallback",
@@ -9121,6 +9121,57 @@
       "acceptance": [
         "Context for subagents is compressed based on task relevance",
         "Tests verify that context is reduced while retaining critical constraints"
+      ]
+    },
+    {
+      "id": "mcp-action-tool-preflight",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Action Tools Preflight Checks",
+      "description": "Inspired by trend: MCP tools integration. Add a pre-flight validation mechanism for all MCP action tools before execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_preflight.py",
+        "tests/test_mcp_preflight.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pre-flight validates parameters before execution",
+        "Tests verify valid vs invalid conditions"
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-ui-metrics",
+      "status": "todo",
+      "area": "UI",
+      "risk": "low",
+      "title": "OpenClaw Canvas Visualization Metrics",
+      "description": "Inspired by trend: OpenClaw Canvas Live Visualization. Structure and export real-time metrics for Q-value updates for canvas consumption.",
+      "allowed_paths": [
+        "magda_agent/learning/canvas_metrics.py",
+        "tests/test_canvas_metrics.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exported data matches OpenClaw schema expectations",
+        "Tests verify JSON formats"
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent-refactor",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Claude Evaluator Subagent Implementation",
+      "description": "Inspired by trend: Planner, Generator, Evaluator pattern. Refactor the Evaluator to be run via an isolated SubAgent execution context.",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_subagent.py",
+        "tests/test_evaluator_subagent.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator runs through a SubAgent layer",
+        "Evaluator retains core evaluation constraints logic"
       ]
     }
   ]

--- a/magda_agent/safety/acs.py
+++ b/magda_agent/safety/acs.py
@@ -2,6 +2,7 @@ import logging
 import re
 from typing import Dict, Any, Tuple, List, Optional
 from magda_agent.safety.policy import PolicyLayer
+from magda_agent.safety.fallback import RealtimeGuardrailFallback
 
 _SENSITIVE_PATTERNS = (
     re.compile(r"api[_-]?key|token|password|private[_-]?key", re.IGNORECASE),
@@ -27,6 +28,7 @@ class ACSWorkflowGuard:
         """
         self.policy_layer = policy_layer or PolicyLayer()
         self.logger = logging.getLogger(__name__)
+        self.fallback = RealtimeGuardrailFallback(self.policy_layer)
 
     def checkpoint_1_input_validation(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
         """

--- a/magda_agent/safety/fallback.py
+++ b/magda_agent/safety/fallback.py
@@ -1,0 +1,33 @@
+"""
+OpenAI Realtime Guardrail Fallback module.
+Implements dynamic fallback strategies when runtime safety guardrails block a tool call.
+"""
+from typing import Any, Callable, Dict, Optional, Tuple
+from magda_agent.safety.policy import PolicyLayer
+
+class RealtimeGuardrailFallback:
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None) -> None:
+        """
+        Initializes the fallback guardrail.
+        """
+        self.policy_layer = policy_layer or PolicyLayer()
+        self.fallback_handlers: Dict[str, Callable] = {}
+
+    def register_fallback(self, tool_name: str, handler: Callable) -> None:
+        """
+        Registers a dynamic fallback handler for a specific tool.
+        """
+        self.fallback_handlers[tool_name] = handler
+
+    def execute_with_fallback(self, tool_func: Callable, tool_name: str, **kwargs: Any) -> Any:
+        """
+        Executes the tool with a fallback mechanism on violation.
+        """
+        allow, explanation = self.policy_layer.evaluate(tool_name, **kwargs)
+        if allow:
+            return tool_func(**kwargs)
+
+        if tool_name in self.fallback_handlers:
+            return self.fallback_handlers[tool_name](explanation, **kwargs)
+
+        raise ValueError(f"Action blocked by policy and no fallback available: {explanation}")

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,53 @@
+import pytest
+from typing import Any
+from magda_agent.safety.fallback import RealtimeGuardrailFallback
+from magda_agent.safety.policy import PolicyLayer
+
+def mock_tool(**kwargs: Any) -> str:
+    """
+    Mock tool function for testing.
+    """
+    return "success"
+
+def mock_fallback(explanation: str, **kwargs: Any) -> str:
+    """
+    Mock fallback handler.
+    """
+    return f"fallback triggered: {explanation}"
+
+class MockPolicyLayer(PolicyLayer):
+    """
+    Mock PolicyLayer for testing.
+    """
+    def evaluate(self, tool_name: str, **kwargs: Any) -> tuple[bool, str]:
+        """
+        Mocks evaluate method.
+        """
+        if tool_name == "blocked_tool":
+            return False, "This tool is blocked"
+        return True, "Allowed"
+
+def test_fallback_success() -> None:
+    """
+    Tests successful execution when tool is allowed.
+    """
+    fallback = RealtimeGuardrailFallback(policy_layer=MockPolicyLayer())
+    result = fallback.execute_with_fallback(mock_tool, "allowed_tool", arg="test")
+    assert result == "success"
+
+def test_fallback_triggered() -> None:
+    """
+    Tests that a fallback handler is executed when a tool is blocked.
+    """
+    fallback = RealtimeGuardrailFallback(policy_layer=MockPolicyLayer())
+    fallback.register_fallback("blocked_tool", mock_fallback)
+    result = fallback.execute_with_fallback(mock_tool, "blocked_tool", arg="test")
+    assert "fallback triggered: This tool is blocked" in result
+
+def test_fallback_no_handler() -> None:
+    """
+    Tests that a ValueError is raised when a tool is blocked and no handler exists.
+    """
+    fallback = RealtimeGuardrailFallback(policy_layer=MockPolicyLayer())
+    with pytest.raises(ValueError, match="Action blocked by policy and no fallback available"):
+        fallback.execute_with_fallback(mock_tool, "blocked_tool", arg="test")


### PR DESCRIPTION
- Implement `RealtimeGuardrailFallback` module in `magda_agent/safety/fallback.py` to allow dynamic fallbacks for tool execution blocks, inspired by OpenAI agents SDK trends.
- Update `ACSWorkflowGuard` to integrate the fallback.
- Added corresponding tests using `pytest` without real LLM/API calls.
- Resolved and closed backlog item `openai-realtime-guardrail-fallback-v2` in `agent_tasks.json`.
- Added new todo tasks for MCP Action Tools Preflight, Claude Evaluator Subagent Refactor, and OpenClaw Canvas Visualization Metrics.

---
*PR created automatically by Jules for task [13345357465971566145](https://jules.google.com/task/13345357465971566145) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `RealtimeGuardrailFallback` for policy-blocked tool execution in `ACSWorkflowGuard`
> - Adds [`RealtimeGuardrailFallback`](https://github.com/kazah4359-lgtm/Magda-agent/pull/269/files#diff-0df81798b7738882aeae8a3ad4b45802a2334fc798fd73460ede6a22508349f0) with per-tool handler registration; `execute_with_fallback` evaluates policy, runs the tool if allowed, calls a registered fallback handler if blocked, or raises `ValueError` if blocked with no handler.
> - Attaches a `RealtimeGuardrailFallback` instance as `self.fallback` on [`ACSWorkflowGuard`](https://github.com/kazah4359-lgtm/Magda-agent/pull/269/files#diff-dce5e7e13f51229c742e79bd449a438396d520b044f84ca9c513fe89121b4a7b), sharing its existing `PolicyLayer`.
> - Adds three passing tests in [`tests/test_fallback.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/269/files#diff-fe7d7adcc971317281095ea60efd059f0709c33379013cfcaf67a4a8cf1f04c6) covering the allowed, fallback-triggered, and no-handler paths.
> - Updates `agent_tasks.json` with three new task entries and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fefce4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->