### PR TITLE
feat: Implement Claude SDK Git Worktree Isolation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6143,7 +6143,7 @@
     },
     {
       "id": "claude-team-isolation-e8e2a610",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "high",
       "title": "Claude SDK Git Worktree Isolation",
@@ -12279,6 +12279,57 @@
         "TriadCoordinator routes tasks from Planner to Generator and results to Evaluator.",
         "Supports feedback loops for revisions.",
         "Tests verify the routing and communication logic."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-compression-001",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude SDK Subagent Context Compression",
+      "description": "Inspired by Claude Agent SDK Subagent spawning and context compression trend. Implement a context compression wrapper before delegating subtasks to minimize tokens.",
+      "allowed_paths": [
+        "magda_agent/agents/context_compression.py",
+        "tests/test_context_compression_wrapper.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context wrapper intercepts subagent payload and shrinks it according to token limits.",
+        "Tests verify correct context reduction."
+      ]
+    },
+    {
+      "id": "mcp-agent-tools-action-concurrency-002",
+      "status": "todo",
+      "area": "execution",
+      "risk": "high",
+      "title": "OpenAI Agents SDK Action Tools Concurrency",
+      "description": "Inspired by OpenAI Agents SDK Runtime function tool concurrency and MCP Server Prefixes. Implement safe concurrent execution dispatcher for external action tools.",
+      "allowed_paths": [
+        "magda_agent/execution/concurrent_dispatcher.py",
+        "tests/test_concurrent_dispatcher.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Concurrent execution safely wraps and isolates multiple MCP action tools.",
+        "Tests verify reduced execution time via mocked asyncio gather."
+      ]
+    },
+    {
+      "id": "hermes-agent-quality-metric-sync-003",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Agent Longitudinal Tracking Synchronization",
+      "description": "Inspired by Hermes Agent and SWE-Bench Longitudinal metrics. Implement a sync service that flushes quality tracking SQLite metrics to an external endpoint via the Channel Hub periodically.",
+      "allowed_paths": [
+        "magda_agent/operations/metrics_sync.py",
+        "tests/test_metrics_sync.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sync service reads and securely formats quality metrics.",
+        "Tests verify correct formatting and mocked endpoint delivery."
       ]
     }
   ]

--- a/magda_agent/architecture/worktree_isolation.py
+++ b/magda_agent/architecture/worktree_isolation.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from typing import Optional, List, Dict, Any
+
+class WorktreeIsolator:
+    """
+    Manages isolated git worktrees for individual sub-agents running locally.
+    Provides isolation logic so multiple sub-agents can work without cross-contamination.
+    Inspired by Claude Agent SDK trend.
+    """
+
+    def __init__(self, base_dir: str = "/tmp/magda_worktree_isolation") -> None:
+        """
+        Initialize the WorktreeIsolator.
+
+        Args:
+            base_dir (str): Base directory where worktrees will be created.
+        """
+        self.base_dir = base_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.active_worktrees: Dict[str, str] = {}
+
+    async def isolate_agent(self, agent_id: str, branch_name: Optional[str] = None) -> str:
+        """
+        Creates an isolated git worktree for an agent.
+
+        Args:
+            agent_id (str): A unique identifier for the agent.
+            branch_name (Optional[str]): A branch name to create for the agent, defaults to detached HEAD.
+
+        Returns:
+            str: Path to the newly created worktree.
+        """
+        unique_suffix = str(uuid.uuid4())[:8]
+        env_path = os.path.join(self.base_dir, f"subagent_{agent_id}_{unique_suffix}")
+
+        if branch_name:
+            cmd = ["git", "worktree", "add", "-b", branch_name, env_path, "HEAD"]
+        else:
+            cmd = ["git", "worktree", "add", "-d", env_path, "HEAD"]
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                error_msg = stderr.decode().strip()
+                logging.error(f"Failed to create git worktree: {error_msg}")
+                raise RuntimeError(f"Git worktree creation failed: {error_msg}")
+
+            logging.info(f"Agent {agent_id} worktree created at {env_path}")
+            self.active_worktrees[agent_id] = env_path
+            return env_path
+        except Exception as e:
+            logging.error(f"Error during worktree creation for {agent_id}: {e}")
+            raise
+
+    async def cleanup_agent(self, agent_id: str) -> None:
+        """
+        Removes the git worktree associated with an agent.
+
+        Args:
+            agent_id (str): The unique identifier of the agent.
+        """
+        env_path = self.active_worktrees.get(agent_id)
+        if not env_path:
+            logging.warning(f"No active worktree found for agent {agent_id}")
+            return
+
+        cmd = ["git", "worktree", "remove", "--force", env_path]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                logging.error(f"Failed to cleanly remove git worktree for {agent_id}: {stderr.decode().strip()}")
+            else:
+                logging.info(f"Successfully removed worktree for {agent_id}")
+        except Exception as e:
+            logging.error(f"Error removing worktree for {agent_id}: {e}")
+        finally:
+            if os.path.exists(env_path):
+                try:
+                    shutil.rmtree(env_path)
+                except Exception as ex:
+                    logging.error(f"Could not delete worktree folder for {agent_id}: {ex}")
+            self.active_worktrees.pop(agent_id, None)
+
+
+    async def cleanup_all(self) -> None:
+        """
+        Removes all active worktrees.
+        """
+        agents_to_cleanup = list(self.active_worktrees.keys())
+        for agent_id in agents_to_cleanup:
+            await self.cleanup_agent(agent_id)

--- a/tests/test_worktree_isolation.py
+++ b/tests/test_worktree_isolation.py
@@ -1,0 +1,34 @@
+import pytest
+import os
+import shutil
+import asyncio
+from unittest.mock import patch, MagicMock
+
+from magda_agent.architecture.worktree_isolation import WorktreeIsolator
+
+@pytest.mark.asyncio
+async def test_worktree_isolation():
+    isolator = WorktreeIsolator()
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        # Mock successful git worktree add
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+
+        future = asyncio.Future()
+        future.set_result((b"ok", b""))
+        mock_process.communicate.return_value = future
+        mock_exec.return_value = mock_process
+
+        path = await isolator.isolate_agent("test_agent", "test_branch")
+
+        assert "test_agent" in isolator.active_worktrees
+        assert path == isolator.active_worktrees["test_agent"]
+        assert mock_exec.call_count == 1
+
+        # Test clean up
+        with patch("shutil.rmtree") as mock_rmtree, patch("os.path.exists", return_value=True):
+            await isolator.cleanup_agent("test_agent")
+            assert "test_agent" not in isolator.active_worktrees
+            assert mock_exec.call_count == 2
+            mock_rmtree.assert_called_once_with(path)


### PR DESCRIPTION
Implement the Claude SDK Git Worktree Isolation task.
- Created `WorktreeIsolator` in `magda_agent/architecture/worktree_isolation.py`.
- Wrote async unit tests `tests/test_worktree_isolation.py` mocking out git calls.
- Resolved all dependency issues (installed pytest-asyncio and requirements.txt) and made sure tests pass.
- Updated `agent_tasks.json` by marking task as done and adding 3 new trend tasks.

---
*PR created automatically by Jules for task [16428455481950227358](https://jules.google.com/task/16428455481950227358) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WorktreeIsolator` class to manage isolated git worktrees for sub-agents
> - Adds [worktree_isolation.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/339/files#diff-3a05f3584bd4c7374f14aa4e204cbb6a9446c15c42fc820d0e565134bc0f812f) with a `WorktreeIsolator` class that creates, tracks, and removes isolated git worktrees for agents using async subprocess calls.
> - `isolate_agent` creates a unique worktree per agent (optionally on a named branch or detached HEAD) and records the path; `cleanup_agent` removes it via `git worktree remove --force` and `shutil.rmtree`.
> - `cleanup_all` bulk-removes all tracked worktrees by iterating a snapshot of active agent IDs.
> - Adds async pytest coverage in [test_worktree_isolation.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/339/files#diff-41de12a6335aecfb51b8a2d75f53b6db582137d0fab6e4c1e8b74c4d71703622) using mocked subprocess and filesystem calls.
> - Risk: worktree creation failures raise `RuntimeError` propagated to callers; cleanup failures are logged but do not raise, so leaked worktrees are possible if git and filesystem removal both fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05b6fb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->