### PR TITLE
feat: Hermes Cron Scheduler Daily Reports v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6318,7 +6318,7 @@
     },
     {
       "id": "hermes-cron-scheduler-daily-reports-v3",
-      "status": "todo",
+      "status": "done",
       "area": "operations",
       "risk": "low",
       "title": "Hermes Cron Scheduler Daily Reports v3",
@@ -12848,6 +12848,57 @@
       ],
       "acceptance": [
         "Semantic memory updates are visualized live."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-creation-v5",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Agent Skills Creation v5",
+      "description": "Inspired by Hermes Agent trends: Implement a v5 of the skills creation mechanism to autonomously build skills from experience and register them natively.",
+      "allowed_paths": [
+        "magda_agent/learning/skills_creation_v5.py",
+        "tests/test_skills_creation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill creation creates correctly.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-context-compression-v7",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Claude Context Compression v7",
+      "description": "Inspired by Claude Agent SDK context compression trends: Create an enhanced context compression plugin to dynamically shrink long-term memory into working context using semantic cues.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v7.py",
+        "tests/test_compression_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Compression logic triggers.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-semantic-memory-canvas-v3",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Semantic Memory Canvas v3",
+      "description": "Inspired by OpenClaw Canvas Live trends: Implement canvas APIs for displaying semantic memory relations visually.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_api_v3.py",
+        "tests/test_canvas_api_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas API correctly fetches semantic memory visually.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/operations/cron_reports_v3.py
+++ b/magda_agent/operations/cron_reports_v3.py
@@ -1,0 +1,103 @@
+import logging
+from typing import Optional, Any
+from magda_agent.operations.cron_v3 import HermesCronSchedulerV3
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.llm_client import LLMClient
+
+logger = logging.getLogger(__name__)
+
+class DailyReportManagerV3:
+    """
+    Manages scheduled daily reports generation using HermesCronSchedulerV3.
+    It aggregates daily events from EpisodicMemory and generates a report via LLM.
+    Inspired by Hermes Agent trend.
+    """
+    def __init__(
+        self,
+        scheduler: Optional[HermesCronSchedulerV3] = None,
+        memory: Optional[EpisodicMemory] = None,
+        llm: Optional[LLMClient] = None
+    ):
+        """
+        Initializes the DailyReportManagerV3.
+        """
+        self.scheduler = scheduler or HermesCronSchedulerV3()
+        self.memory = memory
+        self.llm = llm
+
+    def register_daily_report(self, name: str, cron_expr: str = "0 8 * * *") -> None:
+        """
+        Registers the report generation as a daily task.
+
+        Args:
+            name: The name of the report task.
+            cron_expr: The cron expression indicating when to generate the report. Defaults to "0 8 * * *".
+        """
+        async def _generate() -> str:
+            return await self.generate_aggregated_report(name)
+
+        # Required to fix name resolution inside lambda/closure within task list if multiple registered
+        _generate.__name__ = f"report_{name}"
+
+        self.scheduler.schedule(cron_expr, _generate, name=name)
+        logger.info(f"Registered daily report '{name}' with schedule '{cron_expr}'")
+
+    async def generate_aggregated_report(self, name: str) -> str:
+        """
+        Aggregates recent events from EpisodicMemory and uses LLM to generate a report.
+        """
+        if not self.memory or not self.llm:
+            error_msg = "Error: Memory or LLM not configured."
+            logger.error(error_msg)
+            return error_msg
+
+        try:
+            # We get up to 100 recent events
+            events = self.memory.get_all_events(limit=100)
+
+            if not events:
+                msg = f"Report {name}: No recent events to report."
+                logger.info(msg)
+                return msg
+
+            event_texts = [evt["text"] for evt in events]
+            context = "\n".join(event_texts)
+            prompt = f"Please generate a daily report named '{name}' summarizing the following events:\n{context}"
+
+            report = await self.llm.generate(prompt)
+            logger.info(f"Generated daily report '{name}': {report}")
+            return report
+        except Exception as e:
+            logger.error(f"Failed to generate report: {e}", exc_info=True)
+            return f"Failed to generate report: {e}"
+
+    async def generate_report_now(self, name: str) -> Optional[str]:
+        """
+        Immediately runs a report task that has been registered.
+        """
+        func = self.scheduler._func_registry.get(name)
+        if not func:
+            logger.error(f"Cannot generate report '{name}', it is not registered.")
+            return None
+
+        logger.info(f"Generating daily report '{name}' immediately.")
+        try:
+            result = await func()
+            return result
+        except Exception as e:
+            logger.error(f"Error generating daily report '{name}': {e}", exc_info=True)
+            return None
+
+    async def start(self) -> None:
+        """
+        Starts the underlying scheduler loop.
+        """
+        logger.info("Starting DailyReportManagerV3 scheduler")
+        await self.scheduler.start()
+
+    async def stop(self) -> None:
+        """
+        Stops the underlying scheduler loop.
+        """
+        logger.info("Stopping DailyReportManagerV3 scheduler")
+        await self.scheduler.stop()

--- a/tests/test_cron_reports_v3.py
+++ b/tests/test_cron_reports_v3.py
@@ -1,0 +1,76 @@
+import pytest
+import pytest_asyncio
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+
+from magda_agent.operations.cron_v3 import HermesCronSchedulerV3
+from magda_agent.operations.cron_reports_v3 import DailyReportManagerV3
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.llm_client import LLMClient
+
+@pytest_asyncio.fixture
+async def scheduler():
+    sched = HermesCronSchedulerV3()
+    yield sched
+    await sched.stop()
+
+@pytest.fixture
+def mock_memory():
+    memory = MagicMock(spec=EpisodicMemory)
+    memory.get_all_events.return_value = [
+        {"text": "Event 1 happened"},
+        {"text": "Event 2 happened"}
+    ]
+    return memory
+
+@pytest.fixture
+def mock_llm():
+    llm = MagicMock(spec=LLMClient)
+    llm.generate = AsyncMock(return_value="This is a generated daily report.")
+    return llm
+
+@pytest.mark.asyncio
+async def test_register_daily_report(scheduler, mock_memory, mock_llm):
+    manager = DailyReportManagerV3(scheduler=scheduler, memory=mock_memory, llm=mock_llm)
+    manager.register_daily_report("daily_update")
+
+    assert "daily_update" in scheduler._func_registry
+
+@pytest.mark.asyncio
+async def test_generate_aggregated_report(scheduler, mock_memory, mock_llm):
+    manager = DailyReportManagerV3(scheduler=scheduler, memory=mock_memory, llm=mock_llm)
+
+    report = await manager.generate_aggregated_report("daily_update")
+
+    assert report == "This is a generated daily report."
+    mock_memory.get_all_events.assert_called_once_with(limit=100)
+    mock_llm.generate.assert_called_once()
+
+    call_args = mock_llm.generate.call_args[0][0]
+    assert "Event 1 happened" in call_args
+    assert "Event 2 happened" in call_args
+    assert "daily_update" in call_args
+
+@pytest.mark.asyncio
+async def test_generate_report_now(scheduler, mock_memory, mock_llm):
+    manager = DailyReportManagerV3(scheduler=scheduler, memory=mock_memory, llm=mock_llm)
+    manager.register_daily_report("daily_update")
+
+    report = await manager.generate_report_now("daily_update")
+    assert report == "This is a generated daily report."
+
+@pytest.mark.asyncio
+async def test_generate_report_no_events(scheduler, mock_memory, mock_llm):
+    mock_memory.get_all_events.return_value = []
+    manager = DailyReportManagerV3(scheduler=scheduler, memory=mock_memory, llm=mock_llm)
+
+    report = await manager.generate_aggregated_report("daily_update")
+    assert report == "Report daily_update: No recent events to report."
+    mock_llm.generate.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_generate_report_missing_deps(scheduler):
+    manager = DailyReportManagerV3(scheduler=scheduler, memory=None, llm=None)
+
+    report = await manager.generate_aggregated_report("daily_update")
+    assert report == "Error: Memory or LLM not configured."


### PR DESCRIPTION
Implemented the Hermes Cron Scheduler Daily Reports v3 by creating `DailyReportManagerV3` in `magda_agent/operations/cron_reports_v3.py`. This class uses `HermesCronSchedulerV3` to schedule daily report tasks that aggregate events from `EpisodicMemory` and use `LLMClient` to generate a summary report.

Also added `tests/test_cron_reports_v3.py` with mock-based unit tests for all public methods. All tests and agent task validation script pass successfully.

Updated `agent_tasks.json` by marking the task "hermes-cron-scheduler-daily-reports-v3" as "done" and added three new tasks from June 2026 AI Agent Trends based on Hermes, Claude, and OpenClaw paradigms.

---
*PR created automatically by Jules for task [10644273987169380059](https://jules.google.com/task/10644273987169380059) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `DailyReportManagerV3` for cron-scheduled daily reports via `HermesCronSchedulerV3`
> - Adds [cron_reports_v3.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/385/files#diff-d96a065ec8a601861003fcef5e7a163fc9356e55caac6bb1aa7fdd01d0f87bae) with `DailyReportManagerV3`, which registers named async report tasks on a cron schedule (default `0 8 * * *`) using `HermesCronSchedulerV3`.
> - `generate_aggregated_report` fetches up to 100 recent events from `EpisodicMemory`, builds a prompt, and calls `LLMClient.generate` to produce a text summary.
> - `generate_report_now` allows immediate on-demand execution of any registered report by looking up the function in `scheduler._func_registry`.
> - Adds tests in [tests/test_cron_reports_v3.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/385/files#diff-cbe21c4ec1af9f448eedc6601d53c0a4d24044621dc813696b3f816826ee1db7) covering registration, LLM report generation, empty events, and missing dependency paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f7491f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->