### PR TITLE
fix(integration): MCP Exporter error translation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5129,7 +5129,7 @@
     },
     {
       "id": "mcp-export-error-translation-v1",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Exporter error translation",
@@ -9640,6 +9640,57 @@
       "acceptance": [
         "Evaluator subagent is created following isolation patterns",
         "Tests simulate generator outputs and confirm evaluator scoring logic works correctly"
+      ]
+    },
+    {
+      "id": "mcpkernel-taint-tracking-db-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCPKernel Taint Tracking Enhancements",
+      "description": "Inspired by trend: MCPKernel sandboxed execution. Add persistent storage for tainted tool execution logs.",
+      "allowed_paths": [
+        "magda_agent/safety/taint_tracking_db.py",
+        "tests/test_taint_tracking_db.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tainted data logs persist to SQLite",
+        "Tests verify that taint logging handles concurrent tool executions correctly"
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-v2",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Subagent Context Compression",
+      "description": "Inspired by trend: Subagent spawning, context compression. Implement auto-compression for context when delegating subtasks to spawned agents.",
+      "allowed_paths": [
+        "magda_agent/agents/context_compression.py",
+        "tests/test_context_compression.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent payload is compressed before RPC dispatch",
+        "Tests ensure no critical goal constraints are lost during compression"
+      ]
+    },
+    {
+      "id": "openclaw-canvas-visualizer-v2",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Detailed Logging",
+      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_logger.py",
+        "tests/test_canvas_logger.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas logger implemented over Context Engine hooks",
+        "Tests verify log generation for each hook event"
       ]
     }
   ]

--- a/magda_agent/integration/mcp_exporter.py
+++ b/magda_agent/integration/mcp_exporter.py
@@ -56,12 +56,16 @@ class MCPExporter:
 
         adapter_result = await self.adapter.call_tool_async(method, params)
 
-        if adapter_result.get("isError"):
-            error_msg = adapter_result.get("content", [{"text": "Unknown error"}])[0].get("text")
+        # Check if the adapter explicitly reported an error, or if it returned a string
+        # that starts with 'Error' (which happens when registry.execute_skill returns an error string).
+        is_error = adapter_result.get("isError", False)
+        error_msg = adapter_result.get("content", [{"text": ""}])[0].get("text", "")
+
+        if is_error or str(error_msg).startswith("Error"):
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "error": {"code": -32000, "message": error_msg}
+                "error": {"code": -32000, "message": error_msg or "Unknown error"}
             }
 
         return {

--- a/tests/test_mcp_exporter.py
+++ b/tests/test_mcp_exporter.py
@@ -85,6 +85,7 @@ async def test_handle_rpc_request_error_in_tool(exporter: MCPExporter) -> None:
         "id": 4
     }
     res = await exporter.handle_rpc_request(req)
-    # The registry catches exceptions and returns "Error executing skill..." which adapter wraps as normal string result.
-    assert "result" in res
-    assert res["result"]["content"][0]["text"].startswith("Error executing skill")
+    # The adapter wraps it, but the exporter now properly returns a JSON-RPC error.
+    assert "error" in res
+    assert res["error"]["code"] == -32000
+    assert res["error"]["message"].startswith("Error executing skill")


### PR DESCRIPTION
This PR fixes an issue where the `MCPExporter` did not correctly translate error strings starting with 'Error' into proper JSON-RPC error responses. It ensures that when the underlying `SkillRegistry` execution returns a string beginning with 'Error', it is wrapped in an `error` block with a `-32000` code, conforming to the MCP JSON-RPC spec. 

Also, it adds 3 new AI-trend-inspired tasks to `agent_tasks.json` based on recent documentation.

---
*PR created automatically by Jules for task [8569284656378360581](https://jules.google.com/task/8569284656378360581) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP Exporter error translation for adapter results that return error text
> - [mcp_exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/280/files#diff-2fc4adfe3dfe68fdd56e055504fc2790338d65fdda87236e866fcbaf91f8cde5): `MCPExporter.handle_rpc_request` now treats adapter results as errors when the returned content text starts with `'Error'`, responding with a JSON-RPC error (code `-32000`) instead of a successful result.
> - Falls back to `'Unknown error'` when the adapter signals an error but provides no message text.
> - Updates [test_mcp_exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/280/files#diff-c8233512ac47a7f069faf85a52ae07fbcf6a267271d62ab2d6ce54813d32f76b) to assert the error response shape instead of a success result.
> - Behavioral Change: Adapter responses previously returned as successful results will now surface as JSON-RPC errors if their text begins with `'Error'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28d2f8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->