### PR TITLE
Implement Online RL User Feedback Loop and add new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9389,7 +9389,7 @@
     },
     {
       "id": "online-rl-feedback-loop-e2767014-e0af-4dd5-8dfe-2883b576fbe4",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Online RL User Feedback Loop",
@@ -12578,6 +12578,40 @@
       "acceptance": [
         "Lifecycle plugins trigger appropriately.",
         "Tests mock memory and verify triggers."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-preflight-validation-v6-1e2612a5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Tool Pre-flight Validation V6 v2",
+      "description": "Implement a pre-flight validation mechanism for all MCP action tools before JSON-RPC execution to verify inputs against a static schema.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_preflight_v6_v2.py",
+        "tests/test_mcp_preflight_v6_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pre-flight validator intercepts invalid requests.",
+        "Tests mock MCP clients to verify blocking behavior."
+      ]
+    },
+    {
+      "id": "a2a-delegation-circuit-breaker-v7-bc9e8aae",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Delegation Circuit Breaker V7 v2",
+      "description": "Implement a circuit breaker pattern to prevent continuous task delegation failures to unresponsive peer agents via A2A.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_circuit_breaker_v7_v2.py",
+        "tests/test_a2a_circuit_breaker_v7_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Circuit breaker trips after consecutive failures.",
+        "Tests verify fallback and trip limits."
       ]
     }
   ]

--- a/magda_agent/learning/openclaw_rl_v3.py
+++ b/magda_agent/learning/openclaw_rl_v3.py
@@ -1,0 +1,73 @@
+import logging
+from typing import Dict, Any
+
+class OnlineRLFeedbackLoop:
+    """
+    Component that captures user feedback signals (e.g. positive/negative replies)
+    and maps them to Q-value updates for skills.
+    Inspired by OpenClaw-RL.
+    """
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        """
+        Initializes the OnlineRLFeedbackLoop.
+
+        Args:
+            db_path (str): The path to the SQLite database. Defaults to in-memory.
+        """
+        self.q_table: Dict[str, float] = {}
+        logging.info("Initialized OnlineRLFeedbackLoop")
+
+    def process_feedback(self, skill_id: str, user_reply: str) -> None:
+        """
+        Processes user feedback and updates the Q-value for a given skill.
+
+        Args:
+            skill_id (str): The identifier of the skill used.
+            user_reply (str): The text of the user's reply.
+        """
+        reward = self._map_reply_to_reward(user_reply)
+
+        current_q = self.q_table.get(skill_id, 0.0)
+
+        # Simple Q-learning update rule with alpha=0.1, gamma=0 (immediate reward only)
+        alpha = 0.1
+        new_q = current_q + alpha * (reward - current_q)
+
+        self.q_table[skill_id] = new_q
+        logging.info(f"Updated Q-value for {skill_id}: {new_q:.2f} (Reward: {reward})")
+
+    def _map_reply_to_reward(self, reply: str) -> float:
+        """
+        Maps a user reply text to a numerical reward score.
+
+        Args:
+            reply (str): The user reply.
+
+        Returns:
+            float: The reward score.
+        """
+        reply_lower = reply.lower()
+
+        # Check negative first, but make sure it's not matching 'know' incorrectly due to 'no'
+        # Tokenize by word
+        words = reply_lower.replace("'", "").replace(".", "").replace(",", "").replace("!", "").split()
+
+        if any(w in ["good", "great", "thanks", "awesome", "yes"] for w in words):
+            return 1.0
+        elif any(w in ["bad", "terrible", "wrong", "no"] for w in words):
+            return -1.0
+        else:
+            return 0.0
+
+    def get_q_value(self, skill_id: str) -> float:
+        """
+        Retrieves the current Q-value for a given skill.
+
+        Args:
+            skill_id (str): The identifier of the skill.
+
+        Returns:
+            float: The current Q-value.
+        """
+        return self.q_table.get(skill_id, 0.0)

--- a/tests/test_openclaw_rl_v3.py
+++ b/tests/test_openclaw_rl_v3.py
@@ -1,0 +1,42 @@
+import pytest
+from magda_agent.learning.openclaw_rl_v3 import OnlineRLFeedbackLoop
+
+def test_map_reply_to_reward_positive() -> None:
+    """Tests parsing positive user replies to reward scores."""
+    loop = OnlineRLFeedbackLoop()
+    assert loop._map_reply_to_reward("That's great") == 1.0
+    assert loop._map_reply_to_reward("good job") == 1.0
+    assert loop._map_reply_to_reward("awesome!") == 1.0
+    assert loop._map_reply_to_reward("Yes please") == 1.0
+    assert loop._map_reply_to_reward("thanks") == 1.0
+
+def test_map_reply_to_reward_negative() -> None:
+    """Tests parsing negative user replies to reward scores."""
+    loop = OnlineRLFeedbackLoop()
+    assert loop._map_reply_to_reward("That's bad") == -1.0
+    assert loop._map_reply_to_reward("terrible") == -1.0
+    assert loop._map_reply_to_reward("no") == -1.0
+    assert loop._map_reply_to_reward("wrong") == -1.0
+
+def test_map_reply_to_reward_neutral() -> None:
+    """Tests parsing neutral user replies to reward scores."""
+    loop = OnlineRLFeedbackLoop()
+    assert loop._map_reply_to_reward("Okay") == 0.0
+    assert loop._map_reply_to_reward("Maybe") == 0.0
+    assert loop._map_reply_to_reward("I don't know") == 0.0
+
+def test_process_feedback() -> None:
+    """Tests processing feedback and verifying Q-value updates."""
+    loop = OnlineRLFeedbackLoop()
+
+    # Test positive feedback
+    loop.process_feedback("skill_1", "Great")
+    assert loop.get_q_value("skill_1") == 0.1  # 0 + 0.1 * (1 - 0)
+
+    # Test multiple positive feedback
+    loop.process_feedback("skill_1", "Good")
+    assert loop.get_q_value("skill_1") == 0.19 # 0.1 + 0.1 * (1 - 0.1)
+
+    # Test negative feedback
+    loop.process_feedback("skill_2", "Bad")
+    assert loop.get_q_value("skill_2") == -0.1 # 0 + 0.1 * (-1 - 0)


### PR DESCRIPTION
This PR implements the `OnlineRLFeedbackLoop` component, tracking Q-value updates for skills based on user replies, and marks the related "todo" task as complete while proposing two new trend-inspired tasks.

---
*PR created automatically by Jules for task [14125519395426035022](https://jules.google.com/task/14125519395426035022) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `OnlineRLFeedbackLoop` class for per-skill Q-value updates from user replies
> - Adds [`OnlineRLFeedbackLoop`](https://github.com/kazah4359-lgtm/Magda-agent/pull/379/files#diff-8edbea7231534e850fa73c8cddc3a09a1cbda1811302b114f8c6922b40efae48) with an in-memory Q-table that updates per-skill Q-values using a Q-learning rule (alpha=0.1, gamma=0) based on user reply sentiment.
> - Reply-to-reward mapping tokenizes the reply and returns 1.0 for positive tokens (e.g. "great", "thanks"), -1.0 for negative tokens (e.g. "bad", "wrong"), and 0.0 otherwise.
> - Adds unit tests covering positive, negative, and neutral reward mapping and verifying Q-value accumulation across multiple feedback calls.
> - Two new task entries are added to `agent_tasks.json` for MCP action tool preflight validation and A2A delegation circuit breaker.
> - Risk: Q-table is stored only in memory, so all learned Q-values are lost when the process restarts despite the constructor accepting a `db_path` parameter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a39431.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->