### PR TITLE
A2A Peer Delegation Discovery V3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6080,7 +6080,7 @@
     },
     {
       "id": "a2a-peer-delegation-discovery-v3",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "high",
       "title": "A2A Peer Delegation Discovery v3",
@@ -12119,6 +12119,41 @@
       "acceptance": [
         "Agent can broadcast Agent Cards in a peer-to-peer mesh.",
         "Tests mock network layer and verify broadcast logic."
+      ]
+    },
+    {
+      "id": "mcp-kernel-taint-isolation-v4",
+      "status": "todo",
+      "area": "security",
+      "risk": "high",
+      "title": "MCP Kernel Taint Tracking Isolation V4",
+      "description": "Inspired by MCP trends: implement an MCP Kernel Taint Tracking Isolation V4 for executing sandboxed plugins.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_kernel_v4.py",
+        "tests/test_mcp_kernel_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP kernel isolates tainted inputs",
+        "Tests mock tainted and clean plugins and pass"
+      ]
+    },
+    {
+      "id": "assert-policy-evaluator-v3",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "ASSERT Policy-Driven Evaluator V3",
+      "description": "Inspired by ASSERT Evaluator trend: implement a policy-driven evaluator V3 to evaluate agent outputs.",
+      "allowed_paths": [
+        "magda_agent/evaluation/assert_evaluator_v3.py",
+        "tests/test_assert_evaluator_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator parses policy rules",
+        "Evaluates outputs according to policy",
+        "Tests pass"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -218,6 +218,7 @@
 * [x] FEATURE: A2A Agent Discovery via Cards v2 (a2a-agent-discovery-cards-v2)
 
 - [x] a2a-peer-delegation-discovery-v2: A2A Peer Delegation Discovery
+- [x] a2a-peer-delegation-discovery-v3: A2A Peer Delegation Discovery v3
 * [x] FEATURE: ACS Workflow Guardrails (acs-workflow-guardrails-v1)
 - [x] openclaw-rl-interactive-learning-v5: OpenClaw-RL Interactive Learning v5
 * [x] FEATURE: MCP Action Tool Exporter v8 (mcp-action-tool-exporter-v8)

--- a/magda_agent/integration/a2a.py
+++ b/magda_agent/integration/a2a.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, List, Optional, Union
 import logging
 from magda_agent.integration.a2a_discovery import AgentCard, A2ADiscovery
 from magda_agent.integration.a2a_discovery_v2 import AgentCardV2, A2ADiscoveryV2
+from magda_agent.integration.a2a_cards import AgentCardV3, A2ADiscoveryV3
 from magda_agent.integration.a2a_delegation import A2ADelegator
 
 class A2AManager:
@@ -10,14 +11,16 @@ class A2AManager:
     of sub-plans/tasks to capable peers in a peer-to-peer network.
     Inspired by A2A Protocol trends.
     """
-    def __init__(self, local_card: Union[AgentCard, AgentCardV2]) -> None:
+    def __init__(self, local_card: Union[AgentCard, AgentCardV2, AgentCardV3]) -> None:
         """
         Initializes the manager with the local agent's identity and capabilities.
 
         Args:
-            local_card: The AgentCard or AgentCardV2 representing this agent.
+            local_card: The AgentCard, AgentCardV2, or AgentCardV3 representing this agent.
         """
-        if isinstance(local_card, AgentCardV2):
+        if isinstance(local_card, AgentCardV3):
+            self.discovery = A2ADiscoveryV3(local_card=local_card) # type: ignore
+        elif isinstance(local_card, AgentCardV2):
             self.discovery = A2ADiscoveryV2(local_card=local_card) # type: ignore
         else:
             self.discovery = A2ADiscovery(local_card=local_card) # type: ignore
@@ -42,12 +45,12 @@ class A2AManager:
             mock_network_cards: Optional list of JSON strings representing mocked Agent Cards.
         """
         logging.info("A2AManager discovering peers...")
-        if isinstance(self.discovery, A2ADiscoveryV2):
+        if isinstance(self.discovery, (A2ADiscoveryV2, A2ADiscoveryV3)):
             await self.discovery.fetch_cards(network_envelopes=mock_network_cards)
         else:
             await self.discovery.fetch_cards(mock_network_cards=mock_network_cards)
 
-    def get_known_peers(self) -> Union[List[AgentCard], List[AgentCardV2]]:
+    def get_known_peers(self) -> Union[List[AgentCard], List[AgentCardV2], List[AgentCardV3]]:
         """
         Retrieves all currently known peers discovered in the network.
 

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,45 @@
+import pytest
+import json
+from magda_agent.integration.a2a import A2AManager
+from magda_agent.integration.a2a_cards import AgentCardV3
+
+@pytest.fixture
+def local_card_v3():
+    return AgentCardV3(
+        agent_id="agent-v3-001",
+        name="MagdaLocalV3",
+        description="Local agent V3 for testing",
+        capabilities=["chat", "code_execution"],
+        endpoints={"rpc": "http://localhost:8080/rpc"}
+    )
+
+@pytest.fixture
+def remote_card_v3():
+    return AgentCardV3(
+        agent_id="agent-remote-v3-001",
+        name="RemoteWorkerV3",
+        description="Worker node V3",
+        capabilities=["image_generation", "chat_advanced"],
+        endpoints={"rpc": "http://192.168.1.10:8080/rpc"}
+    )
+
+@pytest.mark.asyncio
+async def test_a2a_manager_init_v3(local_card_v3):
+    manager = A2AManager(local_card=local_card_v3)
+    assert manager.discovery.__class__.__name__ == "A2ADiscoveryV3"
+
+@pytest.mark.asyncio
+async def test_a2a_manager_discover_peers_v3(local_card_v3, remote_card_v3):
+    manager = A2AManager(local_card=local_card_v3)
+
+    envelope = {
+        "type": "a2a_discovery_broadcast",
+        "version": "3.0",
+        "payload": remote_card_v3.to_json()
+    }
+
+    await manager.discover_peers([json.dumps(envelope)])
+
+    known_peers = manager.get_known_peers()
+    assert len(known_peers) == 1
+    assert known_peers[0].agent_id == "agent-remote-v3-001"


### PR DESCRIPTION
Implement discovery using Agent Cards for the peer-to-peer task delegation efficiently. Added new tasks based on trends.

---
*PR created automatically by Jules for task [6949672058687118569](https://jules.google.com/task/6949672058687118569) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add AgentCardV3 and A2ADiscoveryV3 support to A2AManager for peer delegation discovery
> - Extends [`A2AManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/370/files#diff-f768b47687f1afa793af21f4300b58413cfe22bdea05247a2224dc1372f33d9e) to accept `AgentCardV3` in its constructor and initialize `A2ADiscoveryV3` when provided, alongside existing V1/V2 support.
> - Updates `discover_peers` to pass network cards via the `network_envelopes` parameter when using V2 or V3 discovery (V1 continues to use `mock_network_cards`).
> - Adds tests in [`tests/test_a2a.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/370/files#diff-ef7d6085a53a48c4a852af95fba7ab02166e7a31ae821e26ddb31b73f0c49b80) covering V3 manager initialization and envelope-based peer discovery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5896e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->