### PR TITLE
FEATURE: Claude Agent Evaluator v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6403,7 +6403,7 @@
     },
     {
       "id": "claude-agent-evaluator-v3",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "Claude Agent Evaluator v3",
@@ -13104,6 +13104,57 @@
       ],
       "acceptance": [
         "Canvas updates live based on RL events.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawner-v5",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Subagent Spawner V5",
+      "description": "Inspired by Claude Agent SDK context compression trends: Create an enhanced Subagent Spawner.",
+      "allowed_paths": [
+        "magda_agent/architecture/subagent_spawner_v5.py",
+        "tests/test_subagent_spawner_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Spawns subagent cleanly.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-discovery-mesh-cards-v7",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Discovery Mesh Cards V7",
+      "description": "Enable Agent Card broadcasting across A2A mesh network.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_mesh_v7.py",
+        "tests/test_a2a_discovery_mesh_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Card broadcast is received locally.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-registry-sync-v11",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Registry Synchronization V11",
+      "description": "Inspired by MCP Standard trend: Implement a background loop that periodically polls a configured MCP server URL.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry_sync_v11.py",
+        "tests/test_mcp_registry_sync_v11.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Background loop successfully polls and parses MCP tool schema endpoints.",
         "Tests pass."
       ]
     }

--- a/magda_agent/agents/evaluator_v3.py
+++ b/magda_agent/agents/evaluator_v3.py
@@ -1,0 +1,85 @@
+from typing import Dict, Any
+import logging
+import json
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+
+
+class EvaluatorAgentV3(SubAgent):
+    """
+    Claude-inspired specialized sub-agent for evaluating output from Generator sub-agents.
+    Version 3: Focuses on actionable feedback and precise critique.
+    Inherits from SubAgent for isolated execution capability.
+    """
+    def __init__(self, llm: LLMClient):
+        super().__init__(
+            llm=llm,
+            system_prompt=(
+                "You are an expert code and output Evaluator sub-agent (v3). "
+                "Critique the provided output against the user request and provide actionable feedback. "
+                "You MUST output valid JSON only."
+            ),
+            use_isolation=False
+        )
+
+    async def evaluate_generator_output(self, generator_output: str, user_request: str) -> Dict[str, Any]:
+        """
+        Evaluates the output produced by the Generator Agent and provides critique.
+
+        Args:
+            generator_output (str): The text or code output generated.
+            user_request (str): The initial user request or context.
+
+        Returns:
+            Dict[str, Any]: Parsed JSON representing the critique and feedback containing keys:
+                - score (int): 1-10 evaluation score.
+                - approved (bool): Whether the output is acceptable.
+                - feedback (str): Detailed, actionable critique.
+        """
+        logging.info("Starting EvaluatorAgentV3 evaluation...")
+
+        task = (
+            "Evaluate the generator's output against the user's original request.\n\n"
+            "Return a JSON object with the following schema:\n"
+            '{"score": <int 1-10>, "approved": <bool>, "feedback": "<detailed critique and actionable feedback>"}'
+        )
+
+        full_context = (
+            f"Parent Context:\n"
+            f"User Request:\n{user_request}\n"
+            "------------------------\n"
+            f"Generator Output:\n{generator_output}\n"
+            "------------------------\n"
+            f"\n\nAssigned Task:\n{task}"
+        )
+
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": full_context}
+        ]
+
+        try:
+            response_text = await self.llm.chat_completion(messages, temperature=0.2)
+
+            # Simple markdown cleaning if the LLM wraps it in markdown blocks
+            if "```" in response_text:
+                response_text = response_text.split("```")[1]
+                if response_text.lower().startswith("json"):
+                    response_text = response_text[4:]
+
+            result = json.loads(response_text.strip())
+
+            # Validate expected keys are present
+            if not all(k in result for k in ("score", "approved", "feedback")):
+                raise ValueError("Missing required keys in LLM JSON output")
+
+            return result
+
+        except Exception as e:
+            logging.error(f"EvaluatorAgentV3 review failed: {e}")
+            return {
+                "score": 0,
+                "approved": False,
+                "feedback": f"Evaluation error: {str(e)}"
+            }

--- a/tests/test_evaluator_v3.py
+++ b/tests/test_evaluator_v3.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.evaluator_v3 import EvaluatorAgentV3
+
+@pytest.mark.asyncio
+async def test_evaluator_v3_agent_approve():
+    """Tests the EvaluatorAgentV3 correctly parses a passing score from the LLM."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='{"score": 9, "approved": true, "feedback": "Great response!"}')
+
+    agent = EvaluatorAgentV3(llm=mock_llm)
+    result = await agent.evaluate_generator_output("The sky is blue.", "What color is the sky?")
+
+    assert result["score"] == 9
+    assert result["approved"] is True
+    assert result["feedback"] == "Great response!"
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_v3_agent_reject():
+    """Tests the EvaluatorAgentV3 correctly parses a failing score from the LLM with markdown."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='```json\n{"score": 4, "approved": false, "feedback": "Incorrect color."}\n```')
+
+    agent = EvaluatorAgentV3(llm=mock_llm)
+    result = await agent.evaluate_generator_output("The sky is green.", "What color is the sky?")
+
+    assert result["score"] == 4
+    assert result["approved"] is False
+    assert result["feedback"] == "Incorrect color."
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_v3_agent_error_handling_invalid_json():
+    """Tests the EvaluatorAgentV3 correctly handles JSON parsing errors."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='This is not valid JSON')
+
+    agent = EvaluatorAgentV3(llm=mock_llm)
+    result = await agent.evaluate_generator_output("Some output", "Some request")
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Evaluation error" in result["feedback"] or "Expecting value" in result["feedback"]
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_v3_agent_error_handling_missing_keys():
+    """Tests the EvaluatorAgentV3 correctly handles JSON with missing keys."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='{"score": 9, "approved": true}')
+
+    agent = EvaluatorAgentV3(llm=mock_llm)
+    result = await agent.evaluate_generator_output("Some output", "Some request")
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Evaluation error: Missing required keys in LLM JSON output" in result["feedback"]
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Implement Claude Agent Evaluator v3 with tests and 3 new agent tasks.

---
*PR created automatically by Jules for task [7719926692336054213](https://jules.google.com/task/7719926692336054213) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `EvaluatorAgentV3` sub-agent for structured LLM output critique
> - Adds [`evaluator_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/390/files#diff-8fc56a67c2452229c2088ad17a4511d3feb96d59733241a173a62c97a875e58f) with `EvaluatorAgentV3`, a `SubAgent` subclass that sends generator output to an LLM and returns a structured `{score, approved, feedback}` dict.
> - The agent uses `temperature=0.2` and strips Markdown code fences before JSON parsing; malformed or incomplete responses fall back to `{score: 0, approved: False}` instead of raising exceptions.
> - Adds four async tests in [`test_evaluator_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/390/files#diff-61385433026dd7f24d3d7c1e18066619559681b721c520395deff572c60e6d79) covering approval, markdown-fenced rejection, invalid JSON, and missing keys.
> - Adds three new task entries to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/390/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) tracking follow-on sub-agent work.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 572ae1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->