### PR TITLE
Implement advanced MCP tool taint tracking

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6165,7 +6165,7 @@
     },
     {
       "id": "mcp-advanced-tool-taint-tracking-v2",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "medium",
       "title": "Advanced MCP Tool Taint Tracking",
@@ -12375,6 +12375,57 @@
       "acceptance": [
         "Agent Teams correctly spawns and orchestrates subagents in parallel.",
         "Tests verify parallel execution and state merging."
+      ]
+    },
+    {
+      "id": "mcp-kernel-execution-sandbox-enhancements",
+      "status": "todo",
+      "area": "security",
+      "risk": "high",
+      "title": "MCP Kernel execution sandbox enhancements",
+      "description": "Inspired by MCP Kernel Sandbox Enhancements trend. Enhance the MCPKernel sandbox to allow tighter restrictions and better logging of executed actions.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_kernel.py",
+        "tests/test_mcp_kernel.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox restrictions are tightened and testable.",
+        "Tests mock execution to verify enhanced blocking."
+      ]
+    },
+    {
+      "id": "letta-virtual-context-pagination-v3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Letta virtual context pagination v3",
+      "description": "Inspired by MemGPT/Letta context management trend. Improve the virtual context pagination manager to more aggressively page out unused context blocks to episodic memory.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_v2.py",
+        "tests/test_virtual_context_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Paging triggers properly when limits are approached.",
+        "Tests mock token size tracking to verify page outs."
+      ]
+    },
+    {
+      "id": "acs-runtime-safety-controls-v5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS runtime safety controls v5",
+      "description": "Inspired by ACS runtime safety controls trend. Update ACS guard to correctly intercept and validate complex tool arguments.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_v5.py",
+        "tests/test_acs_guard_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool arguments are correctly intercepted and parsed.",
+        "Tests verify blocking mechanism for invalid arguments."
       ]
     }
   ]

--- a/magda_agent/security/mcp_taint.py
+++ b/magda_agent/security/mcp_taint.py
@@ -44,3 +44,28 @@ def mcp_action_taint_sandbox(critical_params: Optional[List[str]] = None) -> Cal
 
         return wrapper
     return decorator
+
+
+def advanced_mcp_taint_tracker() -> Callable[..., Any]:
+    """
+    Decorator for MCP action tools to track data flow of taint.
+    If any input (arg or kwarg) is tainted, the output is also tainted.
+    """
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Check if any arg is tainted
+            args_tainted = any(is_tainted(arg) for arg in args)
+            # Check if any kwarg is tainted
+            kwargs_tainted = any(is_tainted(val) for val in kwargs.values())
+
+            # Execute the function
+            result: Any = func(*args, **kwargs)
+
+            # If inputs were tainted, taint the output
+            if args_tainted or kwargs_tainted:
+                return mark_tainted(result)
+            return result
+
+        return wrapper
+    return decorator

--- a/tests/test_mcp_taint.py
+++ b/tests/test_mcp_taint.py
@@ -57,3 +57,40 @@ def test_mcp_action_taint_sandbox_v4_param_type_hints() -> None:
     result = process_data(10)
     assert is_tainted(result) is True
     assert result == "ok 10"
+
+
+from magda_agent.security.mcp_taint import advanced_mcp_taint_tracker
+
+def test_advanced_mcp_taint_tracker_tainted_arg() -> None:
+    """Tests that tainted arg results in tainted output."""
+    @advanced_mcp_taint_tracker()
+    def process(data: str) -> str:
+        return f"Processed {data}"
+
+    tainted_data = mark_tainted("secret")
+    result = process(tainted_data)
+    assert is_tainted(result) is True
+    assert result == "Processed secret"
+
+def test_advanced_mcp_taint_tracker_tainted_kwarg() -> None:
+    """Tests that tainted kwarg results in tainted output."""
+    @advanced_mcp_taint_tracker()
+    def process(data: str, meta: str = "") -> str:
+        return f"Processed {data} with {meta}"
+
+    clean_data = "public"
+    tainted_meta = mark_tainted("hidden")
+    result = process(clean_data, meta=tainted_meta)
+    assert is_tainted(result) is True
+    assert result == "Processed public with hidden"
+
+def test_advanced_mcp_taint_tracker_clean_inputs() -> None:
+    """Tests that clean inputs result in clean output."""
+    @advanced_mcp_taint_tracker()
+    def process(data: str) -> str:
+        return f"Processed {data}"
+
+    clean_data = "public"
+    result = process(clean_data)
+    assert is_tainted(result) is False
+    assert result == "Processed public"


### PR DESCRIPTION
Resolves task `mcp-advanced-tool-taint-tracking-v2`.

Changes:
- Added `advanced_mcp_taint_tracker` decorator in `magda_agent/security/mcp_taint.py` to ensure taint tracking follows data flow from MCP tool inputs to outputs.
- Added comprehensive unit tests in `tests/test_mcp_taint.py` to verify this behavior for both args and kwargs.
- Updated `agent_tasks.json` to mark the task as "done".
- Appended 3 new trend-inspired tasks to `agent_tasks.json` (`mcp-kernel-execution-sandbox-enhancements`, `letta-virtual-context-pagination-v3`, `acs-runtime-safety-controls-v5`).
- Ensure no scratch files are left behind.
- All tests pass, and task validation scripts execute successfully.

---
*PR created automatically by Jules for task [7520419670655650724](https://jules.google.com/task/7520419670655650724) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `advanced_mcp_taint_tracker` decorator to propagate taint through MCP tool calls
> Adds the `advanced_mcp_taint_tracker` decorator in [`magda_agent/security/mcp_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/375/files#diff-02c3b4d8419a3de8bacbec4684b3ec1f39eac400f5af247489cf37a5d82de7c9) that inspects all positional and keyword arguments of a wrapped function. If any argument is tainted, the result is marked tainted via `mark_tainted` before being returned; clean inputs pass through unmodified. Three test cases cover tainted positional args, tainted keyword args, and clean inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34a7589.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->