### PR TITLE
feat: Implement CronScheduler v5 and replenish tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5248,7 +5248,7 @@
     },
     {
       "id": "periodic-cron-scheduler-v5",
-      "status": "todo",
+      "status": "done",
       "area": "orchestration",
       "risk": "medium",
       "title": "Periodic Cron Scheduler v5",
@@ -9932,6 +9932,57 @@
       "acceptance": [
         "Round robin orchestration works.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "hermes-skill-experience-generation-v2-08bcfded",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes-inspired Skill Creation v2",
+      "description": "Inspired by trend: Hermes Agent (Self-improving agent). Create a module to auto-generate Python skills from historical trace logs.",
+      "allowed_paths": [
+        "magda_agent/skills/experience_generator_v2.py",
+        "tests/test_experience_generator_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Experience generator created and can parse execution traces.",
+        "Tests pass with mock data."
+      ]
+    },
+    {
+      "id": "openclaw-online-rl-dialogue-v6-e9301cfc",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw Online RL Loop v6",
+      "description": "Inspired by trend: OpenClaw-RL (Trains agent simply by talking). Implement an online RL module that adjusts internal action weights based on parsed next-state user feedback.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl_loop_v6.py",
+        "tests/test_online_rl_loop_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Online RL loop implemented.",
+        "Tests mock feedback and confirm weight adjustments."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-isolation-v2-0c02564e",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Claude Agent Teams Git Worktree Isolation v2",
+      "description": "Inspired by trend: Claude Agent SDK (Agent Teams with git worktree isolation). Implement git worktree management for sub-agents to allow parallel isolated execution.",
+      "allowed_paths": [
+        "magda_agent/agents/worktree_manager_v2.py",
+        "tests/test_worktree_manager_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Git worktree manager can create and clean up isolated worktrees.",
+        "Tests verify git commands are correctly formulated."
       ]
     }
   ]

--- a/magda_agent/scheduler/cron_v5.py
+++ b/magda_agent/scheduler/cron_v5.py
@@ -1,0 +1,124 @@
+import asyncio
+import logging
+from datetime import datetime
+from typing import Callable, Any, Coroutine, Dict, List
+from croniter import croniter
+
+logger = logging.getLogger(__name__)
+
+class CronScheduler:
+    """
+    A lightweight cron-like scheduler for periodic background tasks.
+    Runs tasks periodically based on cron expressions.
+    """
+
+    def __init__(self, result_callback: Callable[[Any], Coroutine[Any, Any, None]] | None = None) -> None:
+        """
+        Initializes the CronScheduler.
+
+        Args:
+            result_callback: Optional async callback to handle the result of a task execution.
+                             Often used to deliver results to a configured channel.
+        """
+        self.jobs: List[Dict[str, Any]] = []
+        self._running: bool = False
+        self._task: asyncio.Task[None] | None = None
+        self.result_callback: Callable[[Any], Coroutine[Any, Any, None]] | None = result_callback
+
+    def schedule(self, cron_expr: str, func: Callable[..., Coroutine[Any, Any, Any]], name: str | None = None, *args: Any, **kwargs: Any) -> None:
+        """
+        Schedules a task to run according to a cron expression.
+
+        Args:
+            cron_expr: The cron expression (e.g., "*/5 * * * *").
+            func: The async function to execute.
+            name: Optional name for the task.
+            *args: Arguments to pass to the function.
+            **kwargs: Keyword arguments to pass to the function.
+        """
+        if not croniter.is_valid(cron_expr):
+            raise ValueError(f"Invalid cron expression: {cron_expr}")
+
+        now = self._get_now()
+        itr = croniter(cron_expr, now)
+        next_run = itr.get_next(datetime)
+
+        job_name = name or func.__name__
+
+        job = {
+            "name": job_name,
+            "cron_expr": cron_expr,
+            "func": func,
+            "args": args,
+            "kwargs": kwargs,
+            "next_run": next_run,
+            "iterator": itr
+        }
+        self.jobs.append(job)
+        logger.info(f"Scheduled task '{job_name}' with cron '{cron_expr}', next run: {next_run}")
+
+    def task(self, cron_expr: str, name: str | None = None) -> Callable[[Callable[..., Coroutine[Any, Any, Any]]], Callable[..., Coroutine[Any, Any, Any]]]:
+        """
+        A decorator to schedule a task.
+        """
+        def decorator(func: Callable[..., Coroutine[Any, Any, Any]]) -> Callable[..., Coroutine[Any, Any, Any]]:
+            self.schedule(cron_expr, func, name=name)
+            return func
+        return decorator
+
+    def _get_now(self) -> datetime:
+        """
+        Returns the current time. Useful for mocking in tests.
+        """
+        return datetime.now()
+
+    async def start(self) -> None:
+        """
+        Starts the scheduler loop in the background.
+        """
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info("CronScheduler started.")
+
+    async def stop(self) -> None:
+        """
+        Stops the scheduler loop.
+        """
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("CronScheduler stopped.")
+
+    async def _loop(self) -> None:
+        """
+        The main loop checking for jobs to run.
+        """
+        while self._running:
+            now = self._get_now()
+            for job in self.jobs:
+                if now >= job["next_run"]:
+                    # Execute task
+                    asyncio.create_task(self._execute_job(job))
+                    # Update next run time
+                    job["next_run"] = job["iterator"].get_next(datetime)
+            await asyncio.sleep(1.0) # Check every second
+
+    async def _execute_job(self, job: Dict[str, Any]) -> None:
+        """
+        Executes a scheduled job and optionally calls the result callback.
+        """
+        func = job["func"]
+        name = job["name"]
+        try:
+            logger.info(f"Executing scheduled task: {name}")
+            result = await func(*job["args"], **job["kwargs"])
+            if self.result_callback and result is not None:
+                await self.result_callback(result)
+        except Exception as e:
+            logger.error(f"Error executing scheduled task {name}: {e}", exc_info=True)

--- a/tests/test_cron_v5.py
+++ b/tests/test_cron_v5.py
@@ -1,0 +1,107 @@
+import pytest
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from magda_agent.scheduler.cron_v5 import CronScheduler
+
+@pytest.fixture
+def scheduler():
+    return CronScheduler()
+
+@pytest.mark.asyncio
+async def test_schedule_valid_cron(scheduler):
+    async def dummy_task():
+        pass
+
+    scheduler.schedule("0 0 * * *", dummy_task, name="daily_task")
+    assert len(scheduler.jobs) == 1
+    assert scheduler.jobs[0]["name"] == "daily_task"
+    assert scheduler.jobs[0]["cron_expr"] == "0 0 * * *"
+
+@pytest.mark.asyncio
+async def test_schedule_invalid_cron(scheduler):
+    async def dummy_task():
+        pass
+
+    with pytest.raises(ValueError, match="Invalid cron expression"):
+        scheduler.schedule("invalid cron", dummy_task)
+
+@pytest.mark.asyncio
+async def test_start_stop(scheduler):
+    await scheduler.start()
+    assert scheduler._running is True
+    assert scheduler._task is not None
+    assert not scheduler._task.done()
+
+    await scheduler.stop()
+    assert scheduler._running is False
+    assert scheduler._task.done() or scheduler._task.cancelled()
+
+@pytest.mark.asyncio
+async def test_execute_job(scheduler):
+    mock_func = MagicMock()
+    async def dummy_task(*args, **kwargs):
+        mock_func(*args, **kwargs)
+        return "result"
+
+    callback = MagicMock()
+    async def dummy_callback(res):
+        callback(res)
+
+    scheduler.result_callback = dummy_callback
+
+    # Schedule a task
+    scheduler.schedule("* * * * *", dummy_task, "test_job", "value1", kwarg1="value2")
+    job = scheduler.jobs[0]
+
+    # Execute it directly
+    await scheduler._execute_job(job)
+
+    mock_func.assert_called_once_with("value1", kwarg1="value2")
+    callback.assert_called_once_with("result")
+
+@pytest.mark.asyncio
+async def test_loop_execution():
+    scheduler = CronScheduler()
+
+    call_count = 0
+    async def dummy_task():
+        nonlocal call_count
+        call_count += 1
+
+    # Mock time inside the scheduler BEFORE scheduling
+    # Need to keep it mutable for _get_now
+    time_dict = {"current": datetime(2023, 1, 1, 12, 0, 0)}
+    def mock_get_now():
+        return time_dict["current"]
+    scheduler._get_now = mock_get_now
+
+    # Schedule to run every minute
+    scheduler.schedule("* * * * *", dummy_task, name="test_job")
+    job = scheduler.jobs[0]
+
+    # Next run should be 12:01:00
+    assert job["next_run"] == datetime(2023, 1, 1, 12, 1, 0)
+
+    # Store original sleep
+    original_sleep = asyncio.sleep
+
+    # Start scheduler loop, but mock sleep to yield to event loop quickly
+    async def mock_sleep(*args):
+        await original_sleep(0.001)
+
+    with patch("asyncio.sleep", mock_sleep):
+        await scheduler.start()
+
+        # Advance time past the next run
+        time_dict["current"] = datetime(2023, 1, 1, 12, 1, 1)
+
+        # Let the event loop run long enough for the loop to catch the new time
+        await original_sleep(0.05)
+
+        await scheduler.stop()
+
+    assert call_count >= 1
+    # Next run should now be 12:02:00
+    assert job["next_run"] == datetime(2023, 1, 1, 12, 2, 0)


### PR DESCRIPTION
Implemented CronScheduler v5 and replenished agent_tasks.json with 3 new tasks based on recent agent trends. Tests and types added.

---
*PR created automatically by Jules for task [16795208605287889831](https://jules.google.com/task/16795208605287889831) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement async cron-based scheduler as `CronScheduler` v5
> - Adds [cron_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/288/files#diff-4d4148cf1732eb50be06317bdf474c5e57e2861d76f5961bf3e6a7fbffd0934b) with a new `CronScheduler` class that runs async callables on cron schedules using `croniter` for expression parsing and next-run tracking.
> - Supports `schedule()` for direct job registration and a `@task` decorator for decorator-based registration; invalid cron expressions raise `ValueError`.
> - Jobs are dispatched via `asyncio.create_task` in a 1-second polling loop; an optional async `result_callback` receives non-None results after each execution.
> - Exceptions in jobs are logged with tracebacks but do not crash the scheduler loop.
> - Adds async pytest suite in [test_cron_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/288/files#diff-e76eb9172d7af7079ffb7134973183786590f187fa6c9e7c1594be6fb77d231f) covering scheduling, lifecycle, result callbacks, and loop-driven execution with time mocking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4483d02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->