### PR TITLE
feat: implement EvaluatorSubagent and update agent_tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9178,7 +9178,7 @@
     },
     {
       "id": "claude-evaluator-subagent-refactor",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "Claude Evaluator Subagent Implementation",
@@ -9432,6 +9432,61 @@
       "acceptance": [
         "Variables returned from tools are marked as tainted",
         "Tests verify taint logic propagates"
+      ]
+    },
+    {
+      "id": "mcp-context-export-tool-v2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "MCP Context Export Tool",
+      "description": "Inspired by trend: MCP tools expansion. Export Context Engine state as an MCP tool for external visualization applications like OpenClaw Canvas.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_context_export.py",
+        "tests/test_mcp_context_export.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Context Export Tool created",
+        "Tool formats context into JSON payload conforming to MCP standard",
+        "Unit tests cover expected formatting behavior using mocks"
+      ]
+    },
+    {
+      "id": "a2a-status-broadcaster-v2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Status Broadcaster",
+      "description": "Inspired by trend: A2A peer discovery and Multi-Agent Orchestration. Broadcast Magda's current availability and task load using Agent Cards.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_status_broadcaster.py",
+        "tests/test_a2a_status_broadcaster.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Status broadcaster class established",
+        "Broadcaster handles serialization of A2A Agent Cards",
+        "Tests ensure resilient broadcasting via mocked network layers"
+      ]
+    },
+    {
+      "id": "scheduled-diagnostic-report-v2",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Scheduled Diagnostic Report",
+      "description": "Inspired by trend: Scheduled operations. Add a new cron job via HermesCronSchedulerV3 to run diagnostic health checks and log results locally without user interaction.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_diagnostics.py",
+        "magda_agent/api.py",
+        "tests/test_cron_diagnostics.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron task registered for local diagnostic checks",
+        "Task gracefully reports failures to logs without interrupting main loop",
+        "Tests mock datetime and execution loop to confirm trigger conditions"
       ]
     }
   ]

--- a/magda_agent/agents/evaluator_subagent.py
+++ b/magda_agent/agents/evaluator_subagent.py
@@ -1,0 +1,114 @@
+import json
+import logging
+from typing import Optional, Dict, Any
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.emotions.engine import PADState
+from magda_agent.agents.sub_agent import SubAgent
+
+class EvaluatorSubagent:
+    """
+    Evaluator implemented as a SubAgent with isolation.
+    Evaluates the agent's responses based on usefulness, accuracy, completeness, and emotional adequacy.
+    Inspired by Claude Agent SDK Subagent evaluation pattern.
+    """
+    def __init__(self, llm: LLMClient, memory: MemorySystem):
+        """
+        Initializes the EvaluatorSubagent.
+
+        Args:
+            llm: The Language Model client.
+            memory: The memory system to store evaluations.
+        """
+        self.memory = memory
+        self.last_evaluation: Optional[Dict[str, Any]] = None
+        self.sub_agent = SubAgent(
+            llm=llm,
+            system_prompt="You are an isolated SubAgent responsible for strictly evaluating responses.",
+            use_isolation=True
+        )
+
+    async def evaluate_response(self, user_input: str, agent_response: str) -> Optional[Dict[str, Any]]:
+        """
+        Evaluates the generated response using the LLM via SubAgent execute and stores the result in memory.
+
+        Args:
+            user_input: The user's original input message.
+            agent_response: The agent's generated response to evaluate.
+
+        Returns:
+            The evaluation dictionary or None if evaluation fails.
+        """
+        task = (
+            "Evaluate the response given by an AI to a user's input.\n"
+            "Score the response from 1 to 10 on the following criteria:\n"
+            "- usefulness\n"
+            "- accuracy\n"
+            "- completeness\n"
+            "- emotional_adequacy\n\n"
+            "Respond ONLY with a JSON object in this format:\n"
+            "{\n"
+            '  "usefulness": 8,\n'
+            '  "accuracy": 9,\n'
+            '  "completeness": 7,\n'
+            '  "emotional_adequacy": 8,\n'
+            '  "average_score": 8.0,\n'
+            '  "feedback": "A short sentence explaining the score"\n'
+            "}"
+        )
+
+        context = (
+            f"User input: {user_input}\n"
+            f"AI Response: {agent_response}"
+        )
+
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.sub_agent.execute(task=task, context=context, temperature=0.1)
+
+                # Remove any markdown formatting (e.g. ```json)
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+
+                # Store in memory
+                content = f"Evaluation of response to '{user_input[:20]}...': Avg Score: {evaluation.get('average_score')} - {evaluation.get('feedback')}"
+                await self.memory.add_memory(
+                    content=content,
+                    importance=0.6,
+                    emotional_state=PADState(0.0, 0.0, 0.0), # Neutral PAD state for evaluation
+                    tags=["evaluation", "metacognition", "subagent"]
+                )
+
+                self.last_evaluation = evaluation
+                return evaluation
+            except json.JSONDecodeError as e:
+                logging.warning(f"JSON decoding error in evaluator attempt {attempt + 1}/{max_retries}: {e}. Retrying...")
+                if attempt == max_retries - 1:
+                    logging.error("Max retries reached for evaluate_response JSON parsing.")
+                    return None
+            except Exception as e:
+                logging.error(f"Failed to evaluate response: {e}")
+                return None
+
+    def get_feedback_for_prompt(self) -> str:
+        """
+        Returns feedback to be included in the next system prompt if the previous evaluation was low.
+
+        Returns:
+            Feedback string or empty string if no evaluation or high score.
+        """
+        if not self.last_evaluation:
+            return ""
+
+        avg_score = self.last_evaluation.get("average_score", 10.0)
+        if avg_score < 7.0:
+            feedback = self.last_evaluation.get("feedback", "Improve response quality.")
+            return f"Note: Your previous response received a low evaluation score ({avg_score}/10). Feedback: {feedback}. Please improve your response quality, accuracy, and emotional adequacy."
+        return ""

--- a/tests/test_evaluator_subagent.py
+++ b/tests/test_evaluator_subagent.py
@@ -1,0 +1,137 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.evaluator_subagent import EvaluatorSubagent
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+
+@pytest.fixture
+def mock_llm_client():
+    return AsyncMock(spec=LLMClient)
+
+@pytest.fixture
+def mock_memory_system():
+    mock = MagicMock(spec=MemorySystem)
+    mock.add_memory = AsyncMock()
+    return mock
+
+@pytest.fixture
+def evaluator_subagent(mock_llm_client, mock_memory_system):
+    return EvaluatorSubagent(llm=mock_llm_client, memory=mock_memory_system)
+
+@pytest.mark.asyncio
+async def test_evaluate_response_success(evaluator_subagent, mock_memory_system):
+    evaluator_subagent.sub_agent.execute = AsyncMock()
+    mock_json_response = '''
+    ```json
+    {
+      "usefulness": 8,
+      "accuracy": 9,
+      "completeness": 7,
+      "emotional_adequacy": 8,
+      "average_score": 8.0,
+      "feedback": "Good response"
+    }
+    ```
+    '''
+    evaluator_subagent.sub_agent.execute.return_value = mock_json_response
+
+    user_input = "Hello"
+    agent_response = "Hi there!"
+
+    result = await evaluator_subagent.evaluate_response(user_input, agent_response)
+
+    # Assert sub_agent execute was called
+    evaluator_subagent.sub_agent.execute.assert_called_once()
+    kwargs = evaluator_subagent.sub_agent.execute.call_args.kwargs
+    assert "task" in kwargs
+    assert "context" in kwargs
+    assert "temperature" in kwargs
+
+    # Assert memory was added
+    mock_memory_system.add_memory.assert_called_once()
+    call_args = mock_memory_system.add_memory.call_args[1]
+    assert "Avg Score: 8.0" in call_args["content"]
+    assert "evaluation" in call_args["tags"]
+    assert "subagent" in call_args["tags"]
+
+    # Assert result
+    assert result is not None
+    assert result["average_score"] == 8.0
+    assert result["feedback"] == "Good response"
+
+    # Assert state updated
+    assert evaluator_subagent.last_evaluation == result
+
+@pytest.mark.asyncio
+async def test_evaluate_response_no_markdown(evaluator_subagent):
+    evaluator_subagent.sub_agent.execute = AsyncMock()
+    mock_json_response = '''{
+      "usefulness": 5,
+      "accuracy": 5,
+      "completeness": 5,
+      "emotional_adequacy": 5,
+      "average_score": 5.0,
+      "feedback": "Average response"
+    }'''
+    evaluator_subagent.sub_agent.execute.return_value = mock_json_response
+
+    result = await evaluator_subagent.evaluate_response("Test", "Response")
+    assert result is not None
+    assert result["average_score"] == 5.0
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_high_score(evaluator_subagent):
+    evaluator_subagent.last_evaluation = {"average_score": 8.5, "feedback": "Great"}
+    feedback = evaluator_subagent.get_feedback_for_prompt()
+    assert feedback == ""
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_low_score(evaluator_subagent):
+    evaluator_subagent.last_evaluation = {"average_score": 4.5, "feedback": "Poor response"}
+    feedback = evaluator_subagent.get_feedback_for_prompt()
+    assert "low evaluation score (4.5/10)" in feedback
+    assert "Poor response" in feedback
+
+@pytest.mark.asyncio
+async def test_get_feedback_for_prompt_no_evaluation(evaluator_subagent):
+    feedback = evaluator_subagent.get_feedback_for_prompt()
+    assert feedback == ""
+
+@pytest.mark.asyncio
+async def test_evaluate_response_exception(evaluator_subagent):
+    evaluator_subagent.sub_agent.execute = AsyncMock(side_effect=Exception("API Error"))
+    result = await evaluator_subagent.evaluate_response("Test", "Response")
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_evaluate_response_retry_success(evaluator_subagent):
+    evaluator_subagent.sub_agent.execute = AsyncMock()
+    invalid_json_response = "this is not valid json"
+    valid_json_response = '''{
+      "usefulness": 9,
+      "accuracy": 9,
+      "completeness": 9,
+      "emotional_adequacy": 9,
+      "average_score": 9.0,
+      "feedback": "Retry success"
+    }'''
+    evaluator_subagent.sub_agent.execute.side_effect = [invalid_json_response, valid_json_response]
+
+    result = await evaluator_subagent.evaluate_response("Test", "Response")
+
+    assert result is not None
+    assert result["average_score"] == 9.0
+    assert result["feedback"] == "Retry success"
+    assert evaluator_subagent.sub_agent.execute.call_count == 2
+
+@pytest.mark.asyncio
+async def test_evaluate_response_retry_failure(evaluator_subagent):
+    evaluator_subagent.sub_agent.execute = AsyncMock()
+    invalid_json_response = "still not valid json"
+    evaluator_subagent.sub_agent.execute.side_effect = [invalid_json_response, invalid_json_response, invalid_json_response]
+
+    result = await evaluator_subagent.evaluate_response("Test", "Response")
+
+    assert result is None
+    assert evaluator_subagent.sub_agent.execute.call_count == 3


### PR DESCRIPTION
This PR implements the `EvaluatorSubagent` utilizing Claude's SubAgent isolation pattern. It replicates evaluating agent responses using standard multi-criteria grading from the legacy `Evaluator`. Furthermore, 3 new tasks are added to the backlog to pursue upcoming trends such as MCP expansion and A2A broadcasting. Full mocked unit tests are included.

---
*PR created automatically by Jules for task [10501956796255067220](https://jules.google.com/task/10501956796255067220) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `EvaluatorSubagent` to score agent responses and persist evaluations to memory
> - Adds [`EvaluatorSubagent`](https://github.com/kazah4359-lgtm/Magda-agent/pull/276/files#diff-dc9fc823c61ffc24fbfa5737e6ce8d53d36ab41677d6d4a94fc6dc7c6a38053b), which uses an isolated `SubAgent` and an LLM to evaluate agent responses, returning a parsed JSON dict with scores and feedback.
> - `evaluate_response` retries JSON parsing up to 3 times on `JSONDecodeError`, stores a summary in `MemorySystem` with neutral PADState and tags, and returns `None` on terminal failure.
> - `get_feedback_for_prompt` returns an advisory string for inclusion in future prompts when the last evaluation's `average_score` is below 7.0.
> - Adds full test coverage in [`tests/test_evaluator_subagent.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/276/files#diff-df86c8d9e7317be57c17869ba5b648ed8c882e434fb4bca74d786798734cd176), including retry success/failure, markdown-fenced JSON stripping, and feedback threshold behavior.
> - Updates [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/276/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) to mark one task done and add three new task entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a27ebec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->