### PR TITLE
Integrate OpenClaw Context Hooks V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5560,7 +5560,7 @@
     },
     {
       "id": "openclaw-context-hooks-v2",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "OpenClaw Context Engine Hooks V2 Integration",
@@ -10624,6 +10624,60 @@
       "acceptance": [
         "Sandbox blocks unauthorized file access.",
         "Tests verify access controls for allowed and disallowed paths."
+      ]
+    },
+    {
+      "id": "hermes-agent-quality-metrics-cd63f5e3-81ff-4e12-a5eb-c54f1b5c8326",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Hermes-inspired Longitudinal Quality Metrics",
+      "description": "Inspired by Hermes Agent trend: Implement a metrics tracking module that persists skill success/failure rates over multiple interactions to enable long-term evaluation and skill improvement.",
+      "allowed_paths": [
+        "magda_agent/evaluation/longitudinal_metrics.py",
+        "tests/test_longitudinal_metrics.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module records success/failure events into an sqlite database.",
+        "Can aggregate and retrieve historical success rates per skill.",
+        "Tests use an in-memory database to verify metrics collection."
+      ]
+    },
+    {
+      "id": "openclaw-rl-learning-2532fea2-ee21-45aa-b438-c0599d239720",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw-RL Online Reinforcement Learning Module",
+      "description": "Inspired by OpenClaw trend: Create a learning module that processes positive/negative next-state signals (user replies) to dynamically adjust sub-agent weights or response generation preferences.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl.py",
+        "tests/test_openclaw_rl.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module can ingest user feedback signals (e.g. positive/negative sentiment).",
+        "Updates a local policy weight file.",
+        "Tests mock the learning loop and verify weight adjustments."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-cc8646b1-345e-4f9b-8283-4d9b7ac86e43",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude SDK Sub-agent Spawning",
+      "description": "Inspired by Claude Agent SDK trend: Create a factory class that dynamically spawns isolated sub-agents (e.g., Planner, Evaluator) with their own dedicated virtual context and runtime boundaries.",
+      "allowed_paths": [
+        "magda_agent/agents/subagent_factory.py",
+        "tests/test_subagent_factory.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Factory can spawn sub-agents with isolated contexts.",
+        "Sub-agents can run their workflows asynchronously without sharing memory state directly.",
+        "Tests verify context isolation between spawned sub-agents."
       ]
     }
   ]

--- a/magda_agent/architecture/context_hooks.py
+++ b/magda_agent/architecture/context_hooks.py
@@ -13,7 +13,8 @@ class HookRegistry:
         if hook_type not in self._hooks:
             self._hooks[hook_type] = []
         self._hooks[hook_type].append(callback)
-        logging.debug(f"Registered hook '{hook_type}': {callback.__name__}")
+        callback_name = getattr(callback, '__name__', str(callback))
+        logging.debug(f"Registered hook '{hook_type}': {callback_name}")
 
     def trigger_hook(self, hook_type: str, *args: Any, **kwargs: Any) -> Any:
         """Triggers all callbacks registered for the hook type."""

--- a/magda_agent/memory/context_engine.py
+++ b/magda_agent/memory/context_engine.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List, Protocol, Any, Callable, Dict, Optional
+from magda_agent.architecture.context_hooks import HookRegistry
 
 class ContextPlugin(Protocol):
     """Protocol defining the lifecycle hooks for a Context Engine plugin."""
@@ -38,12 +39,25 @@ class ContextEngine:
     with lifecycle hooks.
     """
     def __init__(self, plugins: Optional[List[ContextPlugin]] = None, llm: Optional[Any] = None) -> None:
-        self._plugins: List[ContextPlugin] = plugins or []
+        self._plugins: List[ContextPlugin] = []
         self.llm = llm
+        self.hook_registry = HookRegistry()
+
+        if plugins:
+            for plugin in plugins:
+                self.register_plugin(plugin)
 
     def register_plugin(self, plugin: ContextPlugin) -> None:
         """Registers a new plugin with the context engine."""
         self._plugins.append(plugin)
+
+        if hasattr(plugin, 'before_retrieval'):
+            self.hook_registry.register_hook('before_retrieval', plugin.before_retrieval)
+        if hasattr(plugin, 'after_retrieval'):
+            self.hook_registry.register_hook('after_retrieval', plugin.after_retrieval)
+        if hasattr(plugin, 'on_context_update'):
+            self.hook_registry.register_hook('on_context_update', plugin.on_context_update)
+
         logging.debug(f"Registered plugin: {plugin.__class__.__name__}")
 
     def add_plugin(self, plugin: ContextPlugin) -> None:
@@ -52,9 +66,11 @@ class ContextEngine:
 
     async def bootstrap_all(self, config: Dict[str, Any]) -> None:
         """Initialize all plugins."""
+        config_with_hooks = dict(config)
+        config_with_hooks["hook_registry"] = self.hook_registry
         for plugin in self._plugins:
             if hasattr(plugin, 'bootstrap'):
-                await plugin.bootstrap(config)
+                await plugin.bootstrap(config_with_hooks)
 
     async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
         """Run content through ingest hook of all plugins."""
@@ -127,23 +143,20 @@ class ContextEngine:
         Retrieves context by executing lifecycle hooks before and after
         calling the base retrieval function.
         """
-        current_query: str = query
-        for plugin in self._plugins:
-            if hasattr(plugin, 'before_retrieval'):
-                current_query = plugin.before_retrieval(current_query, user_id)
+        current_query: str = self.hook_registry.trigger_hook('before_retrieval', query, user_id)
+        if current_query is None:
+            current_query = query
 
         context: List[Any] = base_retrieval_func(current_query, user_id)
 
-        for plugin in self._plugins:
-            if hasattr(plugin, 'after_retrieval'):
-                context = plugin.after_retrieval(context, current_query, user_id)
+        updated_context = self.hook_registry.trigger_hook('after_retrieval', context, current_query, user_id)
+        if updated_context is None:
+            updated_context = context
 
-        return context
+        return updated_context
 
     def update_context(self, new_context: Any, user_id: int) -> None:
         """Triggers the on_context_update hook for all registered plugins."""
-        for plugin in self._plugins:
-            if hasattr(plugin, 'on_context_update'):
-                plugin.on_context_update(new_context, user_id)
+        self.hook_registry.trigger_hook('on_context_update', new_context, user_id)
 
 # Context Engine lifecycle complete

--- a/tests/test_context_engine.py
+++ b/tests/test_context_engine.py
@@ -43,8 +43,10 @@ async def test_context_engine_lifecycle():
     engine = ContextEngine(plugins=[mock_plugin])
 
     # Test Bootstrap
-    await engine.bootstrap_all({"key": "value"})
+    config = {"key": "value"}
+    await engine.bootstrap_all(config)
     assert mock_plugin.bootstrap_called
+    # Config should remain unchanged at caller level, but inner config had hook_registry
 
     # Test Ingest
     ingested = await engine.ingest("raw", {"user_id": 1})
@@ -124,6 +126,19 @@ def test_context_engine_retrieve_context_hooks() -> None:
     plugin.after_retrieval.assert_called_once_with(["base_context"], "modified_query", 1)
 
     assert result == ["modified_context"]
+
+def test_context_engine_hook_registry_integration() -> None:
+    """Test that HookRegistry is initialized and plugins can register hooks via it."""
+    engine = ContextEngine()
+
+    assert hasattr(engine, "hook_registry")
+
+    mock_hook = MagicMock(return_value="hooked")
+    engine.hook_registry.register_hook("custom_hook", mock_hook)
+
+    result = engine.hook_registry.trigger_hook("custom_hook", "arg1")
+    assert result == "hooked"
+    mock_hook.assert_called_once_with("arg1")
 
 @pytest.mark.asyncio
 async def test_context_engine_builtin_compaction() -> None:


### PR DESCRIPTION
Completed the OpenClaw Context Engine Hooks V2 Integration task. Centralized context plugin hook management via HookRegistry. Also appended 3 new trendy AI tasks (Hermes-inspired Metrics, OpenClaw-RL Online Learning, Claude SDK Spawning) to the tasks registry. All tests continue to pass with updated MagicMock compatibility.

---
*PR created automatically by Jules for task [13314160874583802902](https://jules.google.com/task/13314160874583802902) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Integrate OpenClaw context hooks into `ContextEngine` via `HookRegistry`
> - Adds a `HookRegistry` instance to `ContextEngine`, replacing manual per-plugin iteration for `before_retrieval`, `after_retrieval`, and `on_context_update` lifecycle hooks.
> - `register_plugin` now binds plugin hook methods into the registry; `bootstrap_all` injects the registry into each plugin's config under the `hook_registry` key.
> - Fixes a crash in `HookRegistry.register_hook` when a callback lacks a `__name__` attribute by falling back to `str(callback)`.
> - Adds a new integration test in [test_context_engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/306/files#diff-7add6b30837cf042619f58bbe8e8cebf790deb4553cc61fcbf8193675e5a2ec2) verifying the registry is exposed and custom hooks can be registered and triggered.
> - Behavioral Change: plugins' `bootstrap` now receives a modified config dict containing `hook_registry`; callers' original config dict is not mutated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8171720.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->