### PR TITLE
feat: Expand CronScheduler for dynamic registration and daily reports

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5265,7 +5265,7 @@
     },
     {
       "id": "hermes-cron-scheduler-expansion-v1",
-      "status": "todo",
+      "status": "done",
       "area": "orchestration",
       "risk": "medium",
       "title": "Hermes-inspired Cron Scheduler Expansion",
@@ -9983,6 +9983,59 @@
       "acceptance": [
         "Git worktree manager can create and clean up isolated worktrees.",
         "Tests verify git commands are correctly formulated."
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-sync-v1-d6be4114",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes-inspired agentskills.io Sync CLI",
+      "description": "Inspired by Hermes open standard: Add a CLI command using the Codex bridge module pattern to manually sync external skills from agentskills.io into the local registry.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_sync_cli.py",
+        "tests/test_marketplace_sync_cli*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "CLI command triggers a fetch from the skill marketplace.",
+        "Fetched skills are validated against policy.",
+        "Pytest tests mock network requests."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-validator-v1-9b382453",
+      "status": "todo",
+      "area": "skills",
+      "risk": "high",
+      "title": "MCP Tool Registry Interceptor",
+      "description": "Inspired by MCP Compatibility trend: Add an interceptor to the MCPRegistry to automatically validate dynamic action tool parameters using jsonschema.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_validator.py",
+        "tests/test_mcp_validator*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP tools are intercepted during registration.",
+        "jsonschema is used to validate parameter schemas.",
+        "Invalid schemas raise registration errors."
+      ]
+    },
+    {
+      "id": "anthropic-agent-teams-evaluator-3d382f01",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Agent Teams Evaluator V2",
+      "description": "Inspired by Claude Agent SDK: Add a new agent node that evaluates the output of a specific generator agent against a dynamic rubric.",
+      "allowed_paths": [
+        "magda_agent/evaluation/agent_evaluator_v2.py",
+        "tests/test_agent_evaluator_v2*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator agent is implemented.",
+        "Tests mock generation and evaluate properly."
       ]
     }
   ]

--- a/magda_agent/scheduler/cron_v5.py
+++ b/magda_agent/scheduler/cron_v5.py
@@ -57,6 +57,35 @@ class CronScheduler:
         self.jobs.append(job)
         logger.info(f"Scheduled task '{job_name}' with cron '{cron_expr}', next run: {next_run}")
 
+    def remove_job(self, name: str) -> bool:
+        """
+        Dynamically removes a registered job by its name.
+
+        Args:
+            name: The name of the job to remove.
+
+        Returns:
+            True if the job was found and removed, False otherwise.
+        """
+        initial_length = len(self.jobs)
+        self.jobs = [job for job in self.jobs if job["name"] != name]
+        if len(self.jobs) < initial_length:
+            logger.info(f"Removed job '{name}'")
+            return True
+        return False
+
+    def register_daily_report(self, name: str, report_func: Callable[..., Coroutine[Any, Any, Any]], cron_expr: str = "0 9 * * *") -> None:
+        """
+        Dynamically registers a skeleton daily report job.
+
+        Args:
+            name: The name of the report job.
+            report_func: The async function to execute.
+            cron_expr: The schedule, defaults to 9:00 AM daily.
+        """
+        self.schedule(cron_expr, report_func, name=name)
+        logger.info(f"Registered daily report '{name}' with schedule '{cron_expr}'")
+
     def task(self, cron_expr: str, name: str | None = None) -> Callable[[Callable[..., Coroutine[Any, Any, Any]]], Callable[..., Coroutine[Any, Any, Any]]]:
         """
         A decorator to schedule a task.

--- a/tests/test_cron_v5.py
+++ b/tests/test_cron_v5.py
@@ -105,3 +105,35 @@ async def test_loop_execution():
     assert call_count >= 1
     # Next run should now be 12:02:00
     assert job["next_run"] == datetime(2023, 1, 1, 12, 2, 0)
+
+@pytest.mark.asyncio
+async def test_remove_job(scheduler):
+    async def dummy_task():
+        pass
+
+    scheduler.schedule("0 0 * * *", dummy_task, name="task_1")
+    scheduler.schedule("0 0 * * *", dummy_task, name="task_2")
+
+    assert len(scheduler.jobs) == 2
+
+    # Remove existing
+    removed = scheduler.remove_job("task_1")
+    assert removed is True
+    assert len(scheduler.jobs) == 1
+    assert scheduler.jobs[0]["name"] == "task_2"
+
+    # Remove non-existing
+    removed = scheduler.remove_job("task_3")
+    assert removed is False
+    assert len(scheduler.jobs) == 1
+
+@pytest.mark.asyncio
+async def test_register_daily_report(scheduler):
+    async def report_task():
+        pass
+
+    scheduler.register_daily_report("daily_status", report_task)
+
+    assert len(scheduler.jobs) == 1
+    assert scheduler.jobs[0]["name"] == "daily_status"
+    assert scheduler.jobs[0]["cron_expr"] == "0 9 * * *"


### PR DESCRIPTION
Implements hermes-cron-scheduler-expansion-v1. 
- Expands CronScheduler to support dynamic job registration via remove_job.
- Supports daily reporting functions via register_daily_report.
- Fully tested.

---
*PR created automatically by Jules for task [17954072529366648588](https://jules.google.com/task/17954072529366648588) started by @kazah4359-lgtm*