### PR TITLE
feat: Add Hermes Cron Nightly Backups

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6301,7 +6301,7 @@
     },
     {
       "id": "hermes-cron-nightly-backups-v1-unique",
-      "status": "todo",
+      "status": "done",
       "area": "operations",
       "risk": "low",
       "title": "Hermes Cron Nightly Backups",
@@ -12816,6 +12816,38 @@
       "acceptance": [
         "Canvas updates live based on RL events.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "acs-state-transition-checkpoint-v5-1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS State Transition Checkpoint V5",
+      "description": "Implement Microsoft ACS state transition guardrail.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_state_transition_v5.py",
+        "tests/test_acs_state_transition_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "State transition checkpoint blocks invalid transitions."
+      ]
+    },
+    {
+      "id": "openclaw-semantic-memory-canvas-v2-1",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Semantic Memory Canvas V2",
+      "description": "Add live visualization of semantic memory updates inspired by OpenClaw.",
+      "allowed_paths": [
+        "magda_agent/visualization/openclaw_semantic_canvas_v2.py",
+        "tests/test_openclaw_semantic_canvas_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Semantic memory updates are visualized live."
       ]
     }
   ]

--- a/magda_agent/operations/cron_backups.py
+++ b/magda_agent/operations/cron_backups.py
@@ -1,0 +1,91 @@
+import logging
+import sqlite3
+import os
+import asyncio
+from datetime import datetime, timezone
+from typing import Optional, List, Coroutine, Any, Callable
+
+from magda_agent.operations.cron_v3 import HermesCronSchedulerV3
+
+logger = logging.getLogger(__name__)
+
+class SQLiteCronBackupManager:
+    """
+    Manages the scheduled backup operations for SQLite databases using HermesCronSchedulerV3.
+    """
+
+    def __init__(
+        self,
+        databases: List[str],
+        backup_dir: str,
+        scheduler: Optional[HermesCronSchedulerV3] = None
+    ):
+        """
+        Initializes the SQLiteCronBackupManager.
+
+        Args:
+            databases: A list of paths to the SQLite databases to backup.
+            backup_dir: The directory where backups will be stored.
+            scheduler: The CronScheduler instance. If None, a new one is created using memory db.
+        """
+        self.databases = databases
+        self.backup_dir = backup_dir
+        self.scheduler = scheduler or HermesCronSchedulerV3()
+
+    async def backup_databases(self) -> None:
+        """
+        Performs the backup operation for all registered databases.
+        Copies the databases to the backup directory using sqlite3 backup API.
+        """
+        if not os.path.exists(self.backup_dir):
+            os.makedirs(self.backup_dir, exist_ok=True)
+
+        now_str = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+        for db_path in self.databases:
+            if not os.path.exists(db_path):
+                logger.warning(f"Database {db_path} does not exist, skipping backup.")
+                continue
+
+            db_name = os.path.basename(db_path)
+            backup_path = os.path.join(self.backup_dir, f"{db_name}.{now_str}.bak")
+
+            try:
+                # Use sqlite3.Connection.backup for safe online backups
+                def _do_backup() -> None:
+                    src_conn = sqlite3.connect(db_path)
+                    dst_conn = sqlite3.connect(backup_path)
+                    with src_conn, dst_conn:
+                        src_conn.backup(dst_conn)
+                    src_conn.close()
+                    dst_conn.close()
+
+                await asyncio.to_thread(_do_backup)
+
+                logger.info(f"Successfully backed up {db_path} to {backup_path}")
+            except Exception as e:
+                logger.error(f"Failed to backup {db_path} to {backup_path}: {e}")
+
+    def register_nightly_backup(self, cron_expr: str = "0 2 * * *") -> None:
+        """
+        Registers the backup operation as a nightly task.
+
+        Args:
+            cron_expr: The cron expression indicating when to run the backup. Defaults to "0 2 * * *" (2:00 AM daily).
+        """
+        self.scheduler.schedule(cron_expr, self.backup_databases, name="sqlite_nightly_backup")
+        logger.info(f"Registered nightly backup with schedule '{cron_expr}'")
+
+    async def start(self) -> None:
+        """
+        Starts the underlying scheduler loop.
+        """
+        logger.info("Starting SQLiteCronBackupManager scheduler")
+        await self.scheduler.start()
+
+    async def stop(self) -> None:
+        """
+        Stops the underlying scheduler loop.
+        """
+        logger.info("Stopping SQLiteCronBackupManager scheduler")
+        await self.scheduler.stop()

--- a/tests/test_cron_backups.py
+++ b/tests/test_cron_backups.py
@@ -1,0 +1,114 @@
+import os
+import sqlite3
+import pytest
+import pytest_asyncio
+from magda_agent.operations.cron_backups import SQLiteCronBackupManager
+from magda_agent.operations.cron_v3 import HermesCronSchedulerV3
+
+from typing import List, Generator, AsyncGenerator
+import pathlib
+
+@pytest.fixture
+def temp_dbs(tmp_path: pathlib.Path) -> List[str]:
+    """
+    Creates temporary SQLite databases and populates them with test data.
+
+    Args:
+        tmp_path: The temporary path fixture provided by pytest.
+
+    Returns:
+        A list of string paths to the temporary databases.
+    """
+    db1_path = tmp_path / "test1.db"
+    db2_path = tmp_path / "test2.db"
+
+    # Create dummy dbs
+    conn1 = sqlite3.connect(db1_path)
+    conn1.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+    conn1.execute("INSERT INTO users (name) VALUES ('Alice')")
+    conn1.commit()
+    conn1.close()
+
+    conn2 = sqlite3.connect(db2_path)
+    conn2.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)")
+    conn2.execute("INSERT INTO settings (key, value) VALUES ('theme', 'dark')")
+    conn2.commit()
+    conn2.close()
+
+    return [str(db1_path), str(db2_path)]
+
+@pytest.fixture
+def backup_dir(tmp_path: pathlib.Path) -> str:
+    """
+    Creates a temporary directory for storing database backups.
+
+    Args:
+        tmp_path: The temporary path fixture provided by pytest.
+
+    Returns:
+        A string path to the created backup directory.
+    """
+    path = tmp_path / "backups"
+    path.mkdir()
+    return str(path)
+
+@pytest_asyncio.fixture
+async def backup_manager(temp_dbs: List[str], backup_dir: str) -> AsyncGenerator[SQLiteCronBackupManager, None]:
+    """
+    Initializes a SQLiteCronBackupManager with temporary databases and backup directory.
+
+    Args:
+        temp_dbs: The list of temporary database paths.
+        backup_dir: The directory path for storing backups.
+
+    Yields:
+        An instance of SQLiteCronBackupManager ready for testing.
+    """
+    scheduler = HermesCronSchedulerV3()
+    manager = SQLiteCronBackupManager(databases=temp_dbs, backup_dir=backup_dir, scheduler=scheduler)
+    yield manager
+    await manager.stop()
+
+@pytest.mark.asyncio
+async def test_backup_databases(backup_manager: SQLiteCronBackupManager, backup_dir: str) -> None:
+    """
+    Tests that the backup manager successfully copies SQLite databases to the backup directory.
+
+    Args:
+        backup_manager: The initialized SQLiteCronBackupManager fixture.
+        backup_dir: The string path to the backup directory fixture.
+    """
+    await backup_manager.backup_databases()
+
+    # Verify backup files were created
+    files = os.listdir(backup_dir)
+    assert len(files) == 2
+
+    db1_backup = next(f for f in files if f.startswith("test1.db"))
+    db2_backup = next(f for f in files if f.startswith("test2.db"))
+
+    # Verify data in backups
+    conn1 = sqlite3.connect(os.path.join(backup_dir, db1_backup))
+    cursor1 = conn1.cursor()
+    cursor1.execute("SELECT name FROM users")
+    assert cursor1.fetchone()[0] == 'Alice'
+    conn1.close()
+
+    conn2 = sqlite3.connect(os.path.join(backup_dir, db2_backup))
+    cursor2 = conn2.cursor()
+    cursor2.execute("SELECT value FROM settings")
+    assert cursor2.fetchone()[0] == 'dark'
+    conn2.close()
+
+@pytest.mark.asyncio
+async def test_register_nightly_backup(backup_manager: SQLiteCronBackupManager) -> None:
+    """
+    Tests that the nightly backup task is correctly registered with the cron scheduler.
+
+    Args:
+        backup_manager: The initialized SQLiteCronBackupManager fixture.
+    """
+    backup_manager.register_nightly_backup()
+
+    # Verify the job is registered in the scheduler
+    assert "sqlite_nightly_backup" in backup_manager.scheduler._func_registry


### PR DESCRIPTION
Implements the `hermes-cron-nightly-backups-v1-unique` task to run scheduled SQLite backups using HermesCronSchedulerV3 and `sqlite3` `backup()` mechanism. Also updates `agent_tasks.json` with a completed task status and two new future-looking tasks inspired by 2026 AI agent trends (ACS Guardrails and OpenClaw visualization).

---
*PR created automatically by Jules for task [9976098919124054125](https://jules.google.com/task/9976098919124054125) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nightly SQLite backup scheduling via `SQLiteCronBackupManager`
> - Adds [cron_backups.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/384/files#diff-1bc14d8531446b1ead31e94517eb6ccb0d235cacfeefb5e5b78dd492895d9686) with a new `SQLiteCronBackupManager` class that wraps `HermesCronSchedulerV3` to schedule and run SQLite backups.
> - Backups run nightly at 02:00 UTC by default (`0 2 * * *`), using `sqlite3.Connection.backup` in a background thread to produce timestamped `.bak` files named `<db_name>.<YYYYMMDD_HHMMSS>.bak`.
> - Missing databases are skipped with a warning; errors per-database are logged without aborting the remaining backups.
> - Adds tests in [test_cron_backups.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/384/files#diff-42f3b2beaf7505c4238d3152cc82ca2e0634677e074c649ad29dc007ea008ffa) covering backup file creation, data integrity, and job registration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60e9fb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->