### PR TITLE
Agent Teams Parallel Subagents

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6347,7 +6347,7 @@
     },
     {
       "id": "agent-teams-parallel-subagents-v4",
-      "status": "todo",
+      "status": "done",
       "area": "multi_agent",
       "risk": "medium",
       "title": "Agent Teams Parallel Subagents",
@@ -12794,6 +12794,40 @@
       "acceptance": [
         "Orchestrator routes correctly among multiple active sub-agents.",
         "Tests mock routing logic comprehensively."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-tasks-9dc313ca",
+      "status": "todo",
+      "area": "scheduling",
+      "risk": "low",
+      "title": "Hermes Cron Scheduler Tasks",
+      "description": "Inspired by Hermes agent built-in cron scheduler trend (daily reports, nightly backups, scheduled tasks): Implement a periodic cron scheduler to run background maintenance.",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_scheduler_v2.py",
+        "tests/test_cron_scheduler_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A cron scheduler runs periodic tasks.",
+        "Tests verify tasks are executed according to the schedule."
+      ]
+    },
+    {
+      "id": "hermes-skill-creation-experience-bf67873c",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Skill Creation from Experience",
+      "description": "Inspired by Hermes self-improvement loops (Skill creation from experience): Implement a module that can derive skills from conversational experience.",
+      "allowed_paths": [
+        "magda_agent/skills/experience_creator_v2.py",
+        "tests/test_experience_creator_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Experience creator generates skill logic from conversation context.",
+        "Tests mock LLM interactions and verify skill generation."
       ]
     }
   ]

--- a/magda_agent/architecture/parallel_subagents.py
+++ b/magda_agent/architecture/parallel_subagents.py
@@ -1,0 +1,60 @@
+"""
+Parallel Subagents Manager.
+
+This module provides the ParallelSubagentManager class which orchestrates
+the concurrent execution of multiple subagents for independent parallel tasks,
+inspired by the Claude Agent SDK.
+"""
+
+import asyncio
+from typing import List, Dict, Any, Callable, Optional
+
+from magda_agent.architecture.subagent_spawning import SubagentSpawner
+
+class ParallelSubagentManager:
+    """
+    Manages the concurrent execution of multiple subagents.
+    """
+
+    def __init__(self, spawner: Optional[SubagentSpawner] = None) -> None:
+        """
+        Initialize the ParallelSubagentManager.
+
+        Args:
+            spawner: Optional SubagentSpawner instance. If not provided, a new one is created.
+        """
+        self.spawner = spawner or SubagentSpawner()
+
+    async def run_parallel_tasks(
+        self,
+        tasks: List[str],
+        base_context: List[Dict[str, Any]],
+        agent_executor_factory: Callable[[], Any]
+    ) -> List[Any]:
+        """
+        Run multiple tasks concurrently using separate subagents.
+
+        Args:
+            tasks: A list of task descriptions.
+            base_context: The shared conversation or execution context.
+            agent_executor_factory: A callable that returns an agent executor for each task.
+
+        Returns:
+            A list containing the results of each subagent's execution.
+        """
+        coroutines = []
+        for task in tasks:
+            executor = agent_executor_factory()
+
+            # Use a copy of base_context to prevent race conditions during concurrent mutations
+            context_copy = list(base_context)
+
+            coro = self.spawner.spawn_subagent(
+                task_description=task,
+                full_context=context_copy,
+                agent_executor=executor
+            )
+            coroutines.append(coro)
+
+        results = await asyncio.gather(*coroutines)
+        return list(results)

--- a/tests/test_parallel_subagents.py
+++ b/tests/test_parallel_subagents.py
@@ -1,0 +1,86 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+from magda_agent.architecture.parallel_subagents import ParallelSubagentManager
+from magda_agent.architecture.subagent_spawning import SubagentSpawner
+
+class MockExecutor:
+    """Mock agent executor that simulates async work."""
+    def __init__(self, delay: float, result_prefix: str):
+        self.delay = delay
+        self.result_prefix = result_prefix
+
+    async def execute(self, context: list) -> str:
+        await asyncio.sleep(self.delay)
+        # SubagentSpawner appends exactly {"role": "user", "content": f"Task: {task_description}"}
+        # to the context.
+        task_desc_str = context[-1]["content"] if context else "unknown task"
+        return f"{self.result_prefix}: {task_desc_str}"
+
+
+@pytest.mark.asyncio
+async def test_parallel_execution_time():
+    """
+    Test that run_parallel_tasks actually runs concurrently.
+    If sequential, time would be delay * N. If parallel, it should be ~delay.
+    """
+    manager = ParallelSubagentManager()
+    tasks = ["Task 1", "Task 2", "Task 3"]
+    base_context = [{"role": "system", "content": "base"}]
+
+    # 0.1s delay for each task
+    delay = 0.1
+
+    def factory():
+        return MockExecutor(delay=delay, result_prefix="Done")
+
+    start_time = asyncio.get_event_loop().time()
+    results = await manager.run_parallel_tasks(tasks, base_context, factory)
+    end_time = asyncio.get_event_loop().time()
+
+    elapsed = end_time - start_time
+
+    assert len(results) == 3
+    assert "Done: Task: Task 1" in results
+    assert "Done: Task: Task 2" in results
+    assert "Done: Task: Task 3" in results
+
+    # Check if execution time is much less than sequential time (0.3s)
+    # Give some margin for overhead, but it shouldn't take 0.3s.
+    assert elapsed < 0.2, f"Execution took too long ({elapsed}s), might be sequential."
+
+
+@pytest.mark.asyncio
+async def test_empty_tasks():
+    manager = ParallelSubagentManager()
+    results = await manager.run_parallel_tasks([], [], lambda: None)
+    assert results == []
+
+@pytest.mark.asyncio
+async def test_callable_executor():
+    manager = ParallelSubagentManager()
+
+    async def mock_callable(ctx):
+        return "callable done"
+
+    # The SubagentSpawner supports both an object with an .execute method and a raw callable.
+    results = await manager.run_parallel_tasks(["Task X"], [], lambda: mock_callable)
+    assert len(results) == 1
+    assert results[0] == "callable done"
+
+@pytest.mark.asyncio
+async def test_base_context_race_condition():
+    """
+    Test that modifying the context inside SubagentSpawner does not affect the original base_context.
+    """
+    manager = ParallelSubagentManager()
+    tasks = ["Task 1", "Task 2"]
+    base_context = [{"role": "system", "content": "base"}]
+
+    def factory():
+        return MockExecutor(delay=0, result_prefix="Done")
+
+    await manager.run_parallel_tasks(tasks, base_context, factory)
+
+    # base_context should remain unchanged
+    assert len(base_context) == 1


### PR DESCRIPTION
Implements parallel subagent execution for the Agent Teams component.

Closes #1234 (agent-teams-parallel-subagents-v4)

**Changes:**
- `magda_agent/architecture/parallel_subagents.py`: New `ParallelSubagentManager`.
- `tests/test_parallel_subagents.py`: Unit tests.
- `agent_tasks.json`: Updated.

---
*PR created automatically by Jules for task [4954164598031445406](https://jules.google.com/task/4954164598031445406) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ParallelSubagentManager` to run multiple subagents concurrently
> - Adds [parallel_subagents.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/350/files#diff-d6e6a44649e704ba6a51ebd3227065e36c91dc4dd837c0ccd07200b3797cea63) with `ParallelSubagentManager`, which uses `asyncio.gather` to run multiple subagent tasks concurrently via an injected `SubagentSpawner`.
> - Each task gets its own copy of `base_context` to prevent race conditions during concurrent execution.
> - Adds tests in [test_parallel_subagents.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/350/files#diff-ff8515fdf34863df2eb147be68fb22c11756f892c49d6a8b20078290e3f7fd2f) covering concurrency timing, empty input, callable executors, and context mutation safety.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ee634a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->