### PR TITLE
FEATURE: Context Engine Lifecycle Hooks Architecture

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6551,7 +6551,7 @@
     },
     {
       "id": "context-engine-hooks-v1",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine Lifecycle Hooks",
@@ -13221,6 +13221,57 @@
       "acceptance": [
         "ACS module enforces checkpoints on tool execution",
         "Tests verify guardrail blocking logic"
+      ]
+    },
+    {
+      "id": "mcp-skill-marketplace-sync-v2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Skill Marketplace Sync v2",
+      "description": "Inspired by trend: Skill marketplace compatibility. Implement a background sync process that dynamically updates MCP tools from agentskills.io marketplace to maintain the local skill registry.",
+      "allowed_paths": [
+        "magda_agent/integration/skill_marketplace.py",
+        "tests/test_skill_marketplace.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Background sync successfully fetches and registers new tools via MCP.",
+        "Tests verify sync logic with mocked network requests."
+      ]
+    },
+    {
+      "id": "a2a-discovery-agent-cards-v4",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Discovery Agent Cards v4",
+      "description": "Inspired by trend: Agent discovery через Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_cards.py",
+        "tests/test_a2a_cards.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can broadcast and parse Agent Cards v4 over the A2A network.",
+        "Tests mock network layer and verify parsing logic."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-v6",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw-RL Live Telemetry Streaming V6",
+      "description": "Inspired by trend: OpenClaw canvas live visualization. Stream live OpenClaw-RL telemetry (PAD shifts, reward signals) over websockets for canvas visualization.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_distributed_v7.py",
+        "tests/test_a2a_distributed_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL telemetry events are correctly formatted and streamed.",
+        "Tests mock websocket emission and verify event payloads."
       ]
     }
   ]

--- a/magda_agent/memory/context_hooks.py
+++ b/magda_agent/memory/context_hooks.py
@@ -1,0 +1,104 @@
+import logging
+import asyncio
+import inspect
+from typing import Callable, Dict, List, Any, Optional, Protocol, Set
+
+class HookRegistry:
+    """Registry and manager for context lifecycle hooks."""
+
+    def __init__(self) -> None:
+        self._hooks: Dict[str, List[Callable]] = {}
+        logging.debug("Initialized HookRegistry")
+
+    def register_hook(self, hook_type: str, callback: Callable) -> None:
+        """Registers a callback for a specific hook type."""
+        if hook_type not in self._hooks:
+            self._hooks[hook_type] = []
+        if callback not in self._hooks[hook_type]:
+            self._hooks[hook_type].append(callback)
+            callback_name = getattr(callback, '__name__', str(callback))
+            logging.debug(f"Registered hook '{hook_type}': {callback_name}")
+
+    def unregister_hook(self, hook_type: str, callback: Callable) -> None:
+        """Unregisters a callback for a specific hook type."""
+        if hook_type in self._hooks and callback in self._hooks[hook_type]:
+            self._hooks[hook_type].remove(callback)
+            callback_name = getattr(callback, '__name__', str(callback))
+            logging.debug(f"Unregistered hook '{hook_type}': {callback_name}")
+
+    def trigger_hook(self, hook_type: str, *args: Any, **kwargs: Any) -> Any:
+        """Triggers all callbacks registered for the hook type."""
+        logging.debug(f"Triggering hook '{hook_type}'")
+        if hook_type not in self._hooks or not self._hooks[hook_type]:
+            # For pipeline-style hooks like before_retrieval, return the first argument
+            if args:
+                return args[0]
+            return None
+
+        result = None
+        if args:
+            result = args[0]
+
+        for callback in self._hooks[hook_type]:
+            if result is not None:
+                # pass result as first arg for chaining
+                new_args = (result,) + args[1:]
+                result = callback(*new_args, **kwargs)
+            else:
+                result = callback(*args, **kwargs)
+
+        return result
+
+    async def trigger_hook_async(self, hook_type: str, *args: Any, **kwargs: Any) -> Any:
+        """Triggers all async callbacks for the hook type in a pipeline (chained)."""
+        logging.debug(f"Triggering async hook '{hook_type}'")
+        if hook_type not in self._hooks or not self._hooks[hook_type]:
+            if args:
+                return args[0]
+            return None
+
+        result = None
+        if args:
+            result = args[0]
+
+        for callback in self._hooks[hook_type]:
+            if result is not None:
+                new_args = (result,) + args[1:]
+                if inspect.iscoroutinefunction(callback) or asyncio.iscoroutine(callback):
+                    result = await callback(*new_args, **kwargs)
+                else:
+                    result = callback(*new_args, **kwargs)
+            else:
+                if inspect.iscoroutinefunction(callback) or asyncio.iscoroutine(callback):
+                    result = await callback(*args, **kwargs)
+                else:
+                    result = callback(*args, **kwargs)
+
+        return result
+
+    async def trigger_broadcast_async(self, hook_type: str, *args: Any, **kwargs: Any) -> Any:
+        """Triggers all async callbacks independently, returning the last result."""
+        logging.debug(f"Broadcasting async hook '{hook_type}'")
+        if hook_type not in self._hooks or not self._hooks[hook_type]:
+            return None
+
+        result = None
+        for callback in self._hooks[hook_type]:
+            if inspect.iscoroutinefunction(callback) or asyncio.iscoroutine(callback):
+                result = await callback(*args, **kwargs)
+            else:
+                result = callback(*args, **kwargs)
+
+        return result
+
+
+class ContextPluginInterface(Protocol):
+    """Protocol defining the interface for context plugins."""
+
+    def attach(self, registry: HookRegistry) -> None:
+        """Attaches the plugin's hooks to the registry."""
+        ...
+
+    def detach(self, registry: HookRegistry) -> None:
+        """Detaches the plugin's hooks from the registry."""
+        ...

--- a/tests/test_context_hooks.py
+++ b/tests/test_context_hooks.py
@@ -1,5 +1,5 @@
 import pytest
-from magda_agent.architecture.context_hooks import HookRegistry
+from magda_agent.memory.context_hooks import HookRegistry, ContextPluginInterface
 
 def test_hook_registration():
     registry = HookRegistry()
@@ -10,6 +10,17 @@ def test_hook_registration():
     assert "before_retrieval" in registry._hooks
     assert len(registry._hooks["before_retrieval"]) == 1
     assert registry._hooks["before_retrieval"][0] == sample_hook
+
+def test_hook_unregistration():
+    registry = HookRegistry()
+    def sample_hook(query: str, user_id: int) -> str:
+        return query + " modified"
+
+    registry.register_hook("before_retrieval", sample_hook)
+    assert len(registry._hooks["before_retrieval"]) == 1
+
+    registry.unregister_hook("before_retrieval", sample_hook)
+    assert len(registry._hooks["before_retrieval"]) == 0
 
 def test_hook_triggering_pipeline():
     registry = HookRegistry()
@@ -56,3 +67,34 @@ def test_hook_triggering_side_effect():
 
     assert len(context_updates) == 1
     assert context_updates[0] == ({"key": "value"}, 42)
+
+class DummyPlugin:
+    def __init__(self):
+        self.hook_called = False
+
+    def my_hook(self, *args, **kwargs):
+        self.hook_called = True
+        if args:
+            return args[0]
+        return None
+
+    def attach(self, registry: HookRegistry) -> None:
+        registry.register_hook("custom_hook", self.my_hook)
+
+    def detach(self, registry: HookRegistry) -> None:
+        registry.unregister_hook("custom_hook", self.my_hook)
+
+
+def test_plugin_attach_detach():
+    registry = HookRegistry()
+    plugin = DummyPlugin()
+
+    plugin.attach(registry)
+    assert "custom_hook" in registry._hooks
+    assert len(registry._hooks["custom_hook"]) == 1
+
+    registry.trigger_hook("custom_hook")
+    assert plugin.hook_called is True
+
+    plugin.detach(registry)
+    assert len(registry._hooks["custom_hook"]) == 0


### PR DESCRIPTION
This PR implements the `context-engine-hooks-v1` task from the backlog by adding a `HookRegistry` and `ContextPluginInterface` to support dynamically attaching and detaching Context Engine plugins via lifecycle hooks.

In addition, the agent backlog has been updated with 3 new high-priority trend tasks based on June 2026 specs:
- MCP Dynamic Skill Marketplace Sync v2
- A2A Discovery Agent Cards v4
- OpenClaw-RL Live Telemetry Streaming V6

All tests pass including regression checks.

---
*PR created automatically by Jules for task [13327838849059623947](https://jules.google.com/task/13327838849059623947) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context lifecycle hook registry with sync, async pipeline, and broadcast execution
> - Introduces `HookRegistry` in [`magda_agent/memory/context_hooks.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/363/files#diff-5d93e9d869d10032179bf827981fde269eb68dfd3487c3e07d126c978d3fd731) to register, unregister, and invoke callbacks keyed by hook type.
> - Supports three execution modes: synchronous pipeline (`trigger_hook`), async pipeline (`trigger_hook_async`), and async broadcast (`trigger_broadcast_async`); pipeline modes chain results between callbacks.
> - Adds `ContextPluginInterface` protocol defining `attach`/`detach` methods for plugins to integrate with the registry.
> - Tests in [`tests/test_context_hooks.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/363/files#diff-05605e49edfc5a36ee236c64f3b6fe7922ad5ec4c99492f6fbfab3f45c7a92b2) cover registration, unregistration, pipeline triggering, async execution, broadcast, and plugin attach/detach via a `DummyPlugin` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31ac6e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->