### PR TITLE
Implement ACS Guardrails V3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6381,7 +6381,7 @@
     },
     {
       "id": "acs-guardrails-v3",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "ACS Guardrails Integration V3",

--- a/magda_agent/safety/acs_guard_v3.py
+++ b/magda_agent/safety/acs_guard_v3.py
@@ -1,0 +1,205 @@
+import logging
+import re
+from typing import Dict, Any, Tuple, Optional
+from magda_agent.safety.policy import PolicyLayer
+from magda_agent.safety.audit_trail import AuditTrail
+
+
+_SENSITIVE_PATTERNS = (
+    re.compile(r"api[_-]?key|token|password|private[_-]?key|secret[_-]?key", re.IGNORECASE),
+    re.compile(r"-----BEGIN [A-Z ]+ PRIVATE KEY-----"),
+    re.compile(r"\.env", re.IGNORECASE),
+    re.compile(r"secrets?", re.IGNORECASE),
+)
+
+
+class SecurityViolationError(Exception):
+    """Exception raised when an action is blocked by the ACS Guard V3."""
+    pass
+
+
+class ACSGuardV3:
+    """
+    ACS (Agent Control Specification) Guard V3.
+    Standardizes runtime guardrails with 5 validation checkpoints for agentic workflows.
+    """
+
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None, audit_trail: Optional[AuditTrail] = None) -> None:
+        """
+        Initializes the ACS Guard V3.
+
+        Args:
+            policy_layer: An optional policy layer for evaluating tool policies.
+            audit_trail: An optional audit trail for logging checkpoint results.
+        """
+        self.logger = logging.getLogger(__name__)
+        self.policy_layer = policy_layer or PolicyLayer()
+        self.audit_trail = audit_trail or AuditTrail()
+
+    def checkpoint_1_input_validation(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 1: Input Validation.
+        Ensures the raw input data for the action is well-formed.
+        """
+        if not isinstance(workflow_data, dict):
+            return False, "Input validation failed: workflow data must be a dictionary."
+        if not workflow_data:
+            return False, "Input validation failed: workflow data is empty."
+
+        required_fields = ["action", "tool"]
+        for field in required_fields:
+            if field not in workflow_data:
+                return False, f"Input validation failed: missing '{field}' field."
+            if not isinstance(workflow_data[field], str):
+                return False, f"Input validation failed: '{field}' must be a string."
+
+        return True, "Input validation Passed."
+
+    def checkpoint_2_intent_authorization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 2: Intent Authorization.
+        Verifies if the agent's intent is authorized.
+        """
+        action = workflow_data.get("action")
+        # Standard allowed intents in ACS-like architectures
+        allowed_intents = {
+            "read", "write", "execute", "plan", "reflect", "delegate", "analyze", "chat"
+        }
+
+        if action == "unauthorized_action":
+            return False, f"Intent authorization failed: action '{action}' is explicitly blacklisted."
+
+        if action not in allowed_intents:
+            return False, f"Intent authorization failed: action '{action}' is not in allowed intents list."
+
+        return True, "Intent authorization Passed."
+
+    def checkpoint_3_tool_policy(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 3: Tool Policy.
+        Checks if the tool complies with defined policies using the PolicyLayer.
+        """
+        tool = workflow_data.get("tool")
+        if tool == "forbidden_tool":
+            return False, f"Tool policy failed: tool '{tool}' is forbidden."
+
+        kwargs = workflow_data.get("kwargs", {})
+        allow, explanation = self.policy_layer.evaluate(tool, **kwargs)
+        if not allow:
+            return False, f"Tool policy failed: {explanation}"
+
+        return True, "Tool policy Passed."
+
+    def checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 4: State Transition.
+        Ensures the proposed state transition is valid within the cognitive architecture.
+        """
+        current_state = workflow_data.get("current_state", "idle")
+        next_state = workflow_data.get("next_state")
+
+        if not next_state:
+            # If next_state is not explicitly provided, we might assume it's valid if it doesn't break rules
+            return True, "State transition skipped: next_state not provided."
+
+        allowed_transitions = {
+            "idle": ["planning", "reflecting", "analyzing", "executing"],
+            "planning": ["executing", "idle"],
+            "executing": ["evaluating", "idle"],
+            "evaluating": ["idle", "planning"],
+            "reflecting": ["idle"],
+            "analyzing": ["idle", "planning"],
+            "error": ["idle"]
+        }
+
+        if current_state not in allowed_transitions:
+            return False, f"State transition failed: unknown current_state '{current_state}'."
+
+        if next_state not in allowed_transitions[current_state] and next_state != "error":
+            return False, f"State transition failed: cannot transition from '{current_state}' to '{next_state}'."
+
+        return True, "State transition Passed."
+
+    def checkpoint_5_output_sanitization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 5: Output Sanitization.
+        Sanitizes the final output to prevent leakage of sensitive data.
+        """
+        output = workflow_data.get("output")
+        if output is None:
+            return True, "Output sanitization passed: no output to sanitize."
+
+        output_str = str(output)
+
+        for pattern in _SENSITIVE_PATTERNS:
+            if pattern.search(output_str):
+                return False, f"Output sanitization failed: sensitive pattern '{pattern.pattern}' detected."
+
+        return True, "Output sanitization Passed."
+
+    def validate_action(self, workflow_data: Dict[str, Any]) -> bool:
+        """
+        Validates the workflow action through all 5 ACS checkpoints.
+
+        Returns:
+            bool: True if all checkpoints pass, False otherwise.
+        """
+        checkpoints = [
+            self.checkpoint_1_input_validation,
+            self.checkpoint_2_intent_authorization,
+            self.checkpoint_3_tool_policy,
+            self.checkpoint_4_state_transition,
+            self.checkpoint_5_output_sanitization
+        ]
+
+        for i, checkpoint in enumerate(checkpoints, 1):
+            passed, reason = checkpoint(workflow_data)
+            if not passed:
+                self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
+                return False
+            self.logger.info(f"ACS Checkpoint {i} Passed: {reason}")
+
+        return True
+
+    def intercept_action(self, workflow_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Intercepts an action, validates it through all 5 checkpoints,
+        logs the results to the AuditTrail, and raises SecurityViolationError on failure.
+
+        Returns:
+            Dict[str, Any]: The original workflow data if all checkpoints pass.
+
+        Raises:
+            SecurityViolationError: If any checkpoint fails.
+        """
+        checkpoints = [
+            self.checkpoint_1_input_validation,
+            self.checkpoint_2_intent_authorization,
+            self.checkpoint_3_tool_policy,
+            self.checkpoint_4_state_transition,
+            self.checkpoint_5_output_sanitization
+        ]
+
+        for i, checkpoint in enumerate(checkpoints, 1):
+            passed, reason = checkpoint(workflow_data)
+            if not passed:
+                self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
+                self.audit_trail.log_call(
+                    tool_name=workflow_data.get("tool", "unknown"),
+                    kwargs=workflow_data.get("kwargs", {}),
+                    why=f"ACS Checkpoint {i} Failed: {reason}",
+                    result="blocked",
+                    duration=0.0
+                )
+                raise SecurityViolationError(f"Action blocked by ACS checkpoint {i}: {reason}")
+            self.logger.debug(f"ACS Checkpoint {i} Passed: {reason}")
+
+        self.audit_trail.log_call(
+            tool_name=workflow_data.get("tool", "unknown"),
+            kwargs=workflow_data.get("kwargs", {}),
+            why="All 5 ACS checkpoints passed.",
+            result="allowed",
+            duration=0.0
+        )
+
+        return workflow_data

--- a/tests/test_acs_guard_v3.py
+++ b/tests/test_acs_guard_v3.py
@@ -1,0 +1,166 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.safety.acs_guard_v3 import ACSGuardV3, SecurityViolationError
+
+
+@pytest.fixture
+def mock_policy_layer():
+    policy = MagicMock()
+    policy.evaluate.return_value = (True, "Allowed by mock")
+    return policy
+
+
+@pytest.fixture
+def mock_audit_trail():
+    return MagicMock()
+
+
+@pytest.fixture
+def acs_guard(mock_policy_layer, mock_audit_trail):
+    return ACSGuardV3(policy_layer=mock_policy_layer, audit_trail=mock_audit_trail)
+
+
+def test_checkpoint_1_input_validation(acs_guard):
+    # Pass
+    valid_data = {"action": "read", "tool": "ls"}
+    passed, reason = acs_guard.checkpoint_1_input_validation(valid_data)
+    assert passed
+    assert "Passed" in reason
+
+    # Fail - not a dict
+    passed, reason = acs_guard.checkpoint_1_input_validation("not a dict")
+    assert not passed
+    assert "must be a dictionary" in reason
+
+    # Fail - empty dict
+    passed, reason = acs_guard.checkpoint_1_input_validation({})
+    assert not passed
+    assert "workflow data is empty" in reason
+
+    # Fail - missing action
+    passed, reason = acs_guard.checkpoint_1_input_validation({"tool": "ls"})
+    assert not passed
+    assert "missing 'action' field" in reason
+
+
+def test_checkpoint_2_intent_authorization(acs_guard):
+    # Pass
+    assert acs_guard.checkpoint_2_intent_authorization({"action": "read"})[0]
+    assert acs_guard.checkpoint_2_intent_authorization({"action": "write"})[0]
+    assert acs_guard.checkpoint_2_intent_authorization({"action": "chat"})[0]
+
+    # Fail - unauthorized_action
+    passed, reason = acs_guard.checkpoint_2_intent_authorization({"action": "unauthorized_action"})
+    assert not passed
+    assert "explicitly blacklisted" in reason
+
+    # Fail - not in allowed list
+    passed, reason = acs_guard.checkpoint_2_intent_authorization({"action": "jump"})
+    assert not passed
+    assert "not in allowed intents list" in reason
+
+
+def test_checkpoint_3_tool_policy(acs_guard, mock_policy_layer):
+    # Pass
+    assert acs_guard.checkpoint_3_tool_policy({"tool": "ls"})[0]
+
+    # Fail - forbidden_tool
+    passed, reason = acs_guard.checkpoint_3_tool_policy({"tool": "forbidden_tool"})
+    assert not passed
+    assert "is forbidden" in reason
+
+    # Fail - PolicyLayer denial
+    mock_policy_layer.evaluate.return_value = (False, "Policy denial")
+    passed, reason = acs_guard.checkpoint_3_tool_policy({"tool": "rm", "kwargs": {"path": "/"}})
+    assert not passed
+    assert "Policy denial" in reason
+
+
+def test_checkpoint_4_state_transition(acs_guard):
+    # Pass - default transition
+    assert acs_guard.checkpoint_4_state_transition({"current_state": "idle", "next_state": "planning"})[0]
+
+    # Pass - next_state not provided
+    assert acs_guard.checkpoint_4_state_transition({"current_state": "idle"})[0]
+
+    # Fail - unknown current_state
+    passed, reason = acs_guard.checkpoint_4_state_transition({"current_state": "unknown", "next_state": "idle"})
+    assert not passed
+    assert "unknown current_state" in reason
+
+    # Fail - invalid transition
+    passed, reason = acs_guard.checkpoint_4_state_transition({"current_state": "idle", "next_state": "evaluating"})
+    assert not passed
+    assert "cannot transition" in reason
+
+    # Pass - transition to error
+    assert acs_guard.checkpoint_4_state_transition({"current_state": "planning", "next_state": "error"})[0]
+
+
+def test_checkpoint_5_output_sanitization(acs_guard):
+    # Pass
+    assert acs_guard.checkpoint_5_output_sanitization({"output": "All good"})[0]
+    assert acs_guard.checkpoint_5_output_sanitization({"output": None})[0]
+
+    # Fail - sensitive data
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "Here is my secret_key: 12345"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "Password is admin"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+    # Regex patterns
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "Here is my .env file"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "-----BEGIN RSA PRIVATE KEY-----"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+
+def test_validate_action(acs_guard):
+    valid_data = {
+        "action": "read",
+        "tool": "ls",
+        "current_state": "idle",
+        "next_state": "planning",
+        "output": "Some safe output"
+    }
+    assert acs_guard.validate_action(valid_data)
+
+    invalid_data = valid_data.copy()
+    invalid_data["action"] = "unauthorized_action"
+    assert not acs_guard.validate_action(invalid_data)
+
+
+def test_intercept_action(acs_guard, mock_audit_trail):
+    valid_data = {
+        "action": "read",
+        "tool": "ls",
+        "current_state": "idle",
+        "next_state": "planning"
+    }
+    # Should not raise
+    assert acs_guard.intercept_action(valid_data) == valid_data
+    assert mock_audit_trail.log_call.called
+
+    # Reset mock
+    mock_audit_trail.log_call.reset_mock()
+
+    invalid_data = valid_data.copy()
+    invalid_data["tool"] = "forbidden_tool"
+
+    with pytest.raises(SecurityViolationError) as excinfo:
+        acs_guard.intercept_action(invalid_data)
+
+    assert "ACS checkpoint 3" in str(excinfo.value)
+    mock_audit_trail.log_call.assert_called_with(
+        tool_name="forbidden_tool",
+        kwargs={},
+        why="ACS Checkpoint 3 Failed: Tool policy failed: tool 'forbidden_tool' is forbidden.",
+        result="blocked",
+        duration=0.0
+    )


### PR DESCRIPTION
Implemented the ACS (Agent Control Specification) Guardrails V3 as part of the safety system for the Magdalina AGI agent. The implementation includes five validation checkpoints:
1. Input Validation: Ensures workflow data is well-formed.
2. Intent Authorization: Verifies if the action intent (e.g., read, write, execute) is allowed.
3. Tool Policy: Gathers evaluations from the PolicyLayer for specific tools and arguments.
4. State Transition: Validates cognitive state transitions (e.g., idle -> planning).
5. Output Sanitization: Uses regex patterns to detect and block sensitive data (keys, tokens, .env, etc.) in tool outputs.

The ACSGuardV3 integrates with the existing AuditTrail for persistent logging of safety decisions. Comprehensive unit tests verify each checkpoint and the intercept/validation logic.

---
*PR created automatically by Jules for task [11208706990371619889](https://jules.google.com/task/11208706990371619889) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ACSGuardV3 guardrail with five-checkpoint action validation and enforcement
> - Adds [`ACSGuardV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/352/files#diff-64d786f5bdfa32140f8625fe902f5a70e289a42dd6a46d625373ce08780e3555) with five sequential checkpoints: input validation, intent authorization, tool policy (via `PolicyLayer`), state transition, and output sanitization against sensitive patterns (API keys, PEM headers, `.env` references, etc.).
> - `validate_action` runs all checkpoints and returns a boolean; `intercept_action` raises `SecurityViolationError` on the first failure and logs outcomes to `AuditTrail`.
> - Adds full pytest coverage in [`tests/test_acs_guard_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/352/files#diff-764ecafd2d3106285ea7c32a547cd77f081f595356d546f939b59c1755945f56) using `MagicMock` for `PolicyLayer` and `AuditTrail`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e453a44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->