### PR TITLE
feat: Add Hermes Agent Multi-Platform Support

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6420,7 +6420,7 @@
     },
     {
       "id": "hermes-agent-multi-platform-v1",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "high",
       "title": "Hermes Agent Multi-Platform Support",
@@ -13156,6 +13156,40 @@
       "acceptance": [
         "Background loop successfully polls and parses MCP tool schema endpoints.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-agent-teams-isolation-v5",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "MCP Agent Teams Isolation V5",
+      "description": "Inspired by MCP / Agent Teams: Implement git worktree isolation specifically tailored for MCP action tools to prevent state bleed.",
+      "allowed_paths": [
+        "magda_agent/teams/mcp_isolation_v5.py",
+        "tests/test_mcp_isolation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP action tools run in isolated git worktrees.",
+        "Tests verify worktree containment."
+      ]
+    },
+    {
+      "id": "openclaw-memory-compaction-cron",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Memory Compaction Cron",
+      "description": "Inspired by OpenClaw virtual context: Implement a cron job that automatically compacts episodic memory overnight.",
+      "allowed_paths": [
+        "magda_agent/operations/memory_compaction_cron.py",
+        "tests/test_memory_compaction_cron.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory compaction job runs on schedule.",
+        "Tests mock cron execution."
       ]
     }
   ]

--- a/magda_agent/channels/multi_platform_v1.py
+++ b/magda_agent/channels/multi_platform_v1.py
@@ -1,0 +1,88 @@
+from typing import Any, Dict, Optional
+from magda_agent.channels.base import ChannelAdapter
+from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
+from magda_agent.channels.hub import ChannelHub
+from magda_agent.channels.telegram import TelegramAdapter
+from magda_agent.channels.discord import DiscordAdapter
+
+class SlackAdapter(ChannelAdapter):
+    """Adapter for Slack platform."""
+
+    def __init__(self, gateway: GatewayRouter):
+        super().__init__("slack", gateway)
+
+    async def receive(self, raw_data: Any) -> Any:
+        """Process incoming Slack message.
+
+        Args:
+            raw_data (Any): The raw Slack event dictionary.
+
+        Returns:
+            Any: The response from the gateway.
+        """
+        text = ""
+        user_id = ""
+
+        if isinstance(raw_data, dict):
+            text = raw_data.get("text", "")
+            user_id = str(raw_data.get("user", ""))
+        else:
+            text = getattr(raw_data, "text", "")
+            user_id = str(getattr(raw_data, "user", ""))
+
+        msg = UnifiedMessage(
+            channel=self.channel_id,
+            text=text,
+            user_id=user_id,
+            metadata={"raw": raw_data}
+        )
+        return await self.gateway.route_message(msg)
+
+    async def send(self, recipient_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """Send message via Slack.
+
+        Args:
+            recipient_id (str): Slack user ID.
+            text (str): Message text.
+            metadata (Optional[Dict[str, Any]]): Metadata.
+
+        Returns:
+            Any: Mocked sending confirmation.
+        """
+        return f"Slack sent to {recipient_id}: {text}"
+
+
+class MultiPlatformDispatcher:
+    """Orchestrator class that sets up and dispatches to multiple channels."""
+
+    def __init__(self, gateway: GatewayRouter, bot_token: Optional[str] = None):
+        """Initialize multiple platform adapters.
+
+        Args:
+            gateway (GatewayRouter): Gateway router.
+            bot_token (Optional[str]): Bot token for Telegram.
+        """
+        self.gateway = gateway
+        self.hub = ChannelHub()
+
+        self.telegram = TelegramAdapter(gateway, bot_token=bot_token)
+        self.discord = DiscordAdapter(gateway)
+        self.slack = SlackAdapter(gateway)
+
+        self.hub.register_adapter(self.telegram)
+        self.hub.register_adapter(self.discord)
+        self.hub.register_adapter(self.slack)
+
+    async def dispatch(self, channel_id: str, recipient_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """Dispatch a message to the specified channel using the ChannelHub.
+
+        Args:
+            channel_id (str): Target channel (e.g., 'telegram', 'discord', 'slack').
+            recipient_id (str): Recipient ID.
+            text (str): Message text.
+            metadata (Optional[Dict[str, Any]]): Additional metadata.
+
+        Returns:
+            Any: Result of the send operation.
+        """
+        return await self.hub.send_to_channel(channel_id, recipient_id, text, metadata)

--- a/tests/test_multi_platform_v1.py
+++ b/tests/test_multi_platform_v1.py
@@ -1,0 +1,83 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
+from magda_agent.channels.multi_platform_v1 import SlackAdapter, MultiPlatformDispatcher
+
+@pytest.fixture
+def mock_gateway():
+    gateway = MagicMock(spec=GatewayRouter)
+    gateway.route_message = AsyncMock(return_value="Routed successfully")
+    return gateway
+
+@pytest.mark.asyncio
+async def test_slack_adapter_receive_dict(mock_gateway):
+    """Test receiving a dictionary via SlackAdapter."""
+    adapter = SlackAdapter(mock_gateway)
+    raw_data = {"text": "hello slack", "user": "U12345"}
+
+    result = await adapter.receive(raw_data)
+
+    assert result == "Routed successfully"
+    mock_gateway.route_message.assert_called_once()
+    msg = mock_gateway.route_message.call_args[0][0]
+    assert isinstance(msg, UnifiedMessage)
+    assert msg.channel == "slack"
+    assert msg.text == "hello slack"
+    assert msg.user_id == "U12345"
+
+@pytest.mark.asyncio
+async def test_slack_adapter_receive_object(mock_gateway):
+    """Test receiving an object via SlackAdapter."""
+    class MockSlackMessage:
+        def __init__(self, text, user):
+            self.text = text
+            self.user = user
+
+    adapter = SlackAdapter(mock_gateway)
+    raw_data = MockSlackMessage("hey object", "U999")
+
+    result = await adapter.receive(raw_data)
+
+    assert result == "Routed successfully"
+    mock_gateway.route_message.assert_called_once()
+    msg = mock_gateway.route_message.call_args[0][0]
+    assert msg.text == "hey object"
+    assert msg.user_id == "U999"
+
+@pytest.mark.asyncio
+async def test_slack_adapter_send(mock_gateway):
+    """Test sending a message via SlackAdapter."""
+    adapter = SlackAdapter(mock_gateway)
+
+    result = await adapter.send("U123", "message to slack")
+    assert result == "Slack sent to U123: message to slack"
+
+@pytest.mark.asyncio
+async def test_multi_platform_dispatcher_dispatch(mock_gateway):
+    """Test MultiPlatformDispatcher delegates properly to different channels."""
+    # Note: aiogram checks for a token in the format "ID:TOKEN", so we pass a mock valid one
+    dispatcher = MultiPlatformDispatcher(mock_gateway, bot_token="12345:mock_token_fake")
+
+    # Send via Slack
+    result_slack = await dispatcher.dispatch("slack", "U123", "test slack")
+    assert result_slack == "Slack sent to U123: test slack"
+
+    # Send via Discord
+    result_discord = await dispatcher.dispatch("discord", "111", "test discord")
+    assert result_discord == "Discord sent to 111: test discord"
+
+    # Send via Telegram (mocked no real bot but we'll check the output logic)
+    # We pass a mock bot so it doesn't fail on network
+    mock_bot = MagicMock()
+    mock_bot.send_message = AsyncMock(return_value="Telegram mock sent")
+    result_telegram = await dispatcher.dispatch("telegram", "222", "test tg", metadata={"bot": mock_bot})
+    assert result_telegram == "Telegram mock sent"
+    mock_bot.send_message.assert_called_once_with(chat_id="222", text="test tg")
+
+@pytest.mark.asyncio
+async def test_multi_platform_dispatcher_unknown_channel(mock_gateway):
+    """Test MultiPlatformDispatcher with an unknown channel."""
+    dispatcher = MultiPlatformDispatcher(mock_gateway)
+
+    result = await dispatcher.dispatch("unknown", "333", "hello")
+    assert result == "Error: Channel 'unknown' not found."


### PR DESCRIPTION
Closes `hermes-agent-multi-platform-v1` task.

This PR introduces multi-platform routing capabilities for the gateway router, fulfilling the Hermes-inspired trend to handle dispatch across multiple platforms seamlessly.

## Changes:
- Created `magda_agent/channels/multi_platform_v1.py` with `SlackAdapter` and `MultiPlatformDispatcher`.
- Added mock tests in `tests/test_multi_platform_v1.py` to ensure proper routing across Discord, Telegram, and Slack.
- Updated `agent_tasks.json` to mark the task as "done".
- Generated and appended two new `todo` tasks (MCP isolation and OpenClaw cron compaction) to keep the backlog populated as per the Jules agent protocol.

---
*PR created automatically by Jules for task [5592407818293988806](https://jules.google.com/task/5592407818293988806) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Slack adapter and multi-platform dispatcher to Hermes agent channel layer
> - Adds `SlackAdapter` in [`multi_platform_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/391/files#diff-933c07517568b44dceee57595f199062e8da5afc6fb3e9689a798bef0d466aac) extending `ChannelAdapter`; receives dict or object events, builds a `UnifiedMessage`, and routes via `GatewayRouter`.
> - Adds `MultiPlatformDispatcher` that registers Telegram, Discord, and Slack adapters with a `ChannelHub` and exposes a single `dispatch(channel_id, recipient_id, text, metadata)` entrypoint.
> - Full test coverage added in [`tests/test_multi_platform_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/391/files#diff-6f4f7f706256846f4a6a09ce56e96aded62dabba371e918ee64c247e44711138) covering receive, send, dispatch routing, and unknown channel error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9d194f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->