### PR TITLE
Implement hermes-agent-skills-creation-loop-v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6568,7 +6568,7 @@
     },
     {
       "id": "hermes-agent-skills-creation-loop-v3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Hermes Agent Skills Creation Loop v3",
@@ -13272,6 +13272,57 @@
       "acceptance": [
         "RL telemetry events are correctly formatted and streamed.",
         "Tests mock websocket emission and verify event payloads."
+      ]
+    },
+    {
+      "id": "openclaw-context-hooks-v5-75ccc0a9",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Implement OpenClaw Context Engine lifecycle hooks",
+      "description": "Implement OpenClaw-inspired Context Engine plugin interface with lifecycle hooks for better dynamic context management.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_lifecycle.py",
+        "tests/test_context_engine_lifecycle.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine supports lifecycle hooks",
+        "Tests mock plugin attachments and hook triggers"
+      ]
+    },
+    {
+      "id": "acs-guardrails-integration-v1-6335a739",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "Implement ACS Guardrails for Agent Safety",
+      "description": "Implement ACS standard guardrails using a policy layer. All tool calls must pass through this validation.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_v3.py",
+        "tests/test_acs_guard_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool calls pass through policy layer validation",
+        "Tests mock invalid and valid actions"
+      ]
+    },
+    {
+      "id": "claude-agent-teams-isolation-v2-c3dca071",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Add Agent Teams Git Worktree Isolation",
+      "description": "Implement Claude Agent SDK inspired multi-agent worktree isolation so sub-agents can work safely on parallel tasks.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_v3.py",
+        "tests/test_agent_teams_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agents spawn in isolated worktrees",
+        "Tests verify worktree creation and cleanup"
       ]
     }
   ]

--- a/magda_agent/learning/skills_creation.py
+++ b/magda_agent/learning/skills_creation.py
@@ -1,0 +1,102 @@
+import re
+import json
+import logging
+from typing import Dict, Any, Optional
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.procedural import ProceduralMemory
+
+class ExperienceSkillCreator:
+    """
+    Creates reusable Python skills dynamically from past execution experiences.
+    Inspired by Hermes Agent trend.
+    """
+    def __init__(self, llm_client: LLMClient, procedural_memory: Optional[ProceduralMemory] = None) -> None:
+        """
+        Initializes the ExperienceSkillCreator.
+
+        Args:
+            llm_client: The LLM client used for code generation.
+            procedural_memory: The memory layer used for storing extracted skills.
+        """
+        self.llm_client = llm_client
+        self.procedural_memory = procedural_memory
+        self.created_skills: Dict[str, Dict[str, Any]] = {}
+
+    async def generate_skill_from_experience(self, task_description: str, execution_trace: list[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """
+        Analyzes an execution trace and attempts to generate a Python skill.
+        Also generates an agentskills.io compliant JSON schema for the skill.
+
+        Args:
+            task_description: A description of the task.
+            execution_trace: A list of dicts representing the execution trace.
+
+        Returns:
+            A dictionary containing the generated code and schema, or None if generation failed.
+        """
+        trace_text = ""
+        for i, step in enumerate(execution_trace):
+            action = step.get("action", "unknown action")
+            outcome = step.get("outcome", "unknown outcome")
+            trace_text += f"Step {i+1}: {action} -> {outcome}\n"
+
+        prompt = (
+            "Analyze the following execution trace of a task.\n"
+            "Generate a Python function (a 'skill') that encapsulates this logic and is highly reusable.\n"
+            "Return the Python code enclosed in ```python\n...\n```.\n"
+            "Also return an agentskills.io compliant JSON schema enclosed in ```json\n...\n```.\n"
+            "The JSON schema must have 'name', 'description', and 'parameters' keys.\n\n"
+            f"Task: {task_description}\n\n"
+            f"Execution Trace:\n{trace_text}"
+        )
+
+        messages = [{"role": "user", "content": prompt}]
+
+        try:
+            response = await self.llm_client.chat_completion(messages=messages)
+        except Exception as e:
+            logging.error(f"Failed to generate skill from experience: {e}")
+            return None
+
+        # Extract python code
+        code_match = re.search(r"```python\n(.*?)```", response, re.DOTALL)
+        if not code_match:
+            logging.error("No valid Python code found in response.")
+            return None
+        code = code_match.group(1).strip()
+
+        # Extract json schema
+        json_match = re.search(r"```json\n(.*?)```", response, re.DOTALL)
+        if not json_match:
+            logging.error("No valid JSON schema found in response.")
+            return None
+
+        try:
+            schema = json.loads(json_match.group(1).strip())
+        except json.JSONDecodeError as e:
+            logging.error(f"Failed to decode JSON schema: {e}")
+            return None
+
+        skill_name = schema.get("name", "generated_skill")
+
+        skill_data = {
+            "code": code,
+            "schema": schema
+        }
+
+        self.created_skills[skill_name] = skill_data
+
+        if self.procedural_memory:
+            self.procedural_memory.store_procedure(
+                name=skill_name,
+                procedure=code,
+                metadata={
+                    "source_task": task_description,
+                    "type": "hermes_experience_skill_v3",
+                    "schema": schema
+                }
+            )
+
+        logging.info(f"Dynamically generated and stored new skill from experience: {skill_name}")
+        return skill_data

--- a/tests/test_skills_creation.py
+++ b/tests/test_skills_creation.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.learning.skills_creation import ExperienceSkillCreator
+from magda_agent.memory.procedural import ProceduralMemory
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_llm_client() -> LLMClient:
+    client = MagicMock(spec=LLMClient)
+    client.chat_completion = AsyncMock()
+    return client
+
+@pytest.fixture
+def mock_procedural_memory() -> ProceduralMemory:
+    mem = MagicMock(spec=ProceduralMemory)
+    mem.store_procedure = MagicMock()
+    return mem
+
+@pytest.mark.asyncio
+async def test_generate_skill_success(mock_llm_client: LLMClient, mock_procedural_memory: ProceduralMemory) -> None:
+    mock_response = """
+Here is the skill:
+```python
+def parse_logs(logs):
+    return [l for l in logs if "ERROR" in l]
+```
+And the schema:
+```json
+{
+    "name": "parse_logs",
+    "description": "Parses error logs",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "logs": {"type": "array"}
+        }
+    }
+}
+```
+"""
+    mock_llm_client.chat_completion.return_value = mock_response
+
+    creator = ExperienceSkillCreator(llm_client=mock_llm_client, procedural_memory=mock_procedural_memory)
+
+    trace = [{"action": "read logs", "outcome": "got logs"}, {"action": "filter errors", "outcome": "got errors"}]
+    result = await creator.generate_skill_from_experience("Parse error logs", trace)
+
+    assert result is not None
+    assert "def parse_logs" in result["code"]
+    assert result["schema"]["name"] == "parse_logs"
+    assert "parse_logs" in creator.created_skills
+
+    mock_procedural_memory.store_procedure.assert_called_once_with(
+        name="parse_logs",
+        procedure="def parse_logs(logs):\n    return [l for l in logs if \"ERROR\" in l]",
+        metadata={
+            "source_task": "Parse error logs",
+            "type": "hermes_experience_skill_v3",
+            "schema": result["schema"]
+        }
+    )
+
+@pytest.mark.asyncio
+async def test_generate_skill_missing_code(mock_llm_client: LLMClient, mock_procedural_memory: ProceduralMemory) -> None:
+    mock_response = """
+    No code here
+    ```json
+    {
+        "name": "parse_logs"
+    }
+    ```
+    """
+    mock_llm_client.chat_completion.return_value = mock_response
+
+    creator = ExperienceSkillCreator(llm_client=mock_llm_client, procedural_memory=mock_procedural_memory)
+    result = await creator.generate_skill_from_experience("Task", [{"action": "a", "outcome": "b"}])
+
+    assert result is None
+    mock_procedural_memory.store_procedure.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_generate_skill_invalid_json(mock_llm_client: LLMClient, mock_procedural_memory: ProceduralMemory) -> None:
+    mock_response = """
+    ```python
+    def foo(): pass
+    ```
+    ```json
+    {
+        "name": "foo",
+        "invalid
+    ```
+    """
+    mock_llm_client.chat_completion.return_value = mock_response
+
+    creator = ExperienceSkillCreator(llm_client=mock_llm_client, procedural_memory=mock_procedural_memory)
+    result = await creator.generate_skill_from_experience("Task", [{"action": "a", "outcome": "b"}])
+
+    assert result is None
+    mock_procedural_memory.store_procedure.assert_not_called()


### PR DESCRIPTION
This PR implements the `ExperienceSkillCreator` module inside `magda_agent/learning/skills_creation.py` which dynamically uses an LLM to generate reusable Python skills and schema from an execution trace and stores them in `ProceduralMemory`. It also updates `agent_tasks.json` marking this task as done and adds three new todo tasks based on `docs/trends.md` focused on OpenClaw context hooks, ACS safety guardrails, and Claude Agent teams isolation.

---
*PR created automatically by Jules for task [4655362091405517891](https://jules.google.com/task/4655362091405517891) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ExperienceSkillCreator` class to generate agent skills from execution traces
> - Adds [`ExperienceSkillCreator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/364/files#diff-0ed6e81ccc6f29a9f0ca6dbcbb86ead80563e4d16ff425c41e5de2ac9d79f0a8) in a new `skills_creation` module. It builds a prompt from a task description and execution trace, calls an LLM, and extracts Python code and a JSON schema from fenced blocks in the response.
> - Generated skills are stored in an internal `created_skills` registry and optionally persisted to a `ProceduralMemory` via `store_procedure`.
> - Returns `None` on LLM errors, missing code/schema blocks, or invalid JSON.
> - Adds pytest coverage in [`tests/test_skills_creation.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/364/files#diff-772023e0250f0bb649e184634f7b5ebb19908bf5f9f611def5aff65b6fc99364) for success, missing code block, and invalid JSON cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bed1795.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->