### PR TITLE
feat(memory): Implement OpenClaw Context Engine Plugin Architecture v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6483,7 +6483,7 @@
     },
     {
       "id": "openclaw-context-engine-plugin-v4-abc123",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Plugin Architecture v4",
@@ -13050,6 +13050,41 @@
       "acceptance": [
         "Tools execute concurrently at runtime.",
         "Tests verify concurrency limits and behavior."
+      ]
+    },
+    {
+      "id": "agent-teams-git-worktree-isolation-ecc2d6cf",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Agent SDK Trend: Agent Teams with Git Worktree Isolation",
+      "description": "Implement Claude Agent SDK pattern for Agent Teams: multi-agent with git worktree isolation to allow subagents to work concurrently without clashing.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_v4.py",
+        "tests/test_agent_teams_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent teams manager can spawn subagents.",
+        "Subagents execute in isolated git worktrees.",
+        "Tests verify isolation and parallel execution."
+      ]
+    },
+    {
+      "id": "openclaw-rl-next-state-signals-v1-c9a5b60a",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL: Online Reinforcement Learning from Next-State Signals",
+      "description": "Implement online reinforcement learning from next-state signals (user replies, tool outputs) as inspired by OpenClaw-RL. The agent learns from talking without explicit labeling.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v6.py",
+        "tests/test_openclaw_rl_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can process next-state signals like user replies to update RL weights.",
+        "Tests verify learning loop integration without explicit labeling."
       ]
     }
   ]

--- a/magda_agent/memory/context_plugin_v4.py
+++ b/magda_agent/memory/context_plugin_v4.py
@@ -1,0 +1,172 @@
+import logging
+from typing import Any, Dict, List, Optional
+from magda_agent.memory.context_engine import ContextPlugin
+
+class ContextPluginV4(ContextPlugin):
+    """
+    OpenClaw-inspired v4 plugin architecture for the Context Engine.
+    Implements full lifecycle hooks to manage context dynamically.
+    """
+
+    def __init__(self, llm: Optional[Any] = None) -> None:
+        """
+        Initializes the ContextPluginV4.
+
+        Args:
+            llm: Optional language model integration for intelligent compaction.
+        """
+        self.llm = llm
+        self.config: Dict[str, Any] = {}
+        logging.debug("Initialized ContextPluginV4")
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """
+        Bootstrap lifecycle hook. Initializes plugin state from config.
+
+        Args:
+            config: Configuration dictionary injected by ContextEngine.
+        """
+        self.config = config
+        logging.info("ContextPluginV4 bootstrapped with config.")
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """
+        Ingest lifecycle hook. Process raw content before storing.
+
+        Args:
+            content: Raw string content being ingested.
+            metadata: Additional data associated with the content.
+
+        Returns:
+            Processed content string.
+        """
+        user_id = metadata.get("user_id", "unknown")
+        # Example processing: Adding a V4 tag
+        return f"[V4:{user_id}] {content}"
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """
+        Assemble lifecycle hook. Constructs context prompt.
+
+        Args:
+            context_items: List of retrieved context items.
+            metadata: Metadata controlling assembly format.
+
+        Returns:
+            A formatted string of context ready for the LLM.
+        """
+        if not context_items:
+            return ""
+
+        header = "--- OpenClaw V4 Context Engine ---\n"
+        items_str = "\n".join([f"- {getattr(item, 'content', str(item))}" for item in context_items])
+        return header + items_str + "\n----------------------------------"
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        Compact lifecycle hook. Reduces context size using LLM or truncation.
+
+        Args:
+            context_items: Existing context items.
+            metadata: Metadata controlling compaction rules.
+
+        Returns:
+            A compacted list of context items.
+        """
+        limit = metadata.get("limit", 10)
+        if len(context_items) <= limit:
+            return context_items
+
+        if not self.llm:
+            logging.warning("ContextPluginV4: No LLM available for intelligent compaction. Truncating.")
+            return context_items[-limit:]
+
+        # Simplistic OpenClaw compaction
+        to_compact = context_items[:2]
+        remaining = context_items[2:]
+
+        combined = "\n".join([getattr(i, 'content', str(i)) for i in to_compact])
+        prompt = f"Compact the following interaction into a short bullet point:\n{combined}"
+
+        try:
+            summary = await self.llm.chat_completion([
+                {"role": "system", "content": "You are a context compression engine."},
+                {"role": "user", "content": prompt}
+            ], temperature=0.1)
+
+            # Using basic dictionary to avoid import cycles, though MemoryEntry is standard
+            compacted_item = {"content": summary.strip(), "importance": 0.5, "tags": ["v4_compacted"]}
+
+            class DummyEntry:
+                def __init__(self, content, importance, tags):
+                    self.content = content
+                    self.importance = importance
+                    self.tags = tags
+
+            entry = DummyEntry(summary.strip(), 0.5, ["v4_compacted"])
+            return [entry] + remaining
+
+        except Exception as e:
+            logging.error(f"ContextPluginV4 compaction failed: {e}")
+            return context_items[-limit:]
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """
+        Synchronous hook before context retrieval.
+
+        Args:
+            query: The original search query.
+            user_id: ID of the user requesting context.
+
+        Returns:
+            Modified or original query.
+        """
+        return f"{query} (v4 enhanced for user {user_id})"
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """
+        Synchronous hook after context retrieval.
+
+        Args:
+            context: List of retrieved context elements.
+            query: The query that was executed.
+            user_id: ID of the user.
+
+        Returns:
+            Modified context list.
+        """
+        context.append(f"V4 System Note: Retrieved for query '{query}'")
+        return context
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """
+        Synchronous hook triggered when general context updates.
+
+        Args:
+            new_context: The newly updated context state.
+            user_id: User identifier.
+        """
+        logging.info(f"ContextPluginV4 registered update for user {user_id}.")
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """
+        Synchronous hook before context is written to storage.
+
+        Args:
+            context: The context item to write.
+            user_id: The user identifier.
+
+        Returns:
+            The potentially modified context item to write.
+        """
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """
+        Synchronous hook after context is successfully written.
+
+        Args:
+            context: The context item that was written.
+            user_id: The user identifier.
+        """
+        pass

--- a/tests/test_context_plugin_v4.py
+++ b/tests/test_context_plugin_v4.py
@@ -1,0 +1,82 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.memory.context_plugin_v4 import ContextPluginV4
+
+class DummyEntry:
+    def __init__(self, content):
+        self.content = content
+
+@pytest.fixture
+def mock_llm():
+    llm = MagicMock()
+    llm.chat_completion = AsyncMock(return_value="Summarized v4 content")
+    return llm
+
+@pytest.fixture
+def plugin(mock_llm):
+    return ContextPluginV4(llm=mock_llm)
+
+@pytest.mark.asyncio
+async def test_plugin_bootstrap(plugin):
+    await plugin.bootstrap({"test_key": "test_val"})
+    assert plugin.config == {"test_key": "test_val"}
+
+@pytest.mark.asyncio
+async def test_plugin_ingest(plugin):
+    content = "hello world"
+    res = await plugin.ingest(content, {"user_id": "123"})
+    assert res == "[V4:123] hello world"
+
+@pytest.mark.asyncio
+async def test_plugin_assemble(plugin):
+    items = [DummyEntry("item1"), DummyEntry("item2")]
+    res = await plugin.assemble(items, {})
+    assert "--- OpenClaw V4 Context Engine ---" in res
+    assert "- item1" in res
+    assert "- item2" in res
+    assert "----------------------------------" in res
+
+@pytest.mark.asyncio
+async def test_plugin_assemble_empty(plugin):
+    res = await plugin.assemble([], {})
+    assert res == ""
+
+@pytest.mark.asyncio
+async def test_plugin_compact_under_limit(plugin):
+    items = [DummyEntry("item1"), DummyEntry("item2")]
+    res = await plugin.compact(items, {"limit": 5})
+    assert len(res) == 2
+
+@pytest.mark.asyncio
+async def test_plugin_compact_over_limit_with_llm(plugin):
+    items = [DummyEntry(f"item{i}") for i in range(5)]
+    res = await plugin.compact(items, {"limit": 3})
+    assert len(res) == 4  # 2 compressed into 1, plus 3 remaining
+    assert res[0].content == "Summarized v4 content"
+    assert res[0].tags == ["v4_compacted"]
+
+@pytest.mark.asyncio
+async def test_plugin_compact_over_limit_no_llm():
+    plugin_no_llm = ContextPluginV4(llm=None)
+    items = [DummyEntry(f"item{i}") for i in range(5)]
+    res = await plugin_no_llm.compact(items, {"limit": 3})
+    assert len(res) == 3
+    assert res[0].content == "item2"
+
+def test_plugin_before_retrieval(plugin):
+    res = plugin.before_retrieval("search query", 1)
+    assert res == "search query (v4 enhanced for user 1)"
+
+def test_plugin_after_retrieval(plugin):
+    res = plugin.after_retrieval(["existing"], "query", 1)
+    assert len(res) == 2
+    assert res[1] == "V4 System Note: Retrieved for query 'query'"
+
+def test_plugin_on_context_update(plugin):
+    # Should not raise exception
+    plugin.on_context_update("new context", 1)
+
+def test_plugin_before_after_write(plugin):
+    res = plugin.before_write("context_item", 1)
+    assert res == "context_item"
+    plugin.after_write("context_item", 1) # Should not raise


### PR DESCRIPTION
- Implements `ContextPluginV4` utilizing `ContextPlugin` lifecycle hooks (bootstrap, ingest, assemble, compact, and synchronous hooks).
- Includes comprehensive async testing mock logic.
- Marks the specified `openclaw-context-engine-plugin-v4-abc123` task as done and appends two new OpenClaw/Claude trend tasks to the `agent_tasks.json` tracking system.

---
*PR created automatically by Jules for task [5950785730572821171](https://jules.google.com/task/5950785730572821171) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ContextPluginV4` plugin architecture with lifecycle hooks for context management
> - Adds [context_plugin_v4.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/358/files#diff-b0d777ea5dc4967efda2f09fd040da01c9edc7a18a064e6d21461f9e1a901068) implementing `ContextPluginV4`, a new plugin class with async and sync lifecycle hooks: `bootstrap`, `ingest`, `assemble`, `compact`, `before_retrieval`, `after_retrieval`, `on_context_update`, `before_write`, and `after_write`.
> - The `ingest` hook tags content with a `[V4:{user_id}]` prefix; `assemble` formats context items into a bullet list for LLM consumption.
> - The `compact` hook reduces context lists exceeding a configured limit via LLM summarization when an LLM is provided, otherwise truncates to the most recent items.
> - Adds [tests/test_context_plugin_v4.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/358/files#diff-cd0b08bb44d467f5a64626dc467e0053eb39b4950f43b3083e297c37b08db119) with async and sync tests covering all hooks.
> - Updates [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/358/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) with two new task entries for agent team git worktree isolation and RL next-state signals.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0aa08f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->