### PR TITLE
feat: Add persistent memory layer v3 and new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5112,7 +5112,7 @@
     },
     {
       "id": "persistent-memory-layer-v3",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Persistent Memory Layer Expansion",
@@ -9589,6 +9589,57 @@
       "acceptance": [
         "Parallel tasks execute in isolated git worktrees",
         "Tests verify independent workspace provisioning and cleanup"
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-marketplace-sync",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Agent Skills Marketplace Sync",
+      "description": "Inspired by trend: Hermes Agent (177K+ stars) open standard agentskills.io. Add a routine to fetch, parse, and synchronize new skills periodically from an external marketplace.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_sync.py",
+        "tests/test_marketplace_sync.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Routine fetches and parses agentskills.io format",
+        "Tests mock HTTP calls and verify correct parsing and updating behavior"
+      ]
+    },
+    {
+      "id": "openai-agents-runtime-concurrency-manager",
+      "status": "todo",
+      "area": "execution",
+      "risk": "high",
+      "title": "OpenAI Agents SDK Runtime Concurrency",
+      "description": "Inspired by trend: OpenAI Agents SDK runtime function tool concurrency. Create a robust concurrency manager for asynchronous function tool execution, handling rate limits and backpressure.",
+      "allowed_paths": [
+        "magda_agent/execution/concurrency_manager.py",
+        "tests/test_concurrency_manager.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Manager efficiently handles executing multiple tools concurrently",
+        "Tests verify rate limiting, task tracking, and backpressure handling with simulated async calls"
+      ]
+    },
+    {
+      "id": "claude-code-evaluation-subagent-v2",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Claude SDK Evaluator Subagent",
+      "description": "Inspired by trend: Claude Agent SDK Planner/Generator/Evaluator architecture. Add a specific subagent class tasked strictly with evaluating the output of generator agents against specified goals.",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_subagent_v2.py",
+        "tests/test_evaluator_subagent_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagent is created following isolation patterns",
+        "Tests simulate generator outputs and confirm evaluator scoring logic works correctly"
       ]
     }
   ]

--- a/magda_agent/memory/persistent_v3.py
+++ b/magda_agent/memory/persistent_v3.py
@@ -1,0 +1,52 @@
+from typing import Dict, Any, List
+import logging
+from magda_agent.memory.context_engine import ContextPlugin
+
+class PersistentMemoryLayerV3(ContextPlugin):
+    """
+    Context Engine plugin to directly persist long-running conversational memory
+    chunks safely, inspired by Persistent memory trend.
+    """
+    def __init__(self, db_client: Any) -> None:
+        """
+        Initialize with a mock database client or similar object.
+        """
+        self.db_client = db_client
+        self.persisted_chunks: List[Dict[str, Any]] = []
+        logging.info("PersistentMemoryLayerV3 initialized.")
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration."""
+        logging.info("PersistentMemoryLayerV3 bootstrapping.")
+        pass
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Process incoming content before it is stored or used."""
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Assemble the context string from retrieved items for the LLM."""
+        return "\n".join([str(item) for item in context_items])
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact or summarize the context when limits are reached."""
+        return context_items
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Called before context is retrieved. Can modify the query."""
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """Called after context is retrieved. Can modify the retrieved context."""
+        return context
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """Called when the overall context is updated."""
+        chunk = {
+            "user_id": user_id,
+            "context": new_context
+        }
+        self.persisted_chunks.append(chunk)
+        if hasattr(self.db_client, 'save'):
+            self.db_client.save(chunk)
+        logging.info(f"Persisted context for user {user_id}")

--- a/tests/test_persistent_v3.py
+++ b/tests/test_persistent_v3.py
@@ -1,0 +1,22 @@
+from magda_agent.memory.persistent_v3 import PersistentMemoryLayerV3
+
+class MockDBClient:
+    def __init__(self):
+        self.saved_chunks = []
+
+    def save(self, chunk):
+        self.saved_chunks.append(chunk)
+
+def test_persistent_memory_layer_v3_on_context_update() -> None:
+    mock_db = MockDBClient()
+    plugin = PersistentMemoryLayerV3(db_client=mock_db)
+
+    user_id = 123
+    new_context = "User said hello"
+
+    plugin.on_context_update(new_context, user_id)
+
+    assert len(mock_db.saved_chunks) == 1
+    assert mock_db.saved_chunks[0]["user_id"] == 123
+    assert mock_db.saved_chunks[0]["context"] == "User said hello"
+    assert len(plugin.persisted_chunks) == 1


### PR DESCRIPTION
This PR fulfills the persistent-memory-layer-v3 task by extending the context engine to directly persist long-running conversational memory chunks via `PersistentMemoryLayerV3` plugin. It correctly passes validation, adds tests, marks the task complete, and adds three new tasks.

---
*PR created automatically by Jules for task [7210311919320067843](https://jules.google.com/task/7210311919320067843) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PersistentMemoryLayerV3` context plugin with db_client persistence
> - Adds [`persistent_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/279/files#diff-80a1c04c9a0c1961596c76a52f0466ecae6b9ca7b3ecf627ff7ddada9fc190fc) implementing a `ContextPlugin` that persists conversation context chunks to an in-memory list and optionally to an external `db_client` via its `save` method on each `on_context_update` call.
> - Lifecycle hooks (`ingest`, `assemble`, `compact`, `before_retrieval`, `after_retrieval`) are stubbed as pass-through or no-ops.
> - Adds a unit test in [`tests/test_persistent_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/279/files#diff-4206549942a82f33af18461706d23a07c698faf38a413f8f7656e623d1b8df08) using a `MockDBClient` to verify chunk persistence.
> - Adds three new agent tasks to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/279/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 793e179.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->