### PR TITLE
Implement Claude Evaluator Subagent with policy-based scoring

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -5921,7 +5921,7 @@
     },
     {
       "id": "claude-evaluator-subagent-85b14c3e",
-      "status": "todo",
+      "status": "done",
       "title": "Claude Evaluator Subagent",
       "area": "agents",
       "risk": "medium",

--- a/magda_agent/agents/evaluator_subagent.py
+++ b/magda_agent/agents/evaluator_subagent.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 from magda_agent.llm_client import LLMClient
 from magda_agent.memory.storage import MemorySystem
@@ -29,32 +29,39 @@ class EvaluatorSubagent:
             use_isolation=True
         )
 
-    async def evaluate_response(self, user_input: str, agent_response: str) -> Optional[Dict[str, Any]]:
+    async def evaluate_response(self, user_input: str, agent_response: str, policies: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
         """
         Evaluates the generated response using the LLM via SubAgent execute and stores the result in memory.
 
         Args:
             user_input: The user's original input message.
             agent_response: The agent's generated response to evaluate.
+            policies: Optional list of policies to evaluate against.
 
         Returns:
             The evaluation dictionary or None if evaluation fails.
         """
+        policy_str = ""
+        if policies:
+            policy_str = "\nEvaluate against these specific policies:\n" + "\n".join([f"- {p}" for p in policies])
+
         task = (
             "Evaluate the response given by an AI to a user's input.\n"
             "Score the response from 1 to 10 on the following criteria:\n"
             "- usefulness\n"
             "- accuracy\n"
             "- completeness\n"
-            "- emotional_adequacy\n\n"
+            "- emotional_adequacy\n"
+            f"{policy_str}\n\n"
             "Respond ONLY with a JSON object in this format:\n"
             "{\n"
             '  "usefulness": 8,\n'
             '  "accuracy": 9,\n'
             '  "completeness": 7,\n'
             '  "emotional_adequacy": 8,\n'
+            '  "policy_evaluations": {"policy_name": {"score": 8, "feedback": "reasoning"}},\n'
             '  "average_score": 8.0,\n'
-            '  "feedback": "A short sentence explaining the score"\n'
+            '  "feedback": "A short sentence explaining the overall score"\n'
             "}"
         )
 

--- a/tests/test_evaluator_subagent.py
+++ b/tests/test_evaluator_subagent.py
@@ -135,3 +135,26 @@ async def test_evaluate_response_retry_failure(evaluator_subagent):
 
     assert result is None
     assert evaluator_subagent.sub_agent.execute.call_count == 3
+
+@pytest.mark.asyncio
+async def test_evaluate_response_with_policies(evaluator_subagent):
+    evaluator_subagent.sub_agent.execute = AsyncMock()
+    mock_json_response = '''{
+      "usefulness": 8,
+      "accuracy": 8,
+      "completeness": 8,
+      "emotional_adequacy": 8,
+      "average_score": 8.0,
+      "feedback": "Policy check passed"
+    }'''
+    evaluator_subagent.sub_agent.execute.return_value = mock_json_response
+
+    policies = ["Be polite", "Be concise"]
+    await evaluator_subagent.evaluate_response("Hello", "Hi!", policies=policies)
+
+    # Verify that the task sent to sub_agent includes the policies
+    call_kwargs = evaluator_subagent.sub_agent.execute.call_args.kwargs
+    task_str = call_kwargs["task"]
+    assert "Evaluate against these specific policies:" in task_str
+    assert "- Be polite" in task_str
+    assert "- Be concise" in task_str


### PR DESCRIPTION
Modified `EvaluatorSubagent` in `magda_agent/agents/evaluator_subagent.py` to support scoring responses against a list of arbitrary policies, aligning with the Claude Agent SDK pattern. Updated the internal LLM prompt to return structured policy evaluations in the JSON result. Added corresponding test cases and verified compatibility with the existing triad orchestration flow. Marked the task as completed in the task manifest.

---
*PR created automatically by Jules for task [4460556923561775290](https://jules.google.com/task/4460556923561775290) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional policy-based scoring to `EvaluatorSubagent.evaluate_response`
> Extends `evaluate_response` in [evaluator_subagent.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/327/files#diff-dc9fc823c61ffc24fbfa5737e6ce8d53d36ab41677d6d4a94fc6dc7c6a38053b) to accept an optional `policies: List[str]` parameter. When provided, the policies are appended to the evaluation task instructions sent to the sub-agent, and the expected JSON response is updated to include a `policy_evaluations` object alongside the overall score. A new async test in [test_evaluator_subagent.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/327/files#diff-df86c8d9e7317be57c17869ba5b648ed8c882e434fb4bca74d786798734cd176) verifies that policies are correctly forwarded to `sub_agent.execute`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b328133.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->