### PR TITLE
Implement MCP-compatible Skill Exporter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6517,7 +6517,7 @@
     },
     {
       "id": "mcp-skill-exporter-v1",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP-compatible Skill Exporter",

--- a/magda_agent/skills/mcp_exporter.py
+++ b/magda_agent/skills/mcp_exporter.py
@@ -1,0 +1,137 @@
+import inspect
+from typing import Dict, Any, List, Callable, get_origin
+from magda_agent.skills.registry import SkillRegistry
+
+class MCPSkillExporter:
+    """
+    Exports Magda skills as MCP-compatible JSON-RPC tools.
+    Enables external consumption of agent skills via the Model Context Protocol.
+    """
+    def __init__(self, registry: SkillRegistry) -> None:
+        self.registry = registry
+
+    def _get_json_schema(self, func: Callable) -> Dict[str, Any]:
+        """
+        Extracts JSON schema parameters from the function signature.
+        """
+        if hasattr(func, "__mcp_schema__"):
+            return getattr(func, "__mcp_schema__")
+
+        sig = inspect.signature(func)
+        properties = {}
+        required = []
+
+        for name, param in sig.parameters.items():
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                continue
+            if name == 'self':
+                continue
+
+            # Basic type mapping
+            param_type = "string"
+            annotation = param.annotation
+            origin = get_origin(annotation)
+
+            actual_type = origin if origin is not None else annotation
+
+            if actual_type is int:
+                param_type = "integer"
+            elif actual_type is float:
+                param_type = "number"
+            elif actual_type is bool:
+                param_type = "boolean"
+            elif actual_type in (list, List):
+                param_type = "array"
+            elif actual_type in (dict, Dict):
+                param_type = "object"
+
+            properties[name] = {"type": param_type}
+
+            if param.default is inspect.Parameter.empty:
+                required.append(name)
+
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": required
+        }
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists all registered skills as MCP-compatible tool definitions.
+        """
+        tools = []
+        for name, func in self.registry.skills.items():
+            description = self.registry.descriptions.get(name, "")
+            schema = self._get_json_schema(func)
+            tools.append({
+                "name": name,
+                "description": description,
+                "inputSchema": schema
+            })
+        return tools
+
+    async def handle_rpc_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Handles an incoming JSON-RPC 2.0 request for a tool execution.
+        """
+        req_id = request.get("id")
+        method = request.get("method")
+        params = request.get("params", {})
+
+        if request.get("jsonrpc") != "2.0":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32600, "message": "Invalid Request: Only JSON-RPC 2.0 is supported."}
+            }
+
+        if not method:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": "Method not found: Missing method name."}
+            }
+
+        if not self.registry.has_skill(method):
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method '{method}' not found."}
+            }
+
+        try:
+            result = self.registry.execute_skill(method, **params)
+
+            # Handle potential error string from registry
+            if isinstance(result, str) and result.startswith("Error"):
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32000, "message": result}
+                }
+
+            if inspect.isawaitable(result):
+                try:
+                    result = await result
+                except Exception as e:
+                    return {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "error": {"code": -32000, "message": f"Error executing async skill '{method}': {e}"}
+                    }
+
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "content": [{"type": "text", "text": str(result)}],
+                    "isError": False
+                }
+            }
+        except Exception as e:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32000, "message": f"Error executing skill '{method}': {e}"}
+            }

--- a/tests/test_mcp_exporter.py
+++ b/tests/test_mcp_exporter.py
@@ -1,7 +1,7 @@
 import pytest
 from typing import Dict, Any, List
 from unittest.mock import MagicMock, AsyncMock
-from magda_agent.integration.mcp_exporter import MCPExporter
+from magda_agent.skills.mcp_exporter import MCPSkillExporter
 from magda_agent.skills.registry import SkillRegistry
 
 @pytest.fixture
@@ -29,13 +29,13 @@ def registry() -> SkillRegistry:
     return reg
 
 @pytest.fixture
-def exporter(registry: SkillRegistry) -> MCPExporter:
-    """Creates an MCPExporter fixture."""
-    return MCPExporter(registry)
+def exporter(registry: SkillRegistry) -> MCPSkillExporter:
+    """Creates an MCPSkillExporter fixture."""
+    return MCPSkillExporter(registry)
 
-def test_export_tools(exporter: MCPExporter) -> None:
+def test_export_tools(exporter: MCPSkillExporter) -> None:
     """Tests if tools are correctly exported via the adapter."""
-    tools: List[Dict[str, Any]] = exporter.export_tools()
+    tools: List[Dict[str, Any]] = exporter.list_tools()
     assert len(tools) == 3
     names: List[str] = [t["name"] for t in tools]
     assert "dummy_skill" in names
@@ -58,7 +58,7 @@ def test_export_tools(exporter: MCPExporter) -> None:
     assert "f" not in schema["required"]
 
 @pytest.mark.asyncio
-async def test_handle_rpc_request_success(exporter: MCPExporter) -> None:
+async def test_handle_rpc_request_success(exporter: MCPSkillExporter) -> None:
     """Tests a successful JSON-RPC tool execution request."""
     req = {
         "jsonrpc": "2.0",
@@ -74,7 +74,7 @@ async def test_handle_rpc_request_success(exporter: MCPExporter) -> None:
     assert res["result"]["content"][0]["text"] == "Result: test"
 
 @pytest.mark.asyncio
-async def test_handle_rpc_request_invalid_method(exporter: MCPExporter) -> None:
+async def test_handle_rpc_request_invalid_method(exporter: MCPSkillExporter) -> None:
     """Tests handling of an invalid JSON-RPC method."""
     req = {
         "jsonrpc": "2.0",
@@ -87,7 +87,7 @@ async def test_handle_rpc_request_invalid_method(exporter: MCPExporter) -> None:
     assert res["error"]["code"] == -32601
 
 @pytest.mark.asyncio
-async def test_handle_rpc_request_invalid_jsonrpc(exporter: MCPExporter) -> None:
+async def test_handle_rpc_request_invalid_jsonrpc(exporter: MCPSkillExporter) -> None:
     """Tests handling of an invalid JSON-RPC version."""
     req = {
         "method": "dummy_skill",
@@ -100,7 +100,7 @@ async def test_handle_rpc_request_invalid_jsonrpc(exporter: MCPExporter) -> None
 
 
 @pytest.mark.asyncio
-async def test_handle_rpc_request_error_in_tool(exporter: MCPExporter) -> None:
+async def test_handle_rpc_request_error_in_tool(exporter: MCPSkillExporter) -> None:
     """Tests error handling when the underlying tool raises an exception."""
     req = {
         "jsonrpc": "2.0",


### PR DESCRIPTION
This PR implements the MCPSkillExporter class, allowing Magda's internal skills to be exported as standardized MCP (Model Context Protocol) tools. It includes functionality to generate JSON schemas from function signatures and a JSON-RPC 2.0 handler for tool execution. Tests have been updated and verified.

---
*PR created automatically by Jules for task [18006442113711878922](https://jules.google.com/task/18006442113711878922) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPSkillExporter` to expose `SkillRegistry` skills via JSON-RPC 2.0
> - Adds [mcp_exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/361/files#diff-51d4f3956e0f12608c5be59e521723e3da232b2c97a82a121c8878ce58292f3a) with `MCPSkillExporter`, which wraps a `SkillRegistry` and exposes its skills as MCP-compatible tools.
> - `list_tools()` returns tool definitions with names, descriptions, and input schemas derived from function signatures and type annotations (or an explicit `__mcp_schema__` attribute).
> - `handle_rpc_request()` validates JSON-RPC 2.0 requests, executes skills synchronously or asynchronously, and returns structured success or error responses with standard error codes (-32600, -32601, -32000).
> - Updates tests in [test_mcp_exporter.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/361/files#diff-c8233512ac47a7f069faf85a52ae07fbcf6a267271d62ab2d6ce54813d32f76b) to reference the new class and method names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e33c647.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->