### PR TITLE
feat: MCP dynamic tool registration v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6216,7 +6216,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registration-v4",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registration v4",
@@ -12527,6 +12527,57 @@
       "acceptance": [
         "Habit weights decay over time.",
         "Decay logic is covered in tests."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-tracing-v5",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Enterprise Tracing V5",
+      "description": "Inspired by A2A Protocol trends. Add enterprise tracing and monitoring support for A2A delegated tasks.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_tracing_v5.py",
+        "tests/test_a2a_tracing_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Delegated tasks are traced.",
+        "Tests mock A2A calls and trace data."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-subagent-pattern-v2",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "MCP Action Tool Subagent Pattern V2",
+      "description": "Inspired by Agent Teams trend. Orchestrate an MCP action tool execution inside a dedicated isolated subagent.",
+      "allowed_paths": [
+        "magda_agent/architecture/mcp_subagent_v2.py",
+        "tests/test_mcp_subagent_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent executes MCP tool in isolation.",
+        "Tests mock subagent spawner."
+      ]
+    },
+    {
+      "id": "context-engine-lifecycle-plugins-v6",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Lifecycle Plugins V6",
+      "description": "Inspired by OpenClaw trends. Implement advanced lifecycle plugins for context engine to compress semantic memory dynamically.",
+      "allowed_paths": [
+        "magda_agent/memory/context_plugins_v6.py",
+        "tests/test_context_plugins_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lifecycle plugins trigger appropriately.",
+        "Tests mock memory and verify triggers."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_registry.py
+++ b/magda_agent/skills/mcp_registry.py
@@ -69,3 +69,20 @@ class MCPRegistry:
             List[str]: A list of tool names.
         """
         return list(self.mcp_tools.keys())
+
+    def unload_tool(self, name: str) -> bool:
+        """
+        Dynamically unregisters and removes an MCP tool from the registry.
+
+        Args:
+            name (str): The name of the MCP tool to unload.
+
+        Returns:
+            bool: True if the tool was successfully unloaded, False if not found.
+        """
+        if name in self.mcp_tools:
+            del self.mcp_tools[name]
+            logging.info(f"Successfully unloaded MCP tool: {name}")
+            return True
+        logging.warning(f"Failed to unload MCP tool: {name} not found in registry.")
+        return False

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -66,3 +66,17 @@ def test_list_tools(registry: MCPRegistry) -> None:
     assert len(tools) == 2
     assert "tool1" in tools
     assert "tool2" in tools
+
+def test_unload_existing_tool(registry: MCPRegistry) -> None:
+    """Test unloading an existing tool."""
+    tool = {"name": "test_tool", "description": "A tool to test unloading."}
+    registry.load_tool(tool)
+    assert "test_tool" in registry.list_tools()
+
+    assert registry.unload_tool("test_tool") is True
+    assert "test_tool" not in registry.list_tools()
+    assert registry.get_tool("test_tool") == {}
+
+def test_unload_nonexistent_tool(registry: MCPRegistry) -> None:
+    """Test unloading a tool that does not exist in the registry."""
+    assert registry.unload_tool("nonexistent_tool") is False


### PR DESCRIPTION
Implement dynamic tool registration/unregistration for MCP registry as requested by the task `mcp-dynamic-tool-registration-v4`. Marked the task as done and added 3 new tasks based on June 2026 AI Agent trends.

---
*PR created automatically by Jules for task [11037436572654904985](https://jules.google.com/task/11037436572654904985) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `unload_tool` method to `MCPRegistry` for dynamic tool removal
> Adds `MCPRegistry.unload_tool` in [mcp_registry.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/378/files#diff-7bd31ee3bdddfbf36be0e971eb0b8b7c11b46ba4d33ad77f5f002b7cf127c7ee) to remove a registered MCP tool by name at runtime. Returns `True` and logs success if the tool exists, or `False` with a warning if not. Two tests cover both the existing-tool and missing-tool cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c349f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->