### PR TITLE
Implement taint tracking for all MCPKernel inputs

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5197,7 +5197,7 @@
     },
     {
       "id": "mcp-kernel-taint-tracking-v3",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "high",
       "title": "MCPKernel Taint Tracking v3",
@@ -9830,6 +9830,57 @@
       "acceptance": [
         "Canvas logger implemented for thought processes.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-registration-v7-unique-12345",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Registration V7",
+      "description": "Inspired by trend: MCP Compatibility. Implement a dynamic registry to register MCP action tools at runtime.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry_v7.py",
+        "tests/test_mcp_registry_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP action tools can be registered dynamically",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "a2a-peer-delegation-discovery-v5-unique-12345",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "A2A Peer Delegation Discovery V5",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol). Implement an asynchronous agent discovery service via Agent Cards.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v5.py",
+        "tests/test_a2a_discovery_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent Cards are successfully discovered and parsed asynchronously",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "context-engine-plugin-lifecycle-v6-unique-12345",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Plugin Lifecycle V6",
+      "description": "Inspired by trend: Context Engine plugin architecture. Extend context plugin hooks for custom eviction strategies.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_v6.py",
+        "tests/test_context_engine_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Eviction hooks are exposed in ContextPlugin protocol",
+        "Tests pass"
       ]
     }
   ]

--- a/magda_agent/security/mcp_kernel.py
+++ b/magda_agent/security/mcp_kernel.py
@@ -41,6 +41,10 @@ class MCPKernel:
     def execute(self, code: str, globals_dict: Optional[Dict[str, Any]] = None, locals_dict: Optional[Dict[str, Any]] = None) -> Any:
         if is_tainted(code):
             raise SecurityError("Code is tainted and unsafe to execute.")
+        if globals_dict is not None and is_tainted(globals_dict):
+            raise SecurityError("globals_dict is tainted and unsafe to use in execution.")
+        if locals_dict is not None and is_tainted(locals_dict):
+            raise SecurityError("locals_dict is tainted and unsafe to use in execution.")
         if not self.is_safe(code):
             raise SecurityError("Code contains unsafe operations and was blocked by MCPKernel taint tracking.")
 

--- a/tests/test_mcp_kernel.py
+++ b/tests/test_mcp_kernel.py
@@ -58,3 +58,21 @@ def test_mcp_kernel_blocks_tainted_input() -> None:
     code = mark_tainted("x = 5")
     with pytest.raises(SecurityError, match="Code is tainted and unsafe to execute."):
         kernel.execute(code)
+
+def test_mcp_kernel_blocks_tainted_globals_dict() -> None:
+    """Test blocking when globals_dict is tainted."""
+    kernel = MCPKernel()
+    from magda_agent.security.mcp_kernel_taint import mark_tainted
+    code = "x = 5"
+    globals_dict = {"bad": mark_tainted("stuff")}
+    with pytest.raises(SecurityError, match="globals_dict is tainted and unsafe to use in execution."):
+        kernel.execute(code, globals_dict=globals_dict)
+
+def test_mcp_kernel_blocks_tainted_locals_dict() -> None:
+    """Test blocking when locals_dict is tainted."""
+    kernel = MCPKernel()
+    from magda_agent.security.mcp_kernel_taint import mark_tainted
+    code = "x = 5"
+    locals_dict = {"bad": mark_tainted("stuff")}
+    with pytest.raises(SecurityError, match="locals_dict is tainted and unsafe to use in execution."):
+        kernel.execute(code, locals_dict=locals_dict)


### PR DESCRIPTION
Resolves the `mcp-kernel-taint-tracking-v3` task. Implemented taint checking in `MCPKernel.execute` for `globals_dict` and `locals_dict` to prevent executing code with tainted context dictionaries. Updated `test_mcp_kernel.py` to test both new validation pathways. Also added 3 new `todo` tasks based on current AI Agent trends.

---
*PR created automatically by Jules for task [544242164703244151](https://jules.google.com/task/544242164703244151) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add taint checks for `globals_dict` and `locals_dict` in `MCPKernel.execute`
> Raises `SecurityError` before execution if `globals_dict` or `locals_dict` passed to [`MCPKernel.execute`](https://github.com/kazah4359-lgtm/Magda-agent/pull/284/files#diff-c9496d67499c3235484d0d78f150458a586927e05d02488038ddb89504aafd84) contain tainted values. Two tests cover the new behavior. Risk: callers passing tainted dicts will now get a hard failure instead of proceeding to execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64e6aef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->