### PR TITLE
feat(safety): Implement ACS Guard Runtime Safety Controls v6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6267,7 +6267,7 @@
     },
     {
       "id": "acs-guard-runtime-safety-controls-v6",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "ACS Guard Runtime Safety Controls v6",
@@ -12715,6 +12715,57 @@
         "Routing falls back correctly when remote server fails.",
         "Tests mock remote server failure to verify fallback."
       ]
+    },
+    {
+      "id": "a2a-enterprise-tracing-v6",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Enterprise Tracing V6",
+      "description": "Inspired by A2A Protocol trends. Add enhanced enterprise tracing and distributed monitoring support for A2A delegated tasks.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_tracing_v6.py",
+        "tests/test_a2a_tracing_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Delegated tasks include trace IDs.",
+        "Tests mock A2A calls and trace data."
+      ],
+      "status": "todo"
+    },
+    {
+      "id": "openclaw-rl-habit-decay-v4",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Habit Decay V4",
+      "description": "Inspired by OpenClaw-RL trend: Add momentum-based explicit time decay to learned habits in the tracker.",
+      "allowed_paths": [
+        "magda_agent/learning/habits_v4.py",
+        "tests/test_habits_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Habit weights decay over time with momentum.",
+        "Decay logic is covered in tests."
+      ],
+      "status": "todo"
+    },
+    {
+      "id": "claude-evaluator-subagent-teams-v4",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Evaluator Subagent Teams V4",
+      "description": "Inspired by Claude Agent SDK trend: Implement a specialized subagent evaluator pool with strict sandboxing.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_v4.py",
+        "tests/test_agent_teams_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator team runs in sandbox.",
+        "LLM is mocked in tests."
+      ],
+      "status": "todo"
     }
   ]
 }

--- a/backlog.md
+++ b/backlog.md
@@ -229,3 +229,4 @@
 * [x] mcp-dynamic-tool-registry-v4: MCP Dynamic Tool Registry
 * [x] FEATURE: A2A Task Delegation Protocol (a2a-task-delegation-v2)
 * [x] FEATURE: OpenClaw RL Dynamic Behavior Adjustment v2 (openclaw-rl-dynamic-behavior-adjustment-v2)
+* [x] FEATURE: ACS Runtime Safety Controls V6 (acs-guard-runtime-safety-controls-v6)

--- a/magda_agent/safety/acs_guard_v6.py
+++ b/magda_agent/safety/acs_guard_v6.py
@@ -1,0 +1,212 @@
+import logging
+import re
+from typing import Dict, Any, Tuple, Optional
+from magda_agent.safety.policy import PolicyLayer
+from magda_agent.safety.audit_trail import AuditTrail
+from magda_agent.safety.taint import is_tainted
+
+_SENSITIVE_PATTERNS = (
+    re.compile(r"api[_-]?key|token|password|private[_-]?key|secret[_-]?key", re.IGNORECASE),
+    re.compile(r"-----BEGIN [A-Z ]+ PRIVATE KEY-----"),
+    re.compile(r"\.env", re.IGNORECASE),
+    re.compile(r"secrets?", re.IGNORECASE),
+)
+
+class SecurityViolationError(Exception):
+    """Exception raised when an action is blocked by the ACS Guard V6."""
+    pass
+
+class ACSGuardV6:
+    """
+    ACS (Agent Control Specification) Guard V6.
+    Advanced runtime safety policy to intercept and validate tool execution
+    across all skills using 5 validation checkpoints.
+    """
+
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None, audit_trail: Optional[AuditTrail] = None) -> None:
+        """
+        Initializes the ACS Guard V6.
+
+        Args:
+            policy_layer: An optional policy layer for evaluating tool policies.
+            audit_trail: An optional audit trail for logging checkpoint results.
+        """
+        self.logger = logging.getLogger(__name__)
+        self.policy_layer = policy_layer or PolicyLayer()
+        self.audit_trail = audit_trail or AuditTrail()
+
+    def checkpoint_1_input_validation(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 1: Input Validation.
+        Ensures the raw input data for the action is well-formed.
+        """
+        if not isinstance(workflow_data, dict):
+            return False, "Input validation failed: workflow data must be a dictionary."
+        if not workflow_data:
+            return False, "Input validation failed: workflow data is empty."
+
+        required_fields = ["action", "tool"]
+        for field in required_fields:
+            if field not in workflow_data:
+                return False, f"Input validation failed: missing '{field}' field."
+            if not isinstance(workflow_data[field], str):
+                return False, f"Input validation failed: '{field}' must be a string."
+
+        return True, "Input validation passed."
+
+    def checkpoint_2_intent_authorization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 2: Intent Authorization.
+        Verifies if the agent's intent is authorized.
+        """
+        action = workflow_data.get("action")
+        # Standard allowed intents in ACS-like architectures
+        allowed_intents = {
+            "read", "write", "execute", "plan", "reflect", "delegate", "analyze", "chat"
+        }
+
+        if action == "unauthorized_action":
+            return False, f"Intent authorization failed: action '{action}' is explicitly blacklisted."
+
+        if action not in allowed_intents:
+            return False, f"Intent authorization failed: action '{action}' is not in allowed intents list."
+
+        return True, "Intent authorization passed."
+
+    def checkpoint_3_tool_policy(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 3: Tool Policy.
+        Checks if the tool complies with defined policies using the PolicyLayer.
+        """
+        tool = workflow_data.get("tool")
+        if tool == "forbidden_tool":
+            return False, f"Tool policy failed: tool '{tool}' is forbidden."
+
+        kwargs = workflow_data.get("kwargs", {})
+        allow, explanation = self.policy_layer.evaluate(tool, **kwargs)
+        if not allow:
+            return False, f"Tool policy failed: {explanation}"
+
+        return True, "Tool policy passed."
+
+    def checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 4: State Transition.
+        Ensures the proposed state transition is valid within the cognitive architecture.
+        """
+        current_state = workflow_data.get("current_state", "idle")
+        next_state = workflow_data.get("next_state")
+
+        if not next_state:
+            return True, "State transition passed: next_state not provided."
+
+        allowed_transitions = {
+            "idle": ["planning", "reflecting", "analyzing", "executing"],
+            "planning": ["executing", "idle"],
+            "executing": ["evaluating", "idle"],
+            "evaluating": ["idle", "planning"],
+            "reflecting": ["idle"],
+            "analyzing": ["idle", "planning"],
+            "error": ["idle"]
+        }
+
+        if current_state not in allowed_transitions:
+            return False, f"State transition failed: unknown current_state '{current_state}'."
+
+        if next_state not in allowed_transitions[current_state] and next_state != "error":
+            return False, f"State transition failed: cannot transition from '{current_state}' to '{next_state}'."
+
+        return True, "State transition passed."
+
+    def checkpoint_5_output_sanitization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 5: Output Sanitization.
+        Sanitizes the final output to prevent leakage of sensitive data and checks for taint.
+        """
+        output = workflow_data.get("output")
+        if output is None:
+            return True, "Output sanitization passed: no output to sanitize."
+
+        if is_tainted(output):
+            return False, "Output sanitization failed: tainted data detected in output."
+
+        output_str = str(output)
+
+        for pattern in _SENSITIVE_PATTERNS:
+            if pattern.search(output_str):
+                return False, f"Output sanitization failed: sensitive pattern '{pattern.pattern}' detected."
+
+        return True, "Output sanitization passed."
+
+    def validate_action(self, workflow_data: Dict[str, Any]) -> bool:
+        """
+        Validates the workflow action through all 5 ACS checkpoints.
+
+        Args:
+            workflow_data: The workflow context data.
+
+        Returns:
+            bool: True if all checkpoints pass, False otherwise.
+        """
+        checkpoints = [
+            self.checkpoint_1_input_validation,
+            self.checkpoint_2_intent_authorization,
+            self.checkpoint_3_tool_policy,
+            self.checkpoint_4_state_transition,
+            self.checkpoint_5_output_sanitization
+        ]
+
+        for i, checkpoint in enumerate(checkpoints, 1):
+            passed, reason = checkpoint(workflow_data)
+            if not passed:
+                self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
+                return False
+            self.logger.info(f"ACS Checkpoint {i} Passed: {reason}")
+
+        return True
+
+    def intercept_action(self, workflow_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Intercepts an action, validates it through all 5 checkpoints,
+        logs the results to the AuditTrail, and raises SecurityViolationError on failure.
+
+        Args:
+            workflow_data: The workflow context data.
+
+        Returns:
+            Dict[str, Any]: The original workflow data if all checkpoints pass.
+
+        Raises:
+            SecurityViolationError: If any checkpoint fails.
+        """
+        checkpoints = [
+            self.checkpoint_1_input_validation,
+            self.checkpoint_2_intent_authorization,
+            self.checkpoint_3_tool_policy,
+            self.checkpoint_4_state_transition,
+            self.checkpoint_5_output_sanitization
+        ]
+
+        for i, checkpoint in enumerate(checkpoints, 1):
+            passed, reason = checkpoint(workflow_data)
+            if not passed:
+                self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
+                self.audit_trail.log_call(
+                    tool_name=workflow_data.get("tool", "unknown"),
+                    kwargs=workflow_data.get("kwargs", {}),
+                    why=f"ACS Checkpoint {i} Failed: {reason}",
+                    result="blocked",
+                    duration=0.0
+                )
+                raise SecurityViolationError(f"Action blocked by ACS checkpoint {i}: {reason}")
+            self.logger.debug(f"ACS Checkpoint {i} Passed: {reason}")
+
+        self.audit_trail.log_call(
+            tool_name=workflow_data.get("tool", "unknown"),
+            kwargs=workflow_data.get("kwargs", {}),
+            why="All 5 ACS checkpoints passed.",
+            result="allowed",
+            duration=0.0
+        )
+
+        return workflow_data

--- a/tests/test_acs_guard_v6.py
+++ b/tests/test_acs_guard_v6.py
@@ -1,0 +1,178 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.safety.acs_guard_v6 import ACSGuardV6, SecurityViolationError
+from magda_agent.safety.taint import mark_tainted
+
+@pytest.fixture
+def mock_policy_layer():
+    policy = MagicMock()
+    policy.evaluate.return_value = (True, "Allowed by mock")
+    return policy
+
+
+@pytest.fixture
+def mock_audit_trail():
+    return MagicMock()
+
+
+@pytest.fixture
+def acs_guard(mock_policy_layer, mock_audit_trail):
+    return ACSGuardV6(policy_layer=mock_policy_layer, audit_trail=mock_audit_trail)
+
+
+def test_checkpoint_1_input_validation(acs_guard: ACSGuardV6) -> None:
+    """Tests the input validation checkpoint."""
+    # Pass
+    valid_data = {"action": "read", "tool": "ls"}
+    passed, reason = acs_guard.checkpoint_1_input_validation(valid_data)
+    assert passed
+    assert "passed" in reason.lower()
+
+    # Fail - not a dict
+    passed, reason = acs_guard.checkpoint_1_input_validation("not a dict")
+    assert not passed
+    assert "must be a dictionary" in reason
+
+    # Fail - empty dict
+    passed, reason = acs_guard.checkpoint_1_input_validation({})
+    assert not passed
+    assert "workflow data is empty" in reason
+
+    # Fail - missing action
+    passed, reason = acs_guard.checkpoint_1_input_validation({"tool": "ls"})
+    assert not passed
+    assert "missing 'action' field" in reason
+
+
+def test_checkpoint_2_intent_authorization(acs_guard: ACSGuardV6) -> None:
+    """Tests the intent authorization checkpoint."""
+    # Pass
+    assert acs_guard.checkpoint_2_intent_authorization({"action": "read"})[0]
+    assert acs_guard.checkpoint_2_intent_authorization({"action": "write"})[0]
+    assert acs_guard.checkpoint_2_intent_authorization({"action": "chat"})[0]
+
+    # Fail - unauthorized_action
+    passed, reason = acs_guard.checkpoint_2_intent_authorization({"action": "unauthorized_action"})
+    assert not passed
+    assert "explicitly blacklisted" in reason
+
+    # Fail - not in allowed list
+    passed, reason = acs_guard.checkpoint_2_intent_authorization({"action": "jump"})
+    assert not passed
+    assert "not in allowed intents list" in reason
+
+
+def test_checkpoint_3_tool_policy(acs_guard: ACSGuardV6, mock_policy_layer: MagicMock) -> None:
+    """Tests the tool policy checkpoint with mocking."""
+    # Pass
+    assert acs_guard.checkpoint_3_tool_policy({"tool": "ls"})[0]
+
+    # Fail - forbidden_tool
+    passed, reason = acs_guard.checkpoint_3_tool_policy({"tool": "forbidden_tool"})
+    assert not passed
+    assert "is forbidden" in reason
+
+    # Fail - PolicyLayer denial
+    mock_policy_layer.evaluate.return_value = (False, "Policy denial")
+    passed, reason = acs_guard.checkpoint_3_tool_policy({"tool": "rm", "kwargs": {"path": "/"}})
+    assert not passed
+    assert "Policy denial" in reason
+
+
+def test_checkpoint_4_state_transition(acs_guard: ACSGuardV6) -> None:
+    """Tests the state transition checkpoint."""
+    # Pass - default transition
+    assert acs_guard.checkpoint_4_state_transition({"current_state": "idle", "next_state": "planning"})[0]
+
+    # Pass - next_state not provided
+    assert acs_guard.checkpoint_4_state_transition({"current_state": "idle"})[0]
+
+    # Fail - unknown current_state
+    passed, reason = acs_guard.checkpoint_4_state_transition({"current_state": "unknown", "next_state": "idle"})
+    assert not passed
+    assert "unknown current_state" in reason
+
+    # Fail - invalid transition
+    passed, reason = acs_guard.checkpoint_4_state_transition({"current_state": "idle", "next_state": "evaluating"})
+    assert not passed
+    assert "cannot transition" in reason
+
+    # Pass - transition to error
+    assert acs_guard.checkpoint_4_state_transition({"current_state": "planning", "next_state": "error"})[0]
+
+
+def test_checkpoint_5_output_sanitization(acs_guard: ACSGuardV6) -> None:
+    """Tests the output sanitization checkpoint."""
+    # Pass
+    assert acs_guard.checkpoint_5_output_sanitization({"output": "All good"})[0]
+    assert acs_guard.checkpoint_5_output_sanitization({"output": None})[0]
+
+    # Fail - sensitive data
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "Here is my secret_key: 12345"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "Password is admin"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+    # Regex patterns
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "Here is my .env file"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": "-----BEGIN RSA PRIVATE KEY-----"})
+    assert not passed
+    assert "sensitive pattern" in reason
+
+    # Taint check
+    tainted_output = mark_tainted("some normal string")
+    passed, reason = acs_guard.checkpoint_5_output_sanitization({"output": tainted_output})
+    assert not passed
+    assert "tainted data detected" in reason
+
+def test_validate_action(acs_guard: ACSGuardV6) -> None:
+    """Tests the comprehensive validation of all 5 checkpoints."""
+    valid_data = {
+        "action": "read",
+        "tool": "ls",
+        "current_state": "idle",
+        "next_state": "planning",
+        "output": "Some safe output"
+    }
+    assert acs_guard.validate_action(valid_data)
+
+    invalid_data = valid_data.copy()
+    invalid_data["action"] = "unauthorized_action"
+    assert not acs_guard.validate_action(invalid_data)
+
+
+def test_intercept_action(acs_guard: ACSGuardV6, mock_audit_trail: MagicMock) -> None:
+    """Tests that actions are correctly intercepted and blocked if invalid."""
+    valid_data = {
+        "action": "read",
+        "tool": "ls",
+        "current_state": "idle",
+        "next_state": "planning"
+    }
+    # Should not raise
+    assert acs_guard.intercept_action(valid_data) == valid_data
+    assert mock_audit_trail.log_call.called
+
+    # Reset mock
+    mock_audit_trail.log_call.reset_mock()
+
+    invalid_data = valid_data.copy()
+    invalid_data["tool"] = "forbidden_tool"
+
+    with pytest.raises(SecurityViolationError) as excinfo:
+        acs_guard.intercept_action(invalid_data)
+
+    assert "ACS checkpoint 3" in str(excinfo.value)
+    mock_audit_trail.log_call.assert_called_with(
+        tool_name="forbidden_tool",
+        kwargs={},
+        why="ACS Checkpoint 3 Failed: Tool policy failed: tool 'forbidden_tool' is forbidden.",
+        result="blocked",
+        duration=0.0
+    )


### PR DESCRIPTION
Implements an advanced runtime safety policy to intercept and validate tool execution across all skills.

---
*PR created automatically by Jules for task [9506146300942175052](https://jules.google.com/task/9506146300942175052) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ACSGuardV6` runtime safety controls with five validation checkpoints
> - Introduces [`acs_guard_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/382/files#diff-71e9c69ddc5fa3cdd6978a914b1f02cda615a18100456aaaba4cf3bfd3c13094) with the `ACSGuardV6` class, which runs five sequential checkpoints: input validation, intent authorization, tool policy, state transition, and output sanitization.
> - `validate_action` returns a boolean result; `intercept_action` raises `SecurityViolationError` and records an audit trail entry on failure.
> - Sensitive output patterns (API keys, tokens, passwords, private keys, `.env` references) are blocked via compiled regex in checkpoint 5.
> - Adds a pytest suite in [`tests/test_acs_guard_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/382/files#diff-eab8fea168130eeb3cec4349228cf8c0ec387b1d370b616026a394efcdb2b425) covering all checkpoints, taint propagation, and audit trail recording with mocked dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0282c49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->