### PR TITLE
Implement OpenAI Agents SDK MCP Function Concurrency

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5799,7 +5799,7 @@
     },
     {
       "id": "openai-mcp-function-concurrency-v1",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "OpenAI Agents SDK MCP Function Concurrency",
@@ -11222,6 +11222,59 @@
       "acceptance": [
         "Executor batches concurrent MCP tool calls heading to the same server.",
         "Tests mock MCP clients and verify batching logic."
+      ]
+    },
+    {
+      "id": "1f3e194c-cddb-4c65-9782-1ba9b98fdc8e",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Workflow Orchestrator v2",
+      "description": "Inspired by A2A Protocol open standard: Implement a multi-agent orchestration manager that can dynamically assign tasks via Agent Cards to a network of specialized external sub-agents natively.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_orchestrator_v2.py",
+        "tests/test_a2a_orchestrator_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A Orchestrator correctly routes tasks to the appropriate remote agent based on capability.",
+        "Tests use mock mDNS and HTTP calls to verify task delegation."
+      ]
+    },
+    {
+      "id": "6561db15-0289-4c6a-9a85-b1b43d7f28ca",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Realtime Guardrail Action Interceptor",
+      "description": "Inspired by OpenAI Agents SDK realtime guardrail fallback: Implement a dynamic interceptor that triggers a safe fallback state when external API tool calls detect policy violations mid-execution.",
+      "allowed_paths": [
+        "magda_agent/safety/realtime_interceptor.py",
+        "tests/test_realtime_interceptor.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Interceptor properly captures policy exceptions during tool calls.",
+        "Fallback action is triggered without crashing the main loop.",
+        "Tests mock API responses to trigger violation events."
+      ]
+    },
+    {
+      "id": "bf4a6eb8-c623-4337-b2d3-87885c4044e8",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Live Re-ranker",
+      "description": "Inspired by Context Engine lifecycle hooks: Implement a live re-ranking plugin that dynamically re-orders Working Memory entries based on instantaneous task urgency and emotional arousal context before Planner generation.",
+      "allowed_paths": [
+        "magda_agent/memory/context_reranker.py",
+        "tests/test_context_reranker.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context Engine correctly loads the re-ranker plugin.",
+        "Working Memory entries are sorted by an urgency score.",
+        "Tests verify correct ordering of mocked memory entries."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_concurrency.py
+++ b/magda_agent/skills/mcp_concurrency.py
@@ -1,0 +1,120 @@
+import asyncio
+import inspect
+from typing import Any, Dict, List
+
+class MCPConcurrentSkillExecutor:
+    """Executes multiple MCP server-prefixed skills concurrently using asyncio.gather.
+
+    This class enables runtime function tool concurrency for MCP tools.
+    It batches concurrent MCP tool calls heading to the same server.
+    """
+
+    def __init__(self, mcp_client: Any) -> None:
+        """
+        Initializes the executor with the given MCP client.
+
+        Args:
+            mcp_client: The MCP client or tool registry that can resolve and execute MCP tools.
+        """
+        self.mcp_client = mcp_client
+
+    async def execute_mcp_tools_concurrently(self, tool_calls: List[Dict[str, Any]]) -> List[Any]:
+        """
+        Executes a list of MCP tool calls concurrently, batching calls to the same server.
+        Each element in tool_calls must have 'name' and 'kwargs'.
+        It assumes the server name is the part before the first '-' in the tool name (e.g. 'server1-tool_a').
+
+        Args:
+            tool_calls: A list of tool call dicts containing the tool name and arguments.
+
+        Returns:
+            A list of execution results corresponding to the input tool_calls.
+        """
+        # We need a special marker because legitimate results can be None
+        _UNSET = object()
+
+        # Batch calls by server prefix
+        batches = {}
+        for call in tool_calls:
+            name = call.get("name", "")
+            kwargs = call.get("kwargs", {})
+
+            # Extract server prefix (e.g. 'math_server-add' -> 'math_server')
+            server_prefix = name.split("-")[0] if "-" in name else name
+
+            if server_prefix not in batches:
+                batches[server_prefix] = []
+            batches[server_prefix].append((name, kwargs))
+
+        async def run_tool(n: str, kw: dict) -> Any:
+            """Run a single tool.
+
+            Args:
+                n: Tool name
+                kw: Keyword arguments
+
+            Returns:
+                The result of the execution.
+            """
+            try:
+                if hasattr(self.mcp_client, "execute_tool"):
+                    result = self.mcp_client.execute_tool(n, kw)
+                elif hasattr(self.mcp_client, "execute"):
+                    result = self.mcp_client.execute(n, kw)
+                elif hasattr(self.mcp_client, "skills") and n in self.mcp_client.skills:
+                    skill_func = self.mcp_client.skills[n]
+                    result = skill_func(**kw)
+                else:
+                    return f"Error: MCP Tool '{n}' not found or client missing execute method."
+
+                if inspect.isawaitable(result):
+                    return await result
+                return result
+            except Exception as e:
+                return f"Error executing '{n}': {e}"
+
+        # If the client supports execute_batch, we can use it. Otherwise, fallback to individual execution.
+        async def process_batch(server: str, calls_in_batch: List[tuple[str, dict]]) -> Any:
+            """Process a batch of tools on the given server.
+
+            Args:
+                server: The server prefix.
+                calls_in_batch: A list of tuples containing tool name and kwargs.
+
+            Returns:
+                A list of execution results.
+            """
+            if hasattr(self.mcp_client, "execute_batch"):
+                try:
+                    # Assume execute_batch takes server_prefix and list of dicts with name/kwargs
+                    batch_request = [{"name": n, "kwargs": kw} for n, kw in calls_in_batch]
+                    results = self.mcp_client.execute_batch(server, batch_request)
+                    if inspect.isawaitable(results):
+                        results = await results
+                    return results
+                except Exception as e:
+                    return [f"Error executing batch on '{server}': {e}"] * len(calls_in_batch)
+            else:
+                # Fallback to individual execution
+                return await asyncio.gather(*(run_tool(n, kw) for n, kw in calls_in_batch))
+
+        # Process each server batch concurrently
+        batch_tasks = []
+        server_order = list(batches.keys())
+        for server in server_order:
+            batch_tasks.append(process_batch(server, batches[server]))
+
+        batch_results = await asyncio.gather(*batch_tasks)
+
+        # Reconstruct the results in the original order
+        final_results = [_UNSET] * len(tool_calls)
+        for server, results in zip(server_order, batch_results):
+            for (name, kwargs), result in zip(batches[server], results):
+                # Find the original index. (Note: if there are duplicate calls, this simple find might fail.
+                # So we iterate over tool_calls and find the first matching one that hasn't been filled).
+                for i, call in enumerate(tool_calls):
+                    if call.get("name", "") == name and call.get("kwargs", {}) == kwargs and final_results[i] is _UNSET:
+                        final_results[i] = result
+                        break
+
+        return final_results

--- a/tests/test_mcp_concurrency.py
+++ b/tests/test_mcp_concurrency.py
@@ -80,3 +80,93 @@ async def test_handle_request_empty_batch(handler):
     res_str = await handler.handle_request("[]")
     res = json.loads(res_str)
     assert res["error"]["code"] == -32600
+
+# --- Tests for MCPConcurrentSkillExecutor ---
+from unittest.mock import MagicMock
+from magda_agent.skills.mcp_concurrency import MCPConcurrentSkillExecutor
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tools_concurrently_batch():
+    """
+    Test that execute_mcp_tools_concurrently correctly batches tools by server.
+    """
+    class MockClient:
+        async def execute_batch(self, server, calls):
+            # simulate different delay per server
+            if server == "server1":
+                await asyncio.sleep(0.1)
+                return [f"{c['name']}_res1" for c in calls]
+            elif server == "server2":
+                await asyncio.sleep(0.1)
+                return [f"{c['name']}_res2" for c in calls]
+            return ["unknown"] * len(calls)
+
+    mock_client = MockClient()
+    executor = MCPConcurrentSkillExecutor(mock_client)
+
+    tool_calls = [
+        {"name": "server1-tool_a", "kwargs": {}},
+        {"name": "server2-tool_b", "kwargs": {}},
+        {"name": "server1-tool_c", "kwargs": {}}
+    ]
+
+    import time
+    start_time = time.time()
+    results = await executor.execute_mcp_tools_concurrently(tool_calls)
+    end_time = time.time()
+
+    # Should take roughly 0.1s total because server batches run concurrently
+    assert end_time - start_time < 0.15
+
+    assert results[0] == "server1-tool_a_res1"
+    assert results[1] == "server2-tool_b_res2"
+    assert results[2] == "server1-tool_c_res1"
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tools_concurrently_fallback():
+    """
+    Test fallback to individual execute if execute_batch is not present.
+    """
+    class MockClient:
+        async def execute(self, name, kwargs):
+            await asyncio.sleep(0.1)
+            return f"{name}_res"
+
+    mock_client = MockClient()
+    executor = MCPConcurrentSkillExecutor(mock_client)
+
+    tool_calls = [
+        {"name": "server1-tool_a", "kwargs": {}},
+        {"name": "server2-tool_b", "kwargs": {}}
+    ]
+
+    results = await executor.execute_mcp_tools_concurrently(tool_calls)
+    assert results[0] == "server1-tool_a_res"
+    assert results[1] == "server2-tool_b_res"
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tools_duplicate_calls():
+    """
+    Test when there are duplicate tool calls, results are correctly mapped back,
+    and None return values are handled correctly.
+    """
+    class MockClient:
+        async def execute(self, name, kwargs):
+            if kwargs.get("id") == "none":
+                return None
+            return f"{name}_{kwargs.get('id', '')}"
+
+    mock_client = MockClient()
+    executor = MCPConcurrentSkillExecutor(mock_client)
+
+    # Duplicate tool names with different kwargs
+    tool_calls = [
+        {"name": "server1-tool_a", "kwargs": {"id": "1"}},
+        {"name": "server1-tool_a", "kwargs": {"id": "none"}},
+        {"name": "server1-tool_a", "kwargs": {"id": "1"}} # exactly duplicate
+    ]
+
+    results = await executor.execute_mcp_tools_concurrently(tool_calls)
+    assert results[0] == "server1-tool_a_1"
+    assert results[1] is None
+    assert results[2] == "server1-tool_a_1"


### PR DESCRIPTION
Implemented the `MCPConcurrentSkillExecutor` class in `magda_agent/skills/mcp_concurrency.py` that batches multiple MCP tool calls by their server prefix and runs them concurrently using `asyncio.gather`. Also properly handles tool results including `None`.

Also added new tasks to `agent_tasks.json` inspired by open standards (A2A Workflow Orchestrator, Realtime Guardrail Action Interceptor, and Context Engine Live Re-ranker) and set the task's status to "done". Tests were updated properly in `tests/test_mcp_concurrency.py`.

---
*PR created automatically by Jules for task [12256648185921720469](https://jules.google.com/task/12256648185921720469) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add concurrent MCP tool execution with per-server batching to `MCPConcurrentSkillExecutor`
> - Adds [`mcp_concurrency.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/319/files#diff-b77c907af979815f1f6cc222bd188c6f2dbf0abf2f19b68318c6ab103af1c5bf) with `MCPConcurrentSkillExecutor`, which groups tool calls by server prefix and runs all server batches concurrently via `asyncio.gather`.
> - Uses `mcp_client.execute_batch` when available; falls back to individual `execute_tool` or `execute` calls per tool.
> - Results are reconstructed in original call order, with duplicates and `None` values handled correctly via a sentinel.
> - Adds three async tests in [`test_mcp_concurrency.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/319/files#diff-5f1dc28a34199dd3dd8ae9fa6b1e30d970d82e406934628a244b7efac861ccb5) covering batched execution, individual fallback, and duplicate/None result mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4d786b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->