### PR TITLE
feat: Implement OpenClaw-RL interactive learning v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5543,7 +5543,7 @@
     },
     {
       "id": "openclaw-rl-interactive-learning-v5",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Interactive Learning v5",
@@ -10573,6 +10573,57 @@
       "acceptance": [
         "A WebSocket endpoint is created that emits memory diffs.",
         "Tests mock the WebSocket and verify JSON payloads."
+      ]
+    },
+    {
+      "id": "51f91ae6-38f6-46c9-8710-6a8bda48741a",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw Dynamic Skill Weight Decay",
+      "description": "Inspired by OpenClaw trend: Implement a time-based decay mechanism for learned skill weights so that infrequently used skills gradually return to their baseline values.",
+      "allowed_paths": [
+        "magda_agent/learning/decay.py",
+        "tests/test_decay.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill weights decay over time towards 1.0.",
+        "Tests verify the decay formula."
+      ]
+    },
+    {
+      "id": "96950c3b-415c-4de7-b5af-3c6d656c1277",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "OpenAI Agents SDK Hand-off Protocol",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a robust hand-off protocol allowing one sub-agent to securely transfer execution context and partial results to another sub-agent.",
+      "allowed_paths": [
+        "magda_agent/agents/handoff.py",
+        "tests/test_handoff.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context is preserved during hand-off.",
+        "Tests verify that the receiving agent correctly resumes execution."
+      ]
+    },
+    {
+      "id": "f8acf4d1-72cb-44bf-bb54-97f8b5f7f6cf",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Claude Code Sandbox Isolation Enhancements",
+      "description": "Inspired by Claude Code trend: Enhance the MCP kernel sandbox to restrict file system access only to explicitly allowed directories during tool execution.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_kernel_fs.py",
+        "tests/test_mcp_kernel_fs.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox blocks unauthorized file access.",
+        "Tests verify access controls for allowed and disallowed paths."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -219,3 +219,4 @@
 
 - [x] a2a-peer-delegation-discovery-v2: A2A Peer Delegation Discovery
 * [x] FEATURE: ACS Workflow Guardrails (acs-workflow-guardrails-v1)
+- [x] openclaw-rl-interactive-learning-v5: OpenClaw-RL Interactive Learning v5

--- a/magda_agent/learning/interactive_rl.py
+++ b/magda_agent/learning/interactive_rl.py
@@ -29,7 +29,7 @@ class InteractiveLearner:
         Returns:
             float: A reward score, positive for positive sentiment, negative for negative sentiment.
         """
-        reply_lower = reply_text.lower()
+        reply_lower: str = reply_text.lower()
         if "good" in reply_lower or "great" in reply_lower or "yes" in reply_lower or "thanks" in reply_lower:
             return 1.0
         elif "bad" in reply_lower or "wrong" in reply_lower or "no" in reply_lower or "terrible" in reply_lower:
@@ -53,12 +53,12 @@ class InteractiveLearner:
         if not user_reply:
             return
 
-        reward = self.analyze_signal(user_reply)
+        reward: float = self.analyze_signal(user_reply)
 
         if skill_name not in self.learning_state:
             self.learning_state[skill_name] = 1.0
 
-        adjustment_rate = 0.2
+        adjustment_rate: float = 0.2
         self.learning_state[skill_name] += reward * adjustment_rate
 
         # Clamp between 0.1 and 10.0

--- a/tests/test_interactive_rl.py
+++ b/tests/test_interactive_rl.py
@@ -27,6 +27,11 @@ def test_analyze_signal_neutral(learner):
     assert learner.analyze_signal("What time is it?") == 0.0
 
 
+def test_analyze_signal_empty(learner):
+    """Test empty string reward extraction."""
+    assert learner.analyze_signal("") == 0.0
+
+
 @pytest.mark.asyncio
 async def test_process_interaction_positive(learner):
     """Test state update with positive reply."""


### PR DESCRIPTION
Implemented the `openclaw-rl-interactive-learning-v5` task by adding missing type annotations to the `InteractiveLearner` module as a trivial modification to the existing, complete logic. Enhanced test coverage with `test_analyze_signal_empty` to verify neutral state parsing for empty signals. Updated task progress and appended trending AI tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [17968785843515326118](https://jules.google.com/task/17968785843515326118) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test coverage and type annotations to `InteractiveLearner` for OpenClaw-RL v5
> - Adds a new test in [test_interactive_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/305/files#diff-96b2977acececd52495e9a6da41a0652cd793181b4276e528f0980c4c715eeee) asserting that `analyze_signal` returns `0.0` for empty string input.
> - Adds explicit type annotations to local variables in `analyze_signal` and `process_interaction` in [interactive_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/305/files#diff-2162003f49a166bff3ea32c3a4307aed07d29b9da1d9677f79ac0f694074afd9).
> - Updates task tracking in `agent_tasks.json` and `backlog.md` to mark this feature as complete and append three new planned tasks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27891b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->