### PR TITLE
Implement Context Hooks Telemetry plugin

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5577,7 +5577,7 @@
     },
     {
       "id": "openclaw-context-hooks-telemetry",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "Context Hooks Telemetry plugin",
@@ -10678,6 +10678,57 @@
         "Factory can spawn sub-agents with isolated contexts.",
         "Sub-agents can run their workflows asynchronously without sharing memory state directly.",
         "Tests verify context isolation between spawned sub-agents."
+      ]
+    },
+    {
+      "id": "9e919a81-f62d-429c-a775-97c065058d4b",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "A2A Workflow Handshake Verification",
+      "description": "Inspired by Agent-to-Agent (A2A) trends. Implement a cryptographically signed handshake protocol between interacting sub-agents to verify their identities before delegating sub-tasks, minimizing risks of context injection spoofing.",
+      "allowed_paths": [
+        "magda_agent/architecture/a2a_handshake.py",
+        "tests/test_a2a_handshake.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A handshake protocol generates and verifies signatures.",
+        "Tests verify successful handshake and rejection of spoofed contexts."
+      ]
+    },
+    {
+      "id": "f6d81948-9139-4c7e-931b-be57b6b56f28",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "title": "Skill Execution Experience Extraction",
+      "description": "Inspired by Hermes Agent trend. Add an extractor that reviews recent successful external skill executions and synthesizes reusable 'hints' to speed up subsequent invocations of those same tools.",
+      "allowed_paths": [
+        "magda_agent/learning/skill_hints.py",
+        "tests/test_skill_hints.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module extracts actionable hints from past successes.",
+        "Tests mock tool execution logs and verify the synthesized hints format."
+      ]
+    },
+    {
+      "id": "bf7d6847-f966-4be8-9ee7-403a96e0542c",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Preemptive Tool Call Interception Audit",
+      "description": "Inspired by Falco Prempti trend. Introduce an interception layer that intercepts every action tool execution right before it hits the operating system, writing the exact parameters and timestamps into an immutable local audit log.",
+      "allowed_paths": [
+        "magda_agent/safety/audit_interceptor.py",
+        "tests/test_audit_interceptor.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Interceptor logs action tools preemptively without blocking allowed paths.",
+        "Tests verify that audit logs match tool inputs perfectly."
       ]
     }
   ]

--- a/magda_agent/architecture/telemetry_plugin.py
+++ b/magda_agent/architecture/telemetry_plugin.py
@@ -1,0 +1,126 @@
+import logging
+from typing import Any, Dict, List
+from magda_agent.memory.context_engine import ContextPlugin
+
+
+class TelemetryPlugin(ContextPlugin):
+    """
+    A Context Engine Plugin that provides telemetry tracking over the context hook pipeline.
+    It tracks the number of executions and the context sizes during retrieval operations.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the TelemetryPlugin."""
+        self.metrics: Dict[str, Any] = {
+            "before_retrieval_count": 0,
+            "after_retrieval_count": 0,
+            "total_context_items_retrieved": 0,
+            "bootstrap_count": 0,
+            "ingest_count": 0,
+            "assemble_count": 0,
+            "compact_count": 0,
+            "on_context_update_count": 0
+        }
+        logging.info("TelemetryPlugin initialized.")
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """
+        Initialize the plugin with configuration.
+
+        Args:
+            config: A dictionary containing configuration parameters.
+        """
+        self.metrics["bootstrap_count"] += 1
+        logging.debug(f"TelemetryPlugin bootstrap called. Metrics: {self.metrics}")
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """
+        Process incoming content before it is stored or used.
+
+        Args:
+            content: The incoming content to process.
+            metadata: Metadata associated with the content.
+
+        Returns:
+            The processed content.
+        """
+        self.metrics["ingest_count"] += 1
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """
+        Assemble the context string from retrieved items for the LLM.
+
+        Args:
+            context_items: The list of context items.
+            metadata: Metadata associated with the assembly process.
+
+        Returns:
+            An empty string as this plugin doesn't modify the assembled text,
+            or rely on other plugins to provide the actual string. Actually it should
+            return a reasonable default if it was the only one, but ContextEngine handles that.
+            Since ContextEngine overwrites, we just return the joined string to be safe.
+        """
+        self.metrics["assemble_count"] += 1
+        return "\n".join([str(item) for item in context_items])
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        Compact or summarize the context when limits are reached.
+
+        Args:
+            context_items: The list of context items.
+            metadata: Metadata associated with the compaction process.
+
+        Returns:
+            The list of context items.
+        """
+        self.metrics["compact_count"] += 1
+        return context_items
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """
+        Called before context is retrieved.
+
+        Args:
+            query: The query string used for retrieval.
+            user_id: The ID of the user performing the retrieval.
+
+        Returns:
+            The original query string.
+        """
+        self.metrics["before_retrieval_count"] += 1
+        logging.debug(f"TelemetryPlugin before_retrieval count: {self.metrics['before_retrieval_count']}")
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """
+        Called after context is retrieved.
+
+        Args:
+            context: The retrieved context items.
+            query: The query string used for retrieval.
+            user_id: The ID of the user performing the retrieval.
+
+        Returns:
+            The original list of context items.
+        """
+        self.metrics["after_retrieval_count"] += 1
+        items_count = len(context)
+        self.metrics["total_context_items_retrieved"] += items_count
+        logging.debug(
+            f"TelemetryPlugin after_retrieval. Count: {self.metrics['after_retrieval_count']}, "
+            f"Items added: {items_count}, Total items: {self.metrics['total_context_items_retrieved']}"
+        )
+        return context
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """
+        Called when the overall context is updated.
+
+        Args:
+            new_context: The updated context.
+            user_id: The ID of the user.
+        """
+        self.metrics["on_context_update_count"] += 1
+        logging.debug(f"TelemetryPlugin on_context_update count: {self.metrics['on_context_update_count']}")

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -1,0 +1,65 @@
+import pytest
+from magda_agent.architecture.telemetry_plugin import TelemetryPlugin
+
+
+@pytest.mark.asyncio
+async def test_telemetry_plugin_hooks():
+    plugin = TelemetryPlugin()
+
+    # Check initial state
+    assert plugin.metrics["before_retrieval_count"] == 0
+    assert plugin.metrics["after_retrieval_count"] == 0
+    assert plugin.metrics["total_context_items_retrieved"] == 0
+
+    # Test before_retrieval
+    query = "test query"
+    user_id = 1
+    result_query = plugin.before_retrieval(query, user_id)
+
+    assert result_query == query
+    assert plugin.metrics["before_retrieval_count"] == 1
+
+    # Test after_retrieval
+    context = ["item1", "item2"]
+    result_context = plugin.after_retrieval(context, query, user_id)
+
+    assert result_context == context
+    assert plugin.metrics["after_retrieval_count"] == 1
+    assert plugin.metrics["total_context_items_retrieved"] == 2
+
+    # Call after_retrieval again
+    context2 = ["item3"]
+    plugin.after_retrieval(context2, query, user_id)
+
+    assert plugin.metrics["after_retrieval_count"] == 2
+    assert plugin.metrics["total_context_items_retrieved"] == 3
+
+
+@pytest.mark.asyncio
+async def test_telemetry_plugin_other_hooks():
+    plugin = TelemetryPlugin()
+
+    # Test bootstrap
+    await plugin.bootstrap({"config_key": "value"})
+    assert plugin.metrics["bootstrap_count"] == 1
+
+    # Test ingest
+    content = "test content"
+    result_content = await plugin.ingest(content, {})
+    assert result_content == content
+    assert plugin.metrics["ingest_count"] == 1
+
+    # Test assemble
+    context = ["item1", "item2"]
+    result_assemble = await plugin.assemble(context, {})
+    assert result_assemble == "item1\nitem2"
+    assert plugin.metrics["assemble_count"] == 1
+
+    # Test compact
+    result_compact = await plugin.compact(context, {})
+    assert result_compact == context
+    assert plugin.metrics["compact_count"] == 1
+
+    # Test on_context_update
+    plugin.on_context_update("new_context", 1)
+    assert plugin.metrics["on_context_update_count"] == 1


### PR DESCRIPTION
- Implemented `TelemetryPlugin` in `magda_agent/architecture/telemetry_plugin.py` to track context engine hook telemetry.
- Added comprehensive unit tests in `tests/test_telemetry_plugin.py`.
- Updated `openclaw-context-hooks-telemetry` task status to 'done' in `agent_tasks.json`.
- Appended 3 new tasks to `agent_tasks.json` based on current AI agent trends.

---
*PR created automatically by Jules for task [16262369341393743103](https://jules.google.com/task/16262369341393743103) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TelemetryPlugin` implementing all context lifecycle hooks with metric counters
> Introduces [`TelemetryPlugin`](https://github.com/kazah4359-lgtm/Magda-agent/pull/307/files#diff-783b817561ca7e98942f61fbb320db4b46ac9c36be60e6768437cb2ecfedd097), a `ContextPlugin` implementation that tracks invocation counts for all lifecycle hooks (`bootstrap`, `ingest`, `assemble`, `compact`) and retrieval hooks (`before_retrieval`, `after_retrieval`, `on_context_update`). All hooks pass data through unchanged except `assemble`, which returns a newline-joined string of context items. Tests in [`tests/test_telemetry_plugin.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/307/files#diff-0a18c7c0a325a59e69a9d49f523f756bf31c811ff745f2d4a824081d20980aa6) cover initial metric state, pass-through behavior, and counter accumulation across repeated calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22bc0a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->