### PR TITLE
feat(memory): Implement Claude-style Context Compression Subagent

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5386,7 +5386,7 @@
     },
     {
       "id": "claude-context-compression-subagent",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "high",
       "title": "Claude-style Context Compression Subagent",
@@ -10193,6 +10193,57 @@
         "MCP Tools are annotated with permission scopes.",
         "PolicyLayer blocks high-permission MCP tool execution if confirmation fails.",
         "Tests pass confirming scopes are enforced."
+      ]
+    },
+    {
+      "id": "mcp-tool-exporter-34ceaf62-d284-49ab-821e-44827c99a556",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tool Exporter Plugin",
+      "description": "Inspired by the MCP standard: Implement an MCPExporter class that bridges Magda's internal skills into MCP-compatible JSON-RPC tools.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter.py",
+        "tests/test_mcp_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCPExporter class maps Magda skills to MCP JSON-RPC format.",
+        "Tests verify format conversions using mocks."
+      ]
+    },
+    {
+      "id": "a2a-discovery-enhancement-1195dd93-bfaf-469e-a684-dbda3648a34c",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Discovery Extensions",
+      "description": "Inspired by A2A Protocol trends: Extend A2ADiscoveryV2 to support capability matching and advanced Agent Card querying for cross-agent delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v2.py",
+        "tests/test_a2a_discovery_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2ADiscoveryV2 can filter Agent Cards by capability lists.",
+        "Tests mock a network discovery response and verify parsing."
+      ]
+    },
+    {
+      "id": "online-rl-feedback-loop-e2767014-e0af-4dd5-8dfe-2883b576fbe4",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL User Feedback Loop",
+      "description": "Inspired by OpenClaw-RL: Implement a component that captures user feedback signals (e.g. positive/negative replies) and maps them to Q-value updates for skills.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v3.py",
+        "tests/test_openclaw_rl_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Component parses simple user replies into reward scores.",
+        "Tests mock user messages and verify reward mapping."
       ]
     }
   ]

--- a/magda_agent/agents/compression_subagent.py
+++ b/magda_agent/agents/compression_subagent.py
@@ -1,0 +1,129 @@
+import asyncio
+import logging
+from typing import Optional, List, Dict, Any
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.episodic import EpisodicMemory
+
+class ContextCompressionSubagent:
+    """
+    A lightweight subagent that continuously runs in the background to compress
+    and summarize episodic memories to optimize long-term context storage.
+    Inspired by Claude Context Compression trends.
+    """
+
+    def __init__(
+        self,
+        llm: LLMClient,
+        episodic_memory: EpisodicMemory,
+        batch_size: int = 10,
+        sleep_interval: float = 60.0
+    ):
+        """
+        Initializes the ContextCompressionSubagent.
+
+        Args:
+            llm: Language Model client to be used for summarization.
+            episodic_memory: The episodic memory instance to compress.
+            batch_size: The maximum number of events to fetch per compression cycle.
+            sleep_interval: Time to wait (in seconds) between compression cycles.
+        """
+        self.llm = llm
+        self.episodic_memory = episodic_memory
+        self.batch_size = batch_size
+        self.sleep_interval = sleep_interval
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Starts the continuous compression loop in the background."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self.run_compression_loop())
+        logging.info("ContextCompressionSubagent started.")
+
+    async def stop(self) -> None:
+        """Stops the continuous compression loop."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logging.info("ContextCompressionSubagent stopped.")
+
+    async def run_compression_loop(self) -> None:
+        """
+        The main loop that continuously fetches uncompressed memories,
+        summarizes them, stores the summary, and marks original events as decayed.
+        """
+        while self._running:
+            try:
+                await self.compress_next_batch()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logging.error(f"Error in context compression loop: {e}")
+
+            await asyncio.sleep(self.sleep_interval)
+
+    async def compress_next_batch(self) -> None:
+        """
+        Fetches the next batch of undecayed events, groups them,
+        summarizes them using the LLM, and stores the new summary.
+        """
+        events = self.episodic_memory.get_all_events(
+            include_decayed=False,
+            limit=self.batch_size
+        )
+
+        if not events or len(events) < 2:
+            # Not enough events to compress
+            return
+
+        logging.info(f"Compressing batch of {len(events)} episodic memories.")
+
+        # Group events by user_id if possible, or process them as a single batch
+        user_groups: Dict[Optional[int], List[Dict[str, Any]]] = {}
+        for event in events:
+            user_id = event.get("metadata", {}).get("user_id")
+            if user_id not in user_groups:
+                user_groups[user_id] = []
+            user_groups[user_id].append(event)
+
+        for user_id, user_events in user_groups.items():
+            if len(user_events) < 2:
+                continue
+
+            events_text = "\n".join([f"- {e['text']}" for e in user_events])
+            prompt = (
+                "Please concisely summarize the following episodic memory events. "
+                "Retain the most critical information, entities, and context:\n\n"
+                f"{events_text}"
+            )
+
+            messages = [
+                {"role": "system", "content": "You are a context compression subagent. Summarize the user's episodic memories accurately and concisely."},
+                {"role": "user", "content": prompt}
+            ]
+
+            try:
+                summary = await self.llm.chat_completion(messages, temperature=0.3)
+                summary = summary.strip()
+
+                if summary:
+                    # Store the new summarized event
+                    self.episodic_memory.store_event(
+                        text=summary,
+                        metadata={"type": "compressed_summary"},
+                        user_id=user_id
+                    )
+
+                    # Mark original events as decayed
+                    for event in user_events:
+                        self.episodic_memory.decay_event(event["id"])
+
+                    logging.info(f"Successfully compressed {len(user_events)} events for user_id={user_id}.")
+            except Exception as e:
+                logging.error(f"Failed to compress events for user_id={user_id}: {e}")

--- a/tests/test_compression_subagent.py
+++ b/tests/test_compression_subagent.py
@@ -1,0 +1,89 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from magda_agent.agents.compression_subagent import ContextCompressionSubagent
+
+@pytest.fixture
+def mock_llm_client():
+    llm = MagicMock()
+    llm.chat_completion = AsyncMock(return_value="Compressed summary of events.")
+    return llm
+
+@pytest.fixture
+def mock_episodic_memory():
+    memory = MagicMock()
+    # Mock some undecayed events
+    memory.get_all_events.return_value = [
+        {"id": "1", "text": "Event 1", "metadata": {"user_id": 123}},
+        {"id": "2", "text": "Event 2", "metadata": {"user_id": 123}},
+    ]
+    return memory
+
+@pytest.mark.asyncio
+async def test_compress_next_batch_logic(mock_llm_client, mock_episodic_memory):
+    subagent = ContextCompressionSubagent(
+        llm=mock_llm_client,
+        episodic_memory=mock_episodic_memory,
+        batch_size=10
+    )
+
+    await subagent.compress_next_batch()
+
+    # Verify episodic memory was queried
+    mock_episodic_memory.get_all_events.assert_called_once_with(include_decayed=False, limit=10)
+
+    # Verify LLM was called to summarize
+    mock_llm_client.chat_completion.assert_awaited_once()
+
+    # Verify new summary was stored
+    mock_episodic_memory.store_event.assert_called_once_with(
+        text="Compressed summary of events.",
+        metadata={"type": "compressed_summary"},
+        user_id=123
+    )
+
+    # Verify original events were decayed
+    assert mock_episodic_memory.decay_event.call_count == 2
+    mock_episodic_memory.decay_event.assert_any_call("1")
+    mock_episodic_memory.decay_event.assert_any_call("2")
+
+@pytest.mark.asyncio
+async def test_compress_next_batch_not_enough_events(mock_llm_client, mock_episodic_memory):
+    mock_episodic_memory.get_all_events.return_value = [
+        {"id": "1", "text": "Event 1", "metadata": {"user_id": 123}}
+    ]
+
+    subagent = ContextCompressionSubagent(
+        llm=mock_llm_client,
+        episodic_memory=mock_episodic_memory,
+        batch_size=10
+    )
+
+    await subagent.compress_next_batch()
+
+    # Should not call LLM if < 2 events
+    mock_llm_client.chat_completion.assert_not_called()
+    mock_episodic_memory.store_event.assert_not_called()
+    mock_episodic_memory.decay_event.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compression_loop_runs(mock_llm_client, mock_episodic_memory):
+    subagent = ContextCompressionSubagent(
+        llm=mock_llm_client,
+        episodic_memory=mock_episodic_memory,
+        sleep_interval=0.01  # very short sleep for test
+    )
+
+    # Mock compress_next_batch to ensure it gets called
+    with patch.object(subagent, 'compress_next_batch', new_callable=AsyncMock) as mock_compress:
+        # Start the loop
+        await subagent.start()
+
+        # Let it run for a short time
+        await asyncio.sleep(0.05)
+
+        # Stop the loop
+        await subagent.stop()
+
+        # Verify it was called multiple times
+        assert mock_compress.call_count > 0


### PR DESCRIPTION
This PR implements the Claude-style Context Compression Subagent as described in task `claude-context-compression-subagent`.

Changes:
- Added `ContextCompressionSubagent` in `magda_agent/agents/compression_subagent.py` which continuously polls uncompressed episodic memories and summarizes them asynchronously in the background.
- Added comprehensive pytest tests with mocked LLM calls in `tests/test_compression_subagent.py` to verify loop behavior, memory storage, and decaying logic.
- Updated `agent_tasks.json` to mark the task as "done".
- Appended 3 new unique tasks inspired by June 2026 AI Agent trends (MCP exporter, A2A enhancements, Online RL improvements).
- Verified everything with `scripts/validate_agent_tasks.py` and `pytest`.

---
*PR created automatically by Jules for task [8203301042707518841](https://jules.google.com/task/8203301042707518841) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ContextCompressionSubagent` for background LLM-based episodic memory compression
> - Adds [compression_subagent.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/296/files#diff-d0f80f463a8f49483761adb5a623334dacdf916a515a1de4587bf2bec429fe4a) implementing an async background subagent that periodically fetches non-decayed episodic events, groups them by user, summarizes each group via LLM, stores a `compressed_summary` event, and marks the originals as decayed.
> - The subagent lifecycle is controlled via `start()`/`stop()` methods; `stop()` cancels and awaits the background asyncio task cleanly.
> - Requires at least 2 events per user group before invoking the LLM; fewer events result in a no-op.
> - Adds tests in [test_compression_subagent.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/296/files#diff-365df57f37d3314fefa14848e088156fd77b4d9d3ce60f4a5f6f5dd2d87a1508) covering the happy path, insufficient-events early return, and repeated loop invocation.
> - Risk: background task silently swallows non-cancellation exceptions (logging only), so LLM or memory failures will not surface unless logs are monitored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06d5c83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->