### PR TITLE
feat: implement MCP Action Tool Concurrency v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6585,7 +6585,7 @@
     },
     {
       "id": "mcp-action-tool-concurrency-v5",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Action Tool Concurrency v5",
@@ -13323,6 +13323,48 @@
       "acceptance": [
         "Sub-agents spawn in isolated worktrees",
         "Tests verify worktree creation and cleanup"
+      ]
+    },
+    {
+      "id": "openclaw-rl-signals-v3",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Signals Processor",
+      "description": "Train agent using online reinforcement learning from next-state signals (user replies, tool outputs) based on OpenClaw trend.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_signals.py"
+      ],
+      "acceptance": [
+        "RL processor created and tested"
+      ]
+    },
+    {
+      "id": "claude-agent-teams-isolation-v4",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Agent Teams Worktree Isolation",
+      "description": "Implement git worktree isolation for sub-agents to enable parallel multi-agent task execution without cross-contamination based on Claude Agent Teams trend.",
+      "allowed_paths": [
+        "magda_agent/architecture/worktree_isolation.py"
+      ],
+      "acceptance": [
+        "Subagents run in isolated worktrees"
+      ]
+    },
+    {
+      "id": "acs-runtime-guardrails-v5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Validation Checkpoints",
+      "description": "Implement Agent Control Specification (ACS) 5 validation checkpoints for agentic workflows to ensure policy-driven execution based on Microsoft ACS trend.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_v3.py"
+      ],
+      "acceptance": [
+        "5 checkpoints validated during tool calls"
       ]
     }
   ]

--- a/magda_agent/skills/mcp_concurrency.py
+++ b/magda_agent/skills/mcp_concurrency.py
@@ -57,15 +57,36 @@ class MCPConcurrentSkillExecutor:
                 The result of the execution.
             """
             try:
+                func_to_call = None
+                call_args = ()
+                call_kwargs = {}
+
                 if hasattr(self.mcp_client, "execute_tool"):
-                    result = self.mcp_client.execute_tool(n, kw)
+                    func_to_call = self.mcp_client.execute_tool
+                    call_args = (n, kw)
                 elif hasattr(self.mcp_client, "execute"):
-                    result = self.mcp_client.execute(n, kw)
+                    func_to_call = self.mcp_client.execute
+                    call_args = (n, kw)
                 elif hasattr(self.mcp_client, "skills") and n in self.mcp_client.skills:
-                    skill_func = self.mcp_client.skills[n]
-                    result = skill_func(**kw)
+                    func_to_call = self.mcp_client.skills[n]
+                    call_kwargs = kw
                 else:
                     return f"Error: MCP Tool '{n}' not found or client missing execute method."
+
+                is_async = False
+                if inspect.iscoroutinefunction(func_to_call):
+                    is_async = True
+                elif hasattr(func_to_call, "__is_async__") and getattr(func_to_call, "__is_async__"):
+                    is_async = True
+                elif hasattr(func_to_call, "__call__") and inspect.iscoroutinefunction(func_to_call.__call__):
+                    is_async = True
+
+                if is_async:
+                    result = func_to_call(*call_args, **call_kwargs)
+                else:
+                    def sync_wrapper():
+                        return func_to_call(*call_args, **call_kwargs)
+                    result = await asyncio.to_thread(sync_wrapper)
 
                 if inspect.isawaitable(result):
                     return await result

--- a/tests/test_mcp_concurrency.py
+++ b/tests/test_mcp_concurrency.py
@@ -170,3 +170,33 @@ async def test_execute_mcp_tools_duplicate_calls():
     assert results[0] == "server1-tool_a_1"
     assert results[1] is None
     assert results[2] == "server1-tool_a_1"
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tools_concurrently_sync_blocking():
+    """
+    Test that synchronous fallback methods do not block the event loop.
+    We mock an execute method with time.sleep(0.2) and submit two tools concurrently.
+    The total execution time should be < 0.3s.
+    """
+    import time
+
+    class MockSyncClient:
+        def execute(self, name, kwargs):
+            time.sleep(0.2)
+            return f"{name}_sync_res"
+
+    mock_client = MockSyncClient()
+    executor = MCPConcurrentSkillExecutor(mock_client)
+
+    tool_calls = [
+        {"name": "server1-tool_a", "kwargs": {}},
+        {"name": "server2-tool_b", "kwargs": {}}
+    ]
+
+    start_time = asyncio.get_event_loop().time()
+    results = await executor.execute_mcp_tools_concurrently(tool_calls)
+    end_time = asyncio.get_event_loop().time()
+
+    assert end_time - start_time < 0.3
+    assert results[0] == "server1-tool_a_sync_res"
+    assert results[1] == "server2-tool_b_sync_res"


### PR DESCRIPTION
This PR implements runtime function tool concurrency for MCP tools as requested by the `mcp-action-tool-concurrency-v5` task, inspired by the OpenAI Agents SDK trend.

Specifically, it ensures that when `MCPConcurrentSkillExecutor` calls synchronous fallback methods (like `execute` or `execute_tool`), these calls are wrapped in `asyncio.to_thread`. This guarantees that synchronous tool executions do not block the main asyncio event loop, allowing true concurrency.

Additionally, 3 new trend-inspired tasks have been added to the `agent_tasks.json` backlog. All tests pass successfully and the manifest validates correctly.

---
*PR created automatically by Jules for task [15657678012439622617](https://jules.google.com/task/15657678012439622617) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run synchronous MCP tool calls in a thread pool to prevent event-loop blocking
> - Refactors `MCPConcurrentSkillExecutor.run_single_tool` in [mcp_concurrency.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/365/files#diff-b77c907af979815f1f6cc222bd188c6f2dbf0abf2f19b68318c6ab103af1c5bf) to resolve each tool to a common callable before dispatch, then uses `asyncio.to_thread` to offload synchronous callables to a worker thread.
> - Async detection now uses `inspect.iscoroutinefunction` on the function and its `__call__`, plus a custom `__is_async__` flag, so both async and sync callables are handled correctly.
> - Adds a regression test in [test_mcp_concurrency.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/365/files#diff-5f1dc28a34199dd3dd8ae9fa6b1e30d970d82e406934628a244b7efac861ccb5) that asserts two blocking `time.sleep` tool calls complete in under 0.3s when run concurrently.
> - Behavioral Change: synchronous tool executions that previously ran on the event loop now run in a thread pool, which changes threading context for any sync tools with thread-local state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37e75e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->