### PR TITLE
Complete openclaw-context-hooks-v3 task

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5611,7 +5611,7 @@
     },
     {
       "id": "openclaw-context-hooks-v3",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "OpenClaw Context Engine Hooks V3 Integration",
@@ -10781,6 +10781,44 @@
       "acceptance": [
         "Executor can run multiple MCP tools concurrently.",
         "Performance tests demonstrate time savings vs sequential execution."
+      ]
+    },
+    {
+      "id": "0d6271ab-f941-4745-923a-6267fdd76dff",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw-RL Implicit Feedback Mechanism",
+      "description": "Inspired by OpenClaw trends: Implement an online reinforcement learning mechanism that adjusts tool selection weights simply by analyzing user replies using PAD shifts from MirrorNeurons.",
+      "allowed_paths": [
+        "magda_agent/learning/online.py",
+        "magda_agent/action/selector.py",
+        "tests/test_online_learning*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "User replies act as next-state reinforcement signals",
+        "Tool selection weights in Basal Ganglia update based on positive/negative shifts",
+        "Tests mock feedback PAD to verify weight changes"
+      ]
+    },
+    {
+      "id": "1dabe95a-2797-435d-9e42-5edaad6df0ad",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Agent Teams with Git Worktree Isolation",
+      "description": "Inspired by Claude Agent SDK. Enable spawning independent sub-agents that operate in their own git worktrees, preventing cross-contamination during complex multi-agent coding workflows.",
+      "allowed_paths": [
+        "magda_agent/teams/git_worktree.py",
+        "magda_agent/teams/manager.py",
+        "tests/test_git_worktree*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agents can check out code into isolated worktrees",
+        "Main process and sub-agents operate safely concurrently",
+        "Tests mock git calls and verify isolation"
       ]
     }
   ]

--- a/magda_agent/memory/context_engine.py
+++ b/magda_agent/memory/context_engine.py
@@ -28,6 +28,14 @@ class ContextPlugin(Protocol):
         """Called after context is retrieved. Can modify the retrieved context."""
         ...
 
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """Called before context is written. Can modify the context."""
+        ...
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """Called after context is written."""
+        ...
+
     def on_context_update(self, new_context: Any, user_id: int) -> None:
         """Called when the overall context is updated."""
         ...
@@ -57,6 +65,10 @@ class ContextEngine:
             self.hook_registry.register_hook('after_retrieval', plugin.after_retrieval)
         if hasattr(plugin, 'on_context_update'):
             self.hook_registry.register_hook('on_context_update', plugin.on_context_update)
+        if hasattr(plugin, 'before_write'):
+            self.hook_registry.register_hook('before_write', plugin.before_write)
+        if hasattr(plugin, 'after_write'):
+            self.hook_registry.register_hook('after_write', plugin.after_write)
 
         logging.debug(f"Registered plugin: {plugin.__class__.__name__}")
 
@@ -66,8 +78,9 @@ class ContextEngine:
 
     async def bootstrap_all(self, config: Dict[str, Any]) -> None:
         """Initialize all plugins."""
-        config_with_hooks = dict(config)
+        config_with_hooks: Dict[str, Any] = dict(config)
         config_with_hooks["hook_registry"] = self.hook_registry
+        plugin: ContextPlugin
         for plugin in self._plugins:
             if hasattr(plugin, 'bootstrap'):
                 await plugin.bootstrap(config_with_hooks)
@@ -158,5 +171,16 @@ class ContextEngine:
     def update_context(self, new_context: Any, user_id: int) -> None:
         """Triggers the on_context_update hook for all registered plugins."""
         self.hook_registry.trigger_hook('on_context_update', new_context, user_id)
+
+
+    def write_context(self, context: Any, user_id: int) -> None:
+        """Writes context by executing lifecycle hooks before and after."""
+        current_context: Any = self.hook_registry.trigger_hook('before_write', context, user_id)
+        if current_context is None:
+            current_context = context
+
+        self.update_context(current_context, user_id)
+
+        self.hook_registry.trigger_hook('after_write', current_context, user_id)
 
 # Context Engine lifecycle complete

--- a/tests/test_context_engine.py
+++ b/tests/test_context_engine.py
@@ -34,6 +34,12 @@ class MockPlugin(ContextPlugin):
     def after_retrieval(self, context: list, query: str, user_id: int) -> list:
         return context
 
+    def before_write(self, context: Any, user_id: int) -> Any:
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        pass
+
     def on_context_update(self, new_context: Any, user_id: int) -> None:
         pass
 
@@ -44,9 +50,24 @@ async def test_context_engine_lifecycle():
 
     # Test Bootstrap
     config = {"key": "value"}
+    # Capture the config passed to the plugin's bootstrap method
+    bootstrap_config = None
+
+    async def capture_bootstrap(cfg):
+        nonlocal bootstrap_config
+        bootstrap_config = cfg
+        mock_plugin.bootstrap_called = True
+
+    mock_plugin.bootstrap = capture_bootstrap
+
     await engine.bootstrap_all(config)
     assert mock_plugin.bootstrap_called
     # Config should remain unchanged at caller level, but inner config had hook_registry
+    assert "key" in config
+    assert "hook_registry" not in config
+    assert bootstrap_config is not None
+    assert "hook_registry" in bootstrap_config
+    assert bootstrap_config["hook_registry"] == engine.hook_registry
 
     # Test Ingest
     ingested = await engine.ingest("raw", {"user_id": 1})
@@ -208,3 +229,18 @@ async def test_context_engine_advanced_compaction_tags() -> None:
     call_args = llm.chat_completion.call_args[0][0]
     user_prompt = call_args[1]["content"]
     assert "maintaining key facts and semantic links" in user_prompt
+
+def test_context_engine_write_context_hooks() -> None:
+    """Test before_write and after_write hooks explicitly."""
+    plugin = MockPlugin()
+    plugin.before_write = MagicMock(return_value="modified_context")
+    plugin.after_write = MagicMock()
+    plugin.on_context_update = MagicMock()
+
+    engine = ContextEngine(plugins=[plugin])
+
+    engine.write_context("base_context", 1)
+
+    plugin.before_write.assert_called_once_with("base_context", 1)
+    plugin.on_context_update.assert_called_once_with("modified_context", 1)
+    plugin.after_write.assert_called_once_with("modified_context", 1)


### PR DESCRIPTION
Implemented `before_write` and `after_write` context engine hooks. Added corresponding `write_context` orchestrator method and mock-based tests in `ContextEngine`. Also updated `agent_tasks.json` to mark the task as "done" and added two new unique tasks based on AI trends.

---
*PR created automatically by Jules for task [11342954892009643898](https://jules.google.com/task/11342954892009643898) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `before_write` and `after_write` lifecycle hooks to `ContextEngine`
> - Adds `before_write` and `after_write` optional methods to the `ContextPlugin` protocol in [context_engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/309/files#diff-fab03bcfe0f765456ec92f34d62d5c84a4a8584d49428a1a0a33ddd76bb62aa0), allowing plugins to intercept and mutate context before it is persisted.
> - Adds `write_context` method to `ContextEngine` that triggers `before_write` hooks (using the returned value as the new context), calls `update_context`, then triggers `after_write` hooks.
> - Extends `register_plugin` to register these new hooks when present on a plugin.
> - Adds tests covering hook invocation order and context mutation in [test_context_engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/309/files#diff-7add6b30837cf042619f58bbe8e8cebf790deb4553cc61fcbf8193675e5a2ec2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66eafc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->