### PR TITLE
feat: implement openclaw-rl interactive learning v7

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5680,7 +5680,7 @@
     },
     {
       "id": "openclaw-rl-interactive-learning-v7",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Interactive Learning v7",
@@ -10924,6 +10924,58 @@
       "acceptance": [
         "RL Metrics System adapter correctly pushes next-state signals to a time-series store format.",
         "Tests mock the time-series store and verify data format."
+      ]
+    },
+    {
+      "id": "agent-teams-subagent-isolation-v8-71e81f8b",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Agent Teams Subagent Isolation v8",
+      "description": "Inspired by Claude Agent SDK Agent Teams trend: Update the subagent worktree spawner to properly isolate memory and context for highly parallel tasks.",
+      "allowed_paths": [
+        "magda_agent/agents/worktree_isolation_v8.py",
+        "tests/test_worktree_isolation_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents can be spawned with strictly isolated contexts in git worktrees.",
+        "Tests verify concurrent isolated operations."
+      ]
+    },
+    {
+      "id": "a2a-discovery-enhancements-v4-b68bc3d3",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Discovery Enhancements v4",
+      "description": "Inspired by A2A Protocol trends: Extend A2ADiscovery to support capability matching and advanced Agent Card querying for cross-agent delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v4_ext.py",
+        "tests/test_a2a_discovery_v4_ext.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A Discovery can filter Agent Cards by capability lists.",
+        "Tests mock a network discovery response and verify parsing."
+      ]
+    },
+    {
+      "id": "mcp-tools-integration-dynamic-v2-c96eac36",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tools Dynamic Integration v2",
+      "description": "Inspired by MCP standardization trend: Build a dynamic module to seamlessly import and execute external MCP tools at runtime.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_dynamic_integration_v2.py",
+        "tests/test_mcp_dynamic_integration_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module can dynamically read MCP standard tool definitions.",
+        "Module wraps MCP tools dynamically into skill registry.",
+        "Tests mock external MCP tool execution."
       ]
     }
   ]

--- a/magda_agent/learning/interactive_rl.py
+++ b/magda_agent/learning/interactive_rl.py
@@ -30,9 +30,9 @@ class InteractiveLearner:
             float: A reward score, positive for positive sentiment, negative for negative sentiment.
         """
         reply_lower: str = reply_text.lower()
-        if any(word in reply_lower for word in ["good", "great", "yes", "thanks", "awesome", "excellent"]):
+        if any(word in reply_lower for word in ["good", "great", "yes", "thanks", "awesome", "excellent", "amazing"]):
             return 1.0
-        elif any(word in reply_lower for word in ["bad", "wrong", "no", "terrible", "awful", "horrible"]):
+        elif any(word in reply_lower for word in ["bad", "wrong", "no", "terrible", "awful", "horrible", "stop", "halt", "cancel"]):
             return -1.0
         return 0.0
 
@@ -62,7 +62,8 @@ class InteractiveLearner:
         self.learning_state[skill_name] += reward * adjustment_rate
 
         # Clamp between 0.1 and 10.0
-        self.learning_state[skill_name] = max(0.1, min(10.0, self.learning_state[skill_name]))
+        current_weight: float = self.learning_state[skill_name]
+        self.learning_state[skill_name] = max(0.1, min(10.0, current_weight))
 
         logging.info(f"Updated interactive learning state for skill '{skill_name}' to {self.learning_state[skill_name]:.2f} based on reward {reward}")
 

--- a/tests/test_interactive_rl.py
+++ b/tests/test_interactive_rl.py
@@ -107,3 +107,11 @@ async def test_process_batch_interactions(learner):
 
     assert "skill_c" in state
     assert state["skill_c"] == 1.0
+
+def test_analyze_signal_positive_amazing(learner: InteractiveLearner) -> None:
+    """Test positive reward extraction for new keyword."""
+    assert learner.analyze_signal("This is amazing!") == 1.0
+
+def test_analyze_signal_negative_stop(learner: InteractiveLearner) -> None:
+    """Test negative reward extraction for new keyword."""
+    assert learner.analyze_signal("Stop doing that.") == -1.0


### PR DESCRIPTION
Implement the OpenClaw-RL Interactive Learning v7 task. Extends the online reinforcement learning module to train the agent directly from next-state signals (user replies) by identifying new positive and negative keywords, adjusting tool weights accordingly. Adds corresponding tests and marks the task as completed in the agent_tasks.json while appending 3 new relevant trends-based tasks.

---
*PR created automatically by Jules for task [17139699888190900546](https://jules.google.com/task/17139699888190900546) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend `InteractiveLearner.analyze_signal` keyword heuristics in openclaw-rl
> - Adds `'amazing'` to the positive keyword list (returns `1.0`) and `'stop'`, `'halt'`, `'cancel'` to the negative keyword list (returns `-1.0`) in [`interactive_rl.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/312/files#diff-2162003f49a166bff3ea32c3a4307aed07d29b9da1d9677f79ac0f694074afd9).
> - Adds a `current_weight` intermediate variable in `process_interaction` before clamping skill weights; clamping bounds are unchanged.
> - Adds two tests in [`test_interactive_rl.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/312/files#diff-96b2977acececd52495e9a6da41a0652cd793181b4276e528f0980c4c715eeee) covering the new positive and negative keyword cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a91fb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->