### PR TITLE
Implement A2A delegation protocol v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5456,7 +5456,7 @@
     },
     {
       "id": "a2a-peer-delegation-protocol-v2",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Peer Delegation Protocol v2",
@@ -10382,6 +10382,42 @@
       "acceptance": [
         "Circuit breaker trips after consecutive failures.",
         "Tests verify fallback and trip limits."
+      ]
+    },
+    {
+      "id": "hermes-self-improving-skills-loop-9c22cc29",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Self-Improving Skills Loop",
+      "description": "Inspired by Hermes Agent trend: Implement a self-improving loop that tracks skill usage success/failure and iteratively updates a local skill metadata registry to improve context and performance.",
+      "allowed_paths": [
+        "magda_agent/learning/hermes_skills_loop.py",
+        "tests/test_hermes_skills_loop.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills loop component records skill outcomes.",
+        "Registry metadata is updated incrementally after successful/failed executions.",
+        "Tests verify learning loop update mechanisms."
+      ]
+    },
+    {
+      "id": "claude-git-worktree-isolation-43b47a54",
+      "status": "todo",
+      "area": "isolation",
+      "risk": "high",
+      "title": "Claude Git Worktree Isolation for Sub-Agents",
+      "description": "Inspired by Claude Agent SDK trend: Create a git worktree manager that allows sub-agents (like Evaluators) to run securely in separate git worktrees without impacting the main branch state.",
+      "allowed_paths": [
+        "magda_agent/isolation/git_worktree_manager.py",
+        "tests/test_git_worktree_manager.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Manager can create and tear down git worktrees.",
+        "Sub-agents can execute operations scoped to a worktree.",
+        "Tests verify worktree lifecycle and isolation properties."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_delegation.py
+++ b/magda_agent/integration/a2a_delegation.py
@@ -55,6 +55,53 @@ class A2ADelegator:
 
         return sub_plans
 
+    async def delegate_to_peer(self, target_agent: 'AgentCard', plan_context: Dict[str, Any]) -> str:
+        """
+        Delegates a subplan directly to a specific peer agent using its AgentCard.
+
+        Args:
+            target_agent: The target AgentCard representing the peer.
+            plan_context: The task context or sub-plan to delegate.
+
+        Returns:
+            A result string describing the outcome.
+        """
+        logging.info(f"Delegating directly to Peer Agent: {target_agent.name} (ID: {target_agent.agent_id})")
+
+        endpoint = target_agent.endpoints.get("mcp")
+        if not endpoint:
+            return f"Agent {target_agent.name} missing MCP endpoint"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "execute_subplan",
+            "params": {"context": plan_context}
+        }
+
+        headers = {}
+        # Inject distributed tracing header
+        A2ATracer.inject_headers(headers)
+
+        # Record explicit peer-to-peer delegation trace
+        A2ATracer.record_event("peer_delegation", {"target_agent_id": target_agent.agent_id})
+
+        if self.security_context:
+            token = self.security_context.generate_token()
+            headers["Authorization"] = f"Bearer {token}"
+            self.security_context.trace_action("delegate_to_peer", {"target_agent": target_agent.name})
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(endpoint, json=payload, headers=headers, timeout=10.0)
+                response.raise_for_status()
+                data = response.json()
+                result = data.get("result", {})
+                return f"Delegated to Peer Agent {target_agent.name}: {result.get('status', 'Success')}"
+        except Exception as e:
+            logging.error(f"Failed to delegate to peer {target_agent.name} at {endpoint}: {e}")
+            return f"Delegation to peer {target_agent.name} failed: {e}"
+
     async def execute_plan(self, plan: list[Dict[str, Any]]) -> Dict[str, str]:
         """
         Extracts sub-plans chronologically and delegates them sequentially.

--- a/tests/test_a2a_delegation.py
+++ b/tests/test_a2a_delegation.py
@@ -121,3 +121,53 @@ async def test_a2a_delegator_execute_plan(mock_post, a2a_delegator):
     assert "1" in results
     assert "2" not in results
     assert results["1"] == "Delegated to Agent TestAgent: Success"
+
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_a2a_delegator_delegate_to_peer(mock_post, a2a_delegator, mock_agent_card):
+    from unittest.mock import MagicMock
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": {"status": "Success"}}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    # Need to clear tracer registry to test recording
+    from magda_agent.integration.a2a_tracing import A2ATracer
+    A2ATracer.clear_registry()
+    trace_id = "test_peer_delegation_trace"
+    A2ATracer.set_trace_id(trace_id)
+
+    result = await a2a_delegator.delegate_to_peer(mock_agent_card, {"task": "Direct delegation"})
+    assert result == "Delegated to Peer Agent TestAgent: Success"
+
+    mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    assert "X-A2A-Trace-ID" in kwargs["headers"]
+
+    history = A2ATracer.get_trace(trace_id)
+    # Events should be "delegation_sent" from inject_headers and "peer_delegation"
+    events = [e["event"] for e in history]
+    assert "peer_delegation" in events
+
+    # Check details of peer_delegation
+    peer_event = next(e for e in history if e["event"] == "peer_delegation")
+    assert peer_event["details"]["target_agent_id"] == mock_agent_card.agent_id
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_a2a_delegator_delegate_to_peer_no_endpoint(mock_post, a2a_delegator):
+    from magda_agent.integration.a2a_discovery import AgentCard
+    no_endpoint_card = AgentCard("no-endpoint-id", "NoEndpointAgent", "Desc", ["coding"], {})
+
+    result = await a2a_delegator.delegate_to_peer(no_endpoint_card, {"task": "Direct delegation"})
+    assert result == "Agent NoEndpointAgent missing MCP endpoint"
+    mock_post.assert_not_called()
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_a2a_delegator_delegate_to_peer_failure(mock_post, a2a_delegator, mock_agent_card):
+    mock_post.side_effect = Exception("Network error")
+
+    result = await a2a_delegator.delegate_to_peer(mock_agent_card, {"task": "Direct delegation"})
+    assert result == "Delegation to peer TestAgent failed: Network error"


### PR DESCRIPTION
Enhance A2A tracing module by adding specific peer-to-peer task delegation mechanisms.

---
*PR created automatically by Jules for task [16290216740026478126](https://jules.google.com/task/16290216740026478126) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `delegate_to_peer` method to `A2ADelegator` for direct A2A peer delegation
> - Adds `delegate_to_peer` to [`A2ADelegator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/300/files#diff-63653ef42d92af90747a5f5e269f1df0011e8545b185e8e30afd28662f2c1eb1), which sends a JSON-RPC `execute_subplan` call to a target agent's MCP endpoint via `httpx.AsyncClient`.
> - Injects tracing headers via `A2ATracer` and records a `peer_delegation` event; optionally adds an `Authorization` header using `security_context.generate_token`.
> - Returns a formatted success or failure string; returns a specific message if the target `AgentCard` has no MCP endpoint.
> - Adds three async tests covering the success path (with tracing assertions), missing endpoint, and HTTP failure cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31110fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->