### PR TITLE
feat: Implement MCP Dynamic Action Tool v7

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6284,7 +6284,7 @@
     },
     {
       "id": "mcp-dynamic-action-tool-v7",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "low",
       "title": "MCP Dynamic Action Tool v7",
@@ -12766,6 +12766,57 @@
         "LLM is mocked in tests."
       ],
       "status": "todo"
+    },
+    {
+      "id": "mcp-dynamic-tool-telemetry-v8",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Telemetry v8",
+      "description": "Add telemetry hooks to track MCP dynamic tool exports.",
+      "allowed_paths": [
+        "magda_agent/telemetry/mcp_export_telemetry.py",
+        "tests/test_mcp_export_telemetry.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry is captured on export.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-tracing-v8",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Enterprise Tracing v8",
+      "description": "Add enterprise tracing enhancements for A2A communication.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_tracing_v8.py",
+        "tests/test_a2a_tracing_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tracing enhancements are applied.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-live-v5",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw RL Canvas Live v5",
+      "description": "Live canvas updates for RL openclaw.",
+      "allowed_paths": [
+        "magda_agent/visualization/openclaw_canvas_v5.py",
+        "tests/test_openclaw_canvas_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas updates live based on RL events.",
+        "Tests pass."
+      ]
     }
   ]
 }

--- a/backlog.md
+++ b/backlog.md
@@ -230,3 +230,4 @@
 * [x] FEATURE: A2A Task Delegation Protocol (a2a-task-delegation-v2)
 * [x] FEATURE: OpenClaw RL Dynamic Behavior Adjustment v2 (openclaw-rl-dynamic-behavior-adjustment-v2)
 * [x] FEATURE: ACS Runtime Safety Controls V6 (acs-guard-runtime-safety-controls-v6)
+* [x] FEATURE: MCP Dynamic Action Tool v7 (mcp-dynamic-action-tool-v7)

--- a/magda_agent/skills/mcp_export_v7.py
+++ b/magda_agent/skills/mcp_export_v7.py
@@ -1,0 +1,122 @@
+import inspect
+import logging
+from typing import Dict, Any, Callable, List, get_origin
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_registry import MCPRegistry
+
+
+class MCPDynamicExporterV7:
+    """
+    Enhances skill registry to allow dynamic exporting and registration
+    of action tools over MCP standard.
+    """
+
+    def __init__(self, skill_registry: SkillRegistry, mcp_registry: MCPRegistry) -> None:
+        """
+        Initializes the dynamic exporter with references to both registries.
+
+        Args:
+            skill_registry (SkillRegistry): The primary registry of internal skills.
+            mcp_registry (MCPRegistry): The registry for MCP-compatible tools.
+        """
+        self.skill_registry = skill_registry
+        self.mcp_registry = mcp_registry
+        self.logger = logging.getLogger(__name__)
+
+    def _get_json_schema(self, func: Callable) -> Dict[str, Any]:
+        """
+        Extracts JSON schema parameters from a given function's signature.
+
+        Args:
+            func (Callable): The function to extract the schema from.
+
+        Returns:
+            Dict[str, Any]: The extracted JSON schema.
+        """
+        if hasattr(func, "__mcp_schema__"):
+            return getattr(func, "__mcp_schema__")
+
+        sig = inspect.signature(func)
+        properties = {}
+        required = []
+
+        for name, param in sig.parameters.items():
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                continue
+            if name == 'self':
+                continue
+
+            param_type = "string"
+            annotation = param.annotation
+            origin = get_origin(annotation)
+
+            actual_type = origin if origin is not None else annotation
+
+            if actual_type is int:
+                param_type = "integer"
+            elif actual_type is float:
+                param_type = "number"
+            elif actual_type is bool:
+                param_type = "boolean"
+            elif actual_type in (list, List):
+                param_type = "array"
+            elif actual_type in (dict, Dict):
+                param_type = "object"
+
+            properties[name] = {"type": param_type}
+
+            if param.default is inspect.Parameter.empty:
+                required.append(name)
+
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": required
+        }
+
+    def export_skill_to_mcp(self, skill_name: str) -> bool:
+        """
+        Exports a specific skill from the SkillRegistry to the MCPRegistry.
+
+        Args:
+            skill_name (str): The name of the skill to export.
+
+        Returns:
+            bool: True if exported successfully, False otherwise.
+        """
+        if not self.skill_registry.has_skill(skill_name):
+            self.logger.warning(f"Skill '{skill_name}' not found in SkillRegistry.")
+            return False
+
+        func = self.skill_registry.skills[skill_name]
+        description = self.skill_registry.descriptions.get(skill_name, "")
+        schema = self._get_json_schema(func)
+
+        mcp_tool_schema = {
+            "name": skill_name,
+            "description": description,
+            "inputSchema": schema
+        }
+
+        success = self.mcp_registry.load_tool(mcp_tool_schema)
+        if success:
+            self.logger.info(f"Successfully exported skill '{skill_name}' to MCPRegistry.")
+        else:
+            self.logger.error(f"Failed to export skill '{skill_name}' to MCPRegistry.")
+
+        return success
+
+    def export_all_skills(self) -> int:
+        """
+        Exports all registered skills from SkillRegistry to MCPRegistry dynamically.
+
+        Returns:
+            int: The number of skills successfully exported.
+        """
+        exported_count = 0
+        for name in list(self.skill_registry.skills.keys()):
+            if self.export_skill_to_mcp(name):
+                exported_count += 1
+
+        self.logger.info(f"Exported {exported_count} skills to MCPRegistry.")
+        return exported_count

--- a/tests/test_mcp_export_v7.py
+++ b/tests/test_mcp_export_v7.py
@@ -1,0 +1,63 @@
+import pytest
+from magda_agent.skills.mcp_export_v7 import MCPDynamicExporterV7
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_registry import MCPRegistry
+
+def sample_skill(a: int, b: str = "default") -> str:
+    """Sample skill description."""
+    return f"{a} - {b}"
+
+def test_export_skill_to_mcp_success():
+    """Test successfully exporting a single skill to MCP."""
+    skill_registry = SkillRegistry()
+    skill_registry.register_skill(
+        name="sample_skill",
+        func=sample_skill,
+        description="A sample test skill."
+    )
+
+    mcp_registry = MCPRegistry()
+    exporter = MCPDynamicExporterV7(skill_registry, mcp_registry)
+
+    # Export the skill
+    success = exporter.export_skill_to_mcp("sample_skill")
+
+    assert success is True
+    assert "sample_skill" in mcp_registry.mcp_tools
+
+    tool = mcp_registry.get_tool("sample_skill")
+    assert tool["name"] == "sample_skill"
+    assert tool["description"] == "A sample test skill."
+    assert tool["inputSchema"]["type"] == "object"
+    assert "a" in tool["inputSchema"]["properties"]
+    assert "b" in tool["inputSchema"]["properties"]
+    assert tool["inputSchema"]["properties"]["a"]["type"] == "integer"
+    assert tool["inputSchema"]["properties"]["b"]["type"] == "string"
+    assert "a" in tool["inputSchema"]["required"]
+    assert "b" not in tool["inputSchema"]["required"]
+
+def test_export_skill_not_found():
+    """Test behavior when trying to export a non-existent skill."""
+    skill_registry = SkillRegistry()
+    mcp_registry = MCPRegistry()
+    exporter = MCPDynamicExporterV7(skill_registry, mcp_registry)
+
+    success = exporter.export_skill_to_mcp("non_existent_skill")
+
+    assert success is False
+    assert len(mcp_registry.mcp_tools) == 0
+
+def test_export_all_skills():
+    """Test exporting multiple skills at once."""
+    skill_registry = SkillRegistry()
+    skill_registry.register_skill(name="skill_1", func=lambda x: x, description="Skill 1")
+    skill_registry.register_skill(name="skill_2", func=lambda y: y, description="Skill 2")
+
+    mcp_registry = MCPRegistry()
+    exporter = MCPDynamicExporterV7(skill_registry, mcp_registry)
+
+    exported_count = exporter.export_all_skills()
+
+    assert exported_count == 2
+    assert "skill_1" in mcp_registry.mcp_tools
+    assert "skill_2" in mcp_registry.mcp_tools


### PR DESCRIPTION
Implements MCP Dynamic Action Tool v7 as requested.
- Created `MCPDynamicExporterV7` to export `SkillRegistry` tools into `MCPRegistry`.
- Implemented tests to verify the exporter functionality.
- Updated `agent_tasks.json` with status `done` and added 3 new todo tasks.
- Updated `backlog.md`.

---
*PR created automatically by Jules for task [17442156848745140195](https://jules.google.com/task/17442156848745140195) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPDynamicExporterV7` to export skills from SkillRegistry to MCPRegistry
> - Adds [mcp_export_v7.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/383/files#diff-a7821dbd8195dc183740dec5a47825dd5e8be03d593c8c2fbfe2d4bea88052f3) with `MCPDynamicExporterV7`, which converts registered skills into MCP tools by deriving JSON input schemas from function signatures or a `__mcp_schema__` attribute.
> - Supports both single-skill (`export_skill_to_mcp`) and bulk (`export_all_skills`) export, returning success status or count.
> - Adds tests covering successful export, missing skill handling, and bulk export count validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 731c445.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->