### PR TITLE
feat: Implement MCP Dynamic Tool Registration v6 and append new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6386,7 +6386,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registration-v6",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registration v6",
@@ -13053,6 +13053,58 @@
       "acceptance": [
         "Action tools are intercepted.",
         "Tests mock tool execution to verify interception."
+      ]
+    },
+    {
+      "id": "mcp-kernel-taint-tracking-v3-9077ff09-2e36-4ca9-ba53-99c574098cf7",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCPKernel Taint Tracking V3",
+      "description": "Inspired by Safety & Guardrails trends: Implement MCPKernel taint tracking and sandboxed execution.",
+      "allowed_paths": [
+        "magda_agent/safety/taint_tracking_v3.py",
+        "tests/test_taint_tracking_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tracking successfully implemented.",
+        "Sandboxed execution isolates MCP tools.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-context-compression-v8-ac7afdc4-561b-4671-b419-226fc195b128",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Claude Context Compression V8",
+      "description": "Inspired by Context Compression trends: Enhance context compression algorithms.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v8.py",
+        "tests/test_compression_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context is effectively compressed.",
+        "Tests verify context window limits."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-live-v6-299a89d3-1186-43dc-810e-b9ab9d51c9de",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw RL Canvas Live V6",
+      "description": "Inspired by OpenClaw trends: Implement live canvas updates for RL openclaw.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_v4.py",
+        "tests/test_canvas_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas updates live based on RL events.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_registry_v6.py
+++ b/magda_agent/skills/mcp_registry_v6.py
@@ -1,0 +1,139 @@
+import logging
+from typing import Dict, Any, List, Protocol, runtime_checkable
+
+@runtime_checkable
+class MCPAdapter(Protocol):
+    """
+    Protocol for dynamically providing external MCP tools to the registry.
+    """
+    def get_tools(self) -> List[Dict[str, Any]]:
+        """
+        Retrieves a list of MCP tool schemas from an external source.
+
+        Returns:
+            List[Dict[str, Any]]: A list of tool schemas.
+        """
+        ...
+
+class MCPRegistryV6:
+    """
+    Registry specialized in handling tools exported via the Model Context Protocol (MCP) version 6.
+    Allows for dynamic synchronization from registered adapters.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the MCP Registry V6."""
+        self.mcp_tools: Dict[str, Dict[str, Any]] = {}
+        self.adapters: List[MCPAdapter] = []
+
+    def load_tool(self, tool_schema: Dict[str, Any]) -> bool:
+        """
+        Dynamically loads and verifies an external MCP tool schema.
+
+        Args:
+            tool_schema (Dict[str, Any]): The MCP tool schema dictionary.
+
+        Returns:
+            bool: True if loaded successfully, False otherwise.
+        """
+        if not self._is_valid_schema(tool_schema):
+            logging.error(f"Failed to load MCP tool: Invalid schema {tool_schema}")
+            return False
+
+        name: str = tool_schema["name"]
+        self.mcp_tools[name] = tool_schema
+        logging.info(f"Successfully loaded MCP tool: {name}")
+        return True
+
+    def _is_valid_schema(self, schema: Dict[str, Any]) -> bool:
+        """
+        Verifies if the schema complies with MCP tool standards.
+        Also validates that 'inputSchema' is a dictionary if provided.
+
+        Args:
+            schema (Dict[str, Any]): The MCP tool schema.
+
+        Returns:
+            bool: True if valid, False otherwise.
+        """
+        if not isinstance(schema, dict):
+            return False
+
+        required_fields = ["name", "description"]
+        for field in required_fields:
+            if field not in schema or not isinstance(schema[field], str) or not schema[field]:
+                return False
+
+        # Validate inputSchema if it exists
+        if "inputSchema" in schema and not isinstance(schema["inputSchema"], dict):
+            return False
+
+        return True
+
+    def get_tool(self, name: str) -> Dict[str, Any]:
+        """
+        Retrieve a loaded MCP tool by name.
+
+        Args:
+            name (str): The name of the MCP tool.
+
+        Returns:
+            Dict[str, Any]: The tool schema, or an empty dictionary if not found.
+        """
+        return self.mcp_tools.get(name, {})
+
+    def list_tools(self) -> List[str]:
+        """
+        List all available MCP tools.
+
+        Returns:
+            List[str]: A list of tool names.
+        """
+        return list(self.mcp_tools.keys())
+
+    def unload_tool(self, name: str) -> bool:
+        """
+        Dynamically unregisters and removes an MCP tool from the registry.
+
+        Args:
+            name (str): The name of the MCP tool to unload.
+
+        Returns:
+            bool: True if the tool was successfully unloaded, False if not found.
+        """
+        if name in self.mcp_tools:
+            del self.mcp_tools[name]
+            logging.info(f"Successfully unloaded MCP tool: {name}")
+            return True
+        logging.warning(f"Failed to unload MCP tool: {name} not found in registry.")
+        return False
+
+    def register_adapter(self, adapter: MCPAdapter) -> None:
+        """
+        Registers an adapter to dynamically fetch external tools.
+
+        Args:
+            adapter (MCPAdapter): The adapter instance providing tools.
+        """
+        self.adapters.append(adapter)
+        logging.info(f"Registered MCP adapter: {adapter}")
+
+    def sync_from_adapters(self) -> int:
+        """
+        Synchronizes tools from all registered adapters.
+
+        Returns:
+            int: The total number of tools successfully synced and loaded.
+        """
+        loaded_count = 0
+        for adapter in self.adapters:
+            try:
+                tools = adapter.get_tools()
+                for tool in tools:
+                    if self.load_tool(tool):
+                        loaded_count += 1
+            except Exception as e:
+                logging.error(f"Error syncing from adapter {adapter}: {e}")
+
+        logging.info(f"Synchronized {loaded_count} tools from adapters.")
+        return loaded_count

--- a/tests/test_mcp_registry_v6.py
+++ b/tests/test_mcp_registry_v6.py
@@ -1,0 +1,84 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.skills.mcp_registry_v6 import MCPRegistryV6, MCPAdapter
+
+def test_mcp_registry_v6_init():
+    registry = MCPRegistryV6()
+    assert registry.mcp_tools == {}
+    assert registry.adapters == []
+
+def test_mcp_registry_v6_load_tool_success():
+    registry = MCPRegistryV6()
+    tool_schema = {"name": "test_tool", "description": "A test tool.", "inputSchema": {"type": "object"}}
+
+    assert registry.load_tool(tool_schema) is True
+    assert registry.mcp_tools["test_tool"] == tool_schema
+
+def test_mcp_registry_v6_load_tool_invalid_schema():
+    registry = MCPRegistryV6()
+
+    # Missing description
+    invalid_schema = {"name": "test_tool"}
+    assert registry.load_tool(invalid_schema) is False
+    assert "test_tool" not in registry.mcp_tools
+
+    # Missing name
+    invalid_schema2 = {"description": "test"}
+    assert registry.load_tool(invalid_schema2) is False
+
+    # Not a dict
+    assert registry.load_tool("not a dict") is False # type: ignore
+
+    # Invalid inputSchema type
+    invalid_schema3 = {"name": "test_tool", "description": "test", "inputSchema": "not_a_dict"}
+    assert registry.load_tool(invalid_schema3) is False
+
+def test_mcp_registry_v6_unload_tool_success():
+    registry = MCPRegistryV6()
+    tool_schema = {"name": "test_tool", "description": "A test tool."}
+    registry.load_tool(tool_schema)
+
+    assert registry.unload_tool("test_tool") is True
+    assert "test_tool" not in registry.mcp_tools
+
+def test_mcp_registry_v6_unload_tool_not_found():
+    registry = MCPRegistryV6()
+    assert registry.unload_tool("nonexistent_tool") is False
+
+def test_mcp_registry_v6_get_tool():
+    registry = MCPRegistryV6()
+    tool_schema = {"name": "test_tool", "description": "A test tool."}
+    registry.load_tool(tool_schema)
+
+    assert registry.get_tool("test_tool") == tool_schema
+    assert registry.get_tool("not_found") == {}
+
+def test_mcp_registry_v6_list_tools():
+    registry = MCPRegistryV6()
+    registry.load_tool({"name": "tool1", "description": "First tool"})
+    registry.load_tool({"name": "tool2", "description": "Second tool"})
+
+    tools = registry.list_tools()
+    assert len(tools) == 2
+    assert "tool1" in tools
+    assert "tool2" in tools
+
+def test_mcp_registry_v6_sync_from_adapters():
+    registry = MCPRegistryV6()
+
+    mock_adapter = MagicMock(spec=MCPAdapter)
+    mock_adapter.get_tools.return_value = [
+        {"name": "dynamic_tool_1", "description": "Dynamic 1"},
+        {"name": "dynamic_tool_2", "description": "Dynamic 2"},
+        {"name": "invalid_dynamic"} # Will fail validation
+    ]
+
+    registry.register_adapter(mock_adapter)
+
+    loaded_count = registry.sync_from_adapters()
+
+    assert loaded_count == 2
+    assert "dynamic_tool_1" in registry.mcp_tools
+    assert "dynamic_tool_2" in registry.mcp_tools
+    assert "invalid_dynamic" not in registry.mcp_tools
+    mock_adapter.get_tools.assert_called_once()


### PR DESCRIPTION
This PR introduces the `MCPRegistryV6` class into the Magda AI agent, along with the `MCPAdapter` protocol. This allows for dynamic integration and synchronization of tools. It also adds robust validation tests mimicking the usage of the protocol without actual external calls. Finally, three new tasks inspired by current AI trends have been formally appended to `agent_tasks.json`.

---
*PR created automatically by Jules for task [7504804411701383256](https://jules.google.com/task/7504804411701383256) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPRegistryV6` for dynamic MCP tool registration with adapter sync
> - Introduces [`mcp_registry_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/389/files#diff-574025685531a4eb336363403971c67d963c094d7739d5127bba4370b6f1f584) with `MCPRegistryV6`, a registry that loads, retrieves, lists, and unloads MCP tool schemas with validation enforcing required `name`/`description` fields and optional `inputSchema` type.
> - Adds a runtime-checkable `MCPAdapter` protocol; adapters implementing `get_tools()` can be registered and bulk-synced into the registry via `sync_from_adapters()`.
> - Adds unit tests in [`tests/test_mcp_registry_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/389/files#diff-36b180abbb4b7e45bf1e9691c8026818b62f7a1082b76b947c26199f87039bad) covering all registry operations including invalid schema rejection and adapter sync.
> - Appends three new agent tasks to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/389/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc9a866.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->