### PR TITLE
feat: implement MCP Action Tool Exporter v9 with advanced validation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6296,7 +6296,7 @@
     },
     {
       "id": "mcp-action-tool-exporter-v9-49248ff3",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Exporter v9",
@@ -12640,6 +12640,58 @@
         "MCP preflight validation intercepts incoming JSON-RPC calls.",
         "Strict JSON schema typing is enforced before policy evaluation.",
         "Tests mock tool execution with invalid schemas and verify blocking."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-registry-sync-v9-fe20c694",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tool Registry Sync v9",
+      "description": "Inspired by MCP Standard trend: Implement a background loop that periodically polls a configured MCP server URL and dynamically registers or unregisters tools in the local MCPRegistry.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry_sync_v9.py",
+        "tests/test_mcp_registry_sync_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Background loop successfully polls and parses MCP tool schema endpoints.",
+        "Local MCPRegistry reflects the state of the remote MCP server.",
+        "Tests verify the polling mechanism using a mocked client."
+      ]
+    },
+    {
+      "id": "openclaw-live-canvas-telemetry-v9-5946331c",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw Live Canvas Telemetry v9",
+      "description": "Inspired by OpenClaw trend: Implement a websocket telemetry streamer that broadcasts agent memory state and planner steps in real-time to an external Canvas client.",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_stream_v9.py",
+        "tests/test_canvas_stream_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Streamer correctly broadcasts memory states via websocket events.",
+        "Tests mock the websocket connection and verify broadcast formats."
+      ]
+    },
+    {
+      "id": "claude-sdk-dependency-graph-planner-v9-f356f47e",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Claude SDK Dependency Graph Planner v9",
+      "description": "Inspired by Claude Agent SDK trend: Implement a task planner that builds a dependency graph of sub-tasks instead of a flat list, allowing for parallel sub-agent execution.",
+      "allowed_paths": [
+        "magda_agent/planning/dependency_graph_v9.py",
+        "tests/test_dependency_graph_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner creates a DAG of tasks.",
+        "Tests verify correct topological sorting and parallel execution boundaries."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_exporter_v9.py
+++ b/magda_agent/integration/mcp_exporter_v9.py
@@ -1,0 +1,144 @@
+from typing import Dict, Any, List, Optional
+import uuid
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_export import MagdaMCPAdapter
+
+class MCPExporterV9:
+    """
+    Exports Magda skills as MCP-compatible JSON-RPC tools with advanced validation.
+    Acts as a server-side bridge.
+    """
+    def __init__(self, registry: SkillRegistry) -> None:
+        """Initialize the MCPExporterV9 with a SkillRegistry."""
+        self.registry = registry
+        self.adapter = MagdaMCPAdapter(registry)
+
+    def export_tools(self) -> List[Dict[str, Any]]:
+        """
+        Returns a list of exported MCP tools.
+        """
+        return self.adapter.list_tools()
+
+    def _validate_schema(self, schema: Dict[str, Any], arguments: Dict[str, Any]) -> Optional[str]:
+        """
+        Validates arguments against a simplified JSON schema.
+
+        Args:
+            schema: The tool's inputSchema.
+            arguments: The arguments provided in the request.
+
+        Returns:
+            An error message if validation fails, or None if validation succeeds.
+        """
+        if schema.get("type") != "object":
+            return None # Skip validation if not an object schema
+
+        required_fields = schema.get("required", [])
+        for req in required_fields:
+            if req not in arguments:
+                return f"Missing required parameter: '{req}'"
+
+        properties = schema.get("properties", {})
+        for arg_name, arg_value in arguments.items():
+            if arg_name not in properties:
+                # Based on strict validation, extra args could be allowed or disallowed.
+                # Let's just check the ones that are declared.
+                continue
+
+            expected_type = properties[arg_name].get("type")
+
+            # Basic type checking
+            if expected_type == "string" and not isinstance(arg_value, str):
+                return f"Parameter '{arg_name}' must be of type string"
+            elif expected_type == "integer" and (not isinstance(arg_value, int) or isinstance(arg_value, bool)):
+                # bool is a subclass of int in python, so we check explicitly
+                return f"Parameter '{arg_name}' must be of type integer"
+            elif expected_type == "number" and (not isinstance(arg_value, (int, float)) or isinstance(arg_value, bool)):
+                return f"Parameter '{arg_name}' must be of type number"
+            elif expected_type == "boolean" and not isinstance(arg_value, bool):
+                return f"Parameter '{arg_name}' must be of type boolean"
+            elif expected_type == "array" and not isinstance(arg_value, list):
+                return f"Parameter '{arg_name}' must be of type array"
+            elif expected_type == "object" and not isinstance(arg_value, dict):
+                return f"Parameter '{arg_name}' must be of type object"
+
+        return None
+
+    async def handle_rpc_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Handles an incoming JSON-RPC request for a tool execution.
+
+        Args:
+            request: A dictionary representing a JSON-RPC 2.0 request.
+
+        Returns:
+            A dictionary representing a JSON-RPC 2.0 response.
+        """
+        req_id = request.get("id", str(uuid.uuid4()))
+        method = request.get("method")
+        params: Dict[str, Any] = request.get("params", {})
+
+        arguments: Dict[str, Any] = params.get("arguments", params)
+
+        if request.get("jsonrpc") != "2.0":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32600, "message": "Invalid Request"}
+            }
+
+        if not method:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": "Method not found"}
+            }
+
+        if not self.registry.has_skill(method):
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method '{method}' not found"}
+            }
+
+        # Advanced Validation
+        tools = self.export_tools()
+        tool_schema = None
+        for t in tools:
+            if t["name"] == method:
+                tool_schema = t.get("inputSchema")
+                break
+
+        if tool_schema:
+            validation_error = self._validate_schema(tool_schema, arguments)
+            if validation_error:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": f"Invalid params: {validation_error}"}
+                }
+
+        adapter_result = await self.adapter.call_tool_async(method, arguments)
+
+        # Check if the adapter explicitly reported an error, or if it returned a string
+        # that starts with 'Error' (which happens when registry.execute_skill returns an error string).
+        is_error: bool = adapter_result.get("isError", False)
+
+        # safely extract error message
+        content = adapter_result.get("content", [])
+        error_msg = ""
+        if content and len(content) > 0:
+             error_msg = content[0].get("text", "")
+
+        if is_error or str(error_msg).startswith("Error"):
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32000, "message": error_msg or "Unknown error"}
+            }
+
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": adapter_result
+        }

--- a/tests/test_mcp_exporter_v9.py
+++ b/tests/test_mcp_exporter_v9.py
@@ -1,0 +1,180 @@
+import pytest
+from typing import Dict, Any, List
+from magda_agent.integration.mcp_exporter_v9 import MCPExporterV9
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.fixture
+def registry() -> SkillRegistry:
+    """Creates a SkillRegistry fixture with dummy skills."""
+    reg = SkillRegistry()
+
+    async def dummy_skill(param1: str) -> str:
+        """Dummy async skill."""
+        return f"Result: {param1}"
+
+    def dummy_sync_skill(param2: int) -> int:
+        """Dummy sync skill."""
+        return param2 * 2
+
+    reg.register_skill("dummy_skill", dummy_skill, "A dummy async skill")
+    reg.register_skill("dummy_sync_skill", dummy_sync_skill, "A dummy sync skill")
+
+    def complex_skill(a: int, b: float, c: bool, d: list, e: dict, f: str = "default"):
+        """A skill with complex types."""
+        return "complex"
+
+    reg.register_skill("complex_skill", complex_skill, "A skill with complex types")
+
+    return reg
+
+@pytest.fixture
+def exporter(registry: SkillRegistry) -> MCPExporterV9:
+    """Creates an MCPExporterV9 fixture."""
+    return MCPExporterV9(registry)
+
+def test_export_tools(exporter: MCPExporterV9) -> None:
+    """Tests if tools are correctly exported via the adapter."""
+    tools: List[Dict[str, Any]] = exporter.export_tools()
+    assert len(tools) == 3
+    names: List[str] = [t["name"] for t in tools]
+    assert "dummy_skill" in names
+    assert "dummy_sync_skill" in names
+    assert "complex_skill" in names
+
+    # Verify complex_skill schema
+    complex_tool = next(t for t in tools if t["name"] == "complex_skill")
+    schema = complex_tool["inputSchema"]
+    assert schema["type"] == "object"
+    props = schema["properties"]
+    assert props["a"]["type"] == "integer"
+    assert props["b"]["type"] == "number"
+    assert props["c"]["type"] == "boolean"
+    assert props["d"]["type"] == "array"
+    assert props["e"]["type"] == "object"
+    assert props["f"]["type"] == "string"
+
+    assert "a" in schema["required"]
+    assert "f" not in schema["required"]
+
+
+def test_validate_schema_success(exporter: MCPExporterV9) -> None:
+    """Tests schema validation with valid types."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer"},
+            "b": {"type": "string"},
+            "c": {"type": "boolean"},
+            "d": {"type": "number"},
+            "e": {"type": "array"},
+            "f": {"type": "object"}
+        },
+        "required": ["a", "b"]
+    }
+
+    args = {
+        "a": 5,
+        "b": "hello",
+        "c": True,
+        "d": 3.14,
+        "e": [1, 2],
+        "f": {"key": "value"}
+    }
+
+    error = exporter._validate_schema(schema, args)
+    assert error is None
+
+def test_validate_schema_missing_required(exporter: MCPExporterV9) -> None:
+    """Tests schema validation when required field is missing."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer"}
+        },
+        "required": ["a"]
+    }
+
+    args = {}
+
+    error = exporter._validate_schema(schema, args)
+    assert error is not None
+    assert "Missing required parameter" in error
+
+def test_validate_schema_invalid_type(exporter: MCPExporterV9) -> None:
+    """Tests schema validation with invalid types."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer"}
+        },
+        "required": []
+    }
+
+    args = {"a": "not_an_int"}
+
+    error = exporter._validate_schema(schema, args)
+    assert error is not None
+    assert "must be of type integer" in error
+
+    # Check bool masquerading as int
+    args = {"a": True}
+    error = exporter._validate_schema(schema, args)
+    assert error is not None
+    assert "must be of type integer" in error
+
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_success(exporter: MCPExporterV9) -> None:
+    """Tests a successful JSON-RPC tool execution request."""
+    req = {
+        "jsonrpc": "2.0",
+        "method": "dummy_skill",
+        "params": {"arguments": {"param1": "test"}},
+        "id": 1
+    }
+    res: Dict[str, Any] = await exporter.handle_rpc_request(req)
+    assert res["jsonrpc"] == "2.0"
+    assert res["id"] == 1
+    assert "result" in res
+    assert not res["result"]["isError"]
+    assert res["result"]["content"][0]["text"] == "Result: test"
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_invalid_method(exporter: MCPExporterV9) -> None:
+    """Tests handling of an invalid JSON-RPC method."""
+    req = {
+        "jsonrpc": "2.0",
+        "method": "non_existent_skill",
+        "params": {},
+        "id": 2
+    }
+    res: Dict[str, Any] = await exporter.handle_rpc_request(req)
+    assert "error" in res
+    assert res["error"]["code"] == -32601
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_invalid_jsonrpc(exporter: MCPExporterV9) -> None:
+    """Tests handling of an invalid JSON-RPC version."""
+    req = {
+        "method": "dummy_skill",
+        "params": {"arguments": {"param1": "test"}},
+        "id": 3
+    }
+    res: Dict[str, Any] = await exporter.handle_rpc_request(req)
+    assert "error" in res
+    assert res["error"]["code"] == -32600
+
+
+@pytest.mark.asyncio
+async def test_handle_rpc_request_invalid_params(exporter: MCPExporterV9) -> None:
+    """Tests error handling when the arguments are invalid according to schema."""
+    req = {
+        "jsonrpc": "2.0",
+        "method": "complex_skill",
+        "params": {"arguments": {"a": "not_an_int", "b": 1.0, "c": True, "d": [], "e": {}}}, # a should be int
+        "id": 4
+    }
+    res: Dict[str, Any] = await exporter.handle_rpc_request(req)
+    assert "error" in res
+    assert res["error"]["code"] == -32602
+    assert "Invalid params" in res["error"]["message"]


### PR DESCRIPTION
Implemented the MCP Action Tool Exporter v9 as requested by the task tracker.

This introduces a new class `MCPExporterV9` which acts as a bridge, wrapping the internal `MagdaMCPAdapter` and explicitly enforcing schema validation using a basic type checker logic. 

**Testing:** 
Added unit tests covering normal JSON-RPC request flows as well as various edge cases, such as missing required properties and invalid parameter types (e.g. passing a boolean when an integer is expected). The entire test suite has also been executed locally and passes successfully.

**Task Management:**
Updated `agent_tasks.json` to mark the current task as done and injected three new trend-based tasks with unique hex IDs to maintain queue length.

---
*PR created automatically by Jules for task [17555399186782599774](https://jules.google.com/task/17555399186782599774) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPExporterV9` to bridge Magda skills to JSON-RPC 2.0 MCP tools
> - Adds [`mcp_exporter_v9.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/347/files#diff-ae9313bdec09cda6137078b92134bb3b153b3817428892e4f90d4cabccfeb75d) with `MCPExporterV9`, which wraps `MagdaMCPAdapter` and `SkillRegistry` to expose registered skills as MCP-compatible tool descriptors.
> - `handle_rpc_request` processes async JSON-RPC 2.0 requests, returning structured error codes: `-32600` (invalid request), `-32601` (method not found), `-32602` (invalid params), `-32000` (execution error).
> - `_validate_schema` performs JSON Schema validation on request params, checking required fields and basic types including a guard against `bool` being accepted as `int`/`number`.
> - Adds tests in [`tests/test_mcp_exporter_v9.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/347/files#diff-edf20faadd70087934d097e44948d8b5896f6c1d5bbff5630d297bce142e3037) covering tool export, schema validation edge cases, and all RPC error paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26f0bcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->