### PR TITLE
Implement Context Engine Memory Compression Plugin

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6046,7 +6046,7 @@
     },
     {
       "id": "context-engine-memory-compression-plugin-v1",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine Memory Compression Plugin",
@@ -12034,6 +12034,40 @@
       "acceptance": [
         "Creator produces valid MCP-compatible tool schema from raw log strings.",
         "Tests verify LLM schema generation using mocks."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-action-registry-v7-1edad2b2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Action Registry V7",
+      "description": "Inspired by MCP trends: Implement an MCP-compatible dynamic action registry v7 for dynamic action tools registration.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry_v7.py",
+        "tests/test_mcp_registry_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Registry dynamically registers action tools",
+        "Tests mock MCP requests"
+      ]
+    },
+    {
+      "id": "a2a-peer-task-delegation-v3-d601c251",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Peer Task Delegation V3",
+      "description": "Inspired by A2A trends: Implement A2A peer task delegation v3 to allow agents to delegate tasks to peers efficiently.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegation_v3.py",
+        "tests/test_a2a_delegation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent delegates tasks to peers over A2A",
+        "Tests verify delegation logic"
       ]
     }
   ]

--- a/magda_agent/memory/compression_plugin.py
+++ b/magda_agent/memory/compression_plugin.py
@@ -1,0 +1,97 @@
+import logging
+from typing import Any, Dict, List, Optional
+from magda_agent.memory.context_engine import ContextPlugin
+
+class CompressionPlugin(ContextPlugin):
+    """
+    Plugin for Context Engine that compresses older context items
+    when limits are reached.
+    """
+    def __init__(self, llm: Optional[Any] = None) -> None:
+        """
+        Initializes the CompressionPlugin.
+
+        Args:
+            llm: Optional language model integration for intelligent compaction.
+        """
+        self.llm = llm
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration."""
+        pass
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Process incoming content before it is stored or used."""
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Assemble the context string from retrieved items for the LLM."""
+        return "\n".join([f"- {getattr(item, 'content', str(item))}" for item in context_items])
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact or summarize the context when limits are reached."""
+        limit = metadata.get("limit", 10)
+        if len(context_items) <= limit:
+            return context_items
+
+        if not self.llm:
+            logging.warning("No LLM available for compaction, dropping oldest item.")
+            return context_items[1:]
+
+        to_summarize = context_items[:2]
+        remaining = context_items[2:]
+
+        combined_text = "\n".join([f"- {getattr(e, 'content', str(e))}" for e in to_summarize])
+        prompt = f"Please summarize the following short-term memory context into a single concise bullet point:\n{combined_text}"
+
+        try:
+            summary_content = await self.llm.chat_completion([
+                {"role": "system", "content": "You compress memory context. Return only the summary text."},
+                {"role": "user", "content": prompt}
+            ], temperature=0.3)
+
+            from magda_agent.memory.working import MemoryEntry
+
+            first = to_summarize[0] if to_summarize else None
+            avg_importance = sum(getattr(e, 'importance', 0.5) for e in to_summarize) / max(1, len(to_summarize))
+
+            tags = []
+            for e in to_summarize:
+                e_tags = getattr(e, 'tags', [])
+                if isinstance(e_tags, list):
+                    tags.extend(e_tags)
+            tags = list(set(tags))
+
+            summary_entry = MemoryEntry(
+                content=summary_content.strip(),
+                importance=avg_importance,
+                emotional_state=getattr(first, 'emotional_state', None) if first else None,
+                tags=tags,
+                user_id=getattr(first, 'user_id', None) if first else None
+            )
+
+            return [summary_entry] + remaining
+
+        except Exception as e:
+            logging.error(f"CompressionPlugin compaction failed: {e}")
+            return context_items[1:]
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Called before context is retrieved. Can modify the query."""
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """Called after context is retrieved. Can modify the retrieved context."""
+        return context
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """Called before context is written. Can modify the context."""
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """Called after context is written."""
+        pass
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """Called when the overall context is updated."""
+        pass

--- a/tests/test_compression_plugin.py
+++ b/tests/test_compression_plugin.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.memory.compression_plugin import CompressionPlugin
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+@pytest.fixture
+def mock_llm():
+    llm = MagicMock()
+    llm.chat_completion = AsyncMock(return_value="Compressed summary")
+    return llm
+
+@pytest.fixture
+def pad_state():
+    return PADState(pleasure=0.0, arousal=0.0, dominance=0.0)
+
+@pytest.mark.asyncio
+async def test_compression_plugin_compact_under_limit(mock_llm, pad_state):
+    plugin = CompressionPlugin(llm=mock_llm)
+
+    # 2 items, limit 3 -> should not compact
+    items = [
+        MemoryEntry(content="Item 1", user_id=1, importance=0.5, emotional_state=pad_state),
+        MemoryEntry(content="Item 2", user_id=1, importance=0.5, emotional_state=pad_state)
+    ]
+    metadata = {"limit": 3}
+
+    result = await plugin.compact(items, metadata)
+
+    assert len(result) == 2
+    assert result == items
+    mock_llm.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compression_plugin_compact_over_limit(mock_llm, pad_state):
+    plugin = CompressionPlugin(llm=mock_llm)
+
+    # 4 items, limit 3 -> should compact first two
+    items = [
+        MemoryEntry(content="Item 1", user_id=1, importance=0.6, emotional_state=pad_state, tags=["t1"]),
+        MemoryEntry(content="Item 2", user_id=1, importance=0.8, emotional_state=pad_state, tags=["t2"]),
+        MemoryEntry(content="Item 3", user_id=1, importance=0.5, emotional_state=pad_state),
+        MemoryEntry(content="Item 4", user_id=1, importance=0.5, emotional_state=pad_state)
+    ]
+    metadata = {"limit": 3}
+
+    result = await plugin.compact(items, metadata)
+
+    assert len(result) == 3
+    assert result[0].content == "Compressed summary"
+    assert result[0].importance == 0.7  # (0.6 + 0.8) / 2
+    assert set(result[0].tags) == {"t1", "t2"}
+    assert result[1] == items[2]
+    assert result[2] == items[3]
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_compression_plugin_compact_no_llm(pad_state):
+    plugin = CompressionPlugin(llm=None)
+
+    items = [
+        MemoryEntry(content="Item 1", user_id=1, importance=0.5, emotional_state=pad_state),
+        MemoryEntry(content="Item 2", user_id=1, importance=0.5, emotional_state=pad_state),
+        MemoryEntry(content="Item 3", user_id=1, importance=0.5, emotional_state=pad_state),
+        MemoryEntry(content="Item 4", user_id=1, importance=0.5, emotional_state=pad_state)
+    ]
+    metadata = {"limit": 3}
+
+    # Should drop oldest item
+    result = await plugin.compact(items, metadata)
+
+    assert len(result) == 3
+    assert result == items[1:]


### PR DESCRIPTION
Implements the Context Engine Memory Compression Plugin as specified in agent_tasks.json. Fixes context-engine-memory-compression-plugin-v1.

---
*PR created automatically by Jules for task [6926538811823027785](https://jules.google.com/task/6926538811823027785) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CompressionPlugin` to compress context memory using LLM summarization
> - Adds [compression_plugin.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/368/files#diff-e32a28619c114196c7b17b6785d105d47f389d426077ff18f9b4f65664159028), a `ContextPlugin` implementation that assembles context items into a bulleted string and compacts them when a configurable item limit is exceeded.
> - When over the limit and an LLM is available, the oldest two items are replaced with a single `MemoryEntry` summary with averaged importance and merged tags. Without an LLM, the oldest item is dropped.
> - Includes unit tests covering no-op under limit, LLM summarization path, and fallback drop behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e25602.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->