### PR TITLE
Implement MCP Tools Integration Engine v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5748,7 +5748,7 @@
     },
     {
       "id": "mcp-tools-integration-v4",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Tools Integration Engine v4",
@@ -11084,6 +11084,42 @@
         "Orchestrator spawns and kills subagents based on difficulty score.",
         "Integration tested using isolated mock environments.",
         "Code meets style guidelines."
+      ]
+    },
+    {
+      "id": "2d398426-c5f0-4f31-a671-5fadeb4c4d80",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Continuous Context Summarization V2",
+      "description": "Inspired by Context Compression Subagent trends. Enhance the continuous summarization loop to operate on a background cron schedule, periodically checking the size of EpisodicMemory and summarizing uncompressed segments natively.",
+      "allowed_paths": [
+        "magda_agent/agents/compression_cron_v2.py",
+        "tests/test_compression_cron_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A cron-based background task continuously monitors memory size.",
+        "Triggers LLM summarization without blocking the main event loop.",
+        "Tests mock LLM interactions and verify periodic execution."
+      ]
+    },
+    {
+      "id": "48b4da15-5d63-4af2-83a0-f0ed55cfeda4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "A2A Message Taint Sandbox Integration",
+      "description": "Inspired by both A2A and MCPKernel trends. Apply the MCP taint tracking mechanisms to incoming A2A delegate messages to ensure remote peer subagents cannot inject tainted code or prompt injections into the local executor.",
+      "allowed_paths": [
+        "magda_agent/security/a2a_taint.py",
+        "tests/test_a2a_taint.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A messages are passed through the taint tracker.",
+        "Injections are identified and blocked by the sandbox.",
+        "Tests simulate malicious remote agent messages."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_engine_v4.py
+++ b/magda_agent/skills/mcp_engine_v4.py
@@ -1,0 +1,118 @@
+import logging
+import asyncio
+from typing import Dict, Any, List, Optional
+from magda_agent.skills.mcp_client import MCPClient
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.memory.context_engine import ContextPlugin
+
+class MCPEngineV4(ContextPlugin):
+    """
+    Engine to seamlessly import and execute external MCP tools, converting them
+    into Magda's native procedural skills dynamically, while strictly following
+    the ContextPlugin protocol.
+    """
+    def __init__(self, registry: SkillRegistry, mcp_client: MCPClient) -> None:
+        """
+        Initializes the MCPEngineV4.
+
+        Args:
+            registry (SkillRegistry): Magda's native skill registry.
+            mcp_client (MCPClient): The MCP client used for remote tool execution.
+        """
+        self.registry = registry
+        self.mcp_client = mcp_client
+        self.hook_registry: Optional[Any] = None
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration."""
+        self.hook_registry = config.get("hook_registry")
+        logging.info("MCPEngineV4 bootstrapped.")
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Process incoming content before it is stored or used."""
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Assemble the context string from retrieved items for the LLM."""
+        return "\n".join([str(item) for item in context_items])
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact or summarize the context when limits are reached."""
+        return context_items
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Called before context is retrieved. Can modify the query."""
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """Called after context is retrieved. Can modify the retrieved context."""
+        return context
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """Called before context is written. Can modify the context."""
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """Called after context is written."""
+        pass
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """Called when the overall context is updated."""
+        pass
+
+    def import_mcp_tool(self, tool_def: Dict[str, Any], connection_info: Dict[str, Any]) -> None:
+        """
+        Reads MCP standard tool definitions and wraps them into Magda's SkillRegistry.
+
+        Args:
+            tool_def (Dict[str, Any]): Definition containing at least "name" and "description".
+            connection_info (Dict[str, Any]): Information needed to execute the remote tool.
+        """
+        tool_name = tool_def.get("name")
+        if not tool_name:
+            raise ValueError("MCP tool definition must include a 'name'.")
+
+        description = tool_def.get("description", "Imported MCP tool.")
+        input_schema = tool_def.get("inputSchema", {})
+
+        self.mcp_client.register_remote_tool(tool_name, connection_info)
+
+        async def mcp_wrapper_skill(**kwargs: Any) -> Any:
+            """
+            Dynamically executes the imported MCP tool via the MCPClient,
+            triggering context engine lifecycle hooks before and after tool usage.
+
+            Args:
+                kwargs: Arguments to pass to the MCP tool.
+
+            Returns:
+                Any: Result of the MCP tool execution.
+            """
+            # Trigger before tool usage hook
+            if self.hook_registry and hasattr(self.hook_registry, 'trigger_broadcast_async'):
+                try:
+                    await self.hook_registry.trigger_broadcast_async("before_tool_use", tool_name, kwargs)
+                except Exception as e:
+                    logging.warning(f"Error triggering before_tool_use hook: {e}")
+
+            result = await self.mcp_client.execute_tool(tool_name, **kwargs)
+
+            # Trigger after tool usage hook
+            if self.hook_registry and hasattr(self.hook_registry, 'trigger_broadcast_async'):
+                try:
+                    await self.hook_registry.trigger_broadcast_async("after_tool_use", tool_name, result)
+                except Exception as e:
+                    logging.warning(f"Error triggering after_tool_use hook: {e}")
+
+            return result
+
+        setattr(mcp_wrapper_skill, "__mcp_schema__", input_schema)
+        setattr(mcp_wrapper_skill, "__name__", tool_name)
+
+        self.registry.register_skill(
+            name=tool_name,
+            func=mcp_wrapper_skill,
+            description=description
+        )
+
+        logging.info(f"Dynamically wrapped MCP tool '{tool_name}' into Magda skill registry.")

--- a/tests/test_mcp_engine_v4.py
+++ b/tests/test_mcp_engine_v4.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.skills.mcp_engine_v4 import MCPEngineV4
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_client import MCPClient
+from magda_agent.architecture.context_hooks import HookRegistry
+
+def test_mcp_engine_v4_import() -> None:
+    """Verify MCPEngineV4 reads MCP standard tool definitions and wraps them."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_client.register_remote_tool = MagicMock()
+
+    engine = MCPEngineV4(registry, mcp_client)
+
+    tool_def = {
+        "name": "external_weather",
+        "description": "Get current weather.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            },
+            "required": ["location"]
+        }
+    }
+    connection_info = {"url": "http://localhost:8000/mcp"}
+
+    engine.import_mcp_tool(tool_def, connection_info)
+
+    # Verify tool routing is registered
+    mcp_client.register_remote_tool.assert_called_once_with("external_weather", connection_info)
+
+    # Verify skill is dynamically registered in Magda
+    assert registry.has_skill("external_weather")
+    assert registry.descriptions["external_weather"] == "Get current weather."
+
+    # Verify schema preservation
+    skill_func = registry.skills["external_weather"]
+    assert hasattr(skill_func, "__mcp_schema__")
+    assert getattr(skill_func, "__mcp_schema__") == tool_def["inputSchema"]
+
+@pytest.mark.asyncio
+async def test_mcp_engine_v4_wrapper_execution_and_hooks() -> None:
+    """Verify the dynamically wrapped skill executes correctly and triggers hooks."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_client.execute_tool = AsyncMock(return_value="Sunny, 25C")
+
+    engine = MCPEngineV4(registry, mcp_client)
+    hook_registry = HookRegistry()
+    hook_registry.trigger_broadcast_async = AsyncMock()
+
+    # Bootstrap the plugin
+    await engine.bootstrap({"hook_registry": hook_registry})
+
+    tool_def = {"name": "external_weather"}
+    connection_info = {"url": "mock"}
+
+    engine.import_mcp_tool(tool_def, connection_info)
+
+    result = await registry.execute_skill("external_weather", location="Paris")
+
+    assert result == "Sunny, 25C"
+    mcp_client.execute_tool.assert_awaited_once_with("external_weather", location="Paris")
+
+    # Verify hooks were triggered
+    assert hook_registry.trigger_broadcast_async.await_count == 2
+    hook_registry.trigger_broadcast_async.assert_any_await("before_tool_use", "external_weather", {"location": "Paris"})
+    hook_registry.trigger_broadcast_async.assert_any_await("after_tool_use", "external_weather", "Sunny, 25C")
+
+def test_mcp_engine_v4_invalid_tool_def() -> None:
+    """Verify MCPEngineV4 raises ValueError on invalid tool definition without a name."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    engine = MCPEngineV4(registry, mcp_client)
+
+    with pytest.raises(ValueError, match="must include a 'name'"):
+        engine.import_mcp_tool({"description": "No name tool"}, {})
+
+@pytest.mark.asyncio
+async def test_mcp_engine_v4_protocol_methods() -> None:
+    """Verify the basic ContextPlugin methods."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    engine = MCPEngineV4(registry, mcp_client)
+
+    assert await engine.ingest("data", {}) == "data"
+    assert await engine.assemble(["A", "B"], {}) == "A\nB"
+    assert await engine.compact(["A"], {}) == ["A"]
+
+    assert engine.before_retrieval("query", 1) == "query"
+    assert engine.after_retrieval(["data"], "query", 1) == ["data"]
+    assert engine.before_write("data", 1) == "data"
+
+    # Just asserting no exception on empty pass methods
+    engine.after_write("data", 1)
+    engine.on_context_update("data", 1)


### PR DESCRIPTION
Implementation of MCP Tools Integration Engine v4.

- Created `magda_agent/skills/mcp_engine_v4.py` extending `ContextPlugin`.
- Added tests `tests/test_mcp_engine_v4.py` mocking out client API calls.
- Updated `agent_tasks.json` tracking status.
- Recorded architecture changes to memory.

---
*PR created automatically by Jules for task [14887178143244023702](https://jules.google.com/task/14887178143244023702) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPEngineV4` plugin to bridge MCP tools into the SkillRegistry
> - Introduces [`mcp_engine_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/316/files#diff-bfd447f0c6a71b9bcdea109ba224006c40e646826e645b6d1bea33d00fb88c85), a `ContextPlugin` implementation that dynamically imports remote MCP tools into the `SkillRegistry` via `import_mcp_tool`.
> - Each imported tool is wrapped in an async skill function that calls `mcp_client.execute_tool` and broadcasts `before_tool_use`/`after_tool_use` hooks through `HookRegistry` if present.
> - The wrapper exposes the tool's `inputSchema` as a `__mcp_schema__` attribute and raises `ValueError` if a tool definition lacks a `name`.
> - Adds tests covering tool registration, wrapper execution, hook broadcasting, invalid tool definitions, and `ContextPlugin` protocol passthrough methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 332f21d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->