### PR TITLE
Implement Cross-Platform Channel Hub

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5027,7 +5027,7 @@
     },
     {
       "id": "cross-platform-channel-hub",
-      "status": "todo",
+      "status": "done",
       "area": "channels",
       "risk": "medium",
       "title": "Cross-Platform Channel Hub",
@@ -9279,6 +9279,58 @@
       "acceptance": [
         "Context engine visualizer hook broadcasts context updates",
         "Tests verify JSON export format matches OpenClaw schema"
+      ]
+    },
+    {
+      "id": "slack-channel-adapter-v1",
+      "status": "todo",
+      "area": "channels",
+      "risk": "medium",
+      "title": "Slack Channel Adapter",
+      "description": "Inspired by trend: Multi-platform agents (Hermes). Implement an adapter for Slack to integrate seamlessly with the new ChannelHub.",
+      "allowed_paths": [
+        "magda_agent/channels/slack.py",
+        "tests/test_slack_adapter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "SlackAdapter correctly handles incoming events and formats outgoing messages.",
+        "Tests verify adapter logic without external API calls."
+      ]
+    },
+    {
+      "id": "unified-notification-broadcast",
+      "status": "todo",
+      "area": "channels",
+      "risk": "low",
+      "title": "Cross-Platform Unified Notification Broadcast",
+      "description": "Inspired by trend: Proactive notifications. Create a skill that allows broadcasting critical notifications to a user across all their registered platforms via the ChannelHub.",
+      "allowed_paths": [
+        "magda_agent/skills/notification_broadcast.py",
+        "tests/test_notification_broadcast.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Broadcast skill routes messages to all configured ChannelAdapters via the hub.",
+        "Tests mock the ChannelHub and verify broadcast capability."
+      ]
+    },
+    {
+      "id": "channel-hub-rate-limiter",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Channel Hub Rate Limiter",
+      "description": "Inspired by trend: Agent Guard and runtime governance. Add an explicit rate limiting wrapper around ChannelHub.send_to_channel to prevent API flooding on connected platforms.",
+      "allowed_paths": [
+        "magda_agent/channels/rate_limiter.py",
+        "magda_agent/channels/hub.py",
+        "tests/test_channel_rate_limiter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ChannelHub correctly delays or blocks outgoing messages if rate limit is exceeded.",
+        "Tests verify rate limit behavior with mocked time."
       ]
     }
   ]

--- a/magda_agent/channels/hub.py
+++ b/magda_agent/channels/hub.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, Optional
+from magda_agent.channels.base import ChannelAdapter
+
+class ChannelHub:
+    """
+    Centralized messaging hub that abstracts multiple channel adapters.
+    Manages a collection of ChannelAdapter instances and allows receiving and sending messages across them.
+    """
+    def __init__(self):
+        self._adapters: Dict[str, ChannelAdapter] = {}
+
+    def register_adapter(self, adapter: ChannelAdapter) -> None:
+        """
+        Register a ChannelAdapter with the hub.
+
+        Args:
+            adapter (ChannelAdapter): The adapter instance to register.
+        """
+        self._adapters[adapter.channel_id] = adapter
+
+    def get_adapter(self, channel_id: str) -> Optional[ChannelAdapter]:
+        """
+        Retrieve a registered ChannelAdapter by its ID.
+
+        Args:
+            channel_id (str): The ID of the channel.
+
+        Returns:
+            Optional[ChannelAdapter]: The adapter if found, otherwise None.
+        """
+        return self._adapters.get(channel_id)
+
+    async def receive_from_channel(self, channel_id: str, raw_data: Any) -> Any:
+        """
+        Process incoming messages from a specific channel.
+
+        Args:
+            channel_id (str): The ID of the channel.
+            raw_data (Any): The raw incoming data.
+
+        Returns:
+            Any: The response from the channel adapter's receive method, or None if the adapter is not found.
+        """
+        adapter = self.get_adapter(channel_id)
+        if adapter:
+            return await adapter.receive(raw_data)
+        return None
+
+    async def send_to_channel(self, channel_id: str, recipient_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """
+        Dispatch outgoing messages to a specific channel.
+
+        Args:
+            channel_id (str): The ID of the target channel.
+            recipient_id (str): The ID of the recipient.
+            text (str): The message text.
+            metadata (Optional[Dict[str, Any]]): Additional metadata.
+
+        Returns:
+            Any: The response from the channel adapter's send method, or an error string if the adapter is not found.
+        """
+        adapter = self.get_adapter(channel_id)
+        if adapter:
+            return await adapter.send(recipient_id, text, metadata)
+        return f"Error: Channel '{channel_id}' not found."

--- a/tests/test_channel_hub.py
+++ b/tests/test_channel_hub.py
@@ -1,0 +1,92 @@
+import pytest
+import asyncio
+from typing import Any, Dict
+from magda_agent.channels.base import ChannelAdapter
+from magda_agent.channels.hub import ChannelHub
+from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
+
+class MockChannel(ChannelAdapter):
+    """A mock channel adapter for testing purposes."""
+
+    def __init__(self, channel_id: str, gateway: GatewayRouter) -> None:
+        """Initialize the mock channel."""
+        super().__init__(channel_id, gateway)
+
+    async def receive(self, raw_data: Dict[str, Any]) -> Any:
+        """Process incoming mock data and route it."""
+        text: str = raw_data.get("text", "")
+        user_id: str = raw_data.get("user_id", "")
+        msg = UnifiedMessage(
+            channel=self.channel_id,
+            text=text,
+            user_id=user_id,
+            metadata={"raw": raw_data}
+        )
+        return await self.gateway.route_message(msg)
+
+    async def send(self, recipient_id: str, text: str, metadata: Dict[str, Any] = None) -> str:
+        """Mock sending a message."""
+        return f"Mock {self.channel_id} sent to {recipient_id}: {text}"
+
+@pytest.fixture
+def gateway() -> GatewayRouter:
+    """Fixture that provides a GatewayRouter with a mock message handler."""
+    router = GatewayRouter()
+
+    async def mock_handler(msg: UnifiedMessage) -> Dict[str, str]:
+        return {"handled_text": msg.text, "handled_user": msg.user_id, "channel": msg.channel}
+
+    router.set_message_handler(mock_handler)
+    return router
+
+@pytest.fixture
+def channel_hub() -> ChannelHub:
+    """Fixture that provides a ChannelHub instance."""
+    return ChannelHub()
+
+def test_register_and_get_adapter(gateway: GatewayRouter, channel_hub: ChannelHub) -> None:
+    """Test registering and retrieving adapters."""
+    adapter1 = MockChannel("telegram_mock", gateway)
+    adapter2 = MockChannel("discord_mock", gateway)
+
+    channel_hub.register_adapter(adapter1)
+    channel_hub.register_adapter(adapter2)
+
+    assert channel_hub.get_adapter("telegram_mock") is adapter1
+    assert channel_hub.get_adapter("discord_mock") is adapter2
+    assert channel_hub.get_adapter("unknown") is None
+
+@pytest.mark.asyncio
+async def test_receive_from_channel(gateway: GatewayRouter, channel_hub: ChannelHub) -> None:
+    """Test receiving messages from a specific channel through the hub."""
+    adapter = MockChannel("telegram_mock", gateway)
+    channel_hub.register_adapter(adapter)
+
+    response = await channel_hub.receive_from_channel("telegram_mock", {"text": "hello hub", "user_id": "user1"})
+
+    assert response is not None
+    assert response["handled_text"] == "hello hub"
+    assert response["handled_user"] == "user1"
+    assert response["channel"] == "telegram_mock"
+
+    # Test receiving from an unknown channel
+    response_unknown = await channel_hub.receive_from_channel("unknown_channel", {"text": "hello"})
+    assert response_unknown is None
+
+@pytest.mark.asyncio
+async def test_send_to_channel(gateway: GatewayRouter, channel_hub: ChannelHub) -> None:
+    """Test dispatching outgoing messages to a specific channel through the hub."""
+    adapter1 = MockChannel("telegram_mock", gateway)
+    adapter2 = MockChannel("discord_mock", gateway)
+    channel_hub.register_adapter(adapter1)
+    channel_hub.register_adapter(adapter2)
+
+    response1 = await channel_hub.send_to_channel("telegram_mock", "user1", "message 1")
+    response2 = await channel_hub.send_to_channel("discord_mock", "user2", "message 2")
+
+    assert response1 == "Mock telegram_mock sent to user1: message 1"
+    assert response2 == "Mock discord_mock sent to user2: message 2"
+
+    # Test sending to an unknown channel
+    response_unknown = await channel_hub.send_to_channel("unknown_channel", "user3", "hello")
+    assert response_unknown == "Error: Channel 'unknown_channel' not found."


### PR DESCRIPTION
Implemented the ChannelHub module to abstract messaging across Telegram, Discord, and other channels. Added pytest tests, updated agent_tasks.json marking cross-platform-channel-hub as done, and appended 3 new trends-inspired tasks.

---
*PR created automatically by Jules for task [14155586233020957774](https://jules.google.com/task/14155586233020957774) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ChannelHub` class to route messages across registered channel adapters
> - Introduces [`ChannelHub`](https://github.com/kazah4359-lgtm/Magda-agent/pull/273/files#diff-9293e380c95499807dc7338390df25bb4a40d68dc277a48f9aecffa4506ab748) as a central registry that maps `channel_id` to `ChannelAdapter` instances, with `register_adapter`, `get_adapter`, `receive_from_channel`, and `send_to_channel` async methods.
> - `send_to_channel` returns a string error `'Error: Channel '<id>' not found.'` for unregistered channels; `receive_from_channel` returns `None`.
> - Adds tests in [`tests/test_channel_hub.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/273/files#diff-ed42476fc19234327201de63b0b9952092619656e11027d7248c7571d14523d9) covering adapter registration, receive routing, and send routing including the not-found error path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f09c4de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->