### PR TITLE
feat: OpenClaw-RL Interactive Learning v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5491,7 +5491,7 @@
     },
     {
       "id": "openclaw-rl-interactive-learning-v4",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Interactive Learning v4",
@@ -10453,6 +10453,57 @@
       "acceptance": [
         "A2A Workflow manager orchestrates sequential task handoffs correctly.",
         "Tests verify that context is passed accurately between chained steps."
+      ]
+    },
+    {
+      "id": "claude-agent-dependency-graph-planner-4e97937f-c458-4ee5-9063-0cf7d76f8d48",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Claude Agent SDK Dependency Graph Planner",
+      "description": "Inspired by Claude Agent SDK trend: Implement a task planner that builds a dependency graph of sub-tasks instead of a flat list, allowing for parallel sub-agent execution.",
+      "allowed_paths": [
+        "magda_agent/planning/dependency_graph.py",
+        "tests/test_dependency_graph.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner creates a DAG of tasks.",
+        "Tests verify correct topological sorting and parallel execution boundaries."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-visualization-aa07c2aa-60af-4590-bcf0-64d22a9ac775",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Visualization",
+      "description": "Inspired by OpenClaw trend: Create a Canvas module that visualizes the agent's internal state and memory changes in real-time as a markdown or HTML artifact.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas.py",
+        "tests/test_canvas.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas module renders current memory and emotion state.",
+        "Tests verify output format."
+      ]
+    },
+    {
+      "id": "mcp-server-tool-concurrency-5ec68904-3f7f-4a2e-81c2-14dc184faf34",
+      "status": "todo",
+      "area": "execution",
+      "risk": "medium",
+      "title": "MCP Server-Prefixed Tool Concurrency",
+      "description": "Inspired by OpenAI Agents SDK trend: Build a concurrency module specifically for running multiple MCP action tools in parallel without event loop blocking.",
+      "allowed_paths": [
+        "magda_agent/execution/mcp_concurrent.py",
+        "tests/test_mcp_concurrent.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Multiple MCP tools can run concurrently.",
+        "Tests use mocks to verify parallel execution times."
       ]
     }
   ]

--- a/magda_agent/learning/interactive_rl.py
+++ b/magda_agent/learning/interactive_rl.py
@@ -1,0 +1,76 @@
+import logging
+from typing import Dict, Optional
+
+
+class InteractiveLearner:
+    """
+    OpenClaw-RL pattern interactive learner.
+    Implements online reinforcement learning from next-state signals (user replies).
+    """
+
+    def __init__(self, initial_weights: Optional[Dict[str, float]] = None) -> None:
+        """
+        Initializes the InteractiveLearner.
+
+        Args:
+            initial_weights (Optional[Dict[str, float]]): Initial weights for skills.
+        """
+        self.learning_state: Dict[str, float] = dict(initial_weights) if initial_weights else {}
+        logging.info("Initialized InteractiveLearner")
+
+    def analyze_signal(self, reply_text: str) -> float:
+        """
+        Analyzes the user's reply as a next-state signal.
+        Uses basic heuristics to determine reward.
+
+        Args:
+            reply_text (str): The text of the user's reply.
+
+        Returns:
+            float: A reward score, positive for positive sentiment, negative for negative sentiment.
+        """
+        reply_lower = reply_text.lower()
+        if "good" in reply_lower or "great" in reply_lower or "yes" in reply_lower or "thanks" in reply_lower:
+            return 1.0
+        elif "bad" in reply_lower or "wrong" in reply_lower or "no" in reply_lower or "terrible" in reply_lower:
+            return -1.0
+        return 0.0
+
+    async def process_interaction(
+        self,
+        user_reply: str,
+        skill_name: str = "default_skill",
+        user_id: Optional[int] = None
+    ) -> None:
+        """
+        Analyzes the user's reply and updates learning state.
+
+        Args:
+            user_reply (str): The text of the user's reply.
+            skill_name (str): The name of the skill to adjust based on the reply.
+            user_id (Optional[int]): The ID of the user.
+        """
+        if not user_reply:
+            return
+
+        reward = self.analyze_signal(user_reply)
+
+        if skill_name not in self.learning_state:
+            self.learning_state[skill_name] = 1.0
+
+        adjustment_rate = 0.2
+        self.learning_state[skill_name] += reward * adjustment_rate
+
+        # Clamp between 0.1 and 10.0
+        self.learning_state[skill_name] = max(0.1, min(10.0, self.learning_state[skill_name]))
+
+        logging.info(f"Updated interactive learning state for skill '{skill_name}' to {self.learning_state[skill_name]:.2f} based on reward {reward}")
+
+    def get_state(self) -> Dict[str, float]:
+        """
+        Retrieves the current learning state (skill weights).
+
+        Returns:
+            Dict[str, float]: The current state of learned skill weights.
+        """
+        return self.learning_state

--- a/tests/test_interactive_rl.py
+++ b/tests/test_interactive_rl.py
@@ -1,0 +1,72 @@
+import pytest
+from magda_agent.learning.interactive_rl import InteractiveLearner
+
+
+@pytest.fixture
+def learner():
+    return InteractiveLearner()
+
+
+def test_analyze_signal_positive(learner):
+    """Test positive reward extraction."""
+    assert learner.analyze_signal("This is great!") == 1.0
+    assert learner.analyze_signal("Yes, thanks for that.") == 1.0
+    assert learner.analyze_signal("good job.") == 1.0
+
+
+def test_analyze_signal_negative(learner):
+    """Test negative reward extraction."""
+    assert learner.analyze_signal("This is wrong.") == -1.0
+    assert learner.analyze_signal("No, terrible idea.") == -1.0
+    assert learner.analyze_signal("bad result.") == -1.0
+
+
+def test_analyze_signal_neutral(learner):
+    """Test neutral reward extraction."""
+    assert learner.analyze_signal("I am here.") == 0.0
+    assert learner.analyze_signal("What time is it?") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_process_interaction_positive(learner):
+    """Test state update with positive reply."""
+    await learner.process_interaction("This is great!", "coding_skill")
+    state = learner.get_state()
+    assert "coding_skill" in state
+    assert state["coding_skill"] == 1.2  # 1.0 (default) + 0.2 (1.0 * 0.2)
+
+
+@pytest.mark.asyncio
+async def test_process_interaction_negative(learner):
+    """Test state update with negative reply."""
+    await learner.process_interaction("This is terrible.", "math_skill")
+    state = learner.get_state()
+    assert "math_skill" in state
+    assert state["math_skill"] == 0.8  # 1.0 (default) - 0.2 (1.0 * 0.2)
+
+
+@pytest.mark.asyncio
+async def test_process_interaction_neutral(learner):
+    """Test state update with neutral reply."""
+    await learner.process_interaction("Okay.", "search_skill")
+    state = learner.get_state()
+    assert "search_skill" in state
+    assert state["search_skill"] == 1.0  # 1.0 (default) + 0.0 (0.0 * 0.2)
+
+
+@pytest.mark.asyncio
+async def test_process_interaction_clamp(learner):
+    """Test state clamping to minimum value."""
+    # Force state to go below minimum
+    learner.learning_state["bad_skill"] = 0.2
+    await learner.process_interaction("This is bad.", "bad_skill")
+    state = learner.get_state()
+    assert state["bad_skill"] == 0.1  # Clamped to 0.1
+
+
+@pytest.mark.asyncio
+async def test_process_interaction_empty_reply(learner):
+    """Test state update with empty reply."""
+    await learner.process_interaction("", "empty_skill")
+    state = learner.get_state()
+    assert "empty_skill" not in state


### PR DESCRIPTION
This PR implements the OpenClaw-RL interactive learning pattern by adding the `InteractiveLearner` component. It processes user replies as reinforcement learning signals to dynamically adjust skill weights over time. 

Additionally, comprehensive unit tests have been added, the corresponding task has been marked as completed in `agent_tasks.json`, and three new trend-inspired tasks have been appended to the task backlog.

---
*PR created automatically by Jules for task [5072842966339907196](https://jules.google.com/task/5072842966339907196) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interactive reinforcement learning skill-weight updates to OpenClaw-RL
> - Introduces `InteractiveLearner` in [`interactive_rl.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/302/files#diff-2162003f49a166bff3ea32c3a4307aed07d29b9da1d9677f79ac0f694074afd9), which maintains per-skill weights updated from user reply signals using keyword-based sentiment heuristics (positive/negative/neutral → ±0.2 adjustment, clamped to [0.1, 10.0]).
> - Skills default to weight 1.0 on first encounter; empty replies are ignored.
> - Adds a pytest suite in [`test_interactive_rl.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/302/files#diff-96b2977acececd52495e9a6da41a0652cd793181b4276e528f0980c4c715eeee) covering reward analysis, async weight updates, clamping, and no-op behavior on empty input.
> - Also adds three new task entries to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/302/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) for DAG planning, canvas visualization, and concurrent MCP tool execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b9327b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->