### PR TITLE
Implement A2A delegation v8

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5816,7 +5816,7 @@
     },
     {
       "id": "a2a-delegation-v8",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "A2A Delegation Protocol v8",
@@ -11275,6 +11275,57 @@
         "Context Engine correctly loads the re-ranker plugin.",
         "Working Memory entries are sorted by an urgency score.",
         "Tests verify correct ordering of mocked memory entries."
+      ]
+    },
+    {
+      "id": "dc1dd575-17d0-4d5c-b5f0-f40342a33ac6",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes-inspired Procedural Memory Generator",
+      "description": "Inspired by the Hermes Agent trend: Implement a procedural memory generator that converts multi-step success logs into reusable skill templates.",
+      "allowed_paths": [
+        "magda_agent/skills/procedural_generator.py",
+        "tests/test_procedural_generator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Generator parses success logs to build a skill template.",
+        "Tests verify the created template correctly captures the steps using mocks."
+      ]
+    },
+    {
+      "id": "0d904de7-29ce-4f8d-8baf-d7d3c6300df1",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Event Emitter",
+      "description": "Inspired by the OpenClaw live canvas telemetry trend: Implement a unified event emitter that aggregates agent state changes (planner, memory, execution) and streams them via WebSocket.",
+      "allowed_paths": [
+        "magda_agent/telemetry/live_event_emitter.py",
+        "tests/test_live_event_emitter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Event emitter broadcasts structured state changes via WebSocket.",
+        "Tests mock the WebSocket and verify JSON payload formats."
+      ]
+    },
+    {
+      "id": "bf068055-80e1-41b2-aa4a-52fe9ea89b41",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude-inspired Agent Teams Isolation",
+      "description": "Inspired by the Claude Agent Teams trend: Enhance the Subagent spawner to provision an isolated virtual workspace environment (mocking git worktree capabilities) for parallel agent executions.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_isolation.py",
+        "tests/test_agent_teams_isolation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents execute within an isolated workspace directory context.",
+        "Tests verify that file modifications in one subagent do not leak into another."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_delegation.py
+++ b/magda_agent/integration/a2a_delegation.py
@@ -22,6 +22,7 @@ class A2ADelegator:
         """
         Extracts sub-plans while preserving chronological order.
         Groups contiguous delegation steps for the same capability into sub-plans.
+        Enhancements for v8 include strict fallback handling if capability is missing.
 
         Args:
             plan: The full execution plan.
@@ -29,13 +30,14 @@ class A2ADelegator:
         Returns:
             A list of sub-plans (where each sub-plan is a dict containing capability and steps).
         """
-        sub_plans = []
-        current_capability = None
-        current_steps = []
+        sub_plans: list[Dict[str, Any]] = []
+        current_capability: str | None = None
+        current_steps: list[Dict[str, Any]] = []
 
         for step in plan:
             if step.get("skill") == "delegate_to_agent":
-                capability = step.get("skill_kwargs", {}).get("capability")
+                kwargs: Dict[str, Any] = step.get("skill_kwargs") or {}
+                capability: str | None = kwargs.get("capability")
                 if capability:
                     if capability == current_capability:
                         current_steps.append(step)
@@ -44,6 +46,12 @@ class A2ADelegator:
                             sub_plans.append({"capability": current_capability, "steps": current_steps})
                         current_capability = capability
                         current_steps = [step]
+                else:
+                    logging.warning(f"Delegation step {step.get('id', 'unknown')} is missing 'capability'. Ignoring for sub-plan.")
+                    if current_capability is not None:
+                        sub_plans.append({"capability": current_capability, "steps": current_steps})
+                        current_capability = None
+                        current_steps = []
             else:
                 if current_capability is not None:
                     sub_plans.append({"capability": current_capability, "steps": current_steps})

--- a/tests/test_a2a_delegation.py
+++ b/tests/test_a2a_delegation.py
@@ -104,6 +104,20 @@ async def test_a2a_delegator_split_plan(a2a_delegator):
     assert split[2]["capability"] == "coding"
 
 @pytest.mark.asyncio
+async def test_a2a_delegator_split_plan_missing_capability(a2a_delegator):
+    plan = [
+        {"id": "1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"},
+        {"id": "2", "skill": "delegate_to_agent", "skill_kwargs": {}, "description": "missing capability"},
+        {"id": "3", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "analysis"}, "description": "analyze it"}
+    ]
+    split = a2a_delegator.split_plan(plan)
+    assert len(split) == 2
+    assert split[0]["capability"] == "coding"
+    assert split[0]["steps"][0]["id"] == "1"
+    assert split[1]["capability"] == "analysis"
+    assert split[1]["steps"][0]["id"] == "3"
+
+@pytest.mark.asyncio
 @patch('httpx.AsyncClient.post', new_callable=AsyncMock)
 async def test_a2a_delegator_execute_plan(mock_post, a2a_delegator):
     plan = [


### PR DESCRIPTION
Implement A2A delegation v8 with robust capability extraction and tests.

---
*PR created automatically by Jules for task [6959722164455464379](https://jules.google.com/task/6959722164455464379) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `A2ADelegator.split_plan` to handle delegation steps missing a capability
> - When a `delegate_to_agent` step has no `capability`, `split_plan` now logs a warning, flushes any in-progress sub-plan to the result, and skips the invalid step instead of incorrectly continuing the current grouping.
> - Also tolerates `skill_kwargs` being `None` by defaulting to an empty dict.
> - A new test in [test_a2a_delegation.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/320/files#diff-aaef19c58ed00f96582ff19c938d1502ef202197388b383adaa5e8664e4d131d) covers the case where a capability-less step appears between two valid steps, asserting two sub-plans are returned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6b7bc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->