### PR TITLE
Implement A2A Orchestration Engine

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9302,7 +9302,7 @@
     },
     {
       "id": "a2a-orchestration-engine",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Orchestration Engine",
@@ -12433,6 +12433,57 @@
       "acceptance": [
         "Memory telemetry broadcaster implemented and broadcasts consolidation events.",
         "Tests verify event payloads format matches Canvas UI."
+      ]
+    },
+    {
+      "id": "a2a-orchestration-telemetry-v1-1a9aa424",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "A2A Orchestration Telemetry Integration",
+      "description": "Inspired by trend: A2A Protocol and enterprise-ready agents. Integrate A2ADistributedTelemetryV7 with the A2AOrchestrator to broadcast metrics on concurrent delegation overhead.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_orchestrator.py",
+        "tests/test_a2a_orchestrator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2AOrchestrator emits telemetry events before and after dispatch_concurrently.",
+        "Tests verify telemetry emission."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-orchestrator-integration-v1-a3a8b9a7",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Action Tool Orchestrator Integration",
+      "description": "Inspired by trend: MCP tools proliferation. Enhance A2AOrchestrator so that it can also directly orchestrate execution of remote MCP action tools exposed by peers without going through the full delegation layer.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_orchestrator.py",
+        "tests/test_a2a_orchestrator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2AOrchestrator can process steps meant for direct MCP execution.",
+        "Tests verify concurrent execution of direct MCP actions."
+      ]
+    },
+    {
+      "id": "a2a-orchestrator-fallback-v1-8b09e06f",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Orchestrator Fallback Handling",
+      "description": "Inspired by trend: Agent Teams and Multi-Agent Orchestration. Add a fallback execution path in A2AOrchestrator that falls back to sequential execution if concurrent delegation throws an unexpected network error.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_orchestrator.py",
+        "tests/test_a2a_orchestrator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2AOrchestrator correctly falls back to sequential dispatch upon concurrent failure.",
+        "Tests verify that fallback is triggered and logged."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_orchestrator.py
+++ b/magda_agent/integration/a2a_orchestrator.py
@@ -1,0 +1,75 @@
+from typing import Dict, Any, List
+import logging
+import asyncio
+from magda_agent.integration.a2a_discovery import A2ADiscovery
+from magda_agent.integration.a2a_delegation import A2ADelegator
+
+class A2AOrchestrator:
+    """
+    Coordinates dispatching tasks to multiple A2A sub-agents using A2ADelegator.
+    Supports concurrent delegation for parallelizable tasks.
+    """
+    def __init__(self, discovery: A2ADiscovery, delegator: A2ADelegator):
+        """
+        Initializes the orchestrator with discovery and delegator components.
+        """
+        self.discovery = discovery
+        self.delegator = delegator
+
+    async def dispatch_concurrently(self, sub_plans: List[Dict[str, Any]]) -> Dict[str, str]:
+        """
+        Dispatches multiple sub-plans concurrently to peer agents.
+
+        Args:
+            sub_plans: A list of sub-plans (where each sub-plan is a dict containing capability and steps).
+
+        Returns:
+            A dictionary mapping step IDs to their delegation result.
+        """
+        results = {}
+        tasks = []
+
+        async def _delegate_and_record(capability: str, step: Dict[str, Any]):
+            step_id = step.get("id")
+            result = await self.delegator.delegate_subplan(capability, step)
+            return step_id, result
+
+        for sub_plan in sub_plans:
+            capability = sub_plan.get("capability")
+            for step in sub_plan.get("steps", []):
+                tasks.append(_delegate_and_record(capability, step))
+
+        completed_tasks = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for idx, result in enumerate(completed_tasks):
+            if isinstance(result, Exception):
+                logging.error(f"Error during concurrent delegation: {result}")
+                # We can't easily get the step_id here if the exception happened outside of our inner wrapper,
+                # but because we wrapped it, we should get (step_id, exception/result) unless the wrapper itself failed.
+            else:
+                step_id, delegation_result = result
+                if step_id:
+                    results[step_id] = delegation_result
+
+        return results
+
+    async def execute_orchestrated_plan(self, plan: List[Dict[str, Any]], concurrent: bool = False) -> Dict[str, str]:
+        """
+        Executes a full plan by splitting it into sub-plans and dispatching them either concurrently or sequentially.
+
+        Args:
+            plan: The full execution plan.
+            concurrent: If True, dispatches sub-plans concurrently. If False, executes them sequentially.
+
+        Returns:
+            A dictionary mapping step IDs to their delegation result.
+        """
+        if not plan:
+            return {}
+
+        sub_plans = self.delegator.split_plan(plan)
+
+        if concurrent:
+            return await self.dispatch_concurrently(sub_plans)
+        else:
+            return await self.delegator.execute_plan(plan)

--- a/tests/test_a2a_orchestrator.py
+++ b/tests/test_a2a_orchestrator.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+import asyncio
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_delegation import A2ADelegator
+from magda_agent.integration.a2a_orchestrator import A2AOrchestrator
+
+@pytest.fixture
+def a2a_discovery():
+    local_card = AgentCard("local", "local", "local", [], {})
+    discovery = A2ADiscovery(local_card)
+    return discovery
+
+@pytest.fixture
+def a2a_delegator(a2a_discovery):
+    delegator = A2ADelegator(a2a_discovery)
+    return delegator
+
+@pytest.fixture
+def a2a_orchestrator(a2a_discovery, a2a_delegator):
+    return A2AOrchestrator(a2a_discovery, a2a_delegator)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_concurrently(a2a_orchestrator):
+    # Mock the delegator's delegate_subplan method
+    a2a_orchestrator.delegator.delegate_subplan = AsyncMock()
+
+    async def mock_delegate(capability, step):
+        # Simulate some delay to test concurrency properly
+        await asyncio.sleep(0.01)
+        return f"Delegated {step['id']} for {capability}"
+
+    a2a_orchestrator.delegator.delegate_subplan.side_effect = mock_delegate
+
+    sub_plans = [
+        {"capability": "coding", "steps": [{"id": "step_1"}]},
+        {"capability": "analysis", "steps": [{"id": "step_2"}, {"id": "step_3"}]}
+    ]
+
+    results = await a2a_orchestrator.dispatch_concurrently(sub_plans)
+
+    assert len(results) == 3
+    assert results["step_1"] == "Delegated step_1 for coding"
+    assert results["step_2"] == "Delegated step_2 for analysis"
+    assert results["step_3"] == "Delegated step_3 for analysis"
+    assert a2a_orchestrator.delegator.delegate_subplan.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_dispatch_concurrently_with_exception(a2a_orchestrator, caplog):
+    # Mock the delegator's delegate_subplan method
+    a2a_orchestrator.delegator.delegate_subplan = AsyncMock()
+
+    async def mock_delegate(capability, step):
+        if step['id'] == "step_error":
+            raise Exception("Simulated delegation failure")
+        return f"Delegated {step['id']} for {capability}"
+
+    a2a_orchestrator.delegator.delegate_subplan.side_effect = mock_delegate
+
+    sub_plans = [
+        {"capability": "coding", "steps": [{"id": "step_1"}, {"id": "step_error"}]},
+    ]
+
+    results = await a2a_orchestrator.dispatch_concurrently(sub_plans)
+
+    # step_1 should succeed, step_error should fail and return exception
+    assert len(results) == 1
+    assert results["step_1"] == "Delegated step_1 for coding"
+    assert "Simulated delegation failure" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execute_orchestrated_plan_sequential(a2a_orchestrator):
+    plan = [
+        {"id": "step_1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"}
+    ]
+
+    a2a_orchestrator.delegator.execute_plan = AsyncMock(return_value={"step_1": "Sequential Success"})
+
+    results = await a2a_orchestrator.execute_orchestrated_plan(plan, concurrent=False)
+
+    a2a_orchestrator.delegator.execute_plan.assert_called_once_with(plan)
+    assert results["step_1"] == "Sequential Success"
+
+@pytest.mark.asyncio
+async def test_execute_orchestrated_plan_concurrent(a2a_orchestrator):
+    plan = [
+        {"id": "step_1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"}
+    ]
+
+    # Mock the concurrent dispatch
+    a2a_orchestrator.dispatch_concurrently = AsyncMock(return_value={"step_1": "Concurrent Success"})
+    # Need to make sure split_plan is used
+    a2a_orchestrator.delegator.split_plan = MagicMock(return_value=[{"capability": "coding", "steps": [plan[0]]}])
+
+    results = await a2a_orchestrator.execute_orchestrated_plan(plan, concurrent=True)
+
+    a2a_orchestrator.dispatch_concurrently.assert_called_once()
+    assert results["step_1"] == "Concurrent Success"
+
+@pytest.mark.asyncio
+async def test_execute_orchestrated_plan_empty(a2a_orchestrator):
+    results = await a2a_orchestrator.execute_orchestrated_plan([])
+    assert results == {}


### PR DESCRIPTION
Implemented the `A2AOrchestrator` to dispatch tasks to multiple A2A sub-agents concurrently or sequentially using `A2ADelegator` and `A2ADiscovery`. Added comprehensive pytest coverage using mocks. Appended 3 new trend-inspired tasks to the `agent_tasks.json` backlog.

---
*PR created automatically by Jules for task [6262446591707475214](https://jules.google.com/task/6262446591707475214) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A orchestration engine with concurrent and sequential plan execution
> - Introduces [`A2AOrchestrator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/343/files#diff-dc59c7df99bd2dcfe1e638d3463870fbad68be1faaad9bf26db387016ffdcc16) to coordinate task dispatch to A2A sub-agents via `A2ADelegator`, supporting both concurrent and sequential execution modes.
> - `dispatch_concurrently` uses `asyncio.gather` to run multiple sub-plan steps in parallel, logs errors for failed steps, and omits them from the returned results.
> - `execute_orchestrated_plan` splits a full plan into sub-plans via `delegator.split_plan` for concurrent execution, or falls back to `delegator.execute_plan` for sequential execution.
> - Test coverage in [`tests/test_a2a_orchestrator.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/343/files#diff-1749a25ee4d16d3e6f8c3f3da3c10eacf32e1bf011cd2753bd99201c5eff4ac8) covers concurrent dispatch, exception handling, sequential delegation, and empty plan edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ec6929.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->