### PR TITLE
Implement Context Engine plugin hooks v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5231,7 +5231,7 @@
     },
     {
       "id": "context-engine-plugin-hooks-v5",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine plugin hooks v5",
@@ -9932,6 +9932,59 @@
       "acceptance": [
         "Round robin orchestration works.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "6b808d21-7bfb-414c-882d-df94811e048c",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tool Exporter for Core Skills",
+      "description": "Inspired by 2026 MCP standard trend: Export existing Magda skills as MCP-compatible JSON-RPC tools for better integration.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter_v2.py",
+        "tests/test_mcp_exporter_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP exporter wrapper created.",
+        "Can register and export at least one skill.",
+        "Pytest tests use mocked JSON-RPC calls."
+      ]
+    },
+    {
+      "id": "56252bf5-77a4-4fc0-98ef-234b46d86f14",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A Protocol Discovery Layer",
+      "description": "Inspired by 2026 A2A open standard: Implement Agent discovery via Agent Cards for peer-to-peer task delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery.py",
+        "tests/test_a2a_discovery.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A discovery module implemented.",
+        "Agent Cards can be parsed and validated.",
+        "Pytest tests cover successful and failed parsing without real network."
+      ]
+    },
+    {
+      "id": "60d3a380-1aba-4cbd-9126-bbe0f15201c3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "Working Memory Context Compressor",
+      "description": "Inspired by Claude Agent SDK context compression: Implement a selective compressor for working memory limits.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v3.py",
+        "tests/test_compression_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ContextCompressor v3 correctly truncates and summarizes context.",
+        "Pytest tests assert limits are respected."
       ]
     }
   ]

--- a/magda_agent/memory/context_engine_hooks_v5.py
+++ b/magda_agent/memory/context_engine_hooks_v5.py
@@ -1,0 +1,66 @@
+from typing import Any, List, Dict
+import logging
+
+from magda_agent.memory.context_engine import ContextPlugin
+
+class OrderedContextPluginV5(ContextPlugin):
+    """
+    A V5 Context Engine Plugin that explicitly tracks execution order
+    and implements before_retrieval and after_retrieval lifecycle hooks.
+    Inspired by OpenClaw trends for memory context hooks.
+    """
+    def __init__(self) -> None:
+        """Initialize the plugin and set up execution order tracking."""
+        super().__init__()
+        self.execution_order: List[str] = []
+        logging.debug("Initialized OrderedContextPluginV5")
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """
+        Initialize the plugin with configuration.
+        """
+        self.execution_order.append("bootstrap")
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """
+        Process incoming content before it is stored or used.
+        """
+        self.execution_order.append("ingest")
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """
+        Assemble the context string from retrieved items for the LLM.
+        """
+        self.execution_order.append("assemble")
+        return ""
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        Compact or summarize the context when limits are reached.
+        """
+        self.execution_order.append("compact")
+        return context_items
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """
+        Called before context is retrieved.
+        Modifies the query to indicate V5 pre-retrieval processing.
+        """
+        self.execution_order.append("before_retrieval")
+        return f"{query} [v5_pre_retrieval_modified]"
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """
+        Called after context is retrieved.
+        Appends a metadata item to the retrieved context.
+        """
+        self.execution_order.append("after_retrieval")
+        context.append(f"metadata: v5_post_retrieval executed for user {user_id}")
+        return context
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """
+        Triggered when overall context is updated.
+        """
+        self.execution_order.append("on_context_update")

--- a/tests/test_context_engine_hooks_v5.py
+++ b/tests/test_context_engine_hooks_v5.py
@@ -1,0 +1,48 @@
+import pytest
+from typing import List, Any
+from magda_agent.memory.context_engine import ContextEngine
+from magda_agent.memory.context_engine_hooks_v5 import OrderedContextPluginV5
+
+def dummy_retrieval_func(query: str, user_id: int) -> List[Any]:
+    """A dummy base retrieval function for testing context retrieval."""
+    return [f"retrieved for: {query}"]
+
+@pytest.mark.asyncio
+async def test_ordered_context_plugin_v5_async_methods() -> None:
+    """Test the asynchronous lifecycle methods of OrderedContextPluginV5."""
+    plugin = OrderedContextPluginV5()
+
+    await plugin.bootstrap({"key": "value"})
+    assert plugin.execution_order == ["bootstrap"]
+
+    await plugin.ingest("content", {})
+    assert plugin.execution_order == ["bootstrap", "ingest"]
+
+    await plugin.assemble([], {})
+    assert plugin.execution_order == ["bootstrap", "ingest", "assemble"]
+
+    await plugin.compact([], {})
+    assert plugin.execution_order == ["bootstrap", "ingest", "assemble", "compact"]
+
+def test_context_engine_hooks_v5_execution_order() -> None:
+    """Test the execution order of retrieval hooks in ContextEngine."""
+    plugin = OrderedContextPluginV5()
+    engine = ContextEngine(plugins=[plugin])
+
+    result = engine.retrieve_context("test query", 42, dummy_retrieval_func)
+
+    # Check modifications
+    assert len(result) == 2
+    assert "test query [v5_pre_retrieval_modified]" in result[0]
+    assert "metadata: v5_post_retrieval executed for user 42" in result[1]
+
+    # Check execution order
+    assert plugin.execution_order == ["before_retrieval", "after_retrieval"]
+
+def test_context_engine_hooks_v5_update_context() -> None:
+    """Test the update_context hook triggers correctly."""
+    plugin = OrderedContextPluginV5()
+    engine = ContextEngine(plugins=[plugin])
+
+    engine.update_context("new_context_data", 42)
+    assert plugin.execution_order == ["on_context_update"]


### PR DESCRIPTION
Implementation of Context Engine plugin hooks v5 module, along with unit tests and updating the tracking JSON task file with new tasks inspired by 2026 AI trends.

---
*PR created automatically by Jules for task [13237965196663045853](https://jules.google.com/task/13237965196663045853) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `OrderedContextPluginV5` with lifecycle hook tracking for the Context Engine
> - Adds [`context_engine_hooks_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/287/files#diff-85e9f1b2aeda0f111080a560171f37f79228bf625767efa00ded8e6e299f9f2e) with `OrderedContextPluginV5`, a `ContextPlugin` subclass that records hook invocation order via an internal `execution_order` list.
> - Implements all lifecycle hooks: async `bootstrap`, `ingest`, `assemble`, `compact`; and synchronous `before_retrieval`, `after_retrieval`, `on_context_update`.
> - `before_retrieval` appends a `[v5_pre_retrieval_modified]` marker to the query string; `after_retrieval` appends a metadata entry noting V5 post-retrieval execution and user id to the context list.
> - Adds tests in [`tests/test_context_engine_hooks_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/287/files#diff-cc408890296dab27e8afcc28e23e4483f08633f0eb2485868f7f0a157f08ab9a) covering async hook behavior, execution order, query mutation, and context update triggering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 889b808.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->