### PR TITLE
Implement Falco Prempti Audit Trail v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ procedural_memory_db/
 semantic_memory_db/
 metrics_db/
 metrics_db.sqlite3
+audit_trail.db

--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5903,7 +5903,7 @@
     },
     {
       "id": "falco-prempti-audit-trail-v1",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Falco Prempti Tool Audit Trail v1",
@@ -11520,6 +11520,42 @@
       "acceptance": [
         "Weights shift dynamically in response to mid-session emotion changes",
         "Tests verify immediate updates against simulated PAD shifts"
+      ]
+    },
+    {
+      "id": "613e37a3-5963-4d76-9acf-0454455f7e33",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Hermes-inspired Cron Background Tasks",
+      "description": "Inspired by Hermes Agent trend: Implement a Cron-like scheduler to allow the agent to run periodic background tasks like log cleanup, daily summaries, or status reports.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_tasks.py",
+        "tests/test_cron_tasks.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A background task scheduler can register and run periodic tasks.",
+        "Tasks run correctly at specified intervals.",
+        "Tests verify scheduling without invoking real delays."
+      ]
+    },
+    {
+      "id": "35b9f554-366b-4ea8-be3c-b2d2e32bda20",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "title": "OpenClaw Context Engine Metric Plugin",
+      "description": "Inspired by OpenClaw trend: Create a plugin for the ContextEngine that measures token usage and latency of memory retrievals, outputting to the new AuditTrail.",
+      "allowed_paths": [
+        "magda_agent/memory/metric_plugin.py",
+        "tests/test_metric_plugin.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin hooks into the ContextEngine correctly using lifecycle hooks.",
+        "Token usage and latency are logged accurately.",
+        "Tests verify the plugin logic."
       ]
     }
   ]

--- a/magda_agent/safety/audit_trail.py
+++ b/magda_agent/safety/audit_trail.py
@@ -1,5 +1,7 @@
 import time
 import copy
+import json
+import sqlite3
 from collections import deque
 from typing import Any, Deque, Dict, List, Optional
 
@@ -12,15 +14,44 @@ class AuditTrail:
     Inspired by Prempti (Falco).
     """
 
-    def __init__(self, max_capacity: int = 1000) -> None:
+    def __init__(self, max_capacity: int = 1000, db_path: Optional[str] = "audit_trail.db") -> None:
         """
-        Initializes the AuditTrail with a fixed capacity.
+        Initializes the AuditTrail with a fixed capacity and an SQLite database for persistence.
 
         Args:
-            max_capacity: Maximum number of entries to keep in the trail.
+            max_capacity: Maximum number of entries to keep in the in-memory trail.
+            db_path: Path to the SQLite database file. If None, only in-memory logging is used.
         """
         self.max_capacity = max_capacity
         self.trail: Deque[Dict[str, Any]] = deque(maxlen=max_capacity)
+        self.db_path = db_path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the SQLite database schema if a path is provided."""
+        if not self.db_path:
+            return
+
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    CREATE TABLE IF NOT EXISTS audit_logs (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp REAL NOT NULL,
+                        tool_name TEXT NOT NULL,
+                        kwargs TEXT NOT NULL,
+                        why TEXT NOT NULL,
+                        result TEXT NOT NULL,
+                        duration REAL NOT NULL
+                    )
+                    '''
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            import logging
+            logging.error(f"Failed to initialize SQLite audit database at {self.db_path}: {e}")
 
     def _sanitize(self, data: Any) -> Any:
         """
@@ -59,7 +90,7 @@ class AuditTrail:
 
     def log_call(self, tool_name: str, kwargs: Dict[str, Any], why: str, result: Any, duration: float = 0.0) -> None:
         """
-        Logs a tool call with metadata and sanitization.
+        Logs a tool call with metadata and sanitization, both in memory and to SQLite.
 
         Args:
             tool_name: Name of the tool or action.
@@ -68,19 +99,46 @@ class AuditTrail:
             result: Outcome of the execution or "allowed"/"blocked".
             duration: Time taken in seconds.
         """
+        timestamp = time.time()
+        sanitized_kwargs = self._sanitize(kwargs)
+        sanitized_result = self._sanitize(result)
+
         entry = {
-            "timestamp": time.time(),
+            "timestamp": timestamp,
             "tool_name": tool_name,
-            "kwargs": self._sanitize(kwargs),
+            "kwargs": sanitized_kwargs,
             "why": why,
-            "result": self._sanitize(result),
+            "result": sanitized_result,
             "duration": duration
         }
         self.trail.append(entry)
 
+        if self.db_path:
+            try:
+                with sqlite3.connect(self.db_path) as conn:
+                    cursor = conn.cursor()
+                    cursor.execute(
+                        '''
+                        INSERT INTO audit_logs (timestamp, tool_name, kwargs, why, result, duration)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        ''',
+                        (
+                            timestamp,
+                            tool_name,
+                            json.dumps(sanitized_kwargs),
+                            why,
+                            json.dumps(sanitized_result) if not isinstance(sanitized_result, str) else sanitized_result,
+                            duration
+                        )
+                    )
+                    conn.commit()
+            except sqlite3.Error as e:
+                import logging
+                logging.error(f"Failed to log to SQLite audit database at {self.db_path}: {e}")
+
     def query(self, tool_name: Optional[str] = None, start_time: Optional[float] = None, end_time: Optional[float] = None) -> List[Dict[str, Any]]:
         """
-        Queries the audit trail with optional filters.
+        Queries the audit trail with optional filters from the in-memory trail.
         """
         results = list(self.trail)
         if tool_name:
@@ -91,10 +149,72 @@ class AuditTrail:
             results = [e for e in results if e["timestamp"] <= end_time]
         return results
 
+    def query_db(self, tool_name: Optional[str] = None, start_time: Optional[float] = None, end_time: Optional[float] = None) -> List[Dict[str, Any]]:
+        """
+        Queries the audit trail from the SQLite database.
+        """
+        if not self.db_path:
+            return []
+
+        results = []
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                query = "SELECT timestamp, tool_name, kwargs, why, result, duration FROM audit_logs WHERE 1=1"
+                params = []
+
+                if tool_name:
+                    query += " AND tool_name = ?"
+                    params.append(tool_name)
+                if start_time is not None:
+                    query += " AND timestamp >= ?"
+                    params.append(start_time)
+                if end_time is not None:
+                    query += " AND timestamp <= ?"
+                    params.append(end_time)
+
+                cursor.execute(query, tuple(params))
+                rows = cursor.fetchall()
+
+                for row in rows:
+                    try:
+                        kwargs_dict = json.loads(row[2])
+                    except json.JSONDecodeError:
+                        kwargs_dict = row[2]
+
+                    try:
+                        result_obj = json.loads(row[4])
+                    except (json.JSONDecodeError, TypeError):
+                        result_obj = row[4]
+
+                    results.append({
+                        "timestamp": row[0],
+                        "tool_name": row[1],
+                        "kwargs": kwargs_dict,
+                        "why": row[3],
+                        "result": result_obj,
+                        "duration": row[5]
+                    })
+        except sqlite3.Error as e:
+            import logging
+            logging.error(f"Failed to query SQLite audit database at {self.db_path}: {e}")
+
+        return results
+
     def get_all(self) -> List[Dict[str, Any]]:
         """Returns all entries in the audit trail."""
         return list(self.trail)
 
     def clear(self) -> None:
-        """Clears all entries from the audit trail."""
+        """Clears all entries from the in-memory audit trail and the SQLite database."""
         self.trail.clear()
+
+        if self.db_path:
+            try:
+                with sqlite3.connect(self.db_path) as conn:
+                    cursor = conn.cursor()
+                    cursor.execute("DELETE FROM audit_logs")
+                    conn.commit()
+            except sqlite3.Error as e:
+                import logging
+                logging.error(f"Failed to clear SQLite audit database at {self.db_path}: {e}")

--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -1,10 +1,16 @@
 import pytest
 import time
+import os
 from magda_agent.safety.audit_trail import AuditTrail
 
-def test_audit_trail_log_call() -> None:
+@pytest.fixture
+def temp_db_path(tmp_path):
+    """Fixture to provide a temporary database path."""
+    return str(tmp_path / "test_audit_trail.db")
+
+def test_audit_trail_log_call(temp_db_path) -> None:
     """Test that log_call correctly appends an entry to the trail."""
-    trail_obj = AuditTrail()
+    trail_obj = AuditTrail(db_path=temp_db_path)
     trail_obj.log_call(
         tool_name="test_tool",
         kwargs={"arg1": "value1"},
@@ -22,9 +28,9 @@ def test_audit_trail_log_call() -> None:
     assert all_entries[0]["duration"] == 0.5
     assert "timestamp" in all_entries[0]
 
-def test_audit_trail_query() -> None:
+def test_audit_trail_query(temp_db_path) -> None:
     """Test that query correctly filters log entries."""
-    trail_obj = AuditTrail()
+    trail_obj = AuditTrail(db_path=temp_db_path)
     start_time = time.time()
 
     trail_obj.log_call("tool1", {}, "why1", "res1", 0.1)
@@ -41,9 +47,9 @@ def test_audit_trail_query() -> None:
     assert len(results) == 1
     assert results[0]["tool_name"] == "tool1"
 
-def test_audit_trail_sanitize() -> None:
+def test_audit_trail_sanitize(temp_db_path) -> None:
     """Test that sensitive data is correctly sanitized."""
-    trail_obj = AuditTrail()
+    trail_obj = AuditTrail(db_path=temp_db_path)
     sensitive_kwargs = {
         "password": "my_secret_password",
         "api_key": "1234567890",
@@ -89,9 +95,9 @@ def test_audit_trail_sanitize() -> None:
     entry2 = trail_obj.get_all()[1]
     assert entry2["kwargs"]["api_key"] == ["***", "***"]
 
-def test_audit_trail_bounded_capacity() -> None:
+def test_audit_trail_bounded_capacity(temp_db_path) -> None:
     """Test that the audit trail respects the maximum capacity."""
-    trail_obj = AuditTrail(max_capacity=5)
+    trail_obj = AuditTrail(max_capacity=5, db_path=temp_db_path)
     for i in range(10):
         trail_obj.log_call(f"tool_{i}", {}, "testing", "Success", 0.1)
 
@@ -100,10 +106,76 @@ def test_audit_trail_bounded_capacity() -> None:
     assert all_entries[0]["tool_name"] == "tool_5"
     assert all_entries[-1]["tool_name"] == "tool_9"
 
-def test_audit_trail_clear() -> None:
+def test_audit_trail_clear(temp_db_path) -> None:
     """Test that clear empties the logs."""
-    trail_obj = AuditTrail()
+    trail_obj = AuditTrail(db_path=temp_db_path)
     trail_obj.log_call("test_tool", {}, "testing", "Success", 0.1)
     assert len(trail_obj.get_all()) == 1
+
+    # Also verify SQLite DB has 1 entry
+    db_results = trail_obj.query_db()
+    assert len(db_results) == 1
+
+    trail_obj.clear()
+    assert len(trail_obj.get_all()) == 0
+
+    # Verify SQLite DB is empty
+    db_results_after_clear = trail_obj.query_db()
+    assert len(db_results_after_clear) == 0
+
+def test_audit_trail_sqlite_logging(temp_db_path) -> None:
+    """Test that log_call writes to the SQLite database correctly and query_db works."""
+    trail_obj = AuditTrail(db_path=temp_db_path)
+
+    start_time = time.time()
+    trail_obj.log_call(
+        tool_name="sqlite_tool",
+        kwargs={"test_key": "test_value"},
+        why="SQLite test",
+        result={"status": "ok"},
+        duration=0.5
+    )
+    time.sleep(0.01)
+    mid_time = time.time()
+    time.sleep(0.01)
+
+    trail_obj.log_call(
+        tool_name="sqlite_tool_2",
+        kwargs={"test_key": "test_value2"},
+        why="SQLite test 2",
+        result="Success String",
+        duration=0.3
+    )
+
+    db_entries = trail_obj.query_db()
+    assert len(db_entries) == 2
+
+    # Check serialization/deserialization
+    assert db_entries[0]["tool_name"] == "sqlite_tool"
+    assert db_entries[0]["kwargs"] == {"test_key": "test_value"}
+    assert db_entries[0]["why"] == "SQLite test"
+    assert db_entries[0]["result"] == {"status": "ok"}
+    assert db_entries[0]["duration"] == 0.5
+
+    assert db_entries[1]["tool_name"] == "sqlite_tool_2"
+    assert db_entries[1]["result"] == "Success String"
+
+    # Test query_db filters
+    filtered_entries = trail_obj.query_db(tool_name="sqlite_tool_2")
+    assert len(filtered_entries) == 1
+    assert filtered_entries[0]["tool_name"] == "sqlite_tool_2"
+
+    time_filtered_entries = trail_obj.query_db(start_time=start_time, end_time=mid_time)
+    assert len(time_filtered_entries) == 1
+    assert time_filtered_entries[0]["tool_name"] == "sqlite_tool"
+
+def test_audit_trail_no_db() -> None:
+    """Test that AuditTrail works normally when db_path is None."""
+    trail_obj = AuditTrail(db_path=None)
+    trail_obj.log_call("test_tool", {}, "testing", "Success", 0.1)
+
+    assert len(trail_obj.get_all()) == 1
+    assert trail_obj.query_db() == []
+
     trail_obj.clear()
     assert len(trail_obj.get_all()) == 0


### PR DESCRIPTION
Implemented the Falco Prempti Tool Audit Trail v1 task from agent_tasks.json. This updates the `AuditTrail` class in `magda_agent/safety/audit_trail.py` to support logging tool executions to a durable SQLite database while maintaining the in-memory deque. Included tests and added `.gitignore` entry to prevent committing the binary database file. Also appended 2 new trend-inspired tasks to agent_tasks.json.

---
*PR created automatically by Jules for task [4530333941909308538](https://jules.google.com/task/4530333941909308538) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SQLite persistence to `AuditTrail` for Falco Prempti audit logging
> - Extends [`AuditTrail`](https://github.com/kazah4359-lgtm/Magda-agent/pull/325/files#diff-09611c7012df8df111e8e9df04730bb2a5a3fe55039c456ba6230d44f4a838b3) with an optional `db_path` parameter (defaults to `"audit_trail.db"`) that initializes a SQLite `audit_logs` table on construction.
> - `log_call` now writes each sanitized entry to SQLite in addition to the existing in-memory deque; SQLite failures are logged but do not block in-memory logging.
> - Adds `query_db()` for persistent log retrieval with optional filters for `tool_name`, `start_time`, and `end_time`; `clear()` now also deletes all rows from SQLite.
> - New and updated tests in [`tests/test_audit_trail.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/325/files#diff-aa29599c3e8158d96083cb927d9f0c813be9caca8b8a22da4d1d711c4ceb3c13) cover SQLite write/read, deserialization, filtering, and `db_path=None` fallback behavior.
> - Behavioral Change: default instantiation of `AuditTrail` now creates a `audit_trail.db` file on disk unless `db_path=None` is passed explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad29044.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->