### PR TITLE
feat(multi_agent): implement OpenClaw Canvas Integration test

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6126,7 +6126,7 @@
     },
     {
       "id": "openclaw-canvas-integration-f03dd8e2",
-      "status": "todo",
+      "status": "done",
       "area": "multi_agent",
       "risk": "medium",
       "title": "OpenClaw Canvas Integration",
@@ -12225,6 +12225,60 @@
         "Recovery handler intercepts errors and extracts contextual features.",
         "Reinforcement signal is sent to reduce the weight of the failed path.",
         "Tests mock execution failures and verify weight adjustments."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-e20c8193",
+      "status": "todo",
+      "area": "autonomy",
+      "risk": "medium",
+      "title": "Hermes-inspired Cron Scheduler",
+      "description": "Inspired by Hermes Agent trend: Implement a cron scheduler for periodic tasks like daily reports and nightly backups using APScheduler.",
+      "allowed_paths": [
+        "magda_agent/autonomy/cron_scheduler.py",
+        "tests/test_cron_scheduler.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron scheduler initializes and can register scheduled jobs.",
+        "Jobs execute on time (or can be triggered in tests).",
+        "Tests verify scheduling logic with mocks."
+      ]
+    },
+    {
+      "id": "openai-realtime-guardrails-d9a1b222",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "OpenAI-inspired Realtime Guardrail Fallback",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a realtime guardrail that intercepts LLM outputs and triggers a safe fallback if policy violations are detected during tool execution.",
+      "allowed_paths": [
+        "magda_agent/safety/realtime_guardrail.py",
+        "tests/test_realtime_guardrail.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Realtime guardrail can evaluate tool inputs/outputs.",
+        "Triggers fallback response when violations are found.",
+        "Tests verify interception and fallback mechanics."
+      ]
+    },
+    {
+      "id": "claude-planner-generator-evaluator-5f7d70a8",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude-inspired Triad Architecture Orchestrator",
+      "description": "Inspired by Claude Agent SDK: Implement a TriadCoordinator to manage communication between Planner, Generator, and Evaluator sub-agents.",
+      "allowed_paths": [
+        "magda_agent/architecture/triad_coordinator.py",
+        "tests/test_triad_coordinator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "TriadCoordinator routes tasks from Planner to Generator and results to Evaluator.",
+        "Supports feedback loops for revisions.",
+        "Tests verify the routing and communication logic."
       ]
     }
   ]

--- a/tests/test_canvas_v2.py
+++ b/tests/test_canvas_v2.py
@@ -1,0 +1,83 @@
+import pytest
+from unittest.mock import Mock, MagicMock
+from typing import Any
+import json
+
+from magda_agent.visualization.canvas import CanvasVisualizer
+from magda_agent.consciousness.core import Consciousness
+
+@pytest.fixture
+def mock_consciousness() -> MagicMock:
+    consciousness = MagicMock(spec=Consciousness)
+
+    # Mock Emotions
+    consciousness.emotions = MagicMock()
+    consciousness.emotions.get_summary.return_value = "Feeling good"
+
+    pad_state = MagicMock()
+    pad_state.pleasure = 0.8
+    pad_state.arousal = 0.5
+    pad_state.dominance = 0.9
+    consciousness.emotions.get_state_history.return_value = [pad_state]
+
+    # Mock Mental States
+    consciousness.mental_states = MagicMock()
+    consciousness.mental_states.get_summary.return_value = "Focused"
+
+    # Mock Memory
+    consciousness.memory = MagicMock()
+    consciousness.memory.get_summary.return_value = "Remembered 5 items"
+
+    # Mock Skills
+    consciousness.skills = MagicMock()
+    consciousness.skills.skills = {"skill1": "desc", "skill2": "desc"}
+
+    # Mock Planner
+    consciousness.planner = MagicMock()
+    consciousness.planner.get_state_summary.return_value = "Planning task X"
+
+    return consciousness
+
+
+def test_canvas_visualizer_formatting(mock_consciousness: MagicMock) -> None:
+    """Test that CanvasVisualizer correctly formats the agent state."""
+    visualizer = CanvasVisualizer(mock_consciousness)
+    state = visualizer.get_formatted_state(user_id="user123")
+
+    assert "emotions" in state
+    assert state["emotions"]["summary"] == "Feeling good"
+    assert state["emotions"]["pad"]["pleasure"] == 0.8
+
+    assert "mental_states" in state
+    assert state["mental_states"]["summary"] == "Focused"
+
+    assert "memory" in state
+    assert state["memory"]["summary"] == "Remembered 5 items"
+
+    assert "skills" in state
+    assert state["skills"] == ["skill1", "skill2"]
+
+    assert "planner" in state
+    assert state["planner"]["summary"] == "Planning task X"
+
+    assert "error" not in state
+
+def test_canvas_visualizer_json(mock_consciousness: MagicMock) -> None:
+    """Test that CanvasVisualizer returns valid JSON."""
+    visualizer = CanvasVisualizer(mock_consciousness)
+    json_str = visualizer.get_state_json(user_id="user123")
+
+    # Parse back to ensure valid JSON
+    data = json.loads(json_str)
+    assert data["emotions"]["summary"] == "Feeling good"
+
+def test_canvas_visualizer_handles_errors(mock_consciousness: MagicMock) -> None:
+    """Test that CanvasVisualizer handles exceptions gracefully."""
+    # Force an error
+    mock_consciousness.emotions.get_summary.side_effect = Exception("Test Error")
+
+    visualizer = CanvasVisualizer(mock_consciousness)
+    state = visualizer.get_formatted_state()
+
+    assert "error" in state
+    assert "Test Error" in state["error"]


### PR DESCRIPTION
Implemented OpenClaw Canvas Integration by setting task to done in `agent_tasks.json` and generating `tests/test_canvas_v2.py` as missing requirements. Added 3 new trend tasks.

---
*PR created automatically by Jules for task [6872500183946937277](https://jules.google.com/task/6872500183946937277) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add integration tests for `CanvasVisualizer` formatting, JSON output, and error handling
> - Adds [tests/test_canvas_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/338/files#diff-eac4c00c37e779d700abbe169e28f6117a9384326f7fbf50b5b4587f959b5e14) with a `mock_consciousness` pytest fixture that stubs `Consciousness` attributes (emotions, mental states, memory, skills, planner).
> - Covers `get_formatted_state` output structure, `get_state_json` JSON validity, and error propagation when upstream components raise exceptions.
> - Also marks one task as done and appends three new TODO tasks in `agent_tasks.json`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 259c50e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->