### PR TITLE
feat(learning): implement online rl feedback processor

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6432,7 +6432,7 @@
     },
     {
       "id": "online-rl-from-feedback-v2-v3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online RL from Interaction Feedback",
@@ -12982,6 +12982,40 @@
       "acceptance": [
         "Memory manager routes information to correct store.",
         "Tests verify separate retrieval behaviors."
+      ]
+    },
+    {
+      "id": "mcp-skill-export-v2-7760ecd1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Export of Internal Skills v2",
+      "description": "Inspired by MCP Trend: Implement an MCP exporter that exposes Magda skills as MCP-compatible JSON-RPC 2.0 tools.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_export_v2.py",
+        "tests/test_mcp_export_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be exported in MCP schema format.",
+        "Tests mock export conversion logic."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-v2-c87192e5",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Task Delegation Protocol v2",
+      "description": "Inspired by A2A Protocol Trend: Implement a basic peer-to-peer task delegation mechanism for discovering and assigning tasks to other agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegation_v2.py",
+        "tests/test_a2a_delegation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Delegator correctly discovers peers and formats task payload.",
+        "Tests mock API requests."
       ]
     }
   ]

--- a/magda_agent/learning/online_rl_feedback.py
+++ b/magda_agent/learning/online_rl_feedback.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Optional, Dict
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+class OnlineRLFeedbackProcessor:
+    """
+    Online RL Feedback Processor.
+    Adjusts skill weights dynamically based on explicit and implicit feedback.
+    """
+    def __init__(self, habit_tracker: HabitTracker, mirror_neurons: MirrorNeurons) -> None:
+        """
+        Initializes the OnlineRLFeedbackProcessor.
+
+        Args:
+            habit_tracker (HabitTracker): The habit tracker for tracking skill usage.
+            mirror_neurons (MirrorNeurons): The mirror neurons for processing sentiment.
+        """
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+        self.skill_weights: Dict[str, float] = {}
+
+    async def process_feedback(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: Optional[int] = None,
+        explicit_score: Optional[float] = None,
+        tool_success: bool = False,
+        skill_used: str = "rl_feedback_skill"
+    ) -> None:
+        """
+        Processes feedback signals to adjust habit weights.
+
+        Args:
+            user_reply (str): The user's reply containing implicit feedback.
+            action_context (str): The context of the action.
+            user_id (Optional[int]): The ID of the user.
+            explicit_score (Optional[float]): An explicit score provided, if any.
+            tool_success (bool): Whether a tool was successfully used.
+            skill_used (str): The name of the skill being evaluated.
+        """
+        if not user_reply or not action_context:
+            return
+
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_reply)
+
+        if explicit_score is not None:
+            base_score = explicit_score
+        else:
+            base_score = (p_shift + 1.0) * 5.0
+
+        weight = base_score
+        if tool_success:
+            weight += 2.0
+
+        if skill_used not in self.skill_weights:
+            self.skill_weights[skill_used] = 1.0
+
+        if weight >= 8.0:
+            self.skill_weights[skill_used] += 0.1
+            self.habit_tracker.record_usage(
+                input_text=action_context,
+                skill_used=skill_used,
+                evaluation_score=weight,
+                user_id=user_id
+            )
+            logging.info(f"Online RL: Positive feedback (weight={weight:.2f}). Recorded usage. New weight for {skill_used}: {self.skill_weights[skill_used]:.2f}")
+        else:
+            self.skill_weights[skill_used] = max(0.1, self.skill_weights[skill_used] - 0.1)
+            logging.info(f"Online RL: Negative/Neutral feedback (weight={weight:.2f}). No usage recorded. New weight for {skill_used}: {self.skill_weights[skill_used]:.2f}")

--- a/tests/test_online_rl_feedback.py
+++ b/tests/test_online_rl_feedback.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock
-from magda_agent.learning.online_rl import OnlineRLIntegrator
+from magda_agent.learning.online_rl_feedback import OnlineRLFeedbackProcessor
 from magda_agent.learning.habits import HabitTracker
 from magda_agent.emotions.mirror_neurons import MirrorNeurons
 
@@ -15,9 +15,9 @@ def mock_mirror_neurons():
 @pytest.mark.asyncio
 async def test_process_feedback_implicit_positive(mock_habit_tracker, mock_mirror_neurons):
     mock_mirror_neurons.empathize.return_value = (0.8, 0.1, 0.0)
-    integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
+    processor = OnlineRLFeedbackProcessor(mock_habit_tracker, mock_mirror_neurons)
 
-    await integrator.process_feedback("Great job!", "test_context", user_id=1)
+    await processor.process_feedback("Great job!", "test_context", user_id=1)
 
     mock_habit_tracker.record_usage.assert_called_once_with(
         input_text="test_context",
@@ -25,13 +25,24 @@ async def test_process_feedback_implicit_positive(mock_habit_tracker, mock_mirro
         evaluation_score=9.0,
         user_id=1
     )
+    assert processor.skill_weights["rl_feedback_skill"] == 1.1
+
+@pytest.mark.asyncio
+async def test_process_feedback_implicit_negative(mock_habit_tracker, mock_mirror_neurons):
+    mock_mirror_neurons.empathize.return_value = (-0.8, 0.0, 0.0)
+    processor = OnlineRLFeedbackProcessor(mock_habit_tracker, mock_mirror_neurons)
+
+    await processor.process_feedback("Bad job!", "test_context", user_id=1)
+
+    mock_habit_tracker.record_usage.assert_not_called()
+    assert processor.skill_weights["rl_feedback_skill"] == 0.9
 
 @pytest.mark.asyncio
 async def test_process_feedback_explicit_score(mock_habit_tracker, mock_mirror_neurons):
     mock_mirror_neurons.empathize.return_value = (0.0, 0.0, 0.0)
-    integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
+    processor = OnlineRLFeedbackProcessor(mock_habit_tracker, mock_mirror_neurons)
 
-    await integrator.process_feedback("Okay", "test_context", explicit_score=9.0, skill_used="custom_skill")
+    await processor.process_feedback("Okay", "test_context", explicit_score=9.0, skill_used="custom_skill")
 
     mock_habit_tracker.record_usage.assert_called_once_with(
         input_text="test_context",
@@ -39,13 +50,14 @@ async def test_process_feedback_explicit_score(mock_habit_tracker, mock_mirror_n
         evaluation_score=9.0,
         user_id=None
     )
+    assert processor.skill_weights["custom_skill"] == 1.1
 
 @pytest.mark.asyncio
 async def test_process_feedback_tool_success(mock_habit_tracker, mock_mirror_neurons):
     mock_mirror_neurons.empathize.return_value = (0.5, 0.0, 0.0)
-    integrator = OnlineRLIntegrator(mock_habit_tracker, mock_mirror_neurons)
+    processor = OnlineRLFeedbackProcessor(mock_habit_tracker, mock_mirror_neurons)
     # base_score = 7.5. tool_success + 2.0 = 9.5
-    await integrator.process_feedback("Good", "test_context", tool_success=True)
+    await processor.process_feedback("Good", "test_context", tool_success=True)
 
     mock_habit_tracker.record_usage.assert_called_once_with(
         input_text="test_context",
@@ -53,3 +65,12 @@ async def test_process_feedback_tool_success(mock_habit_tracker, mock_mirror_neu
         evaluation_score=9.5,
         user_id=None
     )
+    assert processor.skill_weights["rl_feedback_skill"] == 1.1
+
+@pytest.mark.asyncio
+async def test_process_feedback_empty(mock_habit_tracker, mock_mirror_neurons):
+    processor = OnlineRLFeedbackProcessor(mock_habit_tracker, mock_mirror_neurons)
+
+    await processor.process_feedback("", "test_context")
+    mock_habit_tracker.record_usage.assert_not_called()
+    assert "rl_feedback_skill" not in processor.skill_weights


### PR DESCRIPTION
This PR implements the `OnlineRLFeedbackProcessor` as requested in the task `online-rl-from-feedback-v2-v3`. It correctly adjusts habit weights dynamically based on user feedback. The PR also updates the corresponding test file and `agent_tasks.json` with the completed status and two new trend-inspired tasks from `docs/trends.md`.

---
*PR created automatically by Jules for task [5092555190543550316](https://jules.google.com/task/5092555190543550316) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `OnlineRLFeedbackProcessor` to compute and update per-skill reinforcement weights
> - Introduces [`OnlineRLFeedbackProcessor`](https://github.com/kazah4359-lgtm/Magda-agent/pull/355/files#diff-620c6ba1a900a7f78ea5c1e3602a3c616a36c3776dd15968376d628e407a07ce) with an async `process_feedback` method that derives a feedback score from an explicit score or sentiment shifts via `MirrorNeurons.empathize`, adding +2.0 on tool success.
> - Per-skill weights start at 1.0; weights >= 8.0 trigger a +0.1 increment and a `HabitTracker.record_usage` call, while lower scores decrement by 0.1 (floor 0.1) without recording.
> - Empty `user_reply` or `action_context` cause an immediate no-op with no weight mutation.
> - Adds five unit tests covering implicit positive/negative, explicit score, tool success, and empty input paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1793de1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->