### PR TITLE
feat: implement MCP Tool Taint Tracking Sandbox v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5525,7 +5525,7 @@
     },
     {
       "id": "mcp-action-tool-taint-tracking-v3",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Tool Taint Tracking Sandbox v3",
@@ -10539,6 +10539,40 @@
         "The 5 distinct ACS validation checkpoints are invoked around state changes.",
         "Workflow aborts or degrades gracefully upon validation failure.",
         "Tests cover each checkpoint with both valid and invalid states."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-creation-d35b0b7e",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes-inspired dynamic skills creation from text",
+      "description": "Inspired by Hermes Agent trend. Automatically parse the user's conversational requests and extract repeatable steps to create a new, reusable skill in the procedural memory.",
+      "allowed_paths": [
+        "magda_agent/skills/dynamic_creator.py",
+        "tests/test_dynamic_creator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can parse conversational requests to create a new skill code.",
+        "Tests mock the LLM conversion process and verify procedural memory addition."
+      ]
+    },
+    {
+      "id": "openclaw-live-canvas-streaming-ee940fcb",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas streaming for working memory",
+      "description": "Inspired by OpenClaw trend. Expose a WebSocket endpoint that streams changes to the agent's working memory in real-time to external visualizer clients.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_streamer.py",
+        "tests/test_canvas_streamer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A WebSocket endpoint is created that emits memory diffs.",
+        "Tests mock the WebSocket and verify JSON payloads."
       ]
     }
   ]

--- a/magda_agent/security/mcp_taint.py
+++ b/magda_agent/security/mcp_taint.py
@@ -8,21 +8,24 @@ class TaintSandboxError(PolicyViolationError):
     """Raised when tainted data violates policy during MCP tool execution."""
     pass
 
-def mcp_action_taint_sandbox(critical_params: Optional[List[str]] = None) -> Callable:
+def mcp_action_taint_sandbox(critical_params: Optional[List[str]] = None) -> Callable[..., Any]:
     """
     Decorator for MCP action tools to track taint and block unsafe calls.
 
     Args:
         critical_params: List of parameter names that must not receive tainted data.
+
+    Returns:
+        A decorator for taint tracking.
     """
     if critical_params is None:
         critical_params = []
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             # Map args and kwargs to parameter names
-            sig = inspect.signature(func)
+            sig: inspect.Signature = inspect.signature(func)
             bound_args = sig.bind(*args, **kwargs)
             bound_args.apply_defaults()
 

--- a/tests/test_mcp_taint.py
+++ b/tests/test_mcp_taint.py
@@ -2,9 +2,10 @@ import pytest
 from magda_agent.security.mcp_taint import mcp_action_taint_sandbox, TaintSandboxError
 from magda_agent.security.mcp_kernel_taint import mark_tainted, is_tainted
 
-def test_mcp_action_taint_sandbox_blocks_critical_param():
+def test_mcp_action_taint_sandbox_blocks_critical_param() -> None:
+    """Tests that the sandbox blocks a critical parameter if it is tainted."""
     @mcp_action_taint_sandbox(critical_params=["command"])
-    def execute_command(command: str, background: bool = False):
+    def execute_command(command: str, background: bool = False) -> str:
         return f"Executed {command}"
 
     tainted_command = mark_tainted("rm -rf /")
@@ -12,18 +13,20 @@ def test_mcp_action_taint_sandbox_blocks_critical_param():
     with pytest.raises(TaintSandboxError, match="Critical parameter 'command' in 'execute_command' received tainted data."):
         execute_command(tainted_command)
 
-def test_mcp_action_taint_sandbox_allows_clean_param():
+def test_mcp_action_taint_sandbox_allows_clean_param() -> None:
+    """Tests that the sandbox allows a clean critical parameter."""
     @mcp_action_taint_sandbox(critical_params=["command"])
-    def execute_command(command: str, background: bool = False):
+    def execute_command(command: str, background: bool = False) -> str:
         return f"Executed {command}"
 
     clean_command = "ls -l"
     result = execute_command(clean_command)
     assert result == "Executed ls -l"
 
-def test_mcp_action_taint_sandbox_taints_output():
+def test_mcp_action_taint_sandbox_taints_output() -> None:
+    """Tests that the sandbox automatically taints the output of the wrapped function."""
     @mcp_action_taint_sandbox(critical_params=["query"])
-    def search_web(query: str):
+    def search_web(query: str) -> dict:
         return {"results": [f"Result for {query}"]}
 
     clean_query = "weather"
@@ -32,9 +35,10 @@ def test_mcp_action_taint_sandbox_taints_output():
     assert is_tainted(result) is True
     assert result == {"results": ["Result for weather"]}
 
-def test_mcp_action_taint_sandbox_allows_taint_on_non_critical_param():
+def test_mcp_action_taint_sandbox_allows_taint_on_non_critical_param() -> None:
+    """Tests that the sandbox allows tainted data on non-critical parameters."""
     @mcp_action_taint_sandbox(critical_params=["query"])
-    def search_web(query: str, extra_info: str = ""):
+    def search_web(query: str, extra_info: str = "") -> dict:
         return {"results": [f"Result for {query} with {extra_info}"]}
 
     clean_query = "weather"


### PR DESCRIPTION
Implements the mcp-action-tool-taint-tracking-v3 task by strictly typing the decorator in magda_agent/security/mcp_taint.py, marking the task done, adding 2 new tasks to agent_tasks.json, and adding strict typing to tests/test_mcp_taint.py.

---
*PR created automatically by Jules for task [16712494262619100279](https://jules.google.com/task/16712494262619100279) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add type annotations and docstrings to MCP taint tracking sandbox
> Strengthens type annotations in [`mcp_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/304/files#diff-02c3b4d8419a3de8bacbec4684b3ec1f39eac400f5af247489cf37a5d82de7c9): the `mcp_action_taint_sandbox` decorator factory now uses explicit `Callable[..., Any]` signatures and an `inspect.Signature` annotation. Test functions in [`test_mcp_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/304/files#diff-11766a2a2fda0a2a3c7fe2e355fecc91a476ab29ec0329863ec60e3373975cf7) gain return type annotations and descriptive docstrings. No behavioral logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 675f30f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->