### PR TITLE
feat: MCP Dynamic Tool Registration v3 Enhanced Validation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6063,7 +6063,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registration-v3",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registration v3",
@@ -12068,6 +12068,57 @@
       "acceptance": [
         "Agent delegates tasks to peers over A2A",
         "Tests verify delegation logic"
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-tool-tracing-0ce2e402",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Tool Execution Tracing",
+      "description": "Inspired by trend: OpenClaw canvas live visualization. Stream live execution traces of MCP tools over websockets for canvas visualization.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_distributed_v7.py",
+        "tests/test_a2a_distributed_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool execution traces are correctly formatted and streamed.",
+        "Tests mock websocket emission and verify trace payloads."
+      ]
+    },
+    {
+      "id": "claude-context-compression-3b4e61af",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Claude SDK Inspired Selective Context Compression",
+      "description": "Inspired by trend: Context compression + selective retrieval. Implement a context compressor that selectively prunes older episodic memories based on Letta/MemGPT virtual context patterns.",
+      "allowed_paths": [
+        "magda_agent/skills/compression_v2.py",
+        "tests/test_compression_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context compressor selectively prunes older memories.",
+        "Tests verify compression logic with mocked memory systems."
+      ]
+    },
+    {
+      "id": "a2a-agent-discovery-mesh-44587abb",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A Protocol Discovery Mesh",
+      "description": "Inspired by trend: Agent discovery через Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_cards.py",
+        "tests/test_a2a_cards.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can broadcast Agent Cards in a peer-to-peer mesh.",
+        "Tests mock network layer and verify broadcast logic."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_dynamic_registry.py
+++ b/magda_agent/skills/mcp_dynamic_registry.py
@@ -19,6 +19,32 @@ class MCPDynamicRegistrarV4:
         """
         self.registry = registry
 
+
+    def _perform_enhanced_validation(self, tool_schema: Dict[str, Any]) -> bool:
+        """
+        Performs enhanced validation on the MCP tool schema.
+
+        Args:
+            tool_schema (Dict[str, Any]): The MCP tool schema to validate.
+
+        Returns:
+            bool: True if validation passes, False otherwise.
+        """
+        # Check if name is valid (e.g., alphanumeric and underscores only)
+        if "name" in tool_schema:
+            import re
+            if not re.match(r"^[a-zA-Z0-9_-]+$", tool_schema["name"]):
+                logging.error("Enhanced Validation Failed: Invalid tool name format.")
+                return False
+
+        # Check if inputSchema exists and is a dictionary if provided
+        if "inputSchema" in tool_schema:
+            if not isinstance(tool_schema["inputSchema"], dict):
+                logging.error("Enhanced Validation Failed: inputSchema must be a dictionary.")
+                return False
+
+        return True
+
     def register_tool_at_runtime(self, tool_schema: Dict[str, Any], is_async: bool = False) -> bool:
         """
         Dynamically registers a new MCP tool at runtime using the provided schema.
@@ -30,7 +56,13 @@ class MCPDynamicRegistrarV4:
         Returns:
             bool: True if the tool was registered successfully, False otherwise.
         """
+
         logging.info("Attempting to dynamically register MCP tool at runtime (V4).")
+
+        # Perform enhanced validation
+        if not self._perform_enhanced_validation(tool_schema):
+            return False
+
 
         # Load the tool into the registry
         success = self.registry.load_tool(tool_schema)

--- a/tests/test_mcp_dynamic_registry.py
+++ b/tests/test_mcp_dynamic_registry.py
@@ -52,3 +52,26 @@ def test_register_tool_at_runtime_failure():
 
     assert result is False
     assert "invalid_tool_v4" not in registry.list_tools()
+
+
+def test_register_tool_at_runtime_enhanced_validation_failure():
+    """Test failing dynamic registration due to enhanced validation (invalid name)."""
+    registry = MCPRegistry()
+    registrar = MCPDynamicRegistrarV4(registry)
+
+    invalid_schema_name = {
+        "name": "invalid name with spaces",
+        "description": "A tool with an invalid name."
+    }
+
+    result = registrar.register_tool_at_runtime(invalid_schema_name)
+    assert result is False
+
+    invalid_schema_input = {
+        "name": "valid_name",
+        "description": "A tool with invalid inputSchema.",
+        "inputSchema": "not_a_dict"
+    }
+
+    result = registrar.register_tool_at_runtime(invalid_schema_input)
+    assert result is False


### PR DESCRIPTION
Implement enhanced validation for MCP dynamic tool registration as described in task `mcp-dynamic-tool-registration-v3`.
This adds a new `_perform_enhanced_validation` method to `MCPDynamicRegistrarV4` that ensures:
1. Tool names contain only alphanumeric characters and underscores.
2. `inputSchema` is correctly typed as a dictionary if present.
Tests have been added to verify these failure modes.
Also marked the task as done and added 3 new "todo" tasks inspired by `docs/trends.md`.

---
*PR created automatically by Jules for task [3453819949519236906](https://jules.google.com/task/3453819949519236906) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add enhanced schema validation to `MCPDynamicRegistrarV4.register_tool_at_runtime`
> - Adds `_perform_enhanced_validation` to [mcp_dynamic_registry.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/369/files#diff-ff63fef83f643de9f2b28fcdcba5856e7b819408a2396ef7e8887d525db12c69), which checks that a tool's `name` matches `[a-zA-Z0-9_-]+` and that `inputSchema`, if present, is a dict.
> - `register_tool_at_runtime` now calls this validator as a pre-registration gate, returning `False` early for invalid schemas without altering the rest of the registration flow.
> - A new test in [test_mcp_dynamic_registry.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/369/files#diff-b6c66782c09392c84b2e5aa122e60a2024e0675e13c764f9ed0c099bc390c5b0) covers rejection of names with spaces and non-dict `inputSchema` values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d6424a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->