### PR TITLE
feat: Implement Telemetry ContextPlugin v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5628,7 +5628,7 @@
     },
     {
       "id": "openclaw-context-hooks-telemetry-v2",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "Context Hooks Telemetry plugin v2",
@@ -10819,6 +10819,59 @@
         "Sub-agents can check out code into isolated worktrees",
         "Main process and sub-agents operate safely concurrently",
         "Tests mock git calls and verify isolation"
+      ]
+    },
+    {
+      "id": "ada7b54a-a81c-4956-99d3-3cc6bb40bea4",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Hermes-inspired Configurable Cron Scheduler",
+      "description": "Inspired by Hermes Agent trend. Extend the current CronScheduler to parse and load dynamic cron jobs from an external YAML or JSON configuration file, enabling daily reports and nightly backups without hardcoded schedules.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_v5.py",
+        "tests/test_cron_scheduler.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler can read dynamic jobs from a config file.",
+        "Jobs execute successfully at their scheduled intervals.",
+        "Tests verify configuration loading and job triggering."
+      ]
+    },
+    {
+      "id": "bff9cf49-f2ca-4402-b1f4-7acd9ecd4699",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Service Discovery using Agent Cards",
+      "description": "Inspired by the A2A protocol trend. Implement a service discovery layer that broadcasts and retrieves AgentCard metadata across peer agents to automate task delegation routing.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery.py",
+        "tests/test_a2a_discovery.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Discovery service registers local agent cards and retrieves remote ones.",
+        "Tests mock the network layer and verify successful broadcast and retrieval."
+      ]
+    },
+    {
+      "id": "045ac595-8f37-4aaf-b438-cd44a66ffb0c",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ASSERT Policy Evaluation Framework Integration",
+      "description": "Inspired by Microsoft's ASSERT framework. Integrate a policy-driven evaluation module that intercepts final agent actions and runs them against a predefined set of safety assertions before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/assert_framework.py",
+        "tests/test_assert_framework.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent actions are evaluated against predefined policies.",
+        "Violations block execution and return an error context.",
+        "Tests simulate safe and unsafe actions and verify policy enforcement."
       ]
     }
   ]

--- a/magda_agent/architecture/telemetry_plugin.py
+++ b/magda_agent/architecture/telemetry_plugin.py
@@ -1,126 +1,72 @@
+from typing import List, Any, Dict
+from collections import deque
 import logging
-from typing import Any, Dict, List
-from magda_agent.memory.context_engine import ContextPlugin
+import time
 
+from magda_agent.memory.context_engine import ContextPlugin
 
 class TelemetryPlugin(ContextPlugin):
     """
-    A Context Engine Plugin that provides telemetry tracking over the context hook pipeline.
-    It tracks the number of executions and the context sizes during retrieval operations.
+    A ContextPlugin that tracks metrics for hook executions and context sizes.
+    Includes comprehensive tracking for all hooks and prevents memory leaks using bounded deques.
     """
 
     def __init__(self) -> None:
-        """Initialize the TelemetryPlugin."""
+        """Initialize the telemetry plugin and its bounded metrics storage."""
         self.metrics: Dict[str, Any] = {
-            "before_retrieval_count": 0,
-            "after_retrieval_count": 0,
-            "total_context_items_retrieved": 0,
+            "before_retrieval_calls": 0,
+            "after_retrieval_calls": 0,
+            "total_retrieved_items": 0,
+            "queries": deque(maxlen=1000),
+            "retrieval_times": deque(maxlen=1000),
             "bootstrap_count": 0,
             "ingest_count": 0,
             "assemble_count": 0,
             "compact_count": 0,
             "on_context_update_count": 0
         }
-        logging.info("TelemetryPlugin initialized.")
+        self._start_time: float = 0.0
 
     async def bootstrap(self, config: Dict[str, Any]) -> None:
-        """
-        Initialize the plugin with configuration.
-
-        Args:
-            config: A dictionary containing configuration parameters.
-        """
         self.metrics["bootstrap_count"] += 1
-        logging.debug(f"TelemetryPlugin bootstrap called. Metrics: {self.metrics}")
+        logging.debug(f"TelemetryPlugin bootstrap count: {self.metrics['bootstrap_count']}")
 
     async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
-        """
-        Process incoming content before it is stored or used.
-
-        Args:
-            content: The incoming content to process.
-            metadata: Metadata associated with the content.
-
-        Returns:
-            The processed content.
-        """
         self.metrics["ingest_count"] += 1
         return content
 
     async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
-        """
-        Assemble the context string from retrieved items for the LLM.
-
-        Args:
-            context_items: The list of context items.
-            metadata: Metadata associated with the assembly process.
-
-        Returns:
-            An empty string as this plugin doesn't modify the assembled text,
-            or rely on other plugins to provide the actual string. Actually it should
-            return a reasonable default if it was the only one, but ContextEngine handles that.
-            Since ContextEngine overwrites, we just return the joined string to be safe.
-        """
         self.metrics["assemble_count"] += 1
         return "\n".join([str(item) for item in context_items])
 
     async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
-        """
-        Compact or summarize the context when limits are reached.
-
-        Args:
-            context_items: The list of context items.
-            metadata: Metadata associated with the compaction process.
-
-        Returns:
-            The list of context items.
-        """
         self.metrics["compact_count"] += 1
         return context_items
 
     def before_retrieval(self, query: str, user_id: int) -> str:
-        """
-        Called before context is retrieved.
-
-        Args:
-            query: The query string used for retrieval.
-            user_id: The ID of the user performing the retrieval.
-
-        Returns:
-            The original query string.
-        """
-        self.metrics["before_retrieval_count"] += 1
-        logging.debug(f"TelemetryPlugin before_retrieval count: {self.metrics['before_retrieval_count']}")
+        self.metrics["before_retrieval_calls"] += 1
+        self.metrics["queries"].append(query)
+        self._start_time = time.time()
+        logging.debug(f"TelemetryPlugin before_retrieval count: {self.metrics['before_retrieval_calls']}")
         return query
 
     def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
-        """
-        Called after context is retrieved.
-
-        Args:
-            context: The retrieved context items.
-            query: The query string used for retrieval.
-            user_id: The ID of the user performing the retrieval.
-
-        Returns:
-            The original list of context items.
-        """
-        self.metrics["after_retrieval_count"] += 1
-        items_count = len(context)
-        self.metrics["total_context_items_retrieved"] += items_count
+        elapsed = time.time() - self._start_time
+        self.metrics["after_retrieval_calls"] += 1
+        self.metrics["total_retrieved_items"] += len(context)
+        self.metrics["retrieval_times"].append(elapsed)
         logging.debug(
-            f"TelemetryPlugin after_retrieval. Count: {self.metrics['after_retrieval_count']}, "
-            f"Items added: {items_count}, Total items: {self.metrics['total_context_items_retrieved']}"
+            f"TelemetryPlugin after_retrieval. Count: {self.metrics['after_retrieval_calls']}, "
+            f"Items added: {len(context)}, Total items: {self.metrics['total_retrieved_items']}"
         )
         return context
 
-    def on_context_update(self, new_context: Any, user_id: int) -> None:
-        """
-        Called when the overall context is updated.
+    def before_write(self, context: Any, user_id: int) -> Any:
+        return context
 
-        Args:
-            new_context: The updated context.
-            user_id: The ID of the user.
-        """
+    def after_write(self, context: Any, user_id: int) -> None:
+        pass
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
         self.metrics["on_context_update_count"] += 1
         logging.debug(f"TelemetryPlugin on_context_update count: {self.metrics['on_context_update_count']}")

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -1,65 +1,90 @@
 import pytest
+from unittest.mock import MagicMock
+from collections import deque
 from magda_agent.architecture.telemetry_plugin import TelemetryPlugin
+from magda_agent.memory.context_engine import ContextEngine
 
+@pytest.fixture
+def telemetry_plugin() -> TelemetryPlugin:
+    """Fixture providing a TelemetryPlugin instance."""
+    return TelemetryPlugin()
 
-@pytest.mark.asyncio
-async def test_telemetry_plugin_hooks():
-    plugin = TelemetryPlugin()
+@pytest.fixture
+def context_engine(telemetry_plugin: TelemetryPlugin) -> ContextEngine:
+    """Fixture providing a ContextEngine instance with a TelemetryPlugin registered."""
+    return ContextEngine(plugins=[telemetry_plugin])
 
-    # Check initial state
-    assert plugin.metrics["before_retrieval_count"] == 0
-    assert plugin.metrics["after_retrieval_count"] == 0
-    assert plugin.metrics["total_context_items_retrieved"] == 0
+def test_telemetry_plugin_initialization(telemetry_plugin: TelemetryPlugin) -> None:
+    """Test that TelemetryPlugin initializes correctly with deques."""
+    assert telemetry_plugin.metrics["before_retrieval_calls"] == 0
+    assert telemetry_plugin.metrics["after_retrieval_calls"] == 0
+    assert telemetry_plugin.metrics["total_retrieved_items"] == 0
+    assert isinstance(telemetry_plugin.metrics["queries"], deque)
+    assert telemetry_plugin.metrics["queries"].maxlen == 1000
+    assert isinstance(telemetry_plugin.metrics["retrieval_times"], deque)
+    assert telemetry_plugin.metrics["bootstrap_count"] == 0
+    assert telemetry_plugin.metrics["ingest_count"] == 0
+    assert telemetry_plugin._start_time == 0.0
 
-    # Test before_retrieval
+def test_telemetry_plugin_hooks_direct(telemetry_plugin: TelemetryPlugin) -> None:
+    """Test TelemetryPlugin hooks directly."""
     query = "test query"
     user_id = 1
-    result_query = plugin.before_retrieval(query, user_id)
 
-    assert result_query == query
-    assert plugin.metrics["before_retrieval_count"] == 1
+    # Trigger before_retrieval
+    ret_query = telemetry_plugin.before_retrieval(query, user_id)
+    assert ret_query == query
+    assert telemetry_plugin.metrics["before_retrieval_calls"] == 1
+    assert query in telemetry_plugin.metrics["queries"]
+    assert telemetry_plugin._start_time > 0.0
 
-    # Test after_retrieval
+    # Trigger after_retrieval
     context = ["item1", "item2"]
-    result_context = plugin.after_retrieval(context, query, user_id)
+    ret_context = telemetry_plugin.after_retrieval(context, query, user_id)
+    assert ret_context == context
+    assert telemetry_plugin.metrics["after_retrieval_calls"] == 1
+    assert telemetry_plugin.metrics["total_retrieved_items"] == 2
+    assert len(telemetry_plugin.metrics["retrieval_times"]) == 1
+    assert telemetry_plugin.metrics["retrieval_times"][0] >= 0.0
 
-    assert result_context == context
-    assert plugin.metrics["after_retrieval_count"] == 1
-    assert plugin.metrics["total_context_items_retrieved"] == 2
+def test_telemetry_plugin_integration_with_context_engine(
+    context_engine: ContextEngine, telemetry_plugin: TelemetryPlugin
+) -> None:
+    """Test TelemetryPlugin integration via ContextEngine's hook registry."""
+    query = "integrated query"
+    user_id = 2
+    mock_retrieval_func = MagicMock(return_value=["res1", "res2", "res3"])
 
-    # Call after_retrieval again
-    context2 = ["item3"]
-    plugin.after_retrieval(context2, query, user_id)
+    # Retrieve context, which should trigger hooks
+    result = context_engine.retrieve_context(query, user_id, mock_retrieval_func)
 
-    assert plugin.metrics["after_retrieval_count"] == 2
-    assert plugin.metrics["total_context_items_retrieved"] == 3
+    # Assert return values
+    assert result == ["res1", "res2", "res3"]
+    mock_retrieval_func.assert_called_once_with(query, user_id)
 
+    # Assert metrics
+    assert telemetry_plugin.metrics["before_retrieval_calls"] == 1
+    assert query in telemetry_plugin.metrics["queries"]
+    assert telemetry_plugin.metrics["after_retrieval_calls"] == 1
+    assert telemetry_plugin.metrics["total_retrieved_items"] == 3
+    assert len(telemetry_plugin.metrics["retrieval_times"]) == 1
 
 @pytest.mark.asyncio
-async def test_telemetry_plugin_other_hooks():
-    plugin = TelemetryPlugin()
+async def test_telemetry_plugin_other_hooks(telemetry_plugin: TelemetryPlugin) -> None:
+    """Test other protocol methods and legacy metrics behave correctly."""
+    await telemetry_plugin.bootstrap({})
+    assert telemetry_plugin.metrics["bootstrap_count"] == 1
 
-    # Test bootstrap
-    await plugin.bootstrap({"config_key": "value"})
-    assert plugin.metrics["bootstrap_count"] == 1
+    assert await telemetry_plugin.ingest("content", {}) == "content"
+    assert telemetry_plugin.metrics["ingest_count"] == 1
 
-    # Test ingest
-    content = "test content"
-    result_content = await plugin.ingest(content, {})
-    assert result_content == content
-    assert plugin.metrics["ingest_count"] == 1
+    assert await telemetry_plugin.assemble(["1", "2"], {}) == "1\n2"
+    assert telemetry_plugin.metrics["assemble_count"] == 1
 
-    # Test assemble
-    context = ["item1", "item2"]
-    result_assemble = await plugin.assemble(context, {})
-    assert result_assemble == "item1\nitem2"
-    assert plugin.metrics["assemble_count"] == 1
+    assert await telemetry_plugin.compact(["1"], {}) == ["1"]
+    assert telemetry_plugin.metrics["compact_count"] == 1
 
-    # Test compact
-    result_compact = await plugin.compact(context, {})
-    assert result_compact == context
-    assert plugin.metrics["compact_count"] == 1
+    telemetry_plugin.on_context_update("context", 1)
+    assert telemetry_plugin.metrics["on_context_update_count"] == 1
 
-    # Test on_context_update
-    plugin.on_context_update("new_context", 1)
-    assert plugin.metrics["on_context_update_count"] == 1
+    assert telemetry_plugin.before_write("context", 1) == "context"


### PR DESCRIPTION
Resolves `openclaw-context-hooks-telemetry-v2`.

* Implements `TelemetryPlugin` to comprehensively track context metrics.
* Ensures metrics scale safely using bounded `deque`.
* Marks task in `agent_tasks.json` as `done`.
* Adds 3 new high-quality agent tasks from `docs/trends.md`.
* Passes `validate_agent_tasks.py` and `pytest`.

---
*PR created automatically by Jules for task [14474673765587060550](https://jules.google.com/task/14474673765587060550) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement TelemetryPlugin v2 with query tracking and retrieval timing
> - Rewrites [`TelemetryPlugin`](https://github.com/kazah4359-lgtm/Magda-agent/pull/310/files#diff-783b817561ca7e98942f61fbb320db4b46ac9c36be60e6768437cb2ecfedd097) to track queries and retrieval durations in bounded deques (`maxlen=1000`) instead of simple counters.
> - Renames metrics keys: `before_retrieval_count`→`before_retrieval_calls`, `after_retrieval_count`→`after_retrieval_calls`, `total_context_items_retrieved`→`total_retrieved_items`.
> - Adds `before_write` (passthrough) and `after_write` (no-op) hooks to complete the plugin interface.
> - Updates [tests](https://github.com/kazah4359-lgtm/Magda-agent/pull/310/files#diff-0a18c7c0a325a59e69a9d49f523f756bf31c811ff745f2d4a824081d20980aa6) to cover deque initialization, timing capture, and `ContextEngine` integration.
> - Behavioral Change: metric keys are renamed, which will break any code reading the old key names from the metrics dict.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e07e2c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->