### PR TITLE
Implement MCP Action Tool Validation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5095,7 +5095,7 @@
     },
     {
       "id": "mcp-action-tool-validation-v2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Action Tool Validation",
@@ -9487,6 +9487,57 @@
         "Cron task registered for local diagnostic checks",
         "Task gracefully reports failures to logs without interrupting main loop",
         "Tests mock datetime and execution loop to confirm trigger conditions"
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-visualization-2a20db5e",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Live Visualization",
+      "description": "Inspired by OpenClaw trend: Canvas для live визуализации. Implement a live visualization hook.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas.py",
+        "tests/test_canvas.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas visualizer is implemented",
+        "Tests confirm live visualization hook works"
+      ]
+    },
+    {
+      "id": "claude-agent-teams-dependency-graph-a5bf63e6",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Claude Agent Teams Dependency Graph",
+      "description": "Inspired by Claude Agent SDK trend: Task system с dependency graphs. Update planning to utilize dependency graphs.",
+      "allowed_paths": [
+        "magda_agent/planning/dependency_graph.py",
+        "tests/test_dependency_graph.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dependency graph task system implemented",
+        "Tests confirm task graph structure"
+      ]
+    },
+    {
+      "id": "openai-agents-sdk-mcp-server-prefixed-tool-names-04d16c9f",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "OpenAI Agents SDK MCP Server Prefixed Tool Names",
+      "description": "Inspired by OpenAI Agents SDK trend: MCP server-prefixed tool names. Ensure correct handling of server-prefixed tool names.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_server_names.py",
+        "tests/test_mcp_server_names.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Server prefixes are correctly parsed",
+        "Tests verify prefix extraction"
       ]
     }
   ]

--- a/magda_agent/skills/mcp_validator.py
+++ b/magda_agent/skills/mcp_validator.py
@@ -1,0 +1,63 @@
+import functools
+import jsonschema
+import inspect
+from typing import Dict, Any, Callable
+
+class MCPActionToolValidator:
+    """
+    Validates schemas of registered MCP action tools.
+    """
+
+    MCP_TOOL_SCHEMA = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "description": {"type": "string"},
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "enum": ["object"]},
+                    "properties": {"type": "object"}
+                },
+                "required": ["type"]
+            }
+        },
+        "required": ["name", "description"]
+    }
+
+    @classmethod
+    def validate_schema(cls, schema: Dict[str, Any]) -> None:
+        """
+        Validates the provided schema against the MCP_TOOL_SCHEMA standard.
+
+        Args:
+            schema (Dict[str, Any]): The MCP tool schema.
+
+        Raises:
+            jsonschema.exceptions.ValidationError: If the schema is invalid.
+        """
+        jsonschema.validate(instance=schema, schema=cls.MCP_TOOL_SCHEMA)
+
+def validate_mcp_tool(func: Callable) -> Callable:
+    """
+    Decorator that validates an MCP tool schema parameter.
+    Assumes the parameter named 'schema' or 'tool_schema' is the schema dictionary.
+    """
+    sig = inspect.signature(func)
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+
+        schema = None
+        if "schema" in bound_args.arguments:
+            schema = bound_args.arguments["schema"]
+        elif "tool_schema" in bound_args.arguments:
+            schema = bound_args.arguments["tool_schema"]
+
+        if schema is not None:
+            MCPActionToolValidator.validate_schema(schema)
+
+        return func(*args, **kwargs)
+    return wrapper

--- a/tests/test_mcp_validator.py
+++ b/tests/test_mcp_validator.py
@@ -1,0 +1,83 @@
+import pytest
+import jsonschema
+from typing import Dict, Any
+from magda_agent.skills.mcp_validator import MCPActionToolValidator, validate_mcp_tool
+
+def test_validate_schema_valid() -> None:
+    schema = {
+        "name": "test_tool",
+        "description": "A test tool",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "arg1": {"type": "string"}
+            }
+        }
+    }
+    # Should not raise any exception
+    MCPActionToolValidator.validate_schema(schema)
+
+def test_validate_schema_missing_name() -> None:
+    schema = {
+        "description": "A test tool"
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        MCPActionToolValidator.validate_schema(schema)
+
+def test_validate_schema_invalid_type() -> None:
+    schema = {
+        "name": 123,  # Invalid type, should be string
+        "description": "A test tool"
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        MCPActionToolValidator.validate_schema(schema)
+
+def test_validate_schema_invalid_input_schema_type() -> None:
+    schema = {
+        "name": "test_tool",
+        "description": "A test tool",
+        "inputSchema": {
+            "type": "array" # Invalid type, should be object
+        }
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        MCPActionToolValidator.validate_schema(schema)
+
+def test_validate_mcp_tool_decorator_valid() -> None:
+    class MockRegistry:
+        @validate_mcp_tool
+        def register_tool(self, tool_schema: Dict[str, Any]) -> bool:
+            return True
+
+    registry = MockRegistry()
+    schema = {
+        "name": "test_tool",
+        "description": "A test tool"
+    }
+    assert registry.register_tool(schema) is True
+
+def test_validate_mcp_tool_decorator_invalid() -> None:
+    class MockRegistry:
+        @validate_mcp_tool
+        def register_tool(self, tool_schema: Dict[str, Any]) -> bool:
+            return True
+
+    registry = MockRegistry()
+    schema = {
+        "description": "A test tool" # Missing name
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        registry.register_tool(tool_schema=schema)
+
+def test_validate_mcp_tool_decorator_positional_invalid() -> None:
+    class MockRegistry:
+        @validate_mcp_tool
+        def register_tool(self, tool_schema: Dict[str, Any]) -> bool:
+            return True
+
+    registry = MockRegistry()
+    schema = {
+        "description": "A test tool" # Missing name
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        registry.register_tool(schema) # Call with positional argument


### PR DESCRIPTION
Implements `MCPActionToolValidator` and `@validate_mcp_tool` decorator using `jsonschema` to automatically validate incoming tool schemas upon registration. Adds comprehensive unit tests handling both valid and invalid schema cases, properly updating the task manifest and appending 3 new future trend-based tasks.

---
*PR created automatically by Jules for task [8739608608048098263](https://jules.google.com/task/8739608608048098263) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP action tool schema validation via `MCPActionToolValidator` and `validate_mcp_tool` decorator
> - Introduces [`MCPActionToolValidator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/277/files#diff-9058e991b510d2f483b722f5f592ba74b6a9aa377391fe7d7c699fbdc7e9bc8f) with a JSON Schema (`MCP_TOOL_SCHEMA`) defining the expected structure for MCP action tools, and a `validate_schema` classmethod that raises `jsonschema.ValidationError` on invalid input.
> - Adds a `validate_mcp_tool` decorator that extracts a `schema` or `tool_schema` argument (positional or keyword) from the decorated function and validates it before execution.
> - Covers both components with unit tests in [`tests/test_mcp_validator.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/277/files#diff-2501b9216ffa699fc40a3a2762685848dfd83a3b571a19312897a4ce12ae44c8) for valid schemas, missing fields, invalid types, and both positional and keyword argument paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized feca508.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->