### PR TITLE
Implement Claude Agent Code Review Worker

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6182,7 +6182,7 @@
     },
     {
       "id": "claude-agent-code-review-worker-v1",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "Claude Agent Code Review Worker",
@@ -12426,6 +12426,57 @@
       "acceptance": [
         "Tool arguments are correctly intercepted and parsed.",
         "Tests verify blocking mechanism for invalid arguments."
+      ]
+    },
+    {
+      "id": "openai-realtime-guardrail-fallback-v2-new-1",
+      "title": "OpenAI Realtime Guardrail Fallback V2",
+      "description": "Inspired by OpenAI Agents SDK trend. Implement a realtime guardrail fallback mechanism.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/realtime_guardrail_v2.py",
+        "tests/test_realtime_guardrail_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Guardrail fallback operates in realtime.",
+        "Tests verify fallback triggers."
+      ]
+    },
+    {
+      "id": "claude-context-compression-v5",
+      "title": "Claude Context Compression V5",
+      "description": "Inspired by Claude Agent SDK context compression. Enhance context compression algorithms.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v5.py",
+        "tests/test_compression_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context is effectively compressed.",
+        "Tests verify context window limits."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backups-v4",
+      "title": "Hermes Cron Nightly Backups V4",
+      "description": "Inspired by Hermes agent trend. Add a dedicated module for managing cron nightly backups.",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "allowed_paths": [
+        "magda_agent/operations/nightly_backups_v4.py",
+        "tests/test_nightly_backups_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Nightly backups are scheduled.",
+        "Tests verify cron jobs."
       ]
     }
   ]

--- a/magda_agent/agents/code_review.py
+++ b/magda_agent/agents/code_review.py
@@ -1,0 +1,84 @@
+import json
+import logging
+from typing import List, Dict, Optional
+
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.llm_client import LLMClient
+
+class CodeReviewWorker(SubAgent):
+    """
+    SubAgent specialized for reviewing code pull requests.
+    Inspired by Claude Agent SDK code review patterns.
+    """
+    def __init__(self, llm: LLMClient, system_prompt: Optional[str] = None, use_isolation: bool = False):
+        """
+        Initializes the CodeReviewWorker.
+
+        Args:
+            llm (LLMClient): The LLM client to use for code review.
+            system_prompt (Optional[str]): Custom system prompt for the worker.
+            use_isolation (bool): Whether to use isolated git worktrees.
+        """
+        default_prompt = (
+            "You are an expert software engineer reviewing a pull request. "
+            "Analyze the provided git diff carefully. Identify any bugs, security vulnerabilities, "
+            "code style issues, or missing tests. "
+            "You must output your review exactly as a JSON array of objects, where each object "
+            'has a "comment_id" and a "reply" string field. '
+            'Example: [{"comment_id": "file.py:10", "reply": "This variable is unused."}]'
+        )
+        prompt = system_prompt or default_prompt
+        super().__init__(llm=llm, system_prompt=prompt, use_isolation=use_isolation)
+
+    async def review_pr(self, pr_diff: str) -> List[Dict[str, str]]:
+        """
+        Reviews a PR diff and returns structured comments.
+
+        Args:
+            pr_diff (str): The git diff string of the pull request.
+
+        Returns:
+            List[Dict[str, str]]: A list of dictionaries, each containing 'comment_id' and 'reply'.
+        """
+        logging.info(f"CodeReviewWorker starting review for diff of length {len(pr_diff)}")
+
+        context = "Please review the following PR diff:\n\n"
+        task = pr_diff
+
+        # We use the parent's execute method to handle the LLM interaction
+        result_text = await self.execute(task=task, context=context)
+
+        # Attempt to parse the JSON output from the LLM
+        try:
+            # We will clean up the result in case there are markdown code block ticks
+            clean_text = result_text.strip()
+            if clean_text.startswith("```json"):
+                clean_text = clean_text[7:]
+            if clean_text.startswith("```"):
+                clean_text = clean_text[3:]
+            if clean_text.endswith("```"):
+                clean_text = clean_text[:-3]
+            clean_text = clean_text.strip()
+
+            comments = json.loads(clean_text)
+
+            if not isinstance(comments, list):
+                logging.error("CodeReviewWorker LLM output was not a JSON list.")
+                return []
+
+            valid_comments = []
+            for comment in comments:
+                if isinstance(comment, dict) and "comment_id" in comment and "reply" in comment:
+                    valid_comments.append({
+                        "comment_id": str(comment["comment_id"]),
+                        "reply": str(comment["reply"])
+                    })
+                else:
+                    logging.warning(f"CodeReviewWorker skipped invalid comment format: {comment}")
+
+            logging.info(f"CodeReviewWorker generated {len(valid_comments)} comments.")
+            return valid_comments
+
+        except json.JSONDecodeError as e:
+            logging.error(f"CodeReviewWorker failed to parse JSON: {e}\nRaw output: {result_text}")
+            return []

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from magda_agent.agents.code_review import CodeReviewWorker
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_llm_client():
+    client = LLMClient(api_key="fake-key", model="fake-model")
+    client.chat_completion = AsyncMock()
+    return client
+
+@pytest.mark.asyncio
+async def test_review_pr_valid_json(mock_llm_client):
+    """
+    Tests that review_pr correctly parses a valid JSON response from the LLM.
+    """
+    worker = CodeReviewWorker(llm=mock_llm_client)
+
+    # Mocking SubAgent.execute instead of chat_completion directly because CodeReviewWorker calls self.execute
+    # Let's mock execute directly on the worker or patch it.
+    with patch.object(worker, "execute", new_callable=AsyncMock) as mock_execute:
+        mock_execute.return_value = '''
+        ```json
+        [
+            {"comment_id": "main.py:42", "reply": "This variable `x` is unused."},
+            {"comment_id": "tests/test_main.py:10", "reply": "Missing assertions here."}
+        ]
+        ```
+        '''
+
+        diff = "diff --git a/main.py b/main.py\n+x = 10\n"
+        comments = await worker.review_pr(diff)
+
+        mock_execute.assert_called_once_with(task=diff, context="Please review the following PR diff:\n\n")
+        assert len(comments) == 2
+        assert comments[0]["comment_id"] == "main.py:42"
+        assert comments[0]["reply"] == "This variable `x` is unused."
+        assert comments[1]["comment_id"] == "tests/test_main.py:10"
+        assert comments[1]["reply"] == "Missing assertions here."
+
+@pytest.mark.asyncio
+async def test_review_pr_invalid_json(mock_llm_client):
+    """
+    Tests that review_pr handles invalid JSON gracefully.
+    """
+    worker = CodeReviewWorker(llm=mock_llm_client)
+
+    with patch.object(worker, "execute", new_callable=AsyncMock) as mock_execute:
+        mock_execute.return_value = "I think the code looks good!"
+
+        diff = "diff --git a/main.py b/main.py\n+y = 20\n"
+        comments = await worker.review_pr(diff)
+
+        mock_execute.assert_called_once()
+        assert len(comments) == 0
+
+@pytest.mark.asyncio
+async def test_review_pr_missing_fields(mock_llm_client):
+    """
+    Tests that review_pr filters out comments missing required fields.
+    """
+    worker = CodeReviewWorker(llm=mock_llm_client)
+
+    with patch.object(worker, "execute", new_callable=AsyncMock) as mock_execute:
+        mock_execute.return_value = '''
+        [
+            {"comment_id": "file.py:1", "reply": "Valid."},
+            {"reply": "Missing comment_id."},
+            {"comment_id": "file.py:2"}
+        ]
+        '''
+
+        diff = "diff --git a/main.py b/main.py\n+z = 30\n"
+        comments = await worker.review_pr(diff)
+
+        mock_execute.assert_called_once()
+        assert len(comments) == 1
+        assert comments[0]["comment_id"] == "file.py:1"
+        assert comments[0]["reply"] == "Valid."


### PR DESCRIPTION
This PR implements the `Claude Agent Code Review Worker` as requested in the initial backlog item. It creates a specialized sub-agent for reviewing code pull requests inspired by the Claude Agent SDK.

### Changes Made:
- Added `CodeReviewWorker` extending `SubAgent` in `magda_agent/agents/code_review.py`.
- Added mock-based pytest suite in `tests/test_code_review.py`.
- Updated `agent_tasks.json` to reflect task completion and add three new trend-inspired tasks.
- Validated `agent_tasks.json` schema.

All tests are passing.

---
*PR created automatically by Jules for task [5162057751901820360](https://jules.google.com/task/5162057751901820360) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CodeReviewWorker` sub-agent to review pull request diffs using an LLM
> - Adds [code_review.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/376/files#diff-b76d8337068ddb7804d832d34af5ab32331d74700baf87b8ce002eda15615208) with a new `CodeReviewWorker` class derived from `SubAgent` that accepts a PR diff and returns structured JSON comments from an LLM.
> - `review_pr` strips markdown code fences from LLM output, parses JSON, validates each item for `comment_id` and `reply` fields, filters invalid entries, and returns an empty list on parse failure.
> - Adds [tests/test_code_review.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/376/files#diff-1290bdfebb12c23833195daf9bee936baba1fe5cfee133457508dfe4946afbb4) covering valid JSON, invalid JSON, and partial field validation cases using a mocked `LLMClient`.
> - Updates [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/376/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) to mark one task as done and adds three new tasks for a realtime guardrail fallback, context compression, and nightly backups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e959bf6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->