### PR TITLE
feat: implement MCP server-prefixed tools support

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6114,7 +6114,7 @@
     },
     {
       "id": "openai-mcp-server-prefixed-tools-v2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Server-Prefixed Tools",
@@ -12205,6 +12205,57 @@
       "acceptance": [
         "Memory can be paged out selectively based on context size limits.",
         "Tests mock memory stores to verify compression logic."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-v4-5e8a3dfa",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Live WebSockets V4",
+      "description": "Inspired by OpenClaw trends: Stream agent states for live OpenClaw Canvas visualization.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_live_v4.py",
+        "tests/test_canvas_live_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent states are correctly streamed.",
+        "Tests mock websocket emission and verify state."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v10-753a6b60",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Export Engine V10",
+      "description": "Inspired by MCP trends: Implement an export engine mapping Magda skills to MCP tools.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter_v10.py",
+        "tests/test_mcp_exporter_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Export engine maps Magda skills.",
+        "Tests verify mapping."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-auth-traversal-v4-f164629c",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A Enterprise Auth Traversal V4",
+      "description": "Inspired by A2A trends: Auth logic for the A2A network mesh traversal.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth_v4.py",
+        "tests/test_a2a_auth_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Auth logic supports network mesh traversal.",
+        "Tests mock networking layer."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_engine.py
+++ b/magda_agent/skills/mcp_engine.py
@@ -19,7 +19,7 @@ class MCPEngine:
         self.registry = registry
         self.mcp_client = mcp_client
 
-    def import_mcp_tool(self, tool_def: Dict[str, Any], connection_info: Dict[str, Any]) -> None:
+    def import_mcp_tool(self, tool_def: Dict[str, Any], connection_info: Dict[str, Any], server_name: str = None) -> None:
         """
         Reads MCP standard tool definitions and wraps them into Magda's SkillRegistry.
 
@@ -27,6 +27,7 @@ class MCPEngine:
             tool_def (Dict[str, Any]): Definition containing at least "name" and "description".
                                        Optionally contains "inputSchema".
             connection_info (Dict[str, Any]): Information needed to execute the remote tool.
+            server_name (str, optional): An optional server name to prefix the tool name to avoid conflicts.
         """
         tool_name = tool_def.get("name")
         if not tool_name:
@@ -35,10 +36,13 @@ class MCPEngine:
         description = tool_def.get("description", "Imported MCP tool.")
         input_schema = tool_def.get("inputSchema", {})
 
-        # 1. Register the remote tool routing with the MCPClient
-        # 1. Register the remote tool routing with the MCPClient
-        # 1. Register the remote tool routing with the MCPClient
-        self.mcp_client.register_remote_tool(tool_name, connection_info)
+        if server_name:
+            # 1a. Register the remote server routing with the MCPClient
+            tool_name = f"{server_name}__{tool_name}"
+            self.mcp_client.register_mcp_server(server_name, connection_info)
+        else:
+            # 1b. Register the remote tool routing directly with the MCPClient
+            self.mcp_client.register_remote_tool(tool_name, connection_info)
 
         import asyncio
         import concurrent.futures

--- a/tests/test_mcp_engine_prefixes.py
+++ b/tests/test_mcp_engine_prefixes.py
@@ -1,0 +1,116 @@
+import pytest
+from unittest.mock import MagicMock
+import asyncio
+
+from magda_agent.skills.mcp_engine import MCPEngine
+from magda_agent.skills.mcp_client import MCPClient
+from magda_agent.skills.registry import SkillRegistry
+
+
+def test_import_mcp_tool_with_server_prefix():
+    """
+    Test that importing an MCP tool with a server name correctly prefixes
+    the tool name and registers the server with the MCP client.
+    """
+    mock_registry = MagicMock(spec=SkillRegistry)
+    mock_mcp_client = MagicMock(spec=MCPClient)
+
+    engine = MCPEngine(registry=mock_registry, mcp_client=mock_mcp_client)
+
+    tool_def = {
+        "name": "search_docs",
+        "description": "Searches documentation.",
+        "inputSchema": {}
+    }
+    connection_info = {"url": "http://example.com"}
+
+    engine.import_mcp_tool(
+        tool_def=tool_def,
+        connection_info=connection_info,
+        server_name="docs_server"
+    )
+
+    # Verify MCP client registered the server, not the tool directly
+    mock_mcp_client.register_mcp_server.assert_called_once_with("docs_server", connection_info)
+    mock_mcp_client.register_remote_tool.assert_not_called()
+
+    # Verify registry registered the prefixed tool
+    mock_registry.register_skill.assert_called_once()
+    registered_kwargs = mock_registry.register_skill.call_args.kwargs
+    assert registered_kwargs["name"] == "docs_server__search_docs"
+    assert registered_kwargs["description"] == "Searches documentation."
+    assert registered_kwargs["func"].__name__ == "docs_server__search_docs"
+    assert getattr(registered_kwargs["func"], "__mcp_schema__") == {}
+
+
+def test_import_mcp_tool_without_server_prefix():
+    """
+    Test that importing an MCP tool without a server name defaults to the original
+    behavior of registering the remote tool directly with the MCP client.
+    """
+    mock_registry = MagicMock(spec=SkillRegistry)
+    mock_mcp_client = MagicMock(spec=MCPClient)
+
+    engine = MCPEngine(registry=mock_registry, mcp_client=mock_mcp_client)
+
+    tool_def = {
+        "name": "search_web",
+        "description": "Searches the web.",
+        "inputSchema": {}
+    }
+    connection_info = {"url": "http://example.com/web"}
+
+    engine.import_mcp_tool(
+        tool_def=tool_def,
+        connection_info=connection_info
+    )
+
+    # Verify MCP client registered the remote tool directly
+    mock_mcp_client.register_remote_tool.assert_called_once_with("search_web", connection_info)
+    mock_mcp_client.register_mcp_server.assert_not_called()
+
+    # Verify registry registered the tool without prefix
+    mock_registry.register_skill.assert_called_once()
+    registered_kwargs = mock_registry.register_skill.call_args.kwargs
+    assert registered_kwargs["name"] == "search_web"
+    assert registered_kwargs["description"] == "Searches the web."
+    assert registered_kwargs["func"].__name__ == "search_web"
+    assert getattr(registered_kwargs["func"], "__mcp_schema__") == {}
+
+
+@pytest.mark.asyncio
+async def test_imported_prefixed_tool_execution():
+    """
+    Test that the dynamically wrapped async skill calls the MCP client
+    with the correctly prefixed tool name.
+    """
+    mock_registry = MagicMock(spec=SkillRegistry)
+    mock_mcp_client = MagicMock(spec=MCPClient)
+
+    # Make the execute_tool method return a coroutine
+    async def mock_execute(*args, **kwargs):
+        return "success result"
+    mock_mcp_client.execute_tool.side_effect = mock_execute
+
+    engine = MCPEngine(registry=mock_registry, mcp_client=mock_mcp_client)
+
+    tool_def = {
+        "name": "get_weather",
+        "description": "Gets weather.",
+        "inputSchema": {}
+    }
+    connection_info = {"url": "http://example.com/weather"}
+
+    engine.import_mcp_tool(
+        tool_def=tool_def,
+        connection_info=connection_info,
+        server_name="weather_station"
+    )
+
+    registered_func = mock_registry.register_skill.call_args.kwargs["func"]
+
+    # Execute the wrapped skill
+    result = await registered_func(location="London")
+
+    assert result == "success result"
+    mock_mcp_client.execute_tool.assert_called_once_with("weather_station__get_weather", location="London")


### PR DESCRIPTION
This PR implements support for MCP server-prefixed tools inspired by the OpenAI Agents SDK trend. 

1. Updates `MCPEngine` to accept an optional `server_name` argument during tool import, prefixing the final imported tool name with `server_name__tool_name`.
2. Registers server-prefixed tools with the underlying `MCPClient` using `register_mcp_server`. 
3. Includes new tests using mocks (coroutine-mocked, not futures) to ensure correctness for both prefixed and un-prefixed imports.
4. Updates `agent_tasks.json` to mark the current task as done and appends 3 newly generated concrete, actionable future tasks inspired by June 2026 AI Agent trends documented in `docs/trends.md`.
5. Backlog.md is verified to be accurate regarding this task.

---
*PR created automatically by Jules for task [6668786507754565714](https://jules.google.com/task/6668786507754565714) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add server-prefixed tool registration to `MCPEngine.import_mcp_tool`
> - Extends [`MCPEngine.import_mcp_tool`](https://github.com/kazah4359-lgtm/Magda-agent/pull/372/files#diff-26572b42493a12c4ec9d8bfa23bfc751544330482e76b956aebd528de7d4c9df) with an optional `server_name` parameter; when provided, the tool is registered under `<server_name>__<tool_name>` and the MCP client calls `register_mcp_server` instead of `register_remote_tool`.
> - Without `server_name`, the original behavior is preserved: the tool is registered with its unprefixed name via `register_remote_tool`.
> - Adds tests in [`tests/test_mcp_engine_prefixes.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/372/files#diff-9cb282feb025bdf145bd1c18446f5c924e9150b4a4236d8018a78307535a5776) covering prefixed and unprefixed registration, and correct forwarding of kwargs during tool execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 382e0d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->