### PR TITLE
Implement A2A Protocol Event Tracing and History

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5335,7 +5335,7 @@
     },
     {
       "id": "a2a-tracing-module-v1",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Protocol Tracing Module",

--- a/magda_agent/integration/a2a_tracing.py
+++ b/magda_agent/integration/a2a_tracing.py
@@ -1,7 +1,9 @@
 import contextvars
 import uuid
 import logging
-from typing import Optional, Dict
+import time
+from collections import deque
+from typing import Optional, Dict, List, Any
 
 _trace_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("a2a_trace_id", default=None)
 
@@ -11,7 +13,14 @@ class A2ATracer:
     """
     Provides distributed tracing capabilities for Agent-to-Agent (A2A) delegations.
     Ensures that a trace ID is propagated across multiple agents involved in a task.
+    Now supports recording and retrieving delegation traces.
     """
+
+    MAX_TRACES = 1000
+    MAX_EVENTS_PER_TRACE = 100
+
+    _trace_registry: Dict[str, List[Dict[str, Any]]] = {}
+    _trace_order: deque = deque()
 
     @staticmethod
     def generate_trace_id() -> str:
@@ -72,7 +81,58 @@ class A2ATracer:
         """
         trace_id = A2ATracer.get_or_create_trace_id()
         headers[TRACE_HEADER] = trace_id
+        A2ATracer.record_event("delegation_sent", {"headers": headers.copy()})
         return headers
+
+    @staticmethod
+    def record_event(name: str, details: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Records an event for the current trace.
+
+        Args:
+            name: The event name.
+            details: Optional event details.
+        """
+        trace_id = A2ATracer.get_current_trace_id()
+        if not trace_id:
+            return
+
+        if trace_id not in A2ATracer._trace_registry:
+            if len(A2ATracer._trace_order) >= A2ATracer.MAX_TRACES:
+                old_id = A2ATracer._trace_order.popleft()
+                A2ATracer._trace_registry.pop(old_id, None)
+
+            A2ATracer._trace_registry[trace_id] = []
+            A2ATracer._trace_order.append(trace_id)
+
+        events = A2ATracer._trace_registry[trace_id]
+        if len(events) < A2ATracer.MAX_EVENTS_PER_TRACE:
+            events.append({
+                "timestamp": time.time(),
+                "event": name,
+                "details": details or {}
+            })
+
+    @staticmethod
+    def get_trace(trace_id: str) -> List[Dict[str, Any]]:
+        """
+        Retrieves the history of events for a specific trace.
+
+        Args:
+            trace_id: The trace ID to retrieve.
+
+        Returns:
+            List[Dict[str, Any]]: The list of recorded events.
+        """
+        return list(A2ATracer._trace_registry.get(trace_id, []))
+
+    @staticmethod
+    def clear_registry() -> None:
+        """
+        Resets the trace registry. Primarily for testing.
+        """
+        A2ATracer._trace_registry.clear()
+        A2ATracer._trace_order.clear()
 
     @staticmethod
     def extract_from_headers(headers: Dict[str, str]) -> Optional[str]:

--- a/tests/test_a2a_tracing.py
+++ b/tests/test_a2a_tracing.py
@@ -86,3 +86,49 @@ async def test_server_extracts_trace():
 
     assert A2ATracer.get_current_trace_id() == "incoming_trace_id"
     planner.generate_plan.assert_called_once()
+
+def test_a2a_tracing_recording():
+    """Test A2ATracer event recording and retrieval."""
+    A2ATracer.clear_registry()
+    trace_id = "test_trace_123"
+    A2ATracer.set_trace_id(trace_id)
+
+    A2ATracer.record_event("start_test", {"meta": "data"})
+    A2ATracer.record_event("mid_test")
+
+    history = A2ATracer.get_trace(trace_id)
+    assert len(history) == 2
+    assert history[0]["event"] == "start_test"
+    assert history[0]["details"] == {"meta": "data"}
+    assert history[1]["event"] == "mid_test"
+    assert history[1]["details"] == {}
+
+def test_a2a_tracing_auto_record():
+    """Test that inject_headers auto-records an event."""
+    A2ATracer.clear_registry()
+    trace_id = "auto_record_trace"
+    A2ATracer.set_trace_id(trace_id)
+
+    headers = {}
+    A2ATracer.inject_headers(headers)
+
+    history = A2ATracer.get_trace(trace_id)
+    assert len(history) == 1
+    assert history[0]["event"] == "delegation_sent"
+    assert history[0]["details"]["headers"][TRACE_HEADER] == trace_id
+
+def test_a2a_tracing_eviction():
+    """Test FIFO eviction of traces when capacity is reached."""
+    A2ATracer.clear_registry()
+    # Mock limits for faster test
+    with patch.object(A2ATracer, "MAX_TRACES", 2):
+        A2ATracer.set_trace_id("t1")
+        A2ATracer.record_event("e1")
+        A2ATracer.set_trace_id("t2")
+        A2ATracer.record_event("e2")
+        A2ATracer.set_trace_id("t3")
+        A2ATracer.record_event("e3")
+
+        assert len(A2ATracer.get_trace("t1")) == 0
+        assert len(A2ATracer.get_trace("t2")) == 1
+        assert len(A2ATracer.get_trace("t3")) == 1


### PR DESCRIPTION
I have enhanced the A2A Protocol Tracing Module by adding event recording and history retrieval capabilities. The `A2ATracer` now maintains a bounded in-memory registry of traces, allowing for the observation of delegation flows across different agents. This fulfills the requirements for task `a2a-tracing-module-v1`. All tests passed, and the implementation includes memory safeguards like FIFO eviction of old traces.

---
*PR created automatically by Jules for task [3193604554606319636](https://jules.google.com/task/3193604554606319636) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-memory event tracing and history to `A2ATracer`
> - Adds `A2ATracer.record_event` to append timestamped, named events with optional details to a per-trace event list stored in `_trace_registry`.
> - Adds `A2ATracer.get_trace` to retrieve recorded events for a given trace ID, and `A2ATracer.clear_registry` to reset state (primarily for tests).
> - `A2ATracer.inject_headers` now automatically records a `delegation_sent` event including a snapshot of the headers on each call.
> - The registry uses a FIFO eviction policy capped at `MAX_TRACES` total traces and `MAX_EVENTS_PER_TRACE` events per trace to bound memory use.
> - Tests covering event recording, auto-recording on header injection, and FIFO eviction are added in [test_a2a_tracing.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/293/files#diff-b25fe76708b4fcf12128f7ef51f23ad172129a0091289492b09ac2ea0ff04747).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2639911.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->