### PR TITLE
feat(visualization): implement OpenClaw Canvas Integration v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6228,7 +6228,7 @@
     },
     {
       "id": "openclaw-canvas-integration-v3",
-      "status": "todo",
+      "status": "done",
       "area": "multi_agent",
       "risk": "medium",
       "title": "OpenClaw Canvas Integration v3",
@@ -12382,6 +12382,57 @@
       "acceptance": [
         "Learner correctly processes multi-turn conversation traces and identifies PAD shifts.",
         "Tests mock interactions and verify weight updates based on the trace history."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-preflight-validation-v6-131f0c68",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Tool Pre-flight Validation V6",
+      "description": "Inspired by MCP Security trend: Implement a pre-flight validation mechanism for all MCP action tools before JSON-RPC execution to verify inputs against a static schema.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_preflight_v6.py",
+        "tests/test_mcp_preflight_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pre-flight validator intercepts invalid requests.",
+        "Tests mock MCP clients to verify blocking behavior."
+      ]
+    },
+    {
+      "id": "a2a-delegation-circuit-breaker-v7-720d9240",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Delegation Circuit Breaker V7",
+      "description": "Inspired by A2A Protocol and enterprise-ready agents trend: Implement a circuit breaker pattern to prevent continuous task delegation failures to unresponsive peer agents via A2A.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_circuit_breaker_v7.py",
+        "tests/test_a2a_circuit_breaker_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Circuit breaker trips after consecutive failures.",
+        "Tests verify fallback and trip limits."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-memory-telemetry-v6-0587cf1e",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Memory Telemetry V6",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend: Create an export module to broadcast episodic memory consolidation events dynamically to a live dashboard using WebSockets.",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_memory_v6.py",
+        "tests/test_canvas_memory_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory telemetry broadcaster implemented and broadcasts consolidation events.",
+        "Tests verify event payloads format matches Canvas UI."
       ]
     }
   ]

--- a/magda_agent/visualization/canvas_v3.py
+++ b/magda_agent/visualization/canvas_v3.py
@@ -1,0 +1,153 @@
+import json
+import logging
+from typing import Dict, Any, Optional
+from magda_agent.consciousness.core import Consciousness
+
+logger = logging.getLogger(__name__)
+
+class CanvasVisualizerV3:
+    """
+    Formats Magda's internal state into a structured JSON dictionary
+    suitable for streaming to a live OpenClaw-inspired Canvas UI.
+    V3 handles complex agent state including expanded memory systems,
+    detailed planner states, emotions, and drives.
+    """
+
+    def __init__(self, consciousness: Consciousness) -> None:
+        """
+        Initializes the visualizer with a reference to the agent's consciousness.
+
+        Args:
+            consciousness: The main Consciousness instance containing the agent's state.
+        """
+        self.consciousness = consciousness
+
+    def get_formatted_state(self, user_id: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Retrieves and formats the agent's internal state into a structured dictionary.
+
+        Args:
+            user_id: Optional user identifier to filter state (e.g., for emotions/memory).
+
+        Returns:
+            Dict[str, Any]: A dictionary representing the agent's current state.
+        """
+        state: Dict[str, Any] = {
+            "emotions": {},
+            "mental_states": {},
+            "memory": {
+                "working": {},
+                "episodic": {},
+                "semantic": {},
+                "procedural": {}
+            },
+            "skills": [],
+            "planner": {},
+            "drives": {},
+            "global_workspace": {}
+        }
+
+        try:
+            # 1. Emotions (Mirror Neurons, Insula, PAD)
+            if self.consciousness.emotions:
+                state["emotions"]["summary"] = self.consciousness.emotions.get_summary(user_id=user_id)
+
+                history = self.consciousness.emotions.get_state_history(user_id=user_id)
+                if history and len(history) > 0:
+                    pad_state = history[0]
+                    state["emotions"]["pad"] = {
+                        "pleasure": getattr(pad_state, 'pleasure', 0.0),
+                        "arousal": getattr(pad_state, 'arousal', 0.0),
+                        "dominance": getattr(pad_state, 'dominance', 0.0)
+                    }
+
+            # 2. Mental States
+            if self.consciousness.mental_states:
+                state["mental_states"]["summary"] = self.consciousness.mental_states.get_summary(user_id=user_id)
+
+            # 3. Memory Systems
+            if self.consciousness.memory:
+                memory_system = self.consciousness.memory
+
+                # Working memory
+                if hasattr(memory_system, 'working_memory') and memory_system.working_memory:
+                    state["memory"]["working"] = {
+                        "count": len(getattr(memory_system.working_memory, 'items', [])),
+                        "summary": memory_system.working_memory.get_summary(user_id=user_id) if hasattr(memory_system.working_memory, 'get_summary') else None
+                    }
+
+                # Episodic memory
+                if hasattr(memory_system, 'episodic') and memory_system.episodic:
+                    state["memory"]["episodic"] = {
+                        "status": "active"
+                    }
+                elif hasattr(self.consciousness, 'long_term_memory') and self.consciousness.long_term_memory:
+                     state["memory"]["episodic"] = {
+                        "status": "legacy_active"
+                    }
+
+                # Semantic memory
+                if hasattr(memory_system, 'semantic') and memory_system.semantic:
+                    state["memory"]["semantic"] = {
+                        "status": "active"
+                    }
+
+                # Procedural memory
+                if hasattr(memory_system, 'procedural') and memory_system.procedural:
+                    state["memory"]["procedural"] = {
+                        "status": "active",
+                        "skills_count": len(getattr(memory_system.procedural, 'skills', {})) if hasattr(memory_system.procedural, 'skills') else 0
+                    }
+
+            # 4. Skills
+            if self.consciousness.skills:
+                skills_dict = getattr(self.consciousness.skills, 'skills', {})
+                state["skills"] = list(skills_dict.keys())
+
+            # 5. Planner
+            if self.consciousness.planner:
+                planner = self.consciousness.planner
+                state["planner"]["summary"] = planner.get_state_summary() if hasattr(planner, 'get_state_summary') else None
+
+                if hasattr(planner, 'current_plan') and planner.current_plan:
+                    plan = planner.current_plan
+                    state["planner"]["current_plan"] = {
+                        "goal": getattr(plan, 'goal', None),
+                        "step_count": len(getattr(plan, 'steps', [])),
+                        "dependencies": getattr(plan, 'dependencies', [])
+                    }
+
+            # 6. Drives (Hypothalamus)
+            if self.consciousness.hypothalamus:
+                hypothalamus = self.consciousness.hypothalamus
+                state["drives"] = {
+                    "energy": getattr(hypothalamus, 'energy', 1.0),
+                    "boredom": getattr(hypothalamus, 'boredom', 0.0),
+                    "summary": hypothalamus.get_summary() if hasattr(hypothalamus, 'get_summary') else None
+                }
+
+            # 7. Global Workspace
+            if hasattr(self.consciousness, 'global_workspace') and self.consciousness.global_workspace:
+                workspace = self.consciousness.global_workspace
+                state["global_workspace"] = {
+                    "focused_event": getattr(workspace, 'focused_event', None),
+                    "active": True
+                }
+
+        except Exception as e:
+            logger.error(f"Error formatting canvas v3 state: {e}")
+            state["error"] = str(e)
+
+        return state
+
+    def get_state_json(self, user_id: Optional[str] = None) -> str:
+        """
+        Returns the formatted state as a JSON string.
+
+        Args:
+            user_id: Optional user identifier.
+
+        Returns:
+            str: JSON-encoded string of the agent state.
+        """
+        return json.dumps(self.get_formatted_state(user_id=user_id))

--- a/magda_agent/visualization/server.py
+++ b/magda_agent/visualization/server.py
@@ -11,8 +11,8 @@ class CanvasServer:
     WebSocket server for streaming live visualization of Magda's internal cognitive state.
     """
     def __init__(self, consciousness: Consciousness, interval: float = 1.0):
-        from magda_agent.visualization.canvas import CanvasVisualizer
-        self.visualizer = CanvasVisualizer(consciousness)
+        from magda_agent.visualization.canvas_v3 import CanvasVisualizerV3
+        self.visualizer = CanvasVisualizerV3(consciousness)
         self.active_connections: List[WebSocket] = []
         self.consciousness = consciousness
         self.interval = interval

--- a/tests/test_canvas_v3.py
+++ b/tests/test_canvas_v3.py
@@ -1,0 +1,125 @@
+import pytest
+import json
+from unittest.mock import MagicMock
+from magda_agent.visualization.canvas_v3 import CanvasVisualizerV3
+
+class DummyPADState:
+    def __init__(self, p, a, d):
+        self.pleasure = p
+        self.arousal = a
+        self.dominance = d
+
+def test_canvas_visualizer_v3_formatting():
+    """Test that the CanvasVisualizerV3 correctly formats the complex agent state."""
+
+    mock_consciousness = MagicMock()
+
+    # Mock Emotions
+    mock_emotions = MagicMock()
+    mock_emotions.get_summary.return_value = "Feeling Neutral"
+    mock_emotions.get_state_history.return_value = [DummyPADState(0.1, 0.2, 0.3)]
+    mock_consciousness.emotions = mock_emotions
+
+    # Mock Mental States
+    mock_mental_states = MagicMock()
+    mock_mental_states.get_summary.return_value = "Focused"
+    mock_consciousness.mental_states = mock_mental_states
+
+    # Mock Memory
+    mock_memory = MagicMock()
+    mock_working = MagicMock()
+    mock_working.items = [1, 2, 3]
+    mock_working.get_summary.return_value = "Working memory summary"
+    mock_memory.working_memory = mock_working
+    mock_memory.episodic = MagicMock()
+    mock_memory.semantic = MagicMock()
+    mock_procedural = MagicMock()
+    mock_procedural.skills = {"skill1": None, "skill2": None}
+    mock_memory.procedural = mock_procedural
+    mock_consciousness.memory = mock_memory
+
+    # Mock Skills
+    mock_skills = MagicMock()
+    mock_skills.skills = {"skill_a": None, "skill_b": None}
+    mock_consciousness.skills = mock_skills
+
+    # Mock Planner
+    mock_planner = MagicMock()
+    mock_planner.get_state_summary.return_value = "Current plan: Execute tasks"
+    mock_plan = MagicMock()
+    mock_plan.goal = "Test Goal"
+    mock_plan.steps = [1, 2]
+    mock_plan.dependencies = ["dep1", "dep2"]
+    mock_planner.current_plan = mock_plan
+    mock_consciousness.planner = mock_planner
+
+    # Mock Drives
+    mock_hypothalamus = MagicMock()
+    mock_hypothalamus.energy = 0.8
+    mock_hypothalamus.boredom = 0.2
+    mock_hypothalamus.get_summary.return_value = "High energy, low boredom"
+    mock_consciousness.hypothalamus = mock_hypothalamus
+
+    # Mock Global Workspace
+    mock_workspace = MagicMock()
+    mock_workspace.focused_event = "User Input"
+    mock_consciousness.global_workspace = mock_workspace
+
+    visualizer = CanvasVisualizerV3(mock_consciousness)
+    state = visualizer.get_formatted_state(user_id="test_user")
+
+    assert state["emotions"]["summary"] == "Feeling Neutral"
+    assert state["emotions"]["pad"]["pleasure"] == 0.1
+
+    assert state["mental_states"]["summary"] == "Focused"
+
+    assert state["memory"]["working"]["count"] == 3
+    assert state["memory"]["working"]["summary"] == "Working memory summary"
+    assert state["memory"]["episodic"]["status"] == "active"
+    assert state["memory"]["semantic"]["status"] == "active"
+    assert state["memory"]["procedural"]["status"] == "active"
+    assert state["memory"]["procedural"]["skills_count"] == 2
+
+    assert set(state["skills"]) == {"skill_a", "skill_b"}
+
+    assert state["planner"]["summary"] == "Current plan: Execute tasks"
+    assert state["planner"]["current_plan"]["goal"] == "Test Goal"
+    assert state["planner"]["current_plan"]["step_count"] == 2
+    assert state["planner"]["current_plan"]["dependencies"] == ["dep1", "dep2"]
+
+    assert state["drives"]["energy"] == 0.8
+    assert state["drives"]["boredom"] == 0.2
+    assert state["drives"]["summary"] == "High energy, low boredom"
+
+    assert state["global_workspace"]["focused_event"] == "User Input"
+    assert state["global_workspace"]["active"] is True
+
+    assert "error" not in state
+
+    json_str = visualizer.get_state_json(user_id="test_user")
+    json_data = json.loads(json_str)
+    assert json_data == state
+
+
+def test_canvas_visualizer_v3_error_handling():
+    """Test that CanvasVisualizerV3 handles missing components gracefully."""
+    mock_consciousness = MagicMock()
+    mock_consciousness.emotions = None
+    mock_consciousness.mental_states = None
+    mock_consciousness.memory = None
+    mock_consciousness.skills = None
+    mock_consciousness.planner = None
+    mock_consciousness.hypothalamus = None
+    mock_consciousness.global_workspace = None
+
+    visualizer = CanvasVisualizerV3(mock_consciousness)
+    state = visualizer.get_formatted_state()
+
+    assert state["emotions"] == {}
+    assert state["mental_states"] == {}
+    assert state["memory"] == {"working": {}, "episodic": {}, "semantic": {}, "procedural": {}}
+    assert state["skills"] == []
+    assert state["planner"] == {}
+    assert state["drives"] == {}
+    assert state["global_workspace"] == {}
+    assert "error" not in state

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -12,6 +12,8 @@ def mock_consciousness():
     mock.memory = None
     mock.skills = None
     mock.planner = None
+    mock.hypothalamus = None
+    mock.global_workspace = None
     return mock
 
 @pytest.fixture


### PR DESCRIPTION
Implemented CanvasVisualizerV3 which formats the complex internal agent state (emotions, memory systems, drives, workspace focus) into a structured JSON dict. Replaced old CanvasVisualizer in CanvasServer with CanvasVisualizerV3. Updated tests and added 3 new todo tasks in agent_tasks.json inspired by trends.

---
*PR created automatically by Jules for task [5570803469530240437](https://jules.google.com/task/5570803469530240437) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `CanvasVisualizerV3` for structured consciousness state streaming
> - Adds [`CanvasVisualizerV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/342/files#diff-edfef7ffab8d95ec2637f3851f0c61ce4cc2db39966d0488cc82e1a52b0b9f1a) which formats a `Consciousness` instance into a structured dict covering emotions (with PAD snapshot), mental states, memory subsystems, skills, planner, drives, and global workspace focus.
> - Updates [`CanvasServer`](https://github.com/kazah4359-lgtm/Magda-agent/pull/342/files#diff-065ec5f3c009b16b28bbdb40945f5318cf31a1490b5772072ad8e047ddb2aa48) to instantiate `CanvasVisualizerV3` instead of the previous `CanvasVisualizer`, changing the shape of data streamed to Canvas clients.
> - Subcomponent access is defensive (presence checks, `hasattr`, and `try/except`) with an `error` key surfaced on exceptions.
> - Adds tests in [`tests/test_canvas_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/342/files#diff-9e46f6800f817e3f7c6e13fea374264daf041af433f24dbaee12be34c64b80e2) covering both a fully mocked consciousness and a graceful none-subcomponent path.
> - Behavioral Change: existing Canvas consumers will receive a different payload structure with V3 keys and richer fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6efdd05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->