### PR TITLE
Implement MCP marketplace integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5352,7 +5352,7 @@
     },
     {
       "id": "mcp-agentskills-marketplace-integration",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP AgentSkills Marketplace Integration",
@@ -10139,6 +10139,60 @@
       "acceptance": [
         "RL module processes multi-turn trajectories to apply delayed rewards.",
         "Tests mock interactions and confirm backpropagated weight changes."
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-publish-cli-2488a5db",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes-inspired agentskills.io Publish CLI",
+      "description": "Inspired by Hermes open standard: Add a CLI command using the Codex bridge module pattern to manually publish and sync local Magda skills to agentskills.io format and push them.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_publish_cli.py",
+        "tests/test_marketplace_publish_cli.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "CLI command triggers a format conversion of skills.",
+        "Exported schema respects agentskills.io standard.",
+        "Pytest tests mock network requests."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-virtual-context-ce0c6f0b",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Virtual Context",
+      "description": "Inspired by OpenClaw: Implement a Virtual Context component inside Context Engine to handle long conversational memory pagination by splitting it into pages of working memory and episodic memory.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_pagination.py",
+        "tests/test_virtual_context_pagination.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Virtual context automatically paginates memory.",
+        "Context Plugin Hooks handle before_retrieval pagination checks.",
+        "Tests confirm contexts are sized within token limits."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-runtime-permission-scoping-70e7d016",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Tool Runtime Permission Scoping",
+      "description": "Inspired by MCP Security trend: Implement a runtime permission scope mapping that ties specific MCP tools to PolicyLayer checkpoints, ensuring sensitive tools demand explicit confirmation via RealtimeGuardrail before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_permission_scoping.py",
+        "tests/test_mcp_permission_scoping.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Tools are annotated with permission scopes.",
+        "PolicyLayer blocks high-permission MCP tool execution if confirmation fails.",
+        "Tests pass confirming scopes are enforced."
       ]
     }
   ]

--- a/magda_agent/skills/marketplace.py
+++ b/magda_agent/skills/marketplace.py
@@ -26,6 +26,8 @@ def _create_dynamic_skill(skill_def: Dict[str, Any]):
     # Attach parameters schema if present
     if "parameters" in skill_def:
         setattr(dynamic_skill, "__mcp_schema__", skill_def["parameters"])
+    elif "inputSchema" in skill_def:
+        setattr(dynamic_skill, "__mcp_schema__", skill_def["inputSchema"])
 
     return dynamic_skill
 

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from magda_agent.skills.marketplace import (
+    _create_dynamic_skill,
+    fetch_and_register_skills,
+    search_marketplace_skills
+)
+from magda_agent.skills.registry import SkillRegistry
+
+def test_create_dynamic_skill_parameters():
+    skill_def = {
+        "name": "test_skill",
+        "description": "A test skill",
+        "parameters": {
+            "type": "object",
+            "properties": {"arg1": {"type": "string"}}
+        }
+    }
+    func = _create_dynamic_skill(skill_def)
+    assert func.__name__ == "test_skill"
+    assert func.__doc__ == "A test skill"
+    assert hasattr(func, "__mcp_schema__")
+    assert getattr(func, "__mcp_schema__") == skill_def["parameters"]
+
+def test_create_dynamic_skill_input_schema():
+    skill_def = {
+        "name": "mcp_tool",
+        "description": "An MCP tool",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"arg1": {"type": "string"}}
+        }
+    }
+    func = _create_dynamic_skill(skill_def)
+    assert func.__name__ == "mcp_tool"
+    assert func.__doc__ == "An MCP tool"
+    assert hasattr(func, "__mcp_schema__")
+    assert getattr(func, "__mcp_schema__") == skill_def["inputSchema"]
+
+@pytest.mark.asyncio
+@patch('aiohttp.ClientSession.get')
+async def test_fetch_and_register_skills(mock_get):
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.raise_for_status = lambda: None
+    mock_response.json.return_value = {
+        "skills": [
+            {
+                "name": "remote_skill_1",
+                "description": "desc 1",
+                "parameters": {"type": "object", "properties": {}}
+            },
+            {
+                "name": "remote_skill_2",
+                "description": "desc 2",
+                "inputSchema": {"type": "object", "properties": {}}
+            }
+        ]
+    }
+    mock_response.__aenter__.return_value = mock_response
+    mock_get.return_value = mock_response
+
+    registry = SkillRegistry()
+    registered_skills = await fetch_and_register_skills("http://test.url/api", registry)
+
+    assert len(registered_skills) == 2
+    assert "remote_skill_1" in registered_skills
+    assert "remote_skill_2" in registered_skills
+
+    assert registry.has_skill("remote_skill_1")
+    assert registry.has_skill("remote_skill_2")
+
+    skill1 = registry.skills["remote_skill_1"]
+    assert getattr(skill1, "__mcp_schema__") == {"type": "object", "properties": {}}
+
+    skill2 = registry.skills["remote_skill_2"]
+    assert getattr(skill2, "__mcp_schema__") == {"type": "object", "properties": {}}
+
+@pytest.mark.asyncio
+@patch('aiohttp.ClientSession.get')
+async def test_search_marketplace_skills(mock_get):
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.raise_for_status = lambda: None
+    mock_response.json.return_value = {
+        "skills": [
+            {
+                "name": "calculator",
+                "description": "Math operations"
+            },
+            {
+                "name": "weather",
+                "description": "Get current weather"
+            },
+            {
+                "name": "math_helper",
+                "description": "Advanced calculations"
+            }
+        ]
+    }
+    mock_response.__aenter__.return_value = mock_response
+    mock_get.return_value = mock_response
+
+    # Search by name
+    results = await search_marketplace_skills("http://test.url/api", "weather")
+    assert len(results) == 1
+    assert results[0]["name"] == "weather"
+
+    # Search by description substring
+    results2 = await search_marketplace_skills("http://test.url/api", "math")
+    assert len(results2) == 2
+    names = [r["name"] for r in results2]
+    assert "calculator" in names
+    assert "math_helper" in names


### PR DESCRIPTION
Updates `_create_dynamic_skill` in `magda_agent/skills/marketplace.py` to check for `inputSchema` as an alternative to `parameters`, allowing standard MCP JSON schemas to be attached to dynamically created skills. Adds comprehensive tests for `marketplace.py` functionalities and updates `agent_tasks.json` by marking the task as done and appending three new trend-inspired tasks.

---
*PR created automatically by Jules for task [9909920659301777028](https://jules.google.com/task/9909920659301777028) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement MCP marketplace skill registration with `inputSchema` support
> - Extends `_create_dynamic_skill` in [marketplace.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/294/files#diff-f97689dc60e4b4ae2feda4f8166dd1660cd9ecfb13ae154957665e6140006270) to set `__mcp_schema__` from `inputSchema` when `parameters` is absent, so both schema formats are supported.
> - Adds `fetch_and_register_skills` and `search_marketplace_skills` with filtering by name and description substring.
> - Adds tests covering schema attachment, skill registration, and search filtering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efd12cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->