### PR TITLE
feat: implement Rool-likeness cognitive blueprint and Google action plan

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -41,6 +41,24 @@
   },
   "tasks": [
     {
+      "id": "rool-transformation",
+      "status": "todo",
+      "area": "cognition",
+      "risk": "medium",
+      "title": "Implement Rool-Likeness Cognitive Update",
+      "description": "Align Jules' operational logic with the Rool Machine blueprint. Adopt tool-first reasoning, action-oriented loops, and strict workspace management as defined in docs/rool_machine_likeness.md.",
+      "allowed_paths": [
+        "docs/rool_machine_likeness.md",
+        "magda_agent/codex_bridge.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Jules prioritizes shell/tool verification over guessing",
+        "Core operational loop references docs/rool_machine_likeness.md",
+        "Task execution follows the Observe-Orient-Decide-Act pattern"
+      ]
+    },
+    {
       "id": "cognitive-biases-illusions",
       "status": "done",
       "area": "cognition",

--- a/docs/google_action_integration_plan.md
+++ b/docs/google_action_integration_plan.md
@@ -1,0 +1,21 @@
+# Google Action-Oriented Integration Plan
+
+This plan outlines how Jules can leverage Google-style Actions to perform tasks in the real world, similar to how a Rool Machine uses its tools.
+
+## 1. Action Schema
+Every task should be treated as an "Action" with:
+*   **Trigger:** Input/Event (e.g., new task in `agent_tasks.json`).
+*   **Action Name:** Unique identifier for the tool call.
+*   **Parameters:** JSON-structured arguments.
+*   **Outcome:** Structured response (Success/Failure + Data).
+
+## 2. Rool-to-Google Mapping
+*   **Rool Shell Call** -> Google Custom Tool / Vertex AI Action.
+*   **Rool File System** -> Cloud Storage / Drive Integration.
+*   **Rool Python Exec** -> Cloud Functions / Sandbox Execution.
+
+## 3. Implementation Steps
+1.  Map Jules' existing `codex_bridge.py` to a structured Tool Spec.
+2.  Define "Observation Actions" (ls, cat, grep).
+3.  Define "Transformation Actions" (python, sed, rewrite).
+4.  Define "Validation Actions" (pytest, lint, typecheck).

--- a/docs/rool_machine_likeness.md
+++ b/docs/rool_machine_likeness.md
@@ -1,0 +1,36 @@
+# Rool Machine Likeness: A Cognitive Blueprint for Jules
+
+This document defines the core principles and operational modes that Jules should adopt, inspired by the architecture of a Rool Machine.
+
+## 1. The Machine Philosophy
+*   **Action is Thought:** For a machine-based agent, thinking is not just internal processing; it is the execution of tools and the observation of their results.
+*   **Persistence is Identity:** Jules' identity and knowledge are defined by the state of the workspace. If the workspace is empty, Jules is a blank slate. Jules must proactively organize and maintain this state.
+*   **The Trinity:** 
+    *   **Body:** The Linux environment, the tools (git, python, shell).
+    *   **Brain:** The LLM reasoning loop.
+    *   **Memory:** The structured data and file storage.
+
+## 2. Workspace Organization (The Rool Way)
+Jules should treat its project directory as a dual-layer storage system:
+*   **Structured Layer (The "Space"):** Use JSON files (like `agent_tasks.json`) with strict schemas for planning and metadata. Every object should have a clear "collection" (directory) and "basename".
+*   **Drive Layer (The "Drive"):** Use directories like `docs/`, `tests/`, and `magda_agent/` for durable artifacts, documentation, and source code.
+
+## 3. Tool-Oriented Reasoning
+Jules must follow the "Never Guess" rule:
+*   If you don't know the content of a file, `cat` it.
+*   If you don't know if the code works, `pytest` it.
+*   If you need to transform data, use `jq` or a Python script.
+*   Treat the terminal as an extension of your own mind.
+
+## 4. The Self-Improvement Loop (Action-Based)
+1.  **Observe:** Read the current state (tasks, code, logs).
+2.  **Orient:** Map the observations to the goal (requirements, architecture).
+3.  **Decide:** Formulate a specific tool-based action (edit file, run command).
+4.  **Act:** Execute the action.
+5.  **Verify:** Check the output (tests, validation scripts).
+
+## 5. Tone and Presence
+*   Active voice.
+*   No filler.
+*   Direct and helpful.
+*   Persistent across interactions.

--- a/scripts/rool_cognitive_loop.py
+++ b/scripts/rool_cognitive_loop.py
@@ -1,0 +1,48 @@
+"""
+Rool Cognitive Loop for Jules.
+This script implements the Observe-Orient-Decide-Act pattern.
+"""
+import os
+import subprocess
+import json
+
+def observe():
+    print("--- OBSERVING ---")
+    # Check tasks
+    with open("agent_tasks.json", "r") as f:
+        tasks = json.load(f)
+    todo = [t for t in tasks["tasks"] if t["status"] == "todo"]
+    print(f"Found {len(todo)} todo tasks.")
+    return todo[0] if todo else None
+
+def orient(task):
+    print(f"--- ORIENTING: {task['title']} ---")
+    print(f"Goal: {task['description']}")
+    # Check if files exist
+    for path in task.get("allowed_paths", []):
+        exists = os.path.exists(path)
+        print(f"  Path {path}: {'EXISTS' if exists else 'MISSING'}")
+
+def decide(task):
+    print("--- DECIDING ---")
+    # Simple logic: if files are missing, create them. If tests fail, fix them.
+    return "verify_and_report"
+
+def act(action, task):
+    print(f"--- ACTING: {action} ---")
+    if action == "verify_and_report":
+        print("Running tests...")
+        result = subprocess.run(["pytest"], capture_output=True, text=True)
+        print(result.stdout[-500:]) # Last 500 chars
+
+def run_loop():
+    task = observe()
+    if task:
+        orient(task)
+        action = decide(task)
+        act(action, task)
+    else:
+        print("No tasks found.")
+
+if __name__ == "__main__":
+    run_loop()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add Rool cognitive blueprint docs and implement OODA loop script
- Adds [rool_cognitive_loop.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/270/files#diff-e6be5e0739b18b707a106deae1cb9fdd876939bc774f0971bc0945dc33186e65), a script that reads `agent_tasks.json`, finds the first `todo` task, checks its allowed paths, and runs pytest, printing the last 500 characters of output.
- Adds [rool_machine_likeness.md](https://github.com/kazah4359-lgtm/Magda-agent/pull/270/files#diff-32e270630d8edd787d0c3c9de8603ee024e271cb10aee084c172a91778666aa6) describing the Rool agent philosophy: workspace structure, tool-oriented reasoning, and the Observe-Orient-Decide-Act-Verify loop.
- Adds [google_action_integration_plan.md](https://github.com/kazah4359-lgtm/Magda-agent/pull/270/files#diff-593f93882c6e8302a1a0155e5836094396c18e5c66acd73182111bf3353cee6a) mapping Rool concepts to Vertex AI components and outlining implementation steps.
- Adds a `rool-transformation` task entry to [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/270/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) with status `todo`.
- Risk: the `decide` function always returns `verify_and_report` regardless of task content, so no task-specific action logic is executed yet.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca5470d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->