### PR TITLE
A2A Service Discovery v2 Implementation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6449,7 +6449,7 @@
     },
     {
       "id": "a2a-service-discovery-v2-2a05c8f7",
-      "status": "todo",
+      "status": "done",
       "area": "multi_agent",
       "risk": "high",
       "title": "A2A Service Discovery using Agent Cards v2",

--- a/magda_agent/integration/a2a_discovery.py
+++ b/magda_agent/integration/a2a_discovery.py
@@ -1,8 +1,9 @@
 from typing import Dict, List, Optional
 import json
 import logging
+import httpx
 from dataclasses import dataclass, asdict
-from typing import Optional
+from typing import Optional, Dict, List, Any
 from magda_agent.integration.a2a_security import A2ASecurityContext
 
 
@@ -17,6 +18,7 @@ class AgentCard:
     description: str
     capabilities: List[str]
     endpoints: Dict[str, str]
+    protocol_version: str = "2.0"
 
     def to_json(self) -> str:
         """
@@ -77,6 +79,54 @@ class A2ADiscovery:
                 self._register_agent(card)
             except Exception as e:
                 logging.error(f"Failed to parse Agent Card: {e}")
+
+    async def register_with_registry(self, registry_url: str, auth_token: Optional[str] = None) -> bool:
+        """
+        Registers the local Agent Card with a central discovery registry.
+        """
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{registry_url}/register",
+                    json=asdict(self.local_card),
+                    headers=headers
+                )
+                response.raise_for_status()
+                logging.info(f"Successfully registered with {registry_url}")
+                return True
+        except Exception as e:
+            logging.error(f"Failed to register with registry {registry_url}: {e}")
+            return False
+
+    async def discover_from_registry(self, registry_url: str, auth_token: Optional[str] = None) -> List[AgentCard]:
+        """
+        Fetches all available Agent Cards from a central discovery registry.
+        """
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(f"{registry_url}/cards", headers=headers)
+                response.raise_for_status()
+                cards_data = response.json()
+
+                discovered = []
+                for card_data in cards_data:
+                    card = AgentCard(**card_data)
+                    self._register_agent(card)
+                    discovered.append(card)
+
+                logging.info(f"Discovered {len(discovered)} agents from {registry_url}")
+                return discovered
+        except Exception as e:
+            logging.error(f"Failed to discover from registry {registry_url}: {e}")
+            return []
 
     def _register_agent(self, card: AgentCard) -> None:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydantic-settings==2.7.0
 duckduckgo-search
 openai
 pytest-asyncio
+respx
 fastapi
 uvicorn
 httpx

--- a/tests/test_a2a_discovery.py
+++ b/tests/test_a2a_discovery.py
@@ -1,5 +1,8 @@
 import pytest
 import json
+import respx
+import httpx
+from dataclasses import asdict
 from magda_agent.integration.a2a_discovery import AgentCard, A2ADiscovery
 
 @pytest.fixture
@@ -86,3 +89,53 @@ async def test_fetch_invalid_card_json(local_card):
 
     # No agents should be discovered
     assert len(discovery._discovered_agents) == 0
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_register_with_registry(local_card):
+    discovery = A2ADiscovery(local_card=local_card)
+    registry_url = "http://discovery-registry.local"
+
+    # Mock the registration endpoint
+    route = respx.post(f"{registry_url}/register").mock(return_value=httpx.Response(201))
+
+    success = await discovery.register_with_registry(registry_url, auth_token="test-token")
+
+    assert success is True
+    assert route.called
+    assert route.calls.last.request.headers["Authorization"] == "Bearer test-token"
+
+    # Verify the payload
+    sent_data = json.loads(route.calls.last.request.content)
+    assert sent_data["agent_id"] == local_card.agent_id
+    assert sent_data["protocol_version"] == "2.0"
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_discover_from_registry(local_card, remote_card_1, remote_card_2):
+    discovery = A2ADiscovery(local_card=local_card)
+    registry_url = "http://discovery-registry.local"
+
+    # Mock the discovery endpoint
+    cards_data = [asdict(remote_card_1), asdict(remote_card_2)]
+    route = respx.get(f"{registry_url}/cards").mock(return_value=httpx.Response(200, json=cards_data))
+
+    discovered = await discovery.discover_from_registry(registry_url)
+
+    assert len(discovered) == 2
+    assert route.called
+    assert discovery.get_agent_by_id(remote_card_1.agent_id).name == remote_card_1.name
+    assert discovery.get_agent_by_id(remote_card_2.agent_id).name == remote_card_2.name
+    assert remote_card_1.name in [c.name for c in discovery.find_agents_by_capability("chat")]
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_register_with_registry_failure(local_card):
+    discovery = A2ADiscovery(local_card=local_card)
+    registry_url = "http://discovery-registry.local"
+
+    # Mock a failure
+    respx.post(f"{registry_url}/register").mock(return_value=httpx.Response(500))
+
+    success = await discovery.register_with_registry(registry_url)
+    assert success is False


### PR DESCRIPTION
I have implemented the A2A Service Discovery v2 task by enhancing the `A2ADiscovery` class and `AgentCard` data model.

Key changes:
- `AgentCard` now includes a `protocol_version` field.
- `A2ADiscovery` has two new asynchronous methods: `register_with_registry` and `discover_from_registry`. These methods use `httpx` to interact with a central discovery service, supporting both authenticated registration and card retrieval.
- Comprehensive unit tests were added to `tests/test_a2a_discovery.py` using the `respx` library to mock registry HTTP responses.
- All A2A discovery-related tests (`test_a2a_discovery.py`, `test_a2a_discovery_v2.py`, `test_a2a_discovery_v4.py`) passed successfully.
- `agent_tasks.json` was updated and validated.

---
*PR created automatically by Jules for task [6843998856706682594](https://jules.google.com/task/6843998856706682594) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add HTTP-based agent registration and discovery to `A2ADiscovery`
> - Adds `A2ADiscovery.register_with_registry` to POST the local `AgentCard` to a central registry endpoint, with optional Bearer token auth, returning a boolean success indicator.
> - Adds `A2ADiscovery.discover_from_registry` to GET remote `AgentCard` entries from a registry, register them internally, and return the discovered list.
> - Adds a `protocol_version` field (default `'2.0'`) to the `AgentCard` dataclass, included in serialization and backward-compatible on deserialization.
> - Adds `respx` to [requirements.txt](https://github.com/kazah4359-lgtm/Magda-agent/pull/356/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552) and covers both new methods with async tests using mocked HTTP responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43d8f09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->