### PR TITLE
Implement MCP tool concurrency

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5300,7 +5300,7 @@
     },
     {
       "id": "mcp-action-tool-concurrency-v1",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Runtime Function Tool Concurrency",
@@ -10070,6 +10070,41 @@
       "acceptance": [
         "MCP tool execution supports async concurrency.",
         "Tests pass with simulated concurrent executions."
+      ]
+    },
+    {
+      "id": "a2a-delegation-retry-v1-33968cf9-506d-412d-b908-b180f27ea1ae",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "A2A Delegation Resiliency",
+      "description": "Inspired by trend: A2A Protocol and enterprise-ready agents. Implement automatic retries for A2A task delegation on transient network failures.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegator.py",
+        "tests/test_a2a_delegator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Delegator retries transient errors.",
+        "Tests pass with simulated network failures."
+      ]
+    },
+    {
+      "id": "mcp-config-reload-v1-5152d2ba-9858-4470-b742-f0071a62b5e7",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "MCP Configuration Hot-Reload",
+      "description": "Inspired by trend: MCP tools proliferation. Allow reloading of MCP tool configurations without restarting the Magda agent.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry.py",
+        "magda_agent/skills/mcp_engine.py",
+        "tests/test_mcp_hot_reload.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP configurations can be hot-reloaded.",
+        "Tests verify that updated configurations are applied immediately."
       ]
     }
   ]

--- a/magda_agent/skills/concurrency.py
+++ b/magda_agent/skills/concurrency.py
@@ -26,6 +26,14 @@ class ConcurrentSkillExecutor:
             # Using the registry's execute_skill method to pass through all guards
             # The registry's execute_skill method handles execution regardless of
             # whether the underlying skill is async or sync.
-            tasks.append(asyncio.to_thread(self.registry.execute_skill, name, **kwargs))
+
+            async def wrap_execution(n=name, k=kwargs):
+                # Run the synchronous part in a thread to unblock the event loop
+                res = await asyncio.to_thread(self.registry.execute_skill, n, **k)
+                if inspect.isawaitable(res):
+                    return await res
+                return res
+
+            tasks.append(wrap_execution())
 
         return await asyncio.gather(*tasks)

--- a/magda_agent/skills/mcp_engine.py
+++ b/magda_agent/skills/mcp_engine.py
@@ -42,10 +42,10 @@ class MCPEngine:
         import concurrent.futures
 
         # 2. Create the wrapper skill that delegates to MCPClient
-        def mcp_wrapper_skill(**kwargs: Any) -> Any:
+        async def mcp_wrapper_skill(**kwargs: Any) -> Any:
             """
             Dynamically executes the imported MCP tool via the MCPClient.
-            Runs synchronously to safely integrate with Magda's executor.
+            Runs asynchronously to support concurrent execution of tools.
 
             Args:
                 kwargs: Arguments to pass to the MCP tool.
@@ -53,13 +53,7 @@ class MCPEngine:
             Returns:
                 Any: Result of the MCP tool execution.
             """
-            coro = self.mcp_client.execute_tool(tool_name, **kwargs)
-            try:
-                loop = asyncio.get_running_loop()
-                with concurrent.futures.ThreadPoolExecutor() as pool:
-                    return pool.submit(asyncio.run, coro).result()
-            except RuntimeError:
-                return asyncio.run(coro)
+            return await self.mcp_client.execute_tool(tool_name, **kwargs)
 
         # Add the schema attribute so MagdaMCPAdapter natively picks it up if needed.
         setattr(mcp_wrapper_skill, "__mcp_schema__", input_schema)

--- a/magda_agent/skills/mcp_registry.py
+++ b/magda_agent/skills/mcp_registry.py
@@ -24,7 +24,7 @@ class MCPRegistry:
             logging.error(f"Failed to load MCP tool: Invalid schema {tool_schema}")
             return False
 
-        name = tool_schema["name"]
+        name: str = tool_schema["name"]
         self.mcp_tools[name] = tool_schema
         logging.info(f"Successfully loaded MCP tool: {name}")
         return True

--- a/tests/test_mcp_engine.py
+++ b/tests/test_mcp_engine.py
@@ -53,7 +53,7 @@ async def test_mcp_engine_wrapper_execution() -> None:
 
     engine.import_mcp_tool(tool_def, connection_info)
 
-    result = registry.execute_skill("external_weather", location="Paris")
+    result = await registry.execute_skill("external_weather", location="Paris")
 
     assert result == "Sunny, 25C"
     mcp_client.execute_tool.assert_awaited_once_with("external_weather", location="Paris")


### PR DESCRIPTION
Implements MCP runtime function tool concurrency by modifying the MCPEngine to execute wrapper skills natively asynchronously rather than blocking using ThreadPoolExecutor. This enables concurrent API calls for external MCP actions in line with AI agent trends. Also updates tests to handle these changes and appends relevant new tasks.

---
*PR created automatically by Jules for task [4564444923981760968](https://jules.google.com/task/4564444923981760968) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP tool concurrency by converting imported tools to async skills
> - Changes `MCPEngine.import_mcp_tool` in [mcp_engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/291/files#diff-26572b42493a12c4ec9d8bfa23bfc751544330482e76b956aebd528de7d4c9df) to generate async wrapper skills that directly `await` MCP client execution, replacing the previous `ThreadPoolExecutor`/`asyncio.run` approach.
> - Fixes `ConcurrentSkillExecutor.execute_concurrently` in [concurrency.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/291/files#diff-1538acd2288a6959065ad34239d8212579a08db64ce29f9026f3ebe0a01853fe) to inspect returned values and await them if awaitable, so async skills return results instead of coroutine objects.
> - Updates [test_mcp_engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/291/files#diff-e02d1cbf73a1d0311aedb16f5b572e14dd6d1f3ce9d577f07d7d08aa08c6cc8a) to await `registry.execute_skill` to match the new async behavior.
> - Behavioral Change: MCP tool wrappers are now async; any code calling them synchronously will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2a55a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->