### PR TITLE
Implement advanced context engine compression

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5439,7 +5439,7 @@
     },
     {
       "id": "openclaw-context-engine-compression-v2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Compression v2",
@@ -10335,6 +10335,40 @@
     },
     {
       "id": "a2a-delegation-circuit-breaker-v6-unique-62a89989",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Delegation Circuit Breaker V6",
+      "description": "Inspired by A2A Protocol and enterprise-ready agents trend: Implement a circuit breaker pattern to prevent continuous task delegation failures to unresponsive peer agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_circuit_breaker_v6.py",
+        "tests/test_a2a_circuit_breaker_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Circuit breaker trips after consecutive failures.",
+        "Tests verify fallback and trip limits."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-preflight-v5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Tool Pre-flight Validation V5",
+      "description": "Inspired by MCP Security trend: Implement a pre-flight validation mechanism for all MCP action tools before JSON-RPC execution to verify inputs against a static blocklist.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_preflight_v5.py",
+        "tests/test_mcp_preflight_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pre-flight validator intercepts invalid requests.",
+        "Tests mock MCP clients to verify blocking behavior."
+      ]
+    },
+    {
+      "id": "a2a-delegation-circuit-breaker-v6",
       "status": "todo",
       "area": "integration",
       "risk": "medium",

--- a/magda_agent/memory/context_engine.py
+++ b/magda_agent/memory/context_engine.py
@@ -90,7 +90,7 @@ class ContextEngine:
             remaining = current_items[2:]
 
             combined_text = "\n".join([f"- {getattr(e, 'content', str(e))}" for e in to_summarize])
-            prompt = f"Please summarize the following short-term memory context into a single concise bullet point:\n{combined_text}"
+            prompt = f"Please summarize the following short-term memory context into a concise summary while maintaining key facts and semantic links:\n{combined_text}"
 
             try:
                 summary_content = await self.llm.chat_completion([
@@ -108,7 +108,7 @@ class ContextEngine:
                     content=summary_content.strip(),
                     importance=avg_importance,
                     emotional_state=getattr(first, 'emotional_state', None) if first else None,
-                    tags=getattr(first, 'tags', []) if first else [],
+                    tags=list(set(t for e in to_summarize if isinstance(getattr(e, 'tags', []), list) for t in getattr(e, 'tags', []))),
                     user_id=getattr(first, 'user_id', None) if first else None
                 )
                 current_items = [summary_entry] + remaining

--- a/tests/test_context_engine.py
+++ b/tests/test_context_engine.py
@@ -164,3 +164,32 @@ async def test_context_engine_builtin_compaction_no_llm() -> None:
 
     assert len(compacted) == 1
     assert compacted[0] == entry2
+
+@pytest.mark.asyncio
+async def test_context_engine_advanced_compaction_tags() -> None:
+    """Tests that the ContextEngine fallback compression merges tags from multiple entries."""
+    llm = AsyncMock()
+    llm.chat_completion.return_value = "advanced summary"
+    engine = ContextEngine(llm=llm)
+
+    entry1 = MagicMock(spec=MemoryEntry)
+    entry1.content = "content1"
+    entry1.importance = 0.5
+    entry1.tags = ["tag1", "tag2"]
+
+    entry2 = MagicMock(spec=MemoryEntry)
+    entry2.content = "content2"
+    entry2.importance = 0.5
+    entry2.tags = ["tag2", "tag3"]
+
+    items = [entry1, entry2]
+    compacted = await engine.compact(items, {"limit": 1})
+
+    assert len(compacted) == 1
+    assert compacted[0].content == "advanced summary"
+    assert set(compacted[0].tags) == {"tag1", "tag2", "tag3"}
+
+    # Also verify prompt contains new instructions
+    call_args = llm.chat_completion.call_args[0][0]
+    user_prompt = call_args[1]["content"]
+    assert "maintaining key facts and semantic links" in user_prompt


### PR DESCRIPTION
Addresses the task `openclaw-context-engine-compression-v2` by improving the context compaction fallback within `ContextEngine`. 

- Updates the LLM prompt to explicitly preserve key facts and semantic links.
- Corrects tag extraction logic so that all unique tags from the summarized entries are aggregated and merged into the new `MemoryEntry`, ensuring semantic connections are not lost.
- Adds comprehensive testing for the tag merging and prompt logic.
- Marks the task done and adds new MCP and A2A trend tasks.

---
*PR created automatically by Jules for task [13213094933260638760](https://jules.google.com/task/13213094933260638760) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve fallback compaction prompt and tag aggregation in `ContextEngine.compact`
> - Updates the fallback LLM prompt in [`context_engine.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/299/files#diff-fab03bcfe0f765456ec92f34d62d5c84a4a8584d49428a1a0a33ddd76bb62aa0) to request a summary that preserves key facts and semantic links, rather than a single bullet point.
> - Changes tag aggregation so the generated summary `MemoryEntry` carries the de-duplicated union of tags from all summarized items, instead of only the first item's tags.
> - Adds a new async test in [`tests/test_context_engine.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/299/files#diff-7add6b30837cf042619f58bbe8e8cebf790deb4553cc61fcbf8193675e5a2ec2) that verifies both the tag union behavior and the updated prompt text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c625e89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->