### PR TITLE
Implement Claude Agent Evaluator v2 and append trend tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6352,7 +6352,7 @@
     },
     {
       "id": "claude-agent-evaluator-v2",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "Claude Agent Evaluator v2",
@@ -12950,6 +12950,58 @@
       "acceptance": [
         "Card broadcast is received locally",
         "Tests pass"
+      ]
+    },
+    {
+      "id": "claude-subagent-token-optimizer-v5-f7574180-20c7-4782-904b-523e23aaaf6a",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Claude Subagent Token Optimizer V5",
+      "description": "Inspired by Claude Agent SDK context compression trend. Enhance context compression algorithms.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v5.py",
+        "tests/test_compression_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context is effectively compressed.",
+        "Tests verify context window limits."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-registry-sync-v10-ab8196e0-d9a4-401f-b9d4-23487568426a",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Registry Synchronization V10",
+      "description": "Inspired by MCP Standard trend: Implement a background loop that periodically polls a configured MCP server URL and dynamically registers or unregisters tools in the local MCPRegistry.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry_sync.py",
+        "tests/test_mcp_registry_sync.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Background loop successfully polls and parses MCP tool schema endpoints.",
+        "Local MCPRegistry reflects the state of the remote MCP server.",
+        "Tests verify the polling mechanism using a mocked client."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-live-memory-telemetry-v7-6a29979c-e215-4b3c-a6e3-87be8ab9f990",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Memory Telemetry V7",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend: Create an export module to broadcast episodic memory consolidation events dynamically to a live dashboard.",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_memory_v5.py",
+        "tests/test_canvas_memory_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory telemetry broadcaster implemented and broadcasts consolidation events.",
+        "Tests verify event payloads format matches Canvas UI."
       ]
     }
   ]

--- a/magda_agent/agents/evaluator_v2.py
+++ b/magda_agent/agents/evaluator_v2.py
@@ -1,0 +1,77 @@
+from typing import Dict, Any, Optional
+import logging
+import json
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+
+
+class EvaluatorAgentV2(SubAgent):
+    """
+    Claude-inspired specialized sub-agent for evaluating output from Generator sub-agents.
+    Inherits from SubAgent for isolated execution capability.
+    """
+    def __init__(self, llm: LLMClient):
+        super().__init__(
+            llm=llm,
+            system_prompt=(
+                "You are an expert code and output Evaluator sub-agent. "
+                "Critique the provided output against the user request and provide actionable feedback. "
+                "You MUST output valid JSON only."
+            ),
+            use_isolation=False
+        )
+
+    async def evaluate_generator_output(self, generator_output: str, user_request: str) -> Dict[str, Any]:
+        """
+        Evaluates the output produced by the Generator Agent and provides critique.
+
+        Args:
+            generator_output (str): The text or code output generated.
+            user_request (str): The initial user request or context.
+
+        Returns:
+            Dict[str, Any]: Parsed JSON representing the critique and feedback containing keys:
+                - score (int): 1-10 evaluation score.
+                - approved (bool): Whether the output is acceptable.
+                - feedback (str): Detailed, actionable critique.
+        """
+        logging.info("Starting EvaluatorAgentV2 evaluation...")
+
+        task = (
+            "Evaluate the generator's output against the user's original request.\n\n"
+            "Return a JSON object with the following schema:\n"
+            '{"score": <int 1-10>, "approved": <bool>, "feedback": "<detailed critique and actionable feedback>"}'
+        )
+
+        context_str = (
+            f"User Request:\n{user_request}\n"
+            "------------------------\n"
+            f"Generator Output:\n{generator_output}\n"
+            "------------------------\n"
+        )
+
+        try:
+            response_text = await self.execute(task=task, context=context_str, temperature=0.2)
+
+            # Simple markdown cleaning if the LLM wraps it in markdown blocks
+            if "```" in response_text:
+                response_text = response_text.split("```")[1]
+                if response_text.lower().startswith("json"):
+                    response_text = response_text[4:]
+
+            result = json.loads(response_text.strip())
+
+            # Validate expected keys are present
+            if not all(k in result for k in ("score", "approved", "feedback")):
+                raise ValueError("Missing required keys in LLM JSON output")
+
+            return result
+
+        except Exception as e:
+            logging.error(f"EvaluatorAgentV2 review failed: {e}")
+            return {
+                "score": 0,
+                "approved": False,
+                "feedback": f"Evaluation error: {str(e)}"
+            }

--- a/tests/test_evaluator_v2.py
+++ b/tests/test_evaluator_v2.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.evaluator_v2 import EvaluatorAgentV2
+
+@pytest.mark.asyncio
+async def test_evaluator_v2_agent_approve():
+    """Tests the EvaluatorAgentV2 correctly parses a passing score from the LLM."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='{"score": 9, "approved": true, "feedback": "Great response!"}')
+
+    agent = EvaluatorAgentV2(llm=mock_llm)
+    result = await agent.evaluate_generator_output("The sky is blue.", "What color is the sky?")
+
+    assert result["score"] == 9
+    assert result["approved"] is True
+    assert result["feedback"] == "Great response!"
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_v2_agent_reject():
+    """Tests the EvaluatorAgentV2 correctly parses a failing score from the LLM with markdown."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='```json\n{"score": 4, "approved": false, "feedback": "Incorrect color."}\n```')
+
+    agent = EvaluatorAgentV2(llm=mock_llm)
+    result = await agent.evaluate_generator_output("The sky is green.", "What color is the sky?")
+
+    assert result["score"] == 4
+    assert result["approved"] is False
+    assert result["feedback"] == "Incorrect color."
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_v2_agent_error_handling_invalid_json():
+    """Tests the EvaluatorAgentV2 correctly handles JSON parsing errors."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='This is not valid JSON')
+
+    agent = EvaluatorAgentV2(llm=mock_llm)
+    result = await agent.evaluate_generator_output("Some output", "Some request")
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Evaluation error" in result["feedback"] or "Expecting value" in result["feedback"]
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_v2_agent_error_handling_missing_keys():
+    """Tests the EvaluatorAgentV2 correctly handles JSON with missing keys."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='{"score": 9, "approved": true}')
+
+    agent = EvaluatorAgentV2(llm=mock_llm)
+    result = await agent.evaluate_generator_output("Some output", "Some request")
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Evaluation error: Missing required keys in LLM JSON output" in result["feedback"]
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Implemented `EvaluatorAgentV2` in `magda_agent/agents/evaluator_v2.py` inspired by the Claude Agent SDK trend for evaluating output from Generator sub-agents. 

Created `tests/test_evaluator_v2.py` with full unit testing using `AsyncMock` to verify LLM evaluation handling of passing, failing, invalid JSON, and missing keys scenarios.

Updated `agent_tasks.json` to mark the task as `done` and successfully injected 3 new tasks mapping to current June 2026 AI trends for Claude context compression, MCP dynamic registry sync, and OpenClaw telemetry.

Validated with `python scripts/validate_agent_tasks.py agent_tasks.json` and `pytest tests/test_evaluator_v2.py`. All tests pass.

---
*PR created automatically by Jules for task [1769676431881142854](https://jules.google.com/task/1769676431881142854) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `EvaluatorAgentV2` sub-agent to evaluate and score generator outputs
> - Adds [`evaluator_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/387/files#diff-65c9a7bfd75a5abb3867d0d8ef8f780d366ed1b816001b44598b8d1a23c7b65a) with a new `EvaluatorAgentV2` class derived from `SubAgent` that sends generator output to Claude and parses a structured JSON critique containing `score`, `approved`, and `feedback` fields.
> - Strips markdown code fences from the LLM response before JSON parsing; returns a deterministic error payload (`score: 0`, `approved: false`) on any failure.
> - Adds four async tests in [`tests/test_evaluator_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/387/files#diff-b610e5ff2c6e57814a8749b08408a4c9e1c2a5830db64960e002a441baea7c4c) covering approval, rejection, invalid JSON, and missing required keys.
> - Appends three new task definitions to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/387/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5a2a27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->