### PR TITLE
MemGPT/Letta Virtual Context Management

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5421,7 +5421,7 @@
     },
     {
       "id": "virtual-context-manager-letta",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT/Letta Virtual Context Management",
@@ -10297,6 +10297,57 @@
         "The 5 distinct ACS validation checkpoints are invoked around state changes.",
         "Workflow aborts or degrades gracefully upon validation failure.",
         "Tests cover each checkpoint with both valid and invalid states."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-v4-unique-d77f4f61",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw-RL Canvas Metrics V4",
+      "description": "Inspired by OpenClaw Live Visualization trend: Create a visual metric stream for Q-value updates inside the online RL learning loop, updating the Canvas.",
+      "allowed_paths": [
+        "magda_agent/visualization/rl_metrics_canvas_v4.py",
+        "tests/test_rl_metrics_canvas_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL Metrics visually represented in Canvas.",
+        "Tests verify format generation."
+      ]
+    },
+    {
+      "id": "mcp-preflight-validation-v5-unique-695ce70f",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Tool Pre-flight Validation V5",
+      "description": "Inspired by MCP Security trend: Implement a pre-flight validation mechanism for all MCP action tools before JSON-RPC execution to verify inputs against a static blocklist.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_preflight_v5.py",
+        "tests/test_mcp_preflight_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pre-flight validator intercepts invalid requests.",
+        "Tests mock MCP clients to verify blocking behavior."
+      ]
+    },
+    {
+      "id": "a2a-delegation-circuit-breaker-v6-unique-62a89989",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Delegation Circuit Breaker V6",
+      "description": "Inspired by A2A Protocol and enterprise-ready agents trend: Implement a circuit breaker pattern to prevent continuous task delegation failures to unresponsive peer agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_circuit_breaker_v6.py",
+        "tests/test_a2a_circuit_breaker_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Circuit breaker trips after consecutive failures.",
+        "Tests verify fallback and trip limits."
       ]
     }
   ]

--- a/magda_agent/memory/virtual_context.py
+++ b/magda_agent/memory/virtual_context.py
@@ -103,6 +103,40 @@ class VirtualContextManager:
                 # Fallback: simple truncation
                 setattr(core, section, " ".join(words[:self.section_limit]) + "...")
 
+
+    def get_token_length(self, entries: List['MemoryEntry']) -> int:
+        """
+        Calculates a heuristic token length for the given memory entries.
+        """
+        total_words = sum(len(e.content.split()) for e in entries)
+        # Using a simple heuristic of 1.3 tokens per word
+        return int(total_words * 1.3)
+
+    async def maintain_working_memory_limits(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, max_tokens: int = 4000) -> None:
+        """
+        Calculates token length of current working context and pages out older memories if the limit is exceeded.
+        """
+        u_id = user_id if user_id is not None else -1
+        entries = working_memory.get_entries(user_id=u_id)
+        if not entries:
+            return
+
+        current_tokens = self.get_token_length(entries)
+        if current_tokens <= max_tokens:
+            return
+
+        logging.info(f"Working memory context length ({current_tokens} tokens) exceeds limit ({max_tokens} tokens). Paging out...")
+
+        # We need to page out oldest entries until we're under the limit
+        # In this simple implementation, we'll page out the oldest entry and then check again.
+        # However, page_out compresses all provided entries into a summary.
+        # It's better to page out one by one or in small batches.
+
+        # Let's just page out the oldest half to quickly reduce size
+        count_to_remove = max(1, len(entries) // 2)
+        await self.page_out(working_memory, episodic_memory, user_id, count=count_to_remove)
+
+
     async def compress_context(self, entries: List['MemoryEntry']) -> 'MemoryEntry':
         """
         Compresses multiple memory entries into a single summary entry.

--- a/magda_agent/memory/working.py
+++ b/magda_agent/memory/working.py
@@ -39,9 +39,11 @@ class WorkingMemory:
                 # Use ContextEngine compact lifecycle hook
                 user_entries = await self.context_engine.compact(user_entries, {"limit": self.limit, "user_id": u_id})
             elif getattr(self, 'virtual_context_manager', None) and getattr(self, 'episodic_memory', None):
-
+                # We enforce token limits explicitly, but also we MUST page out to reduce entry count.
+                # So we call page_out(1) to satisfy the len > limit condition.
+                # Additionally, we can call maintain_working_memory_limits to enforce token bounds.
                 await self.virtual_context_manager.page_out(self, self.episodic_memory, u_id, 1)
-
+                await self.virtual_context_manager.maintain_working_memory_limits(self, self.episodic_memory, u_id)
                 user_entries = self._entries_by_user.get(u_id, [])
 
             elif summarizer:

--- a/tests/test_virtual_context.py
+++ b/tests/test_virtual_context.py
@@ -136,3 +136,58 @@ async def test_core_memory_overflow_llm_summarization():
     core = vcm.get_core_memory(user_id)
     assert core.persona == "Summarized Persona"
     mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_maintain_working_memory_limits_pages_out():
+    wm = WorkingMemory(limit=10) # limit by entries is high
+    em = EpisodicMemory(persist_directory=":memory:")
+    vcm = VirtualContextManager()
+
+    wm.virtual_context_manager = vcm
+    wm.episodic_memory = em
+
+    state = PADState(0, 0, 0)
+
+    # Each entry has 4 words -> ~5 tokens. 3 entries = ~15 tokens
+    e1 = MemoryEntry("word1 word2 word3 word4", 0.5, state, user_id=1)
+    e2 = MemoryEntry("word5 word6 word7 word8", 0.6, state, user_id=1)
+    e3 = MemoryEntry("word9 word10 word11 word12", 0.7, state, user_id=1)
+
+    await wm.add(e1)
+    await wm.add(e2)
+    await wm.add(e3)
+
+    assert len(wm.get_entries(user_id=1)) == 3
+    assert vcm.get_token_length(wm.get_entries(user_id=1)) == int(12 * 1.3)
+
+    # Maintain with max_tokens = 10. Current is ~15, so it should page out entries.
+    await vcm.maintain_working_memory_limits(wm, em, user_id=1, max_tokens=10)
+
+    # It pages out max(1, len(entries)//2) = max(1, 1) = 1 entry.
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 2
+    assert entries[0].content == "word5 word6 word7 word8"
+    assert entries[1].content == "word9 word10 word11 word12"
+
+@pytest.mark.asyncio
+async def test_maintain_working_memory_limits_no_page_out():
+    wm = WorkingMemory(limit=10)
+    em = EpisodicMemory(persist_directory=":memory:")
+    vcm = VirtualContextManager()
+
+    wm.virtual_context_manager = vcm
+    wm.episodic_memory = em
+
+    state = PADState(0, 0, 0)
+
+    # 4 words -> ~5 tokens
+    e1 = MemoryEntry("word1 word2 word3 word4", 0.5, state, user_id=1)
+    await wm.add(e1)
+
+    assert len(wm.get_entries(user_id=1)) == 1
+
+    # Limit is 10, current is 5 -> no page out
+    await vcm.maintain_working_memory_limits(wm, em, user_id=1, max_tokens=10)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 1


### PR DESCRIPTION
Implement VirtualContextManager token logic to automatically page out semantic memories based on a heuristic token count, resolving the virtual-context-manager-letta task. Also appended 3 new AI agent trend tasks to agent_tasks.json.

---
*PR created automatically by Jules for task [637661671898431865](https://jules.google.com/task/637661671898431865) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add token-based virtual context management to enforce working memory limits
> - Adds `VirtualContextManager.get_token_length` in [`virtual_context.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/298/files#diff-753a92d4a4e6dcaa5f5c6ace96f8edce760eaac00102b309d237867b619b5e3e) to estimate token usage for memory entries using a word-count heuristic (×1.3).
> - Adds `VirtualContextManager.maintain_working_memory_limits` which pages out the oldest half of working memory entries (minimum 1) when token usage exceeds a configurable threshold (default 4,000 tokens).
> - `WorkingMemory.add` in [`working.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/298/files#diff-4ab5abd1896168175de3841bbaf095efbcd7e928ea516fc7cf7234ae87467d9b) now calls `maintain_working_memory_limits` after the existing count-based page-out, applying token-based eviction as a second pass.
> - Behavioral Change: inserting entries into working memory can now trigger additional eviction beyond the existing count limit, removing more entries than before when token usage is high.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8237bdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->