### PR TITLE
feat: Implement MCP Action Tool Registry and Append A2A Tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5044,7 +5044,7 @@
     },
     {
       "id": "mcp-action-tool-registry",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Action Tool Registry",
@@ -9331,6 +9331,57 @@
       "acceptance": [
         "ChannelHub correctly delays or blocks outgoing messages if rate limit is exceeded.",
         "Tests verify rate limit behavior with mocked time."
+      ]
+    },
+    {
+      "id": "a2a-agent-cards-discovery-v4",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Agent Cards Discovery V4",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol). Implement Agent discovery utilizing Agent Cards as per the standard to locate external agents dynamically.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v4.py",
+        "tests/test_a2a_discovery_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A agent card discovery module is created",
+        "Tests mock external card registries to ensure robust parsing"
+      ]
+    },
+    {
+      "id": "a2a-peer-task-delegation-v4",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "A2A Peer Task Delegation V4",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol). Extend Magda to allow peer-to-peer task delegation to other agents following the A2A spec.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegator_v4.py",
+        "tests/test_a2a_delegator_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A delegation logic supports sending tasks to peers",
+        "Tests correctly simulate peer responses and handle errors"
+      ]
+    },
+    {
+      "id": "a2a-async-tracing-v4",
+      "status": "todo",
+      "area": "monitoring",
+      "risk": "low",
+      "title": "A2A Async-first Tracing V4",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol). Implement async-first tracing and monitoring for cross-agent workflows.",
+      "allowed_paths": [
+        "magda_agent/tracing/a2a_tracer_v4.py",
+        "tests/test_a2a_tracer_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Async-first tracing is established for remote agent calls",
+        "Tests verify trace correlation IDs match between actions"
       ]
     }
   ]

--- a/magda_agent/skills/mcp_registry.py
+++ b/magda_agent/skills/mcp_registry.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Dict, Any, List
+
+class MCPRegistry:
+    """
+    Registry specialized in handling tools exported via the Model Context Protocol (MCP).
+    """
+
+    def __init__(self) -> None:
+        """Initialize the MCP Registry."""
+        self.mcp_tools: Dict[str, Dict[str, Any]] = {}
+
+    def load_tool(self, tool_schema: Dict[str, Any]) -> bool:
+        """
+        Dynamically loads and verifies an external MCP tool schema.
+
+        Args:
+            tool_schema (Dict[str, Any]): The MCP tool schema dictionary.
+
+        Returns:
+            bool: True if loaded successfully, False otherwise.
+        """
+        if not self._is_valid_schema(tool_schema):
+            logging.error(f"Failed to load MCP tool: Invalid schema {tool_schema}")
+            return False
+
+        name = tool_schema["name"]
+        self.mcp_tools[name] = tool_schema
+        logging.info(f"Successfully loaded MCP tool: {name}")
+        return True
+
+    def _is_valid_schema(self, schema: Dict[str, Any]) -> bool:
+        """
+        Verifies if the schema complies with MCP tool standards.
+
+        Args:
+            schema (Dict[str, Any]): The MCP tool schema.
+
+        Returns:
+            bool: True if valid, False otherwise.
+        """
+        if not isinstance(schema, dict):
+            return False
+
+        required_fields = ["name", "description"]
+        for field in required_fields:
+            if field not in schema or not isinstance(schema[field], str) or not schema[field]:
+                return False
+
+        return True
+
+    def get_tool(self, name: str) -> Dict[str, Any]:
+        """
+        Retrieve a loaded MCP tool by name.
+
+        Args:
+            name (str): The name of the MCP tool.
+
+        Returns:
+            Dict[str, Any]: The tool schema, or empty dict if not found.
+        """
+        return self.mcp_tools.get(name, {})
+
+    def list_tools(self) -> List[str]:
+        """
+        List all available MCP tools.
+
+        Returns:
+            List[str]: A list of tool names.
+        """
+        return list(self.mcp_tools.keys())

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -1,0 +1,68 @@
+import pytest
+from magda_agent.skills.mcp_registry import MCPRegistry
+
+@pytest.fixture
+def registry() -> MCPRegistry:
+    return MCPRegistry()
+
+def test_load_valid_tool(registry: MCPRegistry) -> None:
+    """Test loading a valid MCP tool schema."""
+    valid_schema = {
+        "name": "calculator_tool",
+        "description": "Performs basic mathematical operations.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"expression": {"type": "string"}},
+            "required": ["expression"]
+        }
+    }
+
+    assert registry.load_tool(valid_schema) is True
+    assert "calculator_tool" in registry.list_tools()
+
+    tool = registry.get_tool("calculator_tool")
+    assert tool["name"] == "calculator_tool"
+    assert "inputSchema" in tool
+
+def test_load_invalid_tool_missing_name(registry: MCPRegistry) -> None:
+    """Test loading an invalid MCP tool schema (missing name)."""
+    invalid_schema = {
+        "description": "Missing name field."
+    }
+
+    assert registry.load_tool(invalid_schema) is False
+    assert len(registry.list_tools()) == 0
+
+def test_load_invalid_tool_missing_description(registry: MCPRegistry) -> None:
+    """Test loading an invalid MCP tool schema (missing description)."""
+    invalid_schema = {
+        "name": "some_tool"
+    }
+
+    assert registry.load_tool(invalid_schema) is False
+    assert len(registry.list_tools()) == 0
+
+def test_load_invalid_tool_not_dict(registry: MCPRegistry) -> None:
+    """Test loading an invalid MCP tool schema (not a dict)."""
+    invalid_schema = "this is just a string" # type: ignore
+
+    assert registry.load_tool(invalid_schema) is False
+    assert len(registry.list_tools()) == 0
+
+def test_get_nonexistent_tool(registry: MCPRegistry) -> None:
+    """Test retrieving a tool that has not been loaded."""
+    tool = registry.get_tool("fake_tool")
+    assert tool == {}
+
+def test_list_tools(registry: MCPRegistry) -> None:
+    """Test listing loaded tools."""
+    tool1 = {"name": "tool1", "description": "d1"}
+    tool2 = {"name": "tool2", "description": "d2"}
+
+    registry.load_tool(tool1)
+    registry.load_tool(tool2)
+
+    tools = registry.list_tools()
+    assert len(tools) == 2
+    assert "tool1" in tools
+    assert "tool2" in tools


### PR DESCRIPTION
This pull request addresses the `mcp-action-tool-registry` task by implementing a dedicated MCP Tool Registry that validates schema constraints (like names and descriptions). It includes a fully mock-based test suite verifying edge cases. It also marks the original task as "done" and adds three new tasks related to Agent-to-Agent (A2A) standards inspired by current AI agent trends found in the `docs/trends.md`.

---
*PR created automatically by Jules for task [15761109275133336749](https://jules.google.com/task/15761109275133336749) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPRegistry` class for dynamic MCP tool schema registration and lookup
> - Implements [`mcp_registry.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/274/files#diff-7bd31ee3bdddfbf36be0e971eb0b8b7c11b46ba4d33ad77f5f002b7cf127c7ee) with `MCPRegistry`, supporting `load_tool`, `get_tool`, and `list_tools` methods backed by an in-memory dict.
> - Schema validation requires `name` and `description` to be non-empty strings; invalid schemas are rejected and logged.
> - Adds [`tests/test_mcp_registry.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/274/files#diff-976ad21abd8e6353061c0d81c3a59e1d72fb1e76772916d2e9bc2f493bcf884b) covering valid load, missing fields, non-dict input, unknown key lookup, and multi-tool listing.
> - Appends three new A2A task entries (`a2a-agent-cards-discovery-v4`, `a2a-peer-task-delegation-v4`, `a2a-async-tracing-v4`) to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/274/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a719ccd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->