### PR TITLE
feat(skills): implement Skill Marketplace Importer v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5061,7 +5061,7 @@
     },
     {
       "id": "skill-marketplace-importer-v2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Skill Marketplace Importer v2",
@@ -9382,6 +9382,56 @@
       "acceptance": [
         "Async-first tracing is established for remote agent calls",
         "Tests verify trace correlation IDs match between actions"
+      ]
+    },
+    {
+      "id": "agent-guard-policy-layer-v3",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Agent Guard Policy Layer",
+      "description": "Inspired by trend: Agent Guard runtime governance. Add policy layer between agent and outside world.",
+      "allowed_paths": [
+        "magda_agent/safety/agent_guard.py",
+        "tests/test_agent_guard.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy layer intercepts and evaluates actions",
+        "Tests mock agent outputs and verify policy enforcement"
+      ]
+    },
+    {
+      "id": "post-merge-smoke-tests-loop-v2",
+      "status": "todo",
+      "area": "testing",
+      "risk": "medium",
+      "title": "Post-Merge Smoke Tests Loop",
+      "description": "Inspired by trend: Continuous improvement metrics. Add a post-merge automated smoke testing suite.",
+      "allowed_paths": [
+        "tests/smoke_tests.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Smoke tests run basic agent startup and teardown",
+        "Integration triggers after PR merge"
+      ]
+    },
+    {
+      "id": "mcpkernel-taint-tracking-v2",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCPKernel Taint Tracking",
+      "description": "Inspired by trend: MCPKernel sandboxed execution. Add taint tracking to data returned from tools.",
+      "allowed_paths": [
+        "magda_agent/safety/taint_tracking.py",
+        "tests/test_taint_tracking.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Variables returned from tools are marked as tainted",
+        "Tests verify taint logic propagates"
       ]
     }
   ]

--- a/magda_agent/skills/marketplace.py
+++ b/magda_agent/skills/marketplace.py
@@ -4,6 +4,7 @@ import yaml
 import importlib.util
 from typing import Dict, Any, List, Optional
 from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.marketplace_importer import SkillMarketplaceImporter
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +152,37 @@ async def fetch_and_register_skills(url: str, registry: SkillRegistry) -> List[s
         logger.error(f"Failed to fetch and register skills from {url}: {e}")
 
     return registered_skills
+
+async def load_skill_from_marketplace(skill_name: str, registry: SkillRegistry, importer: Optional[SkillMarketplaceImporter] = None) -> bool:
+    """
+    Loads a single skill from the agentskills.io marketplace using the SkillMarketplaceImporter v2.
+
+    Args:
+        skill_name: The name of the skill to fetch.
+        registry: The SkillRegistry to register the skill in.
+        importer: Optional SkillMarketplaceImporter instance. If None, one is created.
+
+    Returns:
+        True if the skill was successfully fetched and registered, False otherwise.
+    """
+    if importer is None:
+        importer = SkillMarketplaceImporter()
+
+    skill_def = await importer.get_skill(skill_name)
+    if not skill_def:
+        logger.error(f"Could not load skill '{skill_name}' from marketplace.")
+        return False
+
+    name = skill_def.get("name")
+    if not name:
+        logger.error(f"Marketplace skill definition missing 'name' field.")
+        return False
+
+    description = skill_def.get("description", "Dynamic marketplace skill via v2 importer")
+    func = _create_dynamic_skill(skill_def)
+    registry.register_skill(name=name, func=func, description=description)
+    logger.info(f"Successfully registered marketplace skill via importer v2: {name}")
+    return True
 
 async def search_marketplace_skills(url: str, query: str) -> List[Dict[str, Any]]:
     """

--- a/magda_agent/skills/marketplace_importer.py
+++ b/magda_agent/skills/marketplace_importer.py
@@ -1,0 +1,142 @@
+import json
+import logging
+import urllib.parse
+import os
+import shutil
+import aiohttp
+import aiofiles
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+class SkillMarketplaceImporter:
+    """
+    Module for pulling down and caching skills dynamically from the agentskills.io marketplace.
+    """
+
+    def __init__(self, base_url: str = "https://registry.agentskills.io/api/v1/skills", cache_dir: str = ".skill_cache") -> None:
+        """
+        Initialize the Skill Marketplace Importer.
+
+        Args:
+            base_url (str): The base URL of the skill marketplace.
+            cache_dir (str): The directory to use for disk caching of skills.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.cache_dir = cache_dir
+        self.memory_cache: Dict[str, Dict[str, Any]] = {}
+
+        if not os.path.exists(self.cache_dir):
+            os.makedirs(self.cache_dir, exist_ok=True)
+
+    def _get_cache_path(self, skill_name: str) -> str:
+        """
+        Get the file path for a cached skill on disk.
+
+        Args:
+            skill_name (str): The name of the skill.
+
+        Returns:
+            str: The path to the cached JSON file.
+        """
+        safe_name = urllib.parse.quote_plus(skill_name)
+        return os.path.join(self.cache_dir, f"{safe_name}.json")
+
+    async def _fetch_from_network(self, skill_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch the skill definition from the remote marketplace.
+
+        Args:
+            skill_name (str): The name of the skill to fetch.
+
+        Returns:
+            Optional[Dict[str, Any]]: The skill definition if found, None otherwise.
+        """
+        safe_name = urllib.parse.quote(skill_name)
+        url = f"{self.base_url}/{safe_name}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=10, headers={'User-Agent': 'MagdaAgent/1.0'}) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        return data
+        except aiohttp.ClientError as e:
+            logger.error(f"Failed to fetch skill '{skill_name}' from network: {e}")
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse skill '{skill_name}' JSON: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error fetching skill '{skill_name}': {e}")
+        return None
+
+    async def get_skill(self, skill_name: str, force_refresh: bool = False) -> Optional[Dict[str, Any]]:
+        """
+        Retrieve a skill definition, utilizing memory and disk caches unless forced to refresh.
+
+        Args:
+            skill_name (str): The name of the skill to retrieve.
+            force_refresh (bool): If True, bypass caches and fetch from network.
+
+        Returns:
+            Optional[Dict[str, Any]]: The unpacked skill definition, or None if not found.
+        """
+        if not force_refresh:
+            # Check memory cache
+            if skill_name in self.memory_cache:
+                logger.info(f"Skill '{skill_name}' found in memory cache.")
+                return self.memory_cache[skill_name]
+
+            # Check disk cache
+            cache_path = self._get_cache_path(skill_name)
+            if os.path.exists(cache_path):
+                try:
+                    async with aiofiles.open(cache_path, 'r', encoding='utf-8') as f:
+                        contents = await f.read()
+                        skill_data = json.loads(contents)
+                        self.memory_cache[skill_name] = skill_data
+                        logger.info(f"Skill '{skill_name}' loaded from disk cache.")
+                        return skill_data
+                except Exception as e:
+                    logger.error(f"Failed to read disk cache for '{skill_name}': {e}")
+
+        # Fetch from network
+        logger.info(f"Fetching skill '{skill_name}' from marketplace...")
+        skill_data = await self._fetch_from_network(skill_name)
+
+        if skill_data:
+            # Update caches
+            self.memory_cache[skill_name] = skill_data
+            try:
+                async with aiofiles.open(self._get_cache_path(skill_name), 'w', encoding='utf-8') as f:
+                    await f.write(json.dumps(skill_data, indent=2))
+            except Exception as e:
+                logger.error(f"Failed to write disk cache for '{skill_name}': {e}")
+            return skill_data
+
+        return None
+
+    async def invalidate_cache(self, skill_name: Optional[str] = None) -> None:
+        """
+        Invalidate the cache for a specific skill or all skills.
+
+        Args:
+            skill_name (Optional[str]): The name of the skill to invalidate. If None, clears all cache.
+        """
+        if skill_name:
+            if skill_name in self.memory_cache:
+                del self.memory_cache[skill_name]
+            cache_path = self._get_cache_path(skill_name)
+            if os.path.exists(cache_path):
+                try:
+                    os.remove(cache_path)
+                except Exception as e:
+                    logger.error(f"Failed to remove cache file for '{skill_name}': {e}")
+            logger.info(f"Cache invalidated for skill '{skill_name}'.")
+        else:
+            self.memory_cache.clear()
+            if os.path.exists(self.cache_dir):
+                try:
+                    shutil.rmtree(self.cache_dir)
+                    os.makedirs(self.cache_dir, exist_ok=True)
+                except Exception as e:
+                    logger.error(f"Failed to clear cache directory: {e}")
+            logger.info("All skill caches invalidated.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ croniter
 websockets==12.0
 PyYAML
 discord.py>=2.3.2
+aiofiles==24.1.0

--- a/tests/test_marketplace_importer.py
+++ b/tests/test_marketplace_importer.py
@@ -1,0 +1,140 @@
+import pytest
+import json
+import os
+import shutil
+from unittest.mock import patch, mock_open, MagicMock, AsyncMock
+from aiohttp import ClientError
+from magda_agent.skills.marketplace_importer import SkillMarketplaceImporter
+from magda_agent.skills.marketplace import load_skill_from_marketplace
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.fixture
+def temp_cache_dir(tmp_path) -> str:
+    """Fixture for creating a temporary directory for skill caches."""
+    cache_dir = tmp_path / ".test_skill_cache"
+    yield str(cache_dir)
+    if os.path.exists(cache_dir):
+        shutil.rmtree(cache_dir)
+
+@pytest.fixture
+def importer(temp_cache_dir) -> SkillMarketplaceImporter:
+    """Fixture to provide a SkillMarketplaceImporter instance."""
+    return SkillMarketplaceImporter(cache_dir=temp_cache_dir)
+
+def test_initialization(temp_cache_dir) -> None:
+    """Tests the initialization of the importer and cache directory creation."""
+    imp = SkillMarketplaceImporter(cache_dir=temp_cache_dir)
+    assert os.path.exists(temp_cache_dir)
+    assert imp.memory_cache == {}
+
+@pytest.mark.asyncio
+async def test_get_skill_from_memory_cache(importer) -> None:
+    """Tests that a skill is correctly returned from the memory cache."""
+    mock_skill = {"name": "test_skill", "description": "A test skill"}
+    importer.memory_cache["test_skill"] = mock_skill
+
+    skill = await importer.get_skill("test_skill")
+    assert skill == mock_skill
+
+@pytest.mark.asyncio
+async def test_get_skill_from_disk_cache(importer, temp_cache_dir) -> None:
+    """Tests that a skill is returned from the disk cache when not in memory."""
+    mock_skill = {"name": "test_skill", "description": "A test skill from disk"}
+    skill_path = os.path.join(temp_cache_dir, "test_skill.json")
+
+    with open(skill_path, 'w', encoding='utf-8') as f:
+        json.dump(mock_skill, f)
+
+    skill = await importer.get_skill("test_skill")
+    assert skill == mock_skill
+    assert importer.memory_cache["test_skill"] == mock_skill
+
+@pytest.mark.asyncio
+@patch('magda_agent.skills.marketplace_importer.aiohttp.ClientSession.get')
+async def test_get_skill_from_network_success(mock_get, importer, temp_cache_dir) -> None:
+    """Tests a successful fetch of a skill from the network."""
+    mock_skill = {"name": "network_skill", "description": "A test skill from network"}
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = mock_skill
+    mock_response.__aenter__.return_value = mock_response
+    mock_get.return_value = mock_response
+
+    skill = await importer.get_skill("network_skill")
+
+    assert skill == mock_skill
+    assert importer.memory_cache["network_skill"] == mock_skill
+
+    skill_path = os.path.join(temp_cache_dir, "network_skill.json")
+    assert os.path.exists(skill_path)
+    with open(skill_path, 'r', encoding='utf-8') as f:
+        saved_skill = json.load(f)
+    assert saved_skill == mock_skill
+
+@pytest.mark.asyncio
+@patch('magda_agent.skills.marketplace_importer.aiohttp.ClientSession.get')
+async def test_get_skill_from_network_failure(mock_get, importer) -> None:
+    """Tests fetching a skill from the network when a network error occurs."""
+    mock_get.side_effect = ClientError("Network error")
+
+    skill = await importer.get_skill("failed_skill")
+    assert skill is None
+    assert "failed_skill" not in importer.memory_cache
+
+@pytest.mark.asyncio
+async def test_invalidate_specific_skill_cache(importer, temp_cache_dir) -> None:
+    """Tests cache invalidation for a specific skill."""
+    mock_skill = {"name": "test_skill"}
+    importer.memory_cache["test_skill"] = mock_skill
+    skill_path = os.path.join(temp_cache_dir, "test_skill.json")
+    with open(skill_path, 'w', encoding='utf-8') as f:
+        json.dump(mock_skill, f)
+
+    await importer.invalidate_cache("test_skill")
+
+    assert "test_skill" not in importer.memory_cache
+    assert not os.path.exists(skill_path)
+
+@pytest.mark.asyncio
+async def test_invalidate_all_cache(importer, temp_cache_dir) -> None:
+    """Tests total invalidation of the skill cache."""
+    mock_skill = {"name": "test_skill"}
+    importer.memory_cache["test_skill"] = mock_skill
+    skill_path = os.path.join(temp_cache_dir, "test_skill.json")
+    with open(skill_path, 'w', encoding='utf-8') as f:
+        json.dump(mock_skill, f)
+
+    await importer.invalidate_cache()
+
+    assert importer.memory_cache == {}
+    assert os.path.exists(temp_cache_dir)
+    assert not os.path.exists(skill_path)
+
+@pytest.mark.asyncio
+async def test_path_traversal_prevention(importer, temp_cache_dir) -> None:
+    """Tests that a malicious skill name cannot lead to a path traversal attack."""
+    malicious_name = "../../../malicious_skill"
+    cache_path = importer._get_cache_path(malicious_name)
+    assert temp_cache_dir in cache_path
+
+    # We URL encode the input, so "../" becomes "..%2F"
+    # To check path traversal prevention we just ensure it's a valid relative path within cache_dir
+    assert os.path.relpath(cache_path, temp_cache_dir).startswith("..%2F") or ".." not in os.path.relpath(cache_path, temp_cache_dir).split(os.sep)
+
+@pytest.mark.asyncio
+@patch('magda_agent.skills.marketplace_importer.aiohttp.ClientSession.get')
+async def test_load_skill_from_marketplace(mock_get, importer) -> None:
+    """Tests integrating with the marketplace loader by loading and registering a skill."""
+    mock_skill = {"name": "integration_skill", "description": "integration test"}
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = mock_skill
+    mock_response.__aenter__.return_value = mock_response
+    mock_get.return_value = mock_response
+
+    registry = SkillRegistry()
+    success = await load_skill_from_marketplace("integration_skill", registry, importer)
+
+    assert success is True
+    assert "integration_skill" in registry.skills
+    assert registry.descriptions["integration_skill"] == "integration test"


### PR DESCRIPTION
Implements a new `SkillMarketplaceImporter` that handles caching (memory/disk) and network fetching of agentskills.io compatible tools. Wires this functionality into the existing marketplace architecture, adds mocked tests for the new components, and generates three new future tasks based on the provided trends.

---
*PR created automatically by Jules for task [6144616284015629066](https://jules.google.com/task/6144616284015629066) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `SkillMarketplaceImporter` v2 for runtime skill loading with caching
> - Adds [`SkillMarketplaceImporter`](https://github.com/kazah4359-lgtm/Magda-agent/pull/275/files#diff-5fa2f19c106d4d9c22a4cf2e94445c0d938fb395c23f3fe934ef7717b6c72117) with memory and disk caching (via `aiofiles`) and cache invalidation for fetching skill definitions from a remote marketplace endpoint.
> - Adds [`load_skill_from_marketplace`](https://github.com/kazah4359-lgtm/Magda-agent/pull/275/files#diff-f97689dc60e4b4ae2feda4f8166dd1660cd9ecfb13ae154957665e6140006270) as an async function that fetches a skill by name, builds a dynamic callable, and registers it into a `SkillRegistry`, returning a boolean success indicator.
> - Adds a test suite in [`tests/test_marketplace_importer.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/275/files#diff-f8659d9fd5862ab89d7c05fa0892baf66e7020012d0e190f4bec0b603a9e0b3d) covering cache hit/miss paths, network failure, cache invalidation, basic path traversal hardening, and `SkillRegistry` integration.
> - Risk: disk cache writes use URL-encoded skill names; malformed or adversarial names could still interact unexpectedly with the filesystem despite basic path traversal hardening.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8b1025.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->