### PR TITLE
feat: implement OpenClaw RL Dynamic Behavior Adjustment v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6199,7 +6199,7 @@
     },
     {
       "id": "openclaw-rl-dynamic-behavior-adjustment-v2",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "OpenClaw RL Dynamic Behavior Adjustment",
@@ -12477,6 +12477,56 @@
       "acceptance": [
         "Nightly backups are scheduled.",
         "Tests verify cron jobs."
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent-teams",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Evaluator Subagent Teams",
+      "description": "Inspired by Claude Agent SDK trend: Implement a subagent evaluator pool that can test generator team code iteratively.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_v3.py",
+        "tests/test_agent_teams_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator team tests code iteratively.",
+        "LLM is mocked in tests."
+      ]
+    },
+    {
+      "id": "mcp-server-prefixed-routing-v2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Server Prefixed Routing V2",
+      "description": "Inspired by OpenAI Agents SDK trend: Allow MCP tools to use server-prefixed routing inside the core engine.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_engine.py",
+        "tests/test_mcp_engine.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Prefixed routes resolve successfully to corresponding remote servers.",
+        "Tests pass with mocked requests."
+      ]
+    },
+    {
+      "id": "openclaw-rl-habit-decay-v3",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Habit Decay V3",
+      "description": "Inspired by OpenClaw-RL trend: Add explicit time decay to learned habits in the tracker so unused skills gradually reduce their Q-values.",
+      "allowed_paths": [
+        "magda_agent/learning/habits.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Habit weights decay over time.",
+        "Decay logic is covered in tests."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -228,3 +228,4 @@
 
 * [x] mcp-dynamic-tool-registry-v4: MCP Dynamic Tool Registry
 * [x] FEATURE: A2A Task Delegation Protocol (a2a-task-delegation-v2)
+* [x] FEATURE: OpenClaw RL Dynamic Behavior Adjustment v2 (openclaw-rl-dynamic-behavior-adjustment-v2)

--- a/magda_agent/learning/openclaw_rl.py
+++ b/magda_agent/learning/openclaw_rl.py
@@ -94,6 +94,33 @@ class OpenClawInteractiveLearner:
             model_data["preferences"] = {}
         model_data["preferences"]["last_p_shift"] = p_shift
 
+        # Dynamic Behavior Adjustment based on implicit emotional shifts
+        behavior_weights = model_data.setdefault("behavior_weights", {
+            "exploration": 1.0,
+            "verbosity": 1.0,
+            "directness": 1.0
+        })
+
+        # Adjust exploration based on pleasure shift
+        if p_shift > 0.0:
+            behavior_weights["exploration"] = min(2.0, behavior_weights["exploration"] + p_shift * 0.5)
+        elif p_shift < 0.0:
+            behavior_weights["exploration"] = max(0.5, behavior_weights["exploration"] + p_shift * 0.5)
+
+        # Adjust verbosity based on arousal shift
+        if a_shift > 0.0:
+            behavior_weights["verbosity"] = min(2.0, behavior_weights["verbosity"] + a_shift)
+        elif a_shift < 0.0:
+            behavior_weights["verbosity"] = max(0.5, behavior_weights["verbosity"] + a_shift)
+
+        # Adjust directness based on dominance shift
+        if d_shift > 0.0:
+            behavior_weights["directness"] = min(2.0, behavior_weights["directness"] + d_shift)
+        elif d_shift < 0.0:
+            behavior_weights["directness"] = max(0.5, behavior_weights["directness"] + d_shift)
+
+        model_data["behavior_weights"] = behavior_weights
+
         # Save the updated user model back to disk
         self.user_model.save_model(user_id, model_data)
         logging.info(f"OpenClaw-RL: Updated user model for user {user_id}")

--- a/tests/test_openclaw_rl.py
+++ b/tests/test_openclaw_rl.py
@@ -107,3 +107,39 @@ async def test_openclaw_rl_tool_output(mock_habit_tracker: MagicMock, mock_mirro
     model_data = user_model.get_model(3)
     assert model_data["preferences"]["last_p_shift"] == 0.5
     assert "(friendly)" in model_data["communication_style"]
+
+@pytest.mark.asyncio
+async def test_openclaw_rl_dynamic_behavior_weights(mock_habit_tracker: MagicMock, mock_mirror_neurons: MagicMock, user_model: UserModel) -> None:
+    """Tests that dynamic behavior weights are adjusted based on PAD shifts."""
+    learner = OpenClawInteractiveLearner(mock_habit_tracker, mock_mirror_neurons, user_model)
+
+    # Initialize a user model with specific weights
+    user_model.save_model(4, {"behavior_weights": {"exploration": 1.0, "verbosity": 1.0, "directness": 1.0}})
+
+    # Mock empathize
+    # p_shift = 0.4, a_shift = 0.2, d_shift = -0.1
+    mock_mirror_neurons.empathize.return_value = (0.4, 0.2, -0.1)
+
+    await learner.process_next_state_signal("This is great but confusing", "test_context", 4)
+
+    # Verify model modifications
+    model_data = user_model.get_model(4)
+    weights = model_data["behavior_weights"]
+
+    # Exploration: 1.0 + 0.4 * 0.5 = 1.2
+    assert abs(weights["exploration"] - 1.2) < 1e-6
+    # Verbosity: 1.0 + 0.2 = 1.2
+    assert abs(weights["verbosity"] - 1.2) < 1e-6
+    # Directness: 1.0 - 0.1 = 0.9
+    assert abs(weights["directness"] - 0.9) < 1e-6
+
+    # Test bounding logic
+    # Mock empathize with large shifts
+    mock_mirror_neurons.empathize.return_value = (3.0, 3.0, -3.0)
+    await learner.process_next_state_signal("Huge shift", "test_context", 4)
+    model_data2 = user_model.get_model(4)
+    weights2 = model_data2["behavior_weights"]
+
+    assert weights2["exploration"] <= 2.0
+    assert weights2["verbosity"] <= 2.0
+    assert weights2["directness"] >= 0.5

--- a/user_models/user_None.json
+++ b/user_models/user_None.json
@@ -4,5 +4,10 @@
   },
   "communication_style": "default",
   "expertise_level": "unknown",
-  "recurring_topics": []
+  "recurring_topics": [],
+  "behavior_weights": {
+    "exploration": 1.0,
+    "verbosity": 1.0,
+    "directness": 1.0
+  }
 }


### PR DESCRIPTION
Implemented dynamic behavior adjustments to `OpenClawInteractiveLearner` based on emotional PAD shifts. 

Changes include:
- Updating `process_next_state_signal` to map `p_shift`, `a_shift`, and `d_shift` to `exploration`, `verbosity`, and `directness` respectively in the `UserModel`.
- Adding bounded values to ensure weights stay within safe margins (e.g. `0.5` to `2.0`).
- Including extensive unit tests to verify the weight shifts.
- Updating `agent_tasks.json` with three new task derivations inspired by `docs/trends.md`.
- Appending the task status to `backlog.md`.

---
*PR created automatically by Jules for task [16698065513808975036](https://jules.google.com/task/16698065513808975036) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dynamic `behavior_weights` adjustment to `OpenClawInteractiveLearner.process_next_state_signal`
> - Updates `process_next_state_signal` in [openclaw_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/377/files#diff-97cf6ce0be050f90c1268294aaba45efca5e6d006d2802e9455ecce9876f92e0) to compute and persist `behavior_weights` (exploration, verbosity, directness) after each PAD shift.
> - Each weight is adjusted incrementally from PAD shift values and clamped to [0.5, 2.0].
> - Adds `behavior_weights` (all defaulting to 1.0) to the default user model in [user_None.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/377/files#diff-ed49155bd0f30abf6b577d682e5d0c3f7783c2d56e9229691e49b0571ae5f9e0).
> - Adds an async test covering normal updates and bounding behavior under large shifts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdf042f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->