### PR TITLE
feat: Implement Hermes Cron Nightly Backups V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6369,7 +6369,7 @@
     },
     {
       "id": "hermes-cron-nightly-backups-v2",
-      "status": "todo",
+      "status": "done",
       "area": "operations",
       "risk": "low",
       "title": "Hermes Cron Nightly Backups v2",
@@ -13002,6 +13002,57 @@
       "acceptance": [
         "Memory telemetry broadcaster implemented and broadcasts consolidation events.",
         "Tests verify event payloads format matches Canvas UI."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-v7",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "OpenClaw RL Canvas Metrics V7",
+      "description": "Inspired by OpenClaw trends: Implement live RL telemetry streaming via WebSockets, mapping PAD shifts in real-time.",
+      "allowed_paths": [
+        "magda_agent/operations/live_rl_v7.py",
+        "tests/test_live_rl_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module formats telemetry events to JSON.",
+        "Tests verify WebSocket emission."
+      ]
+    },
+    {
+      "id": "a2a-discovery-mesh-cards-v6",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "A2A Discovery Mesh Cards V6",
+      "description": "Inspired by A2A Protocol trends: Enable Agent Card broadcasting across A2A mesh network to discover agents.",
+      "allowed_paths": [
+        "magda_agent/operations/a2a_discovery_mesh_v6.py",
+        "tests/test_a2a_discovery_mesh_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Card broadcast is received locally.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-governance-v6",
+      "status": "todo",
+      "area": "operations",
+      "risk": "high",
+      "title": "MCP Action Tool Governance V6",
+      "description": "Inspired by MCP/ACS: Implement an Action Tool Governance layer that intercepts external tool calls to ensure sandboxed execution.",
+      "allowed_paths": [
+        "magda_agent/operations/mcp_governance_v6.py",
+        "tests/test_mcp_governance_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Action tools are intercepted.",
+        "Tests mock tool execution to verify interception."
       ]
     }
   ]

--- a/magda_agent/operations/cron_backups_v2.py
+++ b/magda_agent/operations/cron_backups_v2.py
@@ -1,0 +1,93 @@
+import logging
+import sqlite3
+import os
+import asyncio
+from datetime import datetime, timezone
+from typing import Optional, List
+
+from magda_agent.operations.cron_v3 import HermesCronSchedulerV3
+
+logger = logging.getLogger(__name__)
+
+class SQLiteCronBackupManagerV2:
+    """
+    Manages the scheduled backup operations for SQLite databases using HermesCronSchedulerV3.
+    """
+
+    def __init__(
+        self,
+        databases: List[str],
+        backup_dir: str,
+        scheduler: Optional[HermesCronSchedulerV3] = None
+    ):
+        """
+        Initializes the SQLiteCronBackupManagerV2.
+
+        Args:
+            databases: A list of paths to the SQLite databases to backup.
+            backup_dir: The directory where backups will be stored.
+            scheduler: The CronScheduler instance. If None, a new one is created using memory db.
+        """
+        self.databases = databases
+        self.backup_dir = backup_dir
+        self.scheduler = scheduler or HermesCronSchedulerV3()
+
+    async def backup_databases(self) -> None:
+        """
+        Performs the backup operation for all registered databases.
+        Copies the databases to the backup directory using sqlite3 backup API.
+        """
+        if not os.path.exists(self.backup_dir):
+            os.makedirs(self.backup_dir, exist_ok=True)
+
+        now_str = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+        for db_path in self.databases:
+            if not os.path.exists(db_path):
+                logger.warning(f"Database {db_path} does not exist, skipping backup.")
+                continue
+
+            db_name = os.path.basename(db_path)
+            backup_path = os.path.join(self.backup_dir, f"{db_name}.{now_str}.bak")
+
+            try:
+                # Use sqlite3.Connection.backup for safe online backups
+                def _do_backup() -> None:
+                    src_conn = sqlite3.connect(db_path)
+                    dst_conn = sqlite3.connect(backup_path)
+                    try:
+                        with src_conn, dst_conn:
+                            src_conn.backup(dst_conn)
+                    finally:
+                        src_conn.close()
+                        dst_conn.close()
+
+                await asyncio.to_thread(_do_backup)
+
+                logger.info(f"Successfully backed up {db_path} to {backup_path}")
+            except Exception as e:
+                logger.error(f"Failed to backup {db_path} to {backup_path}: {e}")
+
+    def register_nightly_backup(self, cron_expr: str = "0 2 * * *") -> None:
+        """
+        Registers the backup operation as a nightly task.
+
+        Args:
+            cron_expr: The cron expression indicating when to run the backup. Defaults to "0 2 * * *" (2:00 AM daily).
+        """
+        self.scheduler.schedule(cron_expr, self.backup_databases, name="sqlite_nightly_backup_v2")
+        logger.info(f"Registered nightly backup with schedule '{cron_expr}'")
+
+    async def start(self) -> None:
+        """
+        Starts the underlying scheduler loop.
+        """
+        logger.info("Starting SQLiteCronBackupManagerV2 scheduler")
+        await self.scheduler.start()
+
+    async def stop(self) -> None:
+        """
+        Stops the underlying scheduler loop.
+        """
+        logger.info("Stopping SQLiteCronBackupManagerV2 scheduler")
+        await self.scheduler.stop()

--- a/tests/test_cron_backups_v2.py
+++ b/tests/test_cron_backups_v2.py
@@ -1,0 +1,114 @@
+import os
+import sqlite3
+import pytest
+import pytest_asyncio
+from magda_agent.operations.cron_backups_v2 import SQLiteCronBackupManagerV2
+from magda_agent.operations.cron_v3 import HermesCronSchedulerV3
+
+from typing import List, AsyncGenerator
+import pathlib
+
+@pytest.fixture
+def temp_dbs_v2(tmp_path: pathlib.Path) -> List[str]:
+    """
+    Creates temporary SQLite databases and populates them with test data.
+
+    Args:
+        tmp_path: The temporary path fixture provided by pytest.
+
+    Returns:
+        A list of string paths to the temporary databases.
+    """
+    db1_path = tmp_path / "test1_v2.db"
+    db2_path = tmp_path / "test2_v2.db"
+
+    # Create dummy dbs
+    conn1 = sqlite3.connect(db1_path)
+    conn1.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+    conn1.execute("INSERT INTO users (name) VALUES ('Bob')")
+    conn1.commit()
+    conn1.close()
+
+    conn2 = sqlite3.connect(db2_path)
+    conn2.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)")
+    conn2.execute("INSERT INTO settings (key, value) VALUES ('theme', 'light')")
+    conn2.commit()
+    conn2.close()
+
+    return [str(db1_path), str(db2_path)]
+
+@pytest.fixture
+def backup_dir_v2(tmp_path: pathlib.Path) -> str:
+    """
+    Creates a temporary directory for storing database backups.
+
+    Args:
+        tmp_path: The temporary path fixture provided by pytest.
+
+    Returns:
+        A string path to the created backup directory.
+    """
+    path = tmp_path / "backups_v2"
+    path.mkdir()
+    return str(path)
+
+@pytest_asyncio.fixture
+async def backup_manager_v2(temp_dbs_v2: List[str], backup_dir_v2: str) -> AsyncGenerator[SQLiteCronBackupManagerV2, None]:
+    """
+    Initializes a SQLiteCronBackupManagerV2 with temporary databases and backup directory.
+
+    Args:
+        temp_dbs_v2: The list of temporary database paths.
+        backup_dir_v2: The directory path for storing backups.
+
+    Yields:
+        An instance of SQLiteCronBackupManagerV2 ready for testing.
+    """
+    scheduler = HermesCronSchedulerV3()
+    manager = SQLiteCronBackupManagerV2(databases=temp_dbs_v2, backup_dir=backup_dir_v2, scheduler=scheduler)
+    yield manager
+    await manager.stop()
+
+@pytest.mark.asyncio
+async def test_backup_databases_v2(backup_manager_v2: SQLiteCronBackupManagerV2, backup_dir_v2: str) -> None:
+    """
+    Tests that the backup manager successfully copies SQLite databases to the backup directory.
+
+    Args:
+        backup_manager_v2: The initialized SQLiteCronBackupManagerV2 fixture.
+        backup_dir_v2: The string path to the backup directory fixture.
+    """
+    await backup_manager_v2.backup_databases()
+
+    # Verify backup files were created
+    files = os.listdir(backup_dir_v2)
+    assert len(files) == 2
+
+    db1_backup = next(f for f in files if f.startswith("test1_v2.db"))
+    db2_backup = next(f for f in files if f.startswith("test2_v2.db"))
+
+    # Verify data in backups
+    conn1 = sqlite3.connect(os.path.join(backup_dir_v2, db1_backup))
+    cursor1 = conn1.cursor()
+    cursor1.execute("SELECT name FROM users")
+    assert cursor1.fetchone()[0] == 'Bob'
+    conn1.close()
+
+    conn2 = sqlite3.connect(os.path.join(backup_dir_v2, db2_backup))
+    cursor2 = conn2.cursor()
+    cursor2.execute("SELECT value FROM settings")
+    assert cursor2.fetchone()[0] == 'light'
+    conn2.close()
+
+@pytest.mark.asyncio
+async def test_register_nightly_backup_v2(backup_manager_v2: SQLiteCronBackupManagerV2) -> None:
+    """
+    Tests that the nightly backup task is correctly registered with the cron scheduler.
+
+    Args:
+        backup_manager_v2: The initialized SQLiteCronBackupManagerV2 fixture.
+    """
+    backup_manager_v2.register_nightly_backup()
+
+    # Verify the job is registered in the scheduler
+    assert "sqlite_nightly_backup_v2" in backup_manager_v2.scheduler._func_registry


### PR DESCRIPTION
Implements the `SQLiteCronBackupManagerV2` to perform safe, online backups of SQLite databases natively via `sqlite3.Connection.backup()`. The backup task runs in an `asyncio.to_thread` block to avoid locking the main event loop and is scheduled automatically via `HermesCronSchedulerV3`. Includes unit tests with mocked environments. Updated `agent_tasks.json` with the new completion status and backlog task generation.

---
*PR created automatically by Jules for task [553862942319806311](https://jules.google.com/task/553862942319806311) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SQLiteCronBackupManagerV2` for nightly SQLite backups via HermesCronSchedulerV3
> - Introduces [`SQLiteCronBackupManagerV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/388/files#diff-8eb911b8cd6d3f7a5155bab90dba00c9943bfad938acfcf3078397571445f9a9) which schedules and runs timestamped SQLite backups using `HermesCronSchedulerV3`.
> - Backups are written as `<db_name>.<utc_timestamp>.bak` files using the `sqlite3` backup API, run in a background thread via `asyncio.to_thread` to avoid blocking the event loop.
> - A nightly cron job is registered under the name `sqlite_nightly_backup_v2` with a default schedule of `0 2 * * *`.
> - Tests in [`tests/test_cron_backups_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/388/files#diff-a946d112db1d10a14a0312d1f8dd4aa4f09dc4709f592ea2ea5ff22a080bd08e) validate backup file creation, data integrity, and job registration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea9ec67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->