### PR TITLE
Implement Online Feedback RL and Verify MCP Exporter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6177,7 +6177,7 @@
     },
     {
       "id": "mcp-action-tool-exporter-v1-af26a87c",
-      "status": "todo",
+      "status": "done",
       "title": "MCP Action Tool Exporter",
       "area": "integration",
       "risk": "medium",
@@ -6194,7 +6194,7 @@
     },
     {
       "id": "online-rl-user-feedback-v1-cf2a4ca2",
-      "status": "todo",
+      "status": "done",
       "title": "Online RL from User Feedback",
       "area": "learning",
       "risk": "high",

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -31,6 +31,7 @@ from magda_agent.learning.online_rl import OnlineRLIntegrator
 from magda_agent.learning.openclaw_rl_v5 import OnlineRLIntegrator as OpenClawRLV5Integrator
 from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
 from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
+from magda_agent.learning.online_feedback_rl import OnlineFeedbackRL
 from magda_agent.learning.feedback_loop import FeedbackLoop
 from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
@@ -110,6 +111,7 @@ class Consciousness:
         self.online_rl_v6 = online_rl_v6
         self.dialogue_online_learner_v3 = dialogue_online_learner_v3
         self.openclaw_rl = openclaw_rl
+        self.online_feedback_rl = OnlineFeedbackRL(habit_tracker, mirror_neurons) if habit_tracker and mirror_neurons else None
         self.feedback_loop = feedback_loop
         self.guardrail = guardrail
         self.tracer = tracer
@@ -166,6 +168,13 @@ class Consciousness:
                 last_context,
                 user_id,
                 skills_used=skills_used
+            )
+        if self.online_feedback_rl:
+            await self.online_feedback_rl.process_feedback(
+                user_input,
+                last_context,
+                skills_used=skills_used,
+                user_id=user_id
             )
         if self.online_rl_v6:
             await self.online_rl_v6.adjust_behavior(user_input, last_context, user_id)

--- a/magda_agent/learning/online_feedback_rl.py
+++ b/magda_agent/learning/online_feedback_rl.py
@@ -1,0 +1,61 @@
+import logging
+import json
+from typing import Optional, Dict, List
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+class OnlineFeedbackRL:
+    """
+    Updates tool execution weights based on user feedback.
+    Inspired by OpenClaw trends: Online learning from interactions.
+    """
+    def __init__(self, habit_tracker: HabitTracker, mirror_neurons: MirrorNeurons) -> None:
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+        self.skill_weights: Dict[str, float] = {}
+
+    async def process_feedback(
+        self,
+        user_reply: str,
+        action_context: str,
+        skills_used: List[str],
+        user_id: Optional[int] = None
+    ) -> None:
+        """
+        Parses user feedback and adjusts weights for the skills used.
+        """
+        if not user_reply or not skills_used:
+            return
+
+        # Implicit feedback via sentiment analysis
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_reply)
+
+        # Heuristic: convert PAD shift to a scalar reward [0, 10]
+        # P shift of 1.0 -> 10.0, P shift of -1.0 -> 0.0
+        reward = (p_shift + 1.0) * 5.0
+
+        logging.info(f"OnlineFeedbackRL: Received feedback '{user_reply[:30]}...', reward: {reward:.2f}")
+
+        for skill in skills_used:
+            if skill not in self.skill_weights:
+                self.skill_weights[skill] = 1.0
+
+            if reward >= 7.0:
+                # Reinforce
+                self.skill_weights[skill] += 0.1
+                # Also record in habit tracker if strongly positive
+                if reward >= 8.5:
+                    self.habit_tracker.record_usage(
+                        input_text=action_context,
+                        skill_used=skill,
+                        evaluation_score=reward,
+                        user_id=user_id
+                    )
+            elif reward <= 3.0:
+                # Penalize
+                self.skill_weights[skill] = max(0.1, self.skill_weights[skill] - 0.2)
+
+            logging.info(f"OnlineFeedbackRL: Updated weight for {skill}: {self.skill_weights[skill]:.2f}")
+
+    def get_skill_weight(self, skill_name: str) -> float:
+        return self.skill_weights.get(skill_name, 1.0)

--- a/tests/test_mcp_exporter.py
+++ b/tests/test_mcp_exporter.py
@@ -19,6 +19,13 @@ def registry() -> SkillRegistry:
 
     reg.register_skill("dummy_skill", dummy_skill, "A dummy async skill")
     reg.register_skill("dummy_sync_skill", dummy_sync_skill, "A dummy sync skill")
+
+    def complex_skill(a: int, b: float, c: bool, d: list, e: dict, f: str = "default"):
+        """A skill with complex types."""
+        return "complex"
+
+    reg.register_skill("complex_skill", complex_skill, "A skill with complex types")
+
     return reg
 
 @pytest.fixture
@@ -29,10 +36,26 @@ def exporter(registry: SkillRegistry) -> MCPExporter:
 def test_export_tools(exporter: MCPExporter) -> None:
     """Tests if tools are correctly exported via the adapter."""
     tools: List[Dict[str, Any]] = exporter.export_tools()
-    assert len(tools) == 2
+    assert len(tools) == 3
     names: List[str] = [t["name"] for t in tools]
     assert "dummy_skill" in names
     assert "dummy_sync_skill" in names
+    assert "complex_skill" in names
+
+    # Verify complex_skill schema
+    complex_tool = next(t for t in tools if t["name"] == "complex_skill")
+    schema = complex_tool["inputSchema"]
+    assert schema["type"] == "object"
+    props = schema["properties"]
+    assert props["a"]["type"] == "integer"
+    assert props["b"]["type"] == "number"
+    assert props["c"]["type"] == "boolean"
+    assert props["d"]["type"] == "array"
+    assert props["e"]["type"] == "object"
+    assert props["f"]["type"] == "string"
+
+    assert "a" in schema["required"]
+    assert "f" not in schema["required"]
 
 @pytest.mark.asyncio
 async def test_handle_rpc_request_success(exporter: MCPExporter) -> None:

--- a/tests/test_online_feedback_rl.py
+++ b/tests/test_online_feedback_rl.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.learning.online_feedback_rl import OnlineFeedbackRL
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+@pytest.fixture
+def mock_habit_tracker():
+    return MagicMock(spec=HabitTracker)
+
+@pytest.fixture
+def mock_mirror_neurons():
+    return MagicMock(spec=MirrorNeurons)
+
+@pytest.mark.asyncio
+async def test_process_feedback_positive(mock_habit_tracker, mock_mirror_neurons):
+    # P shift 0.8 -> Reward (0.8 + 1.0) * 5 = 9.0
+    mock_mirror_neurons.empathize.return_value = (0.8, 0.0, 0.0)
+    rl = OnlineFeedbackRL(mock_habit_tracker, mock_mirror_neurons)
+
+    await rl.process_feedback("Awesome!", "context", ["test_skill"], user_id=123)
+
+    assert rl.get_skill_weight("test_skill") == 1.1
+    mock_habit_tracker.record_usage.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_process_feedback_negative(mock_habit_tracker, mock_mirror_neurons):
+    # P shift -0.6 -> Reward (-0.6 + 1.0) * 5 = 2.0
+    mock_mirror_neurons.empathize.return_value = (-0.6, 0.0, 0.0)
+    rl = OnlineFeedbackRL(mock_habit_tracker, mock_mirror_neurons)
+
+    await rl.process_feedback("Bad.", "context", ["test_skill"])
+
+    assert rl.get_skill_weight("test_skill") == 0.8
+    mock_habit_tracker.record_usage.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_multiple_skills(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (0.5, 0.0, 0.0) # Reward 7.5
+    rl = OnlineFeedbackRL(mock_habit_tracker, mock_mirror_neurons)
+
+    await rl.process_feedback("OK", "context", ["skill1", "skill2"])
+
+    assert rl.get_skill_weight("skill1") == 1.1
+    assert rl.get_skill_weight("skill2") == 1.1
+    # Habit tracker only called for >= 8.5
+    mock_habit_tracker.record_usage.assert_not_called()


### PR DESCRIPTION
This PR completes two key tasks for the Magdalina AGI agent:

1.  **Online RL from User Feedback (`online-rl-user-feedback-v1-cf2a4ca2`):**
    *   Created a new `OnlineFeedbackRL` module in `magda_agent/learning/online_feedback_rl.py`.
    *   This module uses `MirrorNeurons` to perform sentiment analysis (PAD model) on user replies.
    *   It translates emotional shifts into rewards to dynamically adjust the weights of recently used skills.
    *   Integrates with `HabitTracker` to reinforce highly positive interactions.
    *   The `Consciousness` loop now triggers this learning process after receiving user input.

2.  **MCP Action Tool Exporter Verification (`mcp-action-tool-exporter-v1-af26a87c`):**
    *   Verified the existing `MCPExporter` logic.
    *   Expanded `tests/test_mcp_exporter.py` with complex type signatures (int, float, bool, list, dict) to ensure robust JSON-RPC schema generation.
    *   Confirmed that the exporter correctly maps Python types to MCP-compatible schemas.

All changes have been verified with a total of 10 unit tests, and the task manifest was validated.

---
*PR created automatically by Jules for task [16920758087530899573](https://jules.google.com/task/16920758087530899573) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `OnlineFeedbackRL` for skill weight adjustment based on user feedback
> - Adds [`OnlineFeedbackRL`](https://github.com/kazah4359-lgtm/Magda-agent/pull/341/files#diff-16c83e6e04afdaf615ce0a97cf363d40b6657a9543d4b39a8e78b1f6957f3e15) class that maintains per-skill weights, increasing them on positive feedback (≥7.0) and decreasing them on negative feedback (≤3.0), with habit recording triggered at ≥8.5 reward.
> - Integrates `OnlineFeedbackRL` into [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/341/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a), calling `process_feedback` each interaction cycle when both `habit_tracker` and `mirror_neurons` are available.
> - Extends [`tests/test_mcp_exporter.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/341/files#diff-c8233512ac47a7f069faf85a52ae07fbcf6a267271d62ab2d6ce54813d32f76b) with a `complex_skill` fixture to verify schema export for multiple parameter types and optional fields.
> - Adds [`tests/test_online_feedback_rl.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/341/files#diff-06c4095b29fef9bc0bca793506acda9010991d37f1ae16c698bccadde182f138) covering positive, negative, and multi-skill feedback scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 830c94e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->