### PR TITLE
feat(learning): implement OpenClaw RL user feedback v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6250,7 +6250,7 @@
     },
     {
       "id": "openclaw-rl-user-feedback-v5",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL User Feedback v5",
@@ -12663,6 +12663,57 @@
       "acceptance": [
         "Agent behavior adapts via user feedback.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-context-compression-v6",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Claude Context Compression V6",
+      "description": "Inspired by Claude Agent SDK context compression. Enhance context compression algorithms with selective retrieval based on semantic clustering.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v6.py",
+        "tests/test_compression_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context is effectively compressed using semantic clustering.",
+        "Tests verify context window limits."
+      ]
+    },
+    {
+      "id": "a2a-agent-discovery-v5-health",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Agent Discovery v5 Health",
+      "description": "Inspired by A2A Protocol trends. Add health check metadata to Agent Cards discovery, so offline agents are ignored during delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v5.py",
+        "tests/test_a2a_discovery_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Discovery service filters out offline agents based on health check metadata.",
+        "Tests verify filtering logic."
+      ]
+    },
+    {
+      "id": "mcp-engine-prefixed-routing-v3-fallback",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Engine Prefixed Routing v3 Fallback",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement robust fallback mechanisms for MCP server prefixed routing in case the remote server is unreachable.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_engine_v5.py",
+        "tests/test_mcp_engine_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Routing falls back correctly when remote server fails.",
+        "Tests mock remote server failure to verify fallback."
       ]
     }
   ]

--- a/magda_agent/learning/openclaw_rl_v5.py
+++ b/magda_agent/learning/openclaw_rl_v5.py
@@ -7,14 +7,20 @@ class OnlineRLIntegrator:
     Updates skill_weights based on user feedback.
     """
 
-    def __init__(self, initial_weights: Optional[Dict[str, float]] = None) -> None:
+    def __init__(self, initial_weights: Optional[Dict[str, float]] = None, initial_behavior: Optional[Dict[str, float]] = None) -> None:
         """
         Initializes the OnlineRLIntegrator.
 
         Args:
             initial_weights (Optional[Dict[str, float]]): Initial weights for skills.
+            initial_behavior (Optional[Dict[str, float]]): Initial behavior parameters for the agent.
         """
         self.skill_weights: Dict[str, float] = initial_weights or {}
+        self.behavior_parameters: Dict[str, float] = initial_behavior or {
+            "exploration": 1.0,
+            "verbosity": 1.0,
+            "directness": 1.0
+        }
         logging.info("Initialized OnlineRLIntegrator")
 
     def parse_feedback(self, feedback: str) -> float:
@@ -67,3 +73,10 @@ class OnlineRLIntegrator:
         self.skill_weights[skill_used] = max(0.1, self.skill_weights[skill_used])
 
         logging.info(f"Updated weight for skill '{skill_used}' to {self.skill_weights[skill_used]:.2f} based on feedback reward {reward}")
+
+        # Update behavior parameters dynamically
+        behavior_adjustment = reward * 0.1
+        for param in self.behavior_parameters:
+            new_val = self.behavior_parameters[param] + behavior_adjustment
+            self.behavior_parameters[param] = max(0.5, min(2.0, new_val))
+            logging.info(f"Updated behavior parameter '{param}' to {self.behavior_parameters[param]:.2f}")

--- a/tests/test_openclaw_rl_v5.py
+++ b/tests/test_openclaw_rl_v5.py
@@ -26,6 +26,10 @@ async def test_process_feedback_positive(integrator):
         skill_used="search"
     )
     assert integrator.skill_weights["search"] == 1.1
+    # Check behavior parameters (1.0 + 0.1 = 1.1)
+    assert integrator.behavior_parameters["exploration"] == pytest.approx(1.1)
+    assert integrator.behavior_parameters["verbosity"] == pytest.approx(1.1)
+    assert integrator.behavior_parameters["directness"] == pytest.approx(1.1)
 
 @pytest.mark.asyncio
 async def test_process_feedback_negative(integrator):
@@ -36,6 +40,10 @@ async def test_process_feedback_negative(integrator):
         skill_used="search"
     )
     assert integrator.skill_weights["search"] == 0.9
+    # Check behavior parameters (1.0 - 0.1 = 0.9)
+    assert integrator.behavior_parameters["exploration"] == pytest.approx(0.9)
+    assert integrator.behavior_parameters["verbosity"] == pytest.approx(0.9)
+    assert integrator.behavior_parameters["directness"] == pytest.approx(0.9)
 
 @pytest.mark.asyncio
 async def test_process_feedback_new_skill(integrator):


### PR DESCRIPTION
Implements continuous online reinforcement learning from user feedback for adapting agent behavior parameters. Update tasks manifest and append new trends tasks.

---
*PR created automatically by Jules for task [9318077852779093341](https://jules.google.com/task/9318077852779093341) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add behavior parameter adjustment to `OnlineRLIntegrator.process_feedback` in OpenClaw RL v5
> - Extends `OnlineRLIntegrator.__init__` in [openclaw_rl_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/381/files#diff-6e1dc61ed2989e6710ab534835d15bea2b106e015f10097933cf8e43a231f3c1) to accept an optional `initial_behavior` dict, defaulting `exploration`, `verbosity`, and `directness` to `1.0`.
> - `process_feedback` now adjusts each behavior parameter by `reward * 0.1`, clamped to `[0.5, 2.0]`, after updating the skill weight.
> - Tests in [test_openclaw_rl_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/381/files#diff-091f1a47d393ded1aa7323239633da3653e69cf7999d48c388b2d4a91c857f1d) assert parameters shift to ~1.1 after positive feedback and ~0.9 after negative feedback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fafe652.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->