### PR TITLE
feat: MCP Dynamic Tool Registration v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -41,6 +41,58 @@
   },
   "tasks": [
     {
+      "id": "mcp-concurrency-wrapper-v3",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Concurrency Wrapper v3",
+      "description": "Inspired by MCP runtime concurrency trend: Update ConcurrentSkillExecutor to natively handle asynchronous execution wrappers dynamically using the metadata provided by MCPDynamicRegistrarV2.",
+      "allowed_paths": [
+        "magda_agent/skills/concurrency_v3.py",
+        "tests/test_concurrency_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ConcurrentSkillExecutor correctly wraps async tools.",
+        "Tests verify synchronous and asynchronous MCP execution."
+      ]
+    },
+    {
+      "id": "a2a-distributed-telemetry-v7",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "A2A Distributed Telemetry v7",
+      "description": "Inspired by A2A standard trend: Create a module that collects sub-agent telemetry events and broadcasts them over the A2A network for distributed tracking.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_distributed_v7.py",
+        "tests/test_a2a_distributed_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry module tracks distributed events.",
+        "Tests mock A2A broadcasting and verify payload generation."
+      ]
+    },
+    {
+      "id": "virtual-context-manager-v2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Virtual Context Manager V2",
+      "description": "Inspired by MemGPT/Letta context management trend: Implement a context management unit that maintains fixed Working Memory bounds by transparently paging oldest items to Episodic Memory.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_v2.py",
+        "tests/test_virtual_context_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Working memory limits are enforced.",
+        "Oldest items are paged out properly.",
+        "Tests verify paging behavior upon token limit breach."
+      ]
+    },
+    {
       "id": "rool-transformation",
       "status": "done",
       "area": "cognition",
@@ -6057,7 +6109,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registration-v2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registration v2",

--- a/magda_agent/skills/mcp_dynamic_v2.py
+++ b/magda_agent/skills/mcp_dynamic_v2.py
@@ -1,0 +1,51 @@
+import logging
+from typing import Dict, Any
+
+from magda_agent.skills.mcp_registry import MCPRegistry
+
+
+class MCPDynamicRegistrarV2:
+    """
+    Endpoint for dynamically registering new MCP tools at runtime, specifically
+    handling async skills to support true runtime concurrency.
+    """
+
+    def __init__(self, registry: MCPRegistry) -> None:
+        """
+        Initialize the dynamic registrar V2.
+
+        Args:
+            registry (MCPRegistry): The existing MCP tool registry instance.
+        """
+        self.registry = registry
+
+    def register_tool_at_runtime(self, tool_schema: Dict[str, Any], is_async: bool = False) -> bool:
+        """
+        Dynamically registers a new MCP tool at runtime using the provided schema.
+
+        Args:
+            tool_schema (Dict[str, Any]): The MCP tool schema dictionary to register.
+            is_async (bool): If True, indicates the underlying execution will be asynchronous.
+                             Currently, it explicitly validates the schema for async readiness if needed.
+
+        Returns:
+            bool: True if the tool was registered successfully, False otherwise.
+        """
+        logging.info("Attempting to dynamically register MCP tool at runtime (V2).")
+
+        # Load the tool into the registry
+        success = self.registry.load_tool(tool_schema)
+
+        if success:
+            tool_name = tool_schema.get("name", "Unknown")
+
+            # Additional V2 logic: explicitly track or handle async designation in schema
+            # Although registry handles basic load, we tag it if we want to expose this metadata
+            # for ConcurrentSkillExecutor to optimize or for wrapper creation.
+            tool_schema["__is_async__"] = is_async
+
+            logging.info(f"Dynamically registered tool (V2): {tool_name}, is_async={is_async}")
+        else:
+            logging.error("Failed to dynamically register tool (V2).")
+
+        return success

--- a/tests/test_mcp_dynamic_v2.py
+++ b/tests/test_mcp_dynamic_v2.py
@@ -1,0 +1,54 @@
+import pytest
+from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.skills.mcp_dynamic_v2 import MCPDynamicRegistrarV2
+
+def test_register_tool_at_runtime_success_sync():
+    """Test successful dynamic registration of a synchronous MCP tool."""
+    registry = MCPRegistry()
+    registrar = MCPDynamicRegistrarV2(registry)
+
+    valid_schema = {
+        "name": "test_sync_tool",
+        "description": "A tool for testing sync behavior."
+    }
+
+    result = registrar.register_tool_at_runtime(valid_schema, is_async=False)
+
+    assert result is True
+    assert "test_sync_tool" in registry.list_tools()
+    tool = registry.get_tool("test_sync_tool")
+    assert tool["name"] == "test_sync_tool"
+    assert tool["__is_async__"] is False
+
+def test_register_tool_at_runtime_success_async():
+    """Test successful dynamic registration of an asynchronous MCP tool."""
+    registry = MCPRegistry()
+    registrar = MCPDynamicRegistrarV2(registry)
+
+    valid_schema = {
+        "name": "test_async_tool",
+        "description": "A tool for testing async behavior."
+    }
+
+    result = registrar.register_tool_at_runtime(valid_schema, is_async=True)
+
+    assert result is True
+    assert "test_async_tool" in registry.list_tools()
+    tool = registry.get_tool("test_async_tool")
+    assert tool["name"] == "test_async_tool"
+    assert tool["__is_async__"] is True
+
+def test_register_tool_at_runtime_failure():
+    """Test failing dynamic registration of an MCP tool due to invalid schema."""
+    registry = MCPRegistry()
+    registrar = MCPDynamicRegistrarV2(registry)
+
+    invalid_schema = {
+        "name": "invalid_tool"
+        # Missing description
+    }
+
+    result = registrar.register_tool_at_runtime(invalid_schema)
+
+    assert result is False
+    assert "invalid_tool" not in registry.list_tools()


### PR DESCRIPTION
Resolves the first "todo" task in `agent_tasks.json`: MCP Dynamic Tool Registration v2.

This PR introduces an updated endpoint (`MCPDynamicRegistrarV2`) for dynamically registering new MCP tools at runtime while specifically handling async skills by exposing the `__is_async__` capability tag on the tool schema. This provides the necessary foundation for the `ConcurrentSkillExecutor` to natively support runtime concurrency wrappers.

Additionally, `agent_tasks.json` has been updated with the completion of this task and 3 new tasks have been added based on current (June 2026) AI agent trends:
- MCP Concurrency Wrapper v3
- A2A Distributed Telemetry v7
- Virtual Context Manager V2

All tests pass. Type hints and docstrings are included. No external unpermitted files were modified.

---
*PR created automatically by Jules for task [5965814145328933111](https://jules.google.com/task/5965814145328933111) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPDynamicRegistrarV2` class for runtime MCP tool registration with async metadata tagging
> - Introduces [`MCPDynamicRegistrarV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/334/files#diff-fc0191f6b54ea5565ae881ebb0f657fd3035be588a6e6b68103795da8b2cd80a) with a `register_tool_at_runtime` method that loads a tool schema into an `MCPRegistry` instance and annotates it with an `__is_async__` flag on success.
> - Adds tests covering sync registration, async registration, and failure cases where invalid schemas are rejected and not persisted.
> - Updates `agent_tasks.json` with three new task entries and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52c256b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->