### PR TITLE
feat: Implement Claude Agent Teams Git Worktree Isolation v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10023,7 +10023,7 @@
     },
     {
       "id": "claude-agent-teams-isolation-v2-0c02564e",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "high",
       "title": "Claude Agent Teams Git Worktree Isolation v2",
@@ -13136,6 +13136,57 @@
       "acceptance": [
         "Cards are correctly formulated and exchanged.",
         "Tests mock A2A network and pass."
+      ]
+    },
+    {
+      "id": "openclaw-rl-live-telemetry-v3-3a5f2175",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw-RL Live Telemetry Streaming V3",
+      "description": "Inspired by OpenClaw trends: Implement live RL telemetry streaming via WebSockets, mapping PAD shifts in real-time.",
+      "allowed_paths": [
+        "magda_agent/telemetry/live_rl_v3.py",
+        "tests/test_live_rl_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module correctly formats telemetry events to JSON",
+        "Tests verify WebSocket emission"
+      ]
+    },
+    {
+      "id": "claude-subagent-token-context-optimizer-v2-ec3a412d",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Claude Subagent Token Context Optimizer V2",
+      "description": "Inspired by Claude Agent SDK context compression trend: Implement a token compression stage directly prior to subagent spawning.",
+      "allowed_paths": [
+        "magda_agent/memory/token_optimizer_v2.py",
+        "tests/test_token_optimizer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Optimizer compresses context length properly",
+        "Tests mock token counts"
+      ]
+    },
+    {
+      "id": "mcp-dynamic-skill-marketplace-poller-1d28f431",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Skill Marketplace Poller",
+      "description": "Inspired by agentskills.io standard: Implement a background cron job that periodically syncs with the agentskills.io marketplace.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_marketplace_poller.py",
+        "tests/test_mcp_marketplace_poller.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Poller accurately parses agentskills.io JSON formats",
+        "Tests mock network calls"
       ]
     }
   ]

--- a/magda_agent/agents/worktree_manager_v2.py
+++ b/magda_agent/agents/worktree_manager_v2.py
@@ -1,0 +1,103 @@
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from typing import Optional, Dict
+
+class WorktreeManagerV2:
+    """
+    Git worktree manager for sub-agents to allow parallel isolated execution.
+    Inspired by Claude Agent SDK (Agent Teams with git worktree isolation).
+    """
+
+    def __init__(self, base_dir: str = "/tmp/magda_worktree_v2") -> None:
+        """
+        Initialize the WorktreeManagerV2.
+
+        Args:
+            base_dir (str): Base directory where worktrees will be created.
+        """
+        self.base_dir = base_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.active_worktrees: Dict[str, str] = {}
+
+    async def create_worktree(self, agent_id: str, branch_name: Optional[str] = None) -> str:
+        """
+        Creates an isolated git worktree for an agent.
+
+        Args:
+            agent_id (str): A unique identifier for the agent.
+            branch_name (Optional[str]): A branch name to create for the agent, defaults to detached HEAD.
+
+        Returns:
+            str: Path to the newly created worktree.
+        """
+        unique_suffix = str(uuid.uuid4())[:8]
+        env_path = os.path.join(self.base_dir, f"subagent_{agent_id}_{unique_suffix}")
+
+        if branch_name:
+            cmd = ["git", "worktree", "add", "-b", branch_name, env_path, "HEAD"]
+        else:
+            cmd = ["git", "worktree", "add", "-d", env_path, "HEAD"]
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                error_msg = stderr.decode().strip()
+                logging.error(f"Failed to create git worktree: {error_msg}")
+                raise RuntimeError(f"Git worktree creation failed: {error_msg}")
+
+            logging.info(f"Agent {agent_id} worktree created at {env_path}")
+            self.active_worktrees[agent_id] = env_path
+            return env_path
+        except Exception as e:
+            logging.error(f"Error during worktree creation for {agent_id}: {e}")
+            raise
+
+    async def cleanup_worktree(self, agent_id: str) -> None:
+        """
+        Removes the git worktree associated with an agent.
+
+        Args:
+            agent_id (str): The unique identifier of the agent.
+        """
+        env_path = self.active_worktrees.get(agent_id)
+        if not env_path:
+            logging.warning(f"No active worktree found for agent {agent_id}")
+            return
+
+        cmd = ["git", "worktree", "remove", "--force", env_path]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                logging.error(f"Failed to cleanly remove git worktree for {agent_id}: {stderr.decode().strip()}")
+            else:
+                logging.info(f"Successfully removed worktree for {agent_id}")
+        except Exception as e:
+            logging.error(f"Error removing worktree for {agent_id}: {e}")
+        finally:
+            if os.path.exists(env_path):
+                try:
+                    shutil.rmtree(env_path)
+                except Exception as ex:
+                    logging.error(f"Could not delete worktree folder for {agent_id}: {ex}")
+            self.active_worktrees.pop(agent_id, None)
+
+    async def cleanup_all(self) -> None:
+        """
+        Removes all active worktrees.
+        """
+        agents_to_cleanup = list(self.active_worktrees.keys())
+        for agent_id in agents_to_cleanup:
+            await self.cleanup_worktree(agent_id)

--- a/tests/test_worktree_manager_v2.py
+++ b/tests/test_worktree_manager_v2.py
@@ -1,0 +1,150 @@
+import asyncio
+import os
+import shutil
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from magda_agent.agents.worktree_manager_v2 import WorktreeManagerV2
+
+@pytest.fixture
+def base_dir(tmp_path):
+    path = str(tmp_path / "test_worktrees")
+    os.makedirs(path, exist_ok=True)
+    yield path
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+@pytest.mark.asyncio
+async def test_create_worktree(base_dir):
+    """
+    Tests that a worktree is created correctly.
+    """
+    manager = WorktreeManagerV2(base_dir=base_dir)
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        path = await manager.create_worktree("agent123", branch_name="feature-x")
+
+        assert "agent123" in manager.active_worktrees
+        assert manager.active_worktrees["agent123"] == path
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert "git" in args
+        assert "worktree" in args
+        assert "add" in args
+        assert "-b" in args
+        assert "feature-x" in args
+
+@pytest.mark.asyncio
+async def test_create_worktree_detached(base_dir):
+    """
+    Tests that a detached worktree is created correctly.
+    """
+    manager = WorktreeManagerV2(base_dir=base_dir)
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        path = await manager.create_worktree("agent456")
+
+        assert "agent456" in manager.active_worktrees
+        assert manager.active_worktrees["agent456"] == path
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert "git" in args
+        assert "worktree" in args
+        assert "add" in args
+        assert "-d" in args
+
+@pytest.mark.asyncio
+async def test_create_worktree_failure(base_dir):
+    """
+    Tests worktree creation failure.
+    """
+    manager = WorktreeManagerV2(base_dir=base_dir)
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"fatal: error")
+    mock_process.returncode = 128
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+        with pytest.raises(RuntimeError, match="Git worktree creation failed"):
+            await manager.create_worktree("agent123")
+
+@pytest.mark.asyncio
+async def test_cleanup_worktree(base_dir):
+    """
+    Tests that a worktree is removed cleanly.
+    """
+    manager = WorktreeManagerV2(base_dir=base_dir)
+
+    # Manually setup active worktree state
+    test_path = os.path.join(base_dir, "test_agent_path")
+    os.makedirs(test_path, exist_ok=True)
+    manager.active_worktrees["agent123"] = test_path
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        await manager.cleanup_worktree("agent123")
+
+        assert "agent123" not in manager.active_worktrees
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert "git" in args
+        assert "worktree" in args
+        assert "remove" in args
+        assert "--force" in args
+        assert test_path in args
+
+@pytest.mark.asyncio
+async def test_cleanup_worktree_fallback(base_dir):
+    """
+    Tests that a worktree folder is removed even if git command fails.
+    """
+    manager = WorktreeManagerV2(base_dir=base_dir)
+
+    # Manually setup active worktree state
+    test_path = os.path.join(base_dir, "test_agent_path_fallback")
+    os.makedirs(test_path, exist_ok=True)
+    manager.active_worktrees["agent789"] = test_path
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"fatal: git worktree remove failed")
+    mock_process.returncode = 128
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec, \
+         patch("shutil.rmtree") as mock_rmtree:
+        await manager.cleanup_worktree("agent789")
+
+        assert "agent789" not in manager.active_worktrees
+        mock_exec.assert_called_once()
+        mock_rmtree.assert_called_once_with(test_path)
+
+@pytest.mark.asyncio
+async def test_cleanup_all(base_dir):
+    """
+    Tests that all worktrees are cleaned up.
+    """
+    manager = WorktreeManagerV2(base_dir=base_dir)
+    manager.active_worktrees = {
+        "agent1": "/tmp/fake1",
+        "agent2": "/tmp/fake2"
+    }
+
+    with patch.object(manager, "cleanup_worktree", new_callable=AsyncMock) as mock_cleanup:
+        await manager.cleanup_all()
+
+        assert mock_cleanup.call_count == 2
+        mock_cleanup.assert_any_call("agent1")
+        mock_cleanup.assert_any_call("agent2")


### PR DESCRIPTION
Resolves the first "todo" task `claude-agent-teams-isolation-v2-0c02564e`.

- Created `magda_agent/agents/worktree_manager_v2.py` wrapping git subprocess commands to create and delete isolated git worktree environments.
- Implemented robust fallback logic leveraging `shutil.rmtree` when `git worktree remove` fails.
- Wrote extensive `pytest` coverage using `unittest.mock.AsyncMock` to verify all commands, fallbacks, and boundary conditions.
- Updated `agent_tasks.json` to mark the current task as `done`.
- Dynamically generated 3 new trend-inspired tasks (live telemetry, context optimizers, and marketplace pollers) and populated them into `agent_tasks.json`.

---
*PR created automatically by Jules for task [15934762170605415751](https://jules.google.com/task/15934762170605415751) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WorktreeManagerV2` for async git worktree isolation of Claude sub-agents
> - Adds [`worktree_manager_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/360/files#diff-6bb4da04a666d8b6d7fa6fe6e9b892743c016fc42534f7379e168aaa0dbfebaf) with `WorktreeManagerV2`, a class that asynchronously creates and removes isolated git worktrees for individual agents, keyed by `agent_id` with a UUID suffix under `/tmp/magda_worktree_v2`.
> - Supports both branched (`git worktree add -b`) and detached (`git worktree add -d`) worktree creation; raises `RuntimeError` on non-zero git exit.
> - Cleanup falls back to `shutil.rmtree` if `git worktree remove --force` fails, ensuring the directory and in-memory tracking are always cleared.
> - Adds full async test coverage in [`tests/test_worktree_manager_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/360/files#diff-6d2895c9470046fcbed88d0930aa174126b418f65e59b4f5e46e56dc740ae5e6) with mocked subprocess interactions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0802535.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->