### PR TITLE
feat: A2A Peer Delegation Discovery V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5146,7 +5146,7 @@
     },
     {
       "id": "a2a-peer-delegation-discovery-v2",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "high",
       "title": "A2A Peer Delegation Discovery",
@@ -9691,6 +9691,40 @@
       "acceptance": [
         "Canvas logger implemented over Context Engine hooks",
         "Tests verify log generation for each hook event"
+      ]
+    },
+    {
+      "id": "agent-guard-policy-extension-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Agent Guard Policy Extension",
+      "description": "Inspired by trend: Agent Guard runtime governance. Extend PolicyLayer to handle more granular checks.",
+      "allowed_paths": [
+        "magda_agent/safety/policy_layer.py",
+        "tests/test_policy_layer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "PolicyLayer extension implemented.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "assert-evaluation-framework-v1",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "ASSERT Evaluation Framework",
+      "description": "Inspired by trend: ASSERT (Microsoft) policy-driven evaluation framework. Add evaluation checks based on ASSERT concepts.",
+      "allowed_paths": [
+        "magda_agent/evaluation/assert_eval.py",
+        "tests/test_assert_eval.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ASSERT-like evaluation module added.",
+        "Tests pass."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -215,3 +215,5 @@
 * [x] FEATURE: Cross-platform reach channels v2
 * [x] FEATURE: OpenClaw Local-First Gateway
 * [x] FEATURE: A2A Agent Discovery via Cards v2 (a2a-agent-discovery-cards-v2)
+
+- [x] a2a-peer-delegation-discovery-v2: A2A Peer Delegation Discovery

--- a/magda_agent/integration/a2a.py
+++ b/magda_agent/integration/a2a.py
@@ -1,6 +1,7 @@
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Union
 import logging
 from magda_agent.integration.a2a_discovery import AgentCard, A2ADiscovery
+from magda_agent.integration.a2a_discovery_v2 import AgentCardV2, A2ADiscoveryV2
 from magda_agent.integration.a2a_delegation import A2ADelegator
 
 class A2AManager:
@@ -9,15 +10,19 @@ class A2AManager:
     of sub-plans/tasks to capable peers in a peer-to-peer network.
     Inspired by A2A Protocol trends.
     """
-    def __init__(self, local_card: AgentCard):
+    def __init__(self, local_card: Union[AgentCard, AgentCardV2]) -> None:
         """
         Initializes the manager with the local agent's identity and capabilities.
 
         Args:
-            local_card: The AgentCard representing this agent.
+            local_card: The AgentCard or AgentCardV2 representing this agent.
         """
-        self.discovery = A2ADiscovery(local_card=local_card)
-        self.delegator = A2ADelegator(discovery=self.discovery)
+        if isinstance(local_card, AgentCardV2):
+            self.discovery = A2ADiscoveryV2(local_card=local_card) # type: ignore
+        else:
+            self.discovery = A2ADiscovery(local_card=local_card) # type: ignore
+
+        self.delegator = A2ADelegator(discovery=self.discovery) # type: ignore
 
     async def start(self) -> str:
         """
@@ -37,9 +42,12 @@ class A2AManager:
             mock_network_cards: Optional list of JSON strings representing mocked Agent Cards.
         """
         logging.info("A2AManager discovering peers...")
-        await self.discovery.fetch_cards(mock_network_cards=mock_network_cards)
+        if isinstance(self.discovery, A2ADiscoveryV2):
+            await self.discovery.fetch_cards(network_envelopes=mock_network_cards)
+        else:
+            await self.discovery.fetch_cards(mock_network_cards=mock_network_cards)
 
-    def get_known_peers(self) -> List[AgentCard]:
+    def get_known_peers(self) -> Union[List[AgentCard], List[AgentCardV2]]:
         """
         Retrieves all currently known peers discovered in the network.
 

--- a/tests/test_a2a_manager_v2.py
+++ b/tests/test_a2a_manager_v2.py
@@ -1,0 +1,64 @@
+import pytest
+import json
+from unittest.mock import AsyncMock
+from magda_agent.integration.a2a import A2AManager
+from magda_agent.integration.a2a_discovery_v2 import AgentCardV2
+
+@pytest.fixture
+def local_card_v2() -> AgentCardV2:
+    """Fixture for a local AgentCardV2."""
+    return AgentCardV2(
+        agent_id="agent-001",
+        name="MagdaLocal",
+        description="Local agent for testing",
+        capabilities=["chat", "planning"],
+        endpoints={"rpc": "http://localhost:8080/rpc"}
+    )
+
+@pytest.fixture
+def remote_card_v2() -> AgentCardV2:
+    """Fixture for a remote AgentCardV2."""
+    return AgentCardV2(
+        agent_id="agent-remote-001",
+        name="RemoteWorker",
+        description="Worker node",
+        capabilities=["code_execution", "linting"],
+        endpoints={"rpc": "http://192.168.1.10:8080/rpc"}
+    )
+
+@pytest.mark.asyncio
+async def test_a2a_manager_start_v2(local_card_v2: AgentCardV2) -> None:
+    """Test that A2AManager correctly broadcasts its local capabilities using AgentCardV2."""
+    manager = A2AManager(local_card=local_card_v2)
+    broadcast_json = await manager.start()
+
+    envelope = json.loads(broadcast_json)
+    assert envelope["type"] == "a2a_discovery_broadcast"
+
+    payload = json.loads(envelope["payload"])
+    assert payload["agent_id"] == "agent-001"
+    assert "planning" in payload["capabilities"]
+
+@pytest.mark.asyncio
+async def test_a2a_manager_discover_and_delegate_v2(local_card_v2: AgentCardV2, remote_card_v2: AgentCardV2) -> None:
+    """Test that A2AManager discovers peers and delegates subplans correctly using AgentCardV2."""
+    manager = A2AManager(local_card=local_card_v2)
+
+    network_envelopes = [
+        json.dumps({"type": "a2a_discovery_broadcast", "version": "2.0", "payload": remote_card_v2.to_json()})
+    ]
+    await manager.discover_peers(mock_network_cards=network_envelopes)
+
+    peers = manager.get_known_peers()
+    assert len(peers) == 1
+    assert peers[0].agent_id == "agent-remote-001"
+
+    # Test delegation to found peer
+    manager.delegator.delegate_subplan = AsyncMock(return_value="Delegated to Agent RemoteWorker") # type: ignore
+    result = await manager.delegate_task("code_execution", {"code": "print('hello')"})
+    assert result == f"Delegated to Agent RemoteWorker"
+
+    # Test delegation to missing capability
+    manager.delegator.delegate_subplan = AsyncMock(return_value="No agent found") # type: ignore
+    result_missing = await manager.delegate_task("image_generation", {"prompt": "cat"})
+    assert result_missing == "No agent found"


### PR DESCRIPTION
Implements A2A Peer Delegation Discovery v2 as per agent_tasks.json and adds new backlog tasks based on recent trends.

---
*PR created automatically by Jules for task [12528098271417009851](https://jules.google.com/task/12528098271417009851) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A peer delegation discovery V2 support to `A2AManager`
> - [`A2AManager.__init__`](https://github.com/kazah4359-lgtm/Magda-agent/pull/281/files#diff-f768b47687f1afa793af21f4300b58413cfe22bdea05247a2224dc1372f33d9e) now accepts `AgentCardV2` in addition to `AgentCard`; when given a V2 card it instantiates `A2ADiscoveryV2` instead of `A2ADiscovery`.
> - [`discover_peers`](https://github.com/kazah4359-lgtm/Magda-agent/pull/281/files#diff-f768b47687f1afa793af21f4300b58413cfe22bdea05247a2224dc1372f33d9e) forwards mock network cards to the correct `network_envelopes` parameter when using the V2 discovery path.
> - [`get_known_peers`](https://github.com/kazah4359-lgtm/Magda-agent/pull/281/files#diff-f768b47687f1afa793af21f4300b58413cfe22bdea05247a2224dc1372f33d9e) return type is widened to `Union[List[AgentCard], List[AgentCardV2]]`.
> - New tests in [`tests/test_a2a_manager_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/281/files#diff-5143bd0b641bc0df7007fd154aba53625f33168ec9f3875fd657fedd6d25e2e7) cover V2 broadcast, V2 envelope ingestion, task delegation, and missing-capability handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c699fdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->