### PR TITLE
feat: implement AgentSkills to MCP Converter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6160,7 +6160,7 @@
     },
     {
       "id": "agentskills-mcp-converter-7a0a55ff",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "AgentSkills to MCP Converter",
@@ -12330,6 +12330,58 @@
       "acceptance": [
         "Sync service reads and securely formats quality metrics.",
         "Tests verify correct formatting and mocked endpoint delivery."
+      ]
+    },
+    {
+      "id": "hermes-multi-agent-orchestrator-7c1bc17a",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Hermes Multi-Agent Orchestrator",
+      "description": "Inspired by Hermes Agent trend. Implement a multi-agent orchestrator that supports multiple sub-agents dynamically scaling up for parallel processing.",
+      "allowed_paths": [
+        "magda_agent/agents/orchestrator.py",
+        "tests/test_orchestrator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Orchestrator manages the lifecycle of dynamically scaled sub-agents.",
+        "Tests verify that sub-agents can run parallel tasks efficiently using asyncio.",
+        "Included a timeout safety mechanism."
+      ]
+    },
+    {
+      "id": "claude-sdk-agent-teams-isolation-v3-7cc94aca",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude SDK Agent Teams Worktree v3",
+      "description": "Inspired by Claude Agent SDK Agent Teams. Add a new isolated workspace provisioner for sub-agents to avoid overlapping git state changes.",
+      "allowed_paths": [
+        "magda_agent/isolation/workspace_provisioner.py",
+        "tests/test_workspace_provisioner.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Workspace provisioner clones and sets up isolated repositories for sub-agents.",
+        "Tests verify isolated operations without cross-contamination."
+      ]
+    },
+    {
+      "id": "openclaw-rl-interactive-learner-v7-37436a23",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Interactive Learner v7",
+      "description": "Inspired by OpenClaw online reinforcement learning trend. Add an interactive reinforcement learning agent that processes delayed implicit feedback over conversation traces.",
+      "allowed_paths": [
+        "magda_agent/learning/interactive_learner_v7.py",
+        "tests/test_interactive_learner_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Learner correctly processes multi-turn conversation traces and identifies PAD shifts.",
+        "Tests mock interactions and verify weight updates based on the trace history."
       ]
     }
   ]

--- a/magda_agent/integration/agentskills_mcp.py
+++ b/magda_agent/integration/agentskills_mcp.py
@@ -1,0 +1,71 @@
+from typing import Dict, Any, List
+import uuid
+
+class AgentSkillsMCPConverter:
+    """
+    Converter to export legacy Magda skills (agentskills.io format) to standard MCP JSON-RPC.
+    """
+
+    @staticmethod
+    def convert_to_mcp_tool(skill: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Converts a single skill dictionary from agentskills.io format to MCP tool format.
+
+        Args:
+            skill: A dictionary representing an agentskills tool (contains 'parameters').
+
+        Returns:
+            A dictionary representing an MCP tool (contains 'inputSchema').
+        """
+        mcp_tool = {
+            "name": skill.get("name", ""),
+            "description": skill.get("description", ""),
+        }
+
+        # In agentskills, it's 'parameters'. In MCP, it's 'inputSchema'.
+        if "parameters" in skill:
+            mcp_tool["inputSchema"] = skill["parameters"]
+        elif "inputSchema" in skill:
+            # Fallback if it's already in MCP format
+            mcp_tool["inputSchema"] = skill["inputSchema"]
+        else:
+            mcp_tool["inputSchema"] = {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+
+        return mcp_tool
+
+    @staticmethod
+    def convert_all(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Converts a list of skills from agentskills.io format to MCP tool format.
+
+        Args:
+            skills: A list of dictionaries representing agentskills tools.
+
+        Returns:
+            A list of dictionaries representing MCP tools.
+        """
+        return [AgentSkillsMCPConverter.convert_to_mcp_tool(skill) for skill in skills]
+
+    @staticmethod
+    def create_jsonrpc_request(method_name: str, params: Dict[str, Any], req_id: str = None) -> Dict[str, Any]:
+        """
+        Creates a JSON-RPC 2.0 request payload.
+
+        Args:
+            method_name: The name of the method to call.
+            params: The parameters for the method call.
+            req_id: An optional request ID. If None, a UUID will be generated.
+
+        Returns:
+            A JSON-RPC 2.0 request dictionary.
+        """
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id or str(uuid.uuid4()),
+            "method": method_name,
+            "params": params
+        }

--- a/tests/test_agentskills_mcp.py
+++ b/tests/test_agentskills_mcp.py
@@ -1,0 +1,102 @@
+import pytest
+from magda_agent.integration.agentskills_mcp import AgentSkillsMCPConverter
+
+def test_convert_to_mcp_tool_with_parameters():
+    """Test converting a skill with 'parameters' mapping to 'inputSchema'."""
+    agentskills_tool = {
+        "name": "test_skill",
+        "description": "A test skill.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "arg1": {"type": "string"}
+            },
+            "required": ["arg1"]
+        }
+    }
+
+    mcp_tool = AgentSkillsMCPConverter.convert_to_mcp_tool(agentskills_tool)
+
+    assert mcp_tool["name"] == "test_skill"
+    assert mcp_tool["description"] == "A test skill."
+    assert "inputSchema" in mcp_tool
+    assert "parameters" not in mcp_tool
+    assert mcp_tool["inputSchema"] == agentskills_tool["parameters"]
+
+def test_convert_to_mcp_tool_with_inputschema_fallback():
+    """Test converting a skill that already uses 'inputSchema'."""
+    tool = {
+        "name": "test_skill",
+        "description": "A test skill.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "arg1": {"type": "string"}
+            },
+            "required": ["arg1"]
+        }
+    }
+
+    mcp_tool = AgentSkillsMCPConverter.convert_to_mcp_tool(tool)
+
+    assert mcp_tool["name"] == "test_skill"
+    assert mcp_tool["inputSchema"] == tool["inputSchema"]
+
+def test_convert_to_mcp_tool_missing_schema():
+    """Test converting a skill missing schema definition."""
+    tool = {
+        "name": "test_skill",
+        "description": "A test skill."
+    }
+
+    mcp_tool = AgentSkillsMCPConverter.convert_to_mcp_tool(tool)
+
+    assert mcp_tool["name"] == "test_skill"
+    assert "inputSchema" in mcp_tool
+    assert mcp_tool["inputSchema"] == {
+        "type": "object",
+        "properties": {},
+        "required": []
+    }
+
+def test_convert_all():
+    """Test converting a list of skills."""
+    agentskills_tools = [
+        {
+            "name": "tool1",
+            "description": "Tool 1",
+            "parameters": {"type": "object", "properties": {}}
+        },
+        {
+            "name": "tool2",
+            "description": "Tool 2",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    ]
+
+    mcp_tools = AgentSkillsMCPConverter.convert_all(agentskills_tools)
+
+    assert len(mcp_tools) == 2
+    assert mcp_tools[0]["name"] == "tool1"
+    assert mcp_tools[0]["inputSchema"] == agentskills_tools[0]["parameters"]
+    assert mcp_tools[1]["name"] == "tool2"
+    assert mcp_tools[1]["inputSchema"] == agentskills_tools[1]["parameters"]
+
+def test_create_jsonrpc_request_with_req_id():
+    """Test creating a JSON-RPC request with a specified ID."""
+    req = AgentSkillsMCPConverter.create_jsonrpc_request("my_method", {"arg": 1}, req_id="test-id")
+
+    assert req["jsonrpc"] == "2.0"
+    assert req["id"] == "test-id"
+    assert req["method"] == "my_method"
+    assert req["params"] == {"arg": 1}
+
+def test_create_jsonrpc_request_without_req_id():
+    """Test creating a JSON-RPC request without a specified ID generates a UUID."""
+    req = AgentSkillsMCPConverter.create_jsonrpc_request("my_method", {"arg": 1})
+
+    assert req["jsonrpc"] == "2.0"
+    assert "id" in req
+    assert isinstance(req["id"], str)
+    assert req["method"] == "my_method"
+    assert req["params"] == {"arg": 1}


### PR DESCRIPTION
Implemented the AgentSkills to MCP Converter module to bridge legacy Magda skills with standard MCP clients.

**Changes:**
- Created `magda_agent/integration/agentskills_mcp.py` featuring `AgentSkillsMCPConverter` with `convert_to_mcp_tool`, `convert_all`, and `create_jsonrpc_request`.
- Created robust test suite at `tests/test_agentskills_mcp.py` testing parameters to inputSchema fallback and UUID generation.
- Marked `agentskills-mcp-converter-7a0a55ff` as done in `agent_tasks.json`.
- Added 3 new high-priority backlog tasks inspired by trends.md (Hermes Multi-Agent Orchestrator, Claude SDK Worktree Isolation v3, OpenClaw Interactive Learner v7).
- Fixed missing test dependencies and ensured full pytest suite execution.

**Testing:**
- Run `pytest tests/test_agentskills_mcp.py` locally.
- Full `pytest tests/` passes successfully.

---
*PR created automatically by Jules for task [10585632371623912270](https://jules.google.com/task/10585632371623912270) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AgentSkillsMCPConverter` to convert agentskills.io tools to MCP format
> - Adds [agentskills_mcp.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/340/files#diff-d344fd784f6dd93cd2e02116663abd9e8aac1bd173390edbfe26d93643b2afa2) with a new `AgentSkillsMCPConverter` class containing static methods for converting agentskills-format tool dicts to MCP tool dicts and building JSON-RPC 2.0 request payloads.
> - `convert_to_mcp_tool` maps `parameters` to `inputSchema`, falls back to an existing `inputSchema`, or defaults to an empty object schema with `properties={}` and `required=[]`.
> - `create_jsonrpc_request` constructs a JSON-RPC 2.0 dict and auto-generates a UUID v4 `id` when none is provided.
> - Tests in [test_agentskills_mcp.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/340/files#diff-93db0ec1521a25ea416eb39febef56b9415b5d32e1b0b4340dcf58c28efba9b2) cover all three schema-mapping paths, bulk conversion, and both explicit and auto-generated request IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3be8c7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->