### PR TITLE
Implement Hermes-style skill creation from experience

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5765,7 +5765,7 @@
     },
     {
       "id": "hermes-skill-experience-creation-v1",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Hermes-style Skill Creation from Experience",
@@ -11120,6 +11120,57 @@
         "A2A messages are passed through the taint tracker.",
         "Injections are identified and blocked by the sandbox.",
         "Tests simulate malicious remote agent messages."
+      ]
+    },
+    {
+      "id": "mcp-skill-export-tool-v2-73417b33",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Skill Export Tool v2",
+      "description": "Inspired by MCP trend: Implement an MCP exporter that converts Magda skills into standard MCP tools.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_export_v2.py",
+        "tests/test_mcp_export_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Magda skills can be exported as MCP JSON-RPC definitions.",
+        "Tests verify the export format."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-v7-ec457ae2",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "A2A Peer Task Delegation v7",
+      "description": "Inspired by A2A Protocol trend: Implement a peer-to-peer task delegation mechanism to assign sub-tasks to other discovered agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegation_v7.py",
+        "tests/test_a2a_delegation_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tasks can be delegated via A2A protocol.",
+        "Tests mock peer responses and verify delegation flow."
+      ]
+    },
+    {
+      "id": "openclaw-online-learning-v8-ff098179",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw Online Learning Module v8",
+      "description": "Inspired by OpenClaw trend: Implement continuous online reinforcement learning from user feedback during dialogue interactions.",
+      "allowed_paths": [
+        "magda_agent/learning/online_learning_v8.py",
+        "tests/test_online_learning_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module processes user feedback signals and updates skill weights.",
+        "Tests verify weight adjustments based on mock signals."
       ]
     }
   ]

--- a/magda_agent/learning/experience_skills.py
+++ b/magda_agent/learning/experience_skills.py
@@ -1,0 +1,111 @@
+import logging
+import re
+from typing import List, Dict, Optional, Any
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.procedural import ProceduralMemory
+
+
+class HermesSkillExperienceManager:
+    """
+    Hermes-style Skill Creation from Experience.
+
+    This module analyzes execution trace history to automatically synthesize
+    and store new, highly reusable Python skills.
+    """
+
+    def __init__(self, llm: LLMClient, procedural_memory: ProceduralMemory) -> None:
+        """
+        Initializes the HermesSkillExperienceManager.
+
+        Args:
+            llm: The LLMClient instance to use for skill generation.
+            procedural_memory: The ProceduralMemory instance to store generated skills.
+        """
+        self.llm = llm
+        self.procedural_memory = procedural_memory
+
+    async def create_skill_from_experience(
+        self,
+        task_description: str,
+        execution_trace: List[Dict[str, Any]],
+        user_id: Optional[int] = None
+    ) -> Optional[str]:
+        """
+        Parses an execution trace and synthesizes a new Python skill.
+
+        Args:
+            task_description: A description of the task that was completed.
+            execution_trace: A list of dicts representing the steps taken during execution.
+            user_id: The ID of the user for whom this skill should be stored.
+
+        Returns:
+            The generated Python code as a string if successful, or None otherwise.
+        """
+        if not execution_trace:
+            return None
+
+        trace_log = ""
+        for i, step in enumerate(execution_trace):
+            action = step.get("action", "unknown_action")
+            outcome = step.get("outcome", "unknown_outcome")
+            trace_log += f"Step {i+1}: {action} -> {outcome}\n"
+
+        prompt = f"""
+        Analyze the following execution trace of a successful task.
+        If the steps represent a highly reusable procedure, generate a Python function (a 'skill') that encapsulates this logic.
+        Return ONLY valid Python code starting with 'def '. Do not include markdown formatting or explanations.
+        If it's not suitable for a skill, return exactly 'NOT_REUSABLE'.
+
+        Task: {task_description}
+
+        Execution Trace:
+        {trace_log}
+        """
+
+        messages = [{"role": "user", "content": prompt}]
+        try:
+            response = await self.llm.chat_completion(messages)
+            response = response.strip()
+
+            # Remove potential markdown block wrappers
+            if response.startswith("```python"):
+                response = response[9:]
+            elif response.startswith("```"):
+                response = response[3:]
+
+            if response.endswith("```"):
+                response = response[:-3]
+
+            response = response.strip()
+
+            if response == "NOT_REUSABLE" or not response.startswith("def "):
+                logging.info("Trace is not reusable as a skill.")
+                return None
+
+            # Extract function name
+            match = re.search(r"^def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(", response)
+            if not match:
+                logging.warning("Could not extract function name from generated skill.")
+                return None
+
+            skill_name = match.group(1)
+
+            metadata = {
+                "source_task": task_description,
+                "type": "hermes_experience_skill"
+            }
+
+            self.procedural_memory.store_procedure(
+                name=skill_name,
+                procedure=response,
+                user_id=user_id,
+                metadata=metadata
+            )
+
+            logging.info(f"Successfully generated and stored new skill: {skill_name}")
+            return response
+
+        except Exception as e:
+            logging.error(f"Error during skill creation: {e}")
+            return None

--- a/tests/test_experience_skills.py
+++ b/tests/test_experience_skills.py
@@ -1,0 +1,66 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.learning.experience_skills import HermesSkillExperienceManager
+
+
+@pytest.mark.asyncio
+async def test_create_skill_from_experience_success() -> None:
+    """Tests that a valid Python function is parsed, stored, and returned."""
+    mock_llm = AsyncMock()
+    mock_memory = MagicMock()
+
+    manager = HermesSkillExperienceManager(llm=mock_llm, procedural_memory=mock_memory)
+
+    mock_code = "def sample_experience_skill(data):\n    return data.get('key')"
+    mock_llm.chat_completion.return_value = mock_code
+
+    trace = [
+        {"action": "read data", "outcome": "success"},
+        {"action": "extract key", "outcome": "success"}
+    ]
+
+    result = await manager.create_skill_from_experience("Extract key from data dict", trace, user_id=42)
+
+    assert result == mock_code
+
+    mock_memory.store_procedure.assert_called_once()
+    args, kwargs = mock_memory.store_procedure.call_args
+
+    assert kwargs["name"] == "sample_experience_skill"
+    assert kwargs["procedure"] == mock_code
+    assert kwargs["user_id"] == 42
+    assert kwargs["metadata"]["source_task"] == "Extract key from data dict"
+    assert kwargs["metadata"]["type"] == "hermes_experience_skill"
+
+
+@pytest.mark.asyncio
+async def test_create_skill_from_experience_not_reusable() -> None:
+    """Tests that a non-reusable trace does not trigger storage and returns None."""
+    mock_llm = AsyncMock()
+    mock_memory = MagicMock()
+
+    manager = HermesSkillExperienceManager(llm=mock_llm, procedural_memory=mock_memory)
+
+    mock_llm.chat_completion.return_value = "NOT_REUSABLE"
+
+    trace = [{"action": "one-off API call", "outcome": "success"}]
+
+    result = await manager.create_skill_from_experience("One-off task", trace)
+
+    assert result is None
+    mock_memory.store_procedure.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_skill_from_experience_empty_trace() -> None:
+    """Tests that an empty trace returns None without calling LLM."""
+    mock_llm = AsyncMock()
+    mock_memory = MagicMock()
+
+    manager = HermesSkillExperienceManager(llm=mock_llm, procedural_memory=mock_memory)
+
+    result = await manager.create_skill_from_experience("Empty trace task", [])
+
+    assert result is None
+    mock_llm.chat_completion.assert_not_called()
+    mock_memory.store_procedure.assert_not_called()


### PR DESCRIPTION
Inspired by Hermes Agent trend: Implement a self-improving agent capability that automatically creates and refines skills based on past experience and execution trace history.
Also added 3 new todo tasks to agent_tasks.json inspired by recent AI agent trends.

---
*PR created automatically by Jules for task [3144586373922161361](https://jules.google.com/task/3144586373922161361) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Hermes-style skill synthesis from execution traces via `HermesSkillExperienceManager`
> - Introduces [`HermesSkillExperienceManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/317/files#diff-d00f1dc176ed97f93603e57943844c6fefef2ebc4f8045a3d72ebd5cdb345620) which takes an execution trace, prompts an LLM to produce a reusable Python function, and stores it in `ProceduralMemory` if valid.
> - The LLM is expected to return either a `def`-prefixed Python function or `NOT_REUSABLE`; markdown fences are stripped and the function name is extracted via regex before storage.
> - Three async tests cover the success path, the `NOT_REUSABLE` path, and the empty-trace early-exit path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 118aa1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->