### PR TITLE
feat: OpenClaw-RL Online Reinforcement Learning Module v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5214,7 +5214,7 @@
     },
     {
       "id": "openclaw-rl-online-learning-v5",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Online Reinforcement Learning Module v5",
@@ -9881,6 +9881,57 @@
       "acceptance": [
         "Eviction hooks are exposed in ContextPlugin protocol",
         "Tests pass"
+      ]
+    },
+    {
+      "id": "letta-virtual-context-management-v2-124e0720",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Letta Virtual Context Management v2",
+      "description": "Inspired by trend: Virtual context management (MemGPT/Letta). Expand virtual context limits.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_v2.py",
+        "tests/test_virtual_context_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Virtual context v2 handles large contexts.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-v3-f2cd9e46",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Subagent Context Compression V3",
+      "description": "Inspired by trend: Subagent spawning. Add smart summarization logic.",
+      "allowed_paths": [
+        "magda_agent/agents/context_compression_v3.py",
+        "tests/test_context_compression_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Payload is summarized accurately.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "magentic-one-orchestration-v3-37c4eb76",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Magentic-One Multi-Agent Pattern V3",
+      "description": "Inspired by trend: Magentic-One pattern. Introduce round-robin delegation.",
+      "allowed_paths": [
+        "magda_agent/agents/magentic_one_v3.py",
+        "tests/test_magentic_one_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Round robin orchestration works.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -45,6 +45,7 @@ from magda_agent.learning.habits import HabitTracker
 from magda_agent.learning.online import OnlineLearner
 from magda_agent.learning.dialogue_v3 import DialogueOnlineLearnerV3
 from magda_agent.learning.online_rl import OnlineRLIntegrator
+from magda_agent.learning.openclaw_rl_v5 import OnlineRLIntegrator as OpenClawRLV5Integrator
 from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
 from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
 from magda_agent.learning.lessons import TaskRecoveryLessons
@@ -96,6 +97,8 @@ online_rl_integrator = OnlineRLIntegrator(
     habit_tracker=habit_tracker,
     mirror_neurons=mirror_neurons
 )
+
+openclaw_rl_v5 = OpenClawRLV5Integrator()
 
 dialogue_online_learner_v3 = DialogueOnlineLearnerV3()
 
@@ -158,6 +161,7 @@ consciousness = Consciousness(
     skill_creator=skill_creator,
     online_learner=online_learner,
     online_rl_integrator=online_rl_integrator,
+    openclaw_rl_v5=openclaw_rl_v5,
     online_rl_v6=online_rl_v6,
     dialogue_online_learner_v3=dialogue_online_learner_v3,
     openclaw_rl=openclaw_rl,

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -28,6 +28,7 @@ from magda_agent.user_model.model import UserModel
 from magda_agent.learning.online import OnlineLearner
 from magda_agent.learning.dialogue_v3 import DialogueOnlineLearnerV3
 from magda_agent.learning.online_rl import OnlineRLIntegrator
+from magda_agent.learning.openclaw_rl_v5 import OnlineRLIntegrator as OpenClawRLV5Integrator
 from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
 from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
 from magda_agent.learning.feedback_loop import FeedbackLoop
@@ -69,6 +70,7 @@ class Consciousness:
         skill_creator: Optional[SkillCreator] = None,
         online_learner: Optional[OnlineLearner] = None,
         online_rl_integrator: Optional[OnlineRLIntegrator] = None,
+        openclaw_rl_v5: Optional['OpenClawRLV5Integrator'] = None,
         online_rl_v6: Optional[OnlineRLFeedbackLoopV6] = None,
         dialogue_online_learner_v3: Optional[DialogueOnlineLearnerV3] = None,
         openclaw_rl: Optional[OpenClawInteractiveLearner] = None,
@@ -104,6 +106,7 @@ class Consciousness:
         self.skill_creator = skill_creator
         self.online_learner = online_learner
         self.online_rl_integrator = online_rl_integrator
+        self.openclaw_rl_v5 = openclaw_rl_v5
         self.online_rl_v6 = online_rl_v6
         self.dialogue_online_learner_v3 = dialogue_online_learner_v3
         self.openclaw_rl = openclaw_rl
@@ -411,6 +414,9 @@ class Consciousness:
 
         if self.online_rl_integrator:
             await self.online_rl_integrator.process_feedback(user_input, "last_action_context", user_id)
+
+        if self.openclaw_rl_v5:
+            await self.openclaw_rl_v5.process_feedback(user_input, 'last_action_context', user_id, 'chat_skill')
 
         if self.long_term_memory:
             self.long_term_memory.store(text=memory_content, metadata={"type": "conversation"}, user_id=user_id)

--- a/magda_agent/learning/openclaw_rl_v5.py
+++ b/magda_agent/learning/openclaw_rl_v5.py
@@ -1,0 +1,69 @@
+import logging
+from typing import Optional, Dict
+
+class OnlineRLIntegrator:
+    """
+    OpenClaw-RL Online Reinforcement Learning Module v5.
+    Updates skill_weights based on user feedback.
+    """
+
+    def __init__(self, initial_weights: Optional[Dict[str, float]] = None) -> None:
+        """
+        Initializes the OnlineRLIntegrator.
+
+        Args:
+            initial_weights (Optional[Dict[str, float]]): Initial weights for skills.
+        """
+        self.skill_weights: Dict[str, float] = initial_weights or {}
+        logging.info("Initialized OnlineRLIntegrator")
+
+    def parse_feedback(self, feedback: str) -> float:
+        """
+        Parses user feedback to extract a sentiment or reward score.
+        Uses simple heuristics for demonstration in lieu of a full language model.
+
+        Args:
+            feedback (str): The user's feedback text.
+
+        Returns:
+            float: A reward score, typically between -1.0 and 1.0.
+        """
+        feedback_lower = feedback.lower()
+        if "good" in feedback_lower or "great" in feedback_lower or "thanks" in feedback_lower or "excellent" in feedback_lower:
+            return 1.0
+        elif "bad" in feedback_lower or "wrong" in feedback_lower or "terrible" in feedback_lower or "no" in feedback_lower:
+            return -1.0
+        return 0.0
+
+    async def process_feedback(
+        self,
+        user_feedback: str,
+        action_context: str,
+        user_id: Optional[int] = None,
+        skill_used: str = "default_skill"
+    ) -> None:
+        """
+        Processes user feedback and adjusts the weight of the skill used.
+
+        Args:
+            user_feedback (str): The feedback provided by the user.
+            action_context (str): The context in which the action was taken.
+            user_id (Optional[int]): The ID of the user providing feedback.
+            skill_used (str): The name of the skill that was used to generate the response.
+        """
+        if not user_feedback:
+            return
+
+        reward = self.parse_feedback(user_feedback)
+
+        if skill_used not in self.skill_weights:
+            self.skill_weights[skill_used] = 1.0
+
+        # Adjust weight based on reward
+        adjustment_factor = 0.1
+        self.skill_weights[skill_used] += reward * adjustment_factor
+
+        # Ensure weight doesn't go below a minimum threshold
+        self.skill_weights[skill_used] = max(0.1, self.skill_weights[skill_used])
+
+        logging.info(f"Updated weight for skill '{skill_used}' to {self.skill_weights[skill_used]:.2f} based on feedback reward {reward}")

--- a/tests/test_openclaw_rl_v5.py
+++ b/tests/test_openclaw_rl_v5.py
@@ -1,0 +1,59 @@
+import pytest
+import asyncio
+from magda_agent.learning.openclaw_rl_v5 import OnlineRLIntegrator
+
+@pytest.fixture
+def integrator():
+    return OnlineRLIntegrator(initial_weights={"search": 1.0})
+
+def test_parse_feedback_positive(integrator):
+    assert integrator.parse_feedback("That was good, thanks!") == 1.0
+    assert integrator.parse_feedback("Excellent job") == 1.0
+
+def test_parse_feedback_negative(integrator):
+    assert integrator.parse_feedback("That was terrible") == -1.0
+    assert integrator.parse_feedback("No, that is wrong") == -1.0
+
+def test_parse_feedback_neutral(integrator):
+    assert integrator.parse_feedback("Okay") == 0.0
+
+@pytest.mark.asyncio
+async def test_process_feedback_positive(integrator):
+    await integrator.process_feedback(
+        user_feedback="great",
+        action_context="search context",
+        user_id=123,
+        skill_used="search"
+    )
+    assert integrator.skill_weights["search"] == 1.1
+
+@pytest.mark.asyncio
+async def test_process_feedback_negative(integrator):
+    await integrator.process_feedback(
+        user_feedback="bad",
+        action_context="search context",
+        user_id=123,
+        skill_used="search"
+    )
+    assert integrator.skill_weights["search"] == 0.9
+
+@pytest.mark.asyncio
+async def test_process_feedback_new_skill(integrator):
+    await integrator.process_feedback(
+        user_feedback="good",
+        action_context="math context",
+        user_id=123,
+        skill_used="math_skill"
+    )
+    assert integrator.skill_weights["math_skill"] == 1.1
+
+@pytest.mark.asyncio
+async def test_process_feedback_minimum_threshold(integrator):
+    integrator.skill_weights["poor_skill"] = 0.15
+    await integrator.process_feedback(
+        user_feedback="bad",
+        action_context="poor context",
+        user_id=123,
+        skill_used="poor_skill"
+    )
+    assert integrator.skill_weights["poor_skill"] == 0.1


### PR DESCRIPTION
Implement task openclaw-rl-online-learning-v5

---
*PR created automatically by Jules for task [5520779408465743397](https://jules.google.com/task/5520779408465743397) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenClaw-RL v5 online reinforcement learning module to `Consciousness`
> - Adds [`openclaw_rl_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/285/files#diff-6e1dc61ed2989e6710ab534835d15bea2b106e015f10097933cf8e43a231f3c1) with `OnlineRLIntegrator`, which parses user feedback text into a discrete reward signal (+1, 0, -1) using keyword heuristics and adjusts per-skill weights by ±0.1, clamped to a minimum of 0.1.
> - Wires the integrator into [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/285/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a) as an optional `openclaw_rl_v5` parameter; when present, `process_user_input` triggers an async `process_feedback` call after existing RL handling.
> - Unit tests in [`tests/test_openclaw_rl_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/285/files#diff-091f1a47d393ded1aa7323239633da3653e69cf7999d48c388b2d4a91c857f1d) cover positive/negative/neutral feedback paths, new-skill initialization, and the 0.1 minimum threshold.
> - Behavioral Change: skill weight updates are in-memory only with no persistence; weights reset on restart.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 073ac52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->