### PR TITLE
feat: ACS Guard Audit Trail

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6233,7 +6233,7 @@
     },
     {
       "id": "acs-guard-audit-trail-v1",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "medium",
       "title": "ACS Guard Audit Trail",
@@ -12612,6 +12612,57 @@
       "acceptance": [
         "Circuit breaker trips after consecutive failures.",
         "Tests verify fallback and trip limits."
+      ]
+    },
+    {
+      "id": "mcp-server-prefixed-tools-v2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Server Prefixed Tools v2",
+      "description": "Inspired by OpenAI Agents SDK trend: Handle server-prefixed tools by appending the server name and registering them with the MCPClient via register_mcp_server.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_engine.py",
+        "tests/test_mcp_engine.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP tools are correctly prefixed.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-auth-token-delegation-v4",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A Auth Token Delegation v4",
+      "description": "Inspired by A2A Protocol trend: Manage secure token-based authentication delegation for A2A peers.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth.py",
+        "tests/test_a2a_auth.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Active tokens are generated securely.",
+        "Tests verify token generation and validation."
+      ]
+    },
+    {
+      "id": "openclaw-rl-dynamic-behavior-v3",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw RL Dynamic Behavior v3",
+      "description": "Inspired by OpenClaw RL online learning trend: Implement online reinforcement learning from user feedback for adapting agent behavior parameters.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v3.py",
+        "tests/test_openclaw_rl_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent behavior adapts via user feedback.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/safety/acs_audit.py
+++ b/magda_agent/safety/acs_audit.py
@@ -1,0 +1,59 @@
+import time
+from typing import Dict, Any, Optional
+from magda_agent.safety.acs_guard import ACSGuard, SecurityViolationError
+from magda_agent.safety.audit_trail import AuditTrail
+
+class ACSAuditLogger:
+    """
+    Audit logging mechanism that records all tools evaluated and intercepted
+    by the ACSGuard policy layer.
+    """
+
+    def __init__(self, acs_guard: ACSGuard, audit_trail: Optional[AuditTrail] = None) -> None:
+        """
+        Initializes the ACSAuditLogger.
+
+        Args:
+            acs_guard: The ACSGuard instance to wrap.
+            audit_trail: The AuditTrail instance to log to.
+        """
+        self.acs_guard = acs_guard
+        self.audit_trail = audit_trail or AuditTrail()
+
+    def evaluate_and_intercept(self, workflow_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Wraps ACSGuard.intercept_action to log the result to AuditTrail.
+
+        Args:
+            workflow_data: The data for the action to validate.
+
+        Returns:
+            The unmodified workflow data if it passed validation.
+
+        Raises:
+            SecurityViolationError: If validation fails at any checkpoint.
+        """
+        start_time = time.time()
+        tool_name = workflow_data.get("tool", "unknown")
+
+        try:
+            result = self.acs_guard.intercept_action(workflow_data)
+            duration = time.time() - start_time
+            self.audit_trail.log_call(
+                tool_name=tool_name,
+                kwargs=workflow_data.get("kwargs", {}),
+                why="ACSGuard evaluation passed",
+                result="allowed",
+                duration=duration
+            )
+            return result
+        except SecurityViolationError as e:
+            duration = time.time() - start_time
+            self.audit_trail.log_call(
+                tool_name=tool_name,
+                kwargs=workflow_data.get("kwargs", {}),
+                why=f"ACSGuard evaluation failed: {str(e)}",
+                result="blocked",
+                duration=duration
+            )
+            raise

--- a/tests/test_acs_audit.py
+++ b/tests/test_acs_audit.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.safety.acs_guard import ACSGuard, SecurityViolationError
+from magda_agent.safety.audit_trail import AuditTrail
+from magda_agent.safety.acs_audit import ACSAuditLogger
+
+def test_acs_audit_logger_allowed() -> None:
+    """Test that ACSAuditLogger logs an allowed action."""
+    mock_acs_guard = MagicMock(spec=ACSGuard)
+    mock_audit_trail = MagicMock(spec=AuditTrail)
+
+    workflow_data = {"tool": "allowed_tool", "action": "read", "kwargs": {"id": 1}}
+
+    # intercept_action should return the data when successful
+    mock_acs_guard.intercept_action.return_value = workflow_data
+
+    logger = ACSAuditLogger(acs_guard=mock_acs_guard, audit_trail=mock_audit_trail)
+    result = logger.evaluate_and_intercept(workflow_data)
+
+    assert result == workflow_data
+    mock_acs_guard.intercept_action.assert_called_once_with(workflow_data)
+
+    mock_audit_trail.log_call.assert_called_once()
+    call_args = mock_audit_trail.log_call.call_args[1]
+    assert call_args["tool_name"] == "allowed_tool"
+    assert call_args["kwargs"] == {"id": 1}
+    assert call_args["why"] == "ACSGuard evaluation passed"
+    assert call_args["result"] == "allowed"
+    assert "duration" in call_args
+
+def test_acs_audit_logger_blocked() -> None:
+    """Test that ACSAuditLogger logs a blocked action."""
+    mock_acs_guard = MagicMock(spec=ACSGuard)
+    mock_audit_trail = MagicMock(spec=AuditTrail)
+
+    workflow_data = {"tool": "forbidden_tool", "action": "read", "kwargs": {"id": 2}}
+
+    # intercept_action should raise SecurityViolationError when blocked
+    error_msg = "Action blocked by ACS checkpoint 3: Tool policy failed"
+    mock_acs_guard.intercept_action.side_effect = SecurityViolationError(error_msg)
+
+    logger = ACSAuditLogger(acs_guard=mock_acs_guard, audit_trail=mock_audit_trail)
+
+    with pytest.raises(SecurityViolationError, match="Action blocked by ACS checkpoint 3"):
+        logger.evaluate_and_intercept(workflow_data)
+
+    mock_acs_guard.intercept_action.assert_called_once_with(workflow_data)
+
+    mock_audit_trail.log_call.assert_called_once()
+    call_args = mock_audit_trail.log_call.call_args[1]
+    assert call_args["tool_name"] == "forbidden_tool"
+    assert call_args["kwargs"] == {"id": 2}
+    assert call_args["why"] == f"ACSGuard evaluation failed: {error_msg}"
+    assert call_args["result"] == "blocked"
+    assert "duration" in call_args


### PR DESCRIPTION
Implemented ACS Audit Trail logger utilizing ACSGuard and AuditTrail.
Also appended 3 new trend-inspired tasks to agent_tasks.json and marked the current task as done.

---
*PR created automatically by Jules for task [339921201751434855](https://jules.google.com/task/339921201751434855) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ACSAuditLogger` to record ACS Guard evaluation outcomes to an audit trail
> - Introduces [`ACSAuditLogger`](https://github.com/kazah4359-lgtm/Magda-agent/pull/380/files#diff-8cf5fe28ec827220a05e9f35831120502006faa9ea31f52692ba17c717ce6515) in the safety module, composing `ACSGuard` with `AuditTrail` to log each `intercept_action` call with tool name, result (`allowed`/`blocked`), reason, and duration.
> - On success, logs `result='allowed'` and returns the guard result unchanged; on `SecurityViolationError`, logs `result='blocked'` with the error message and re-raises.
> - Adds unit tests in [`tests/test_acs_audit.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/380/files#diff-d1b5c4e4b94e424b2d3464a8a6faffd75fcf79170c707ba8c52b7a543c01a4ba) covering both the allowed and blocked paths using mocked guard and audit trail instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8506900.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->