### PR TITLE
feat(memory): implement OpenClaw Context Engine Plugins

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6437,7 +6437,7 @@
     },
     {
       "id": "openclaw-context-engine-hooks-v1",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Plugins",
@@ -13190,6 +13190,40 @@
       "acceptance": [
         "Memory compaction job runs on schedule.",
         "Tests mock cron execution."
+      ]
+    },
+    {
+      "id": "a2a-peer-delegation-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "A2A Peer Task Delegation",
+      "description": "Inspired by A2A Protocol trend. Implement peer-to-peer task delegation mechanism to assign sub-tasks.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegation_v1.py",
+        "tests/test_a2a_delegation_v1*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can discover and delegate tasks via A2A.",
+        "Tests verify A2A delegation."
+      ]
+    },
+    {
+      "id": "agent-teams-worktree-v1",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Agent Teams Worktree Isolation",
+      "description": "Inspired by Agent Teams trend. Implement worktree isolation for subagents.",
+      "allowed_paths": [
+        "magda_agent/agents/worktree_isolation_v1.py",
+        "tests/test_worktree_isolation_v1*.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents operate in isolated worktrees.",
+        "Tests verify isolation."
       ]
     }
   ]

--- a/magda_agent/memory/context_engine_v1.py
+++ b/magda_agent/memory/context_engine_v1.py
@@ -1,0 +1,154 @@
+import logging
+from typing import List, Protocol, Any, Dict, Optional, Callable
+from magda_agent.architecture.context_hooks_v5 import HookRegistry
+
+class ContextPluginV1(Protocol):
+    """Protocol defining the lifecycle hooks for a Context Engine V1 plugin."""
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration."""
+        ...
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Process incoming content before it is stored or used."""
+        ...
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Assemble the context string from retrieved items for the LLM."""
+        ...
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact or summarize the context when limits are reached."""
+        ...
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Called before context is retrieved. Can modify the query."""
+        ...
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """Called after context is retrieved. Can modify the retrieved context."""
+        ...
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """Called before context is written. Can modify the context."""
+        ...
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """Called after context is written."""
+        ...
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """Called when the overall context is updated."""
+        ...
+
+class ContextEngineV1:
+    """
+    ContextEngineV1 manages context dynamically using a plugin architecture
+    with lifecycle hooks. Uses HookRegistry.
+    """
+    def __init__(self, plugins: Optional[List[ContextPluginV1]] = None, llm: Optional[Any] = None) -> None:
+        self._plugins: List[ContextPluginV1] = []
+        self.llm = llm
+        self.hook_registry = HookRegistry()
+
+        if plugins:
+            for plugin in plugins:
+                self.register_plugin(plugin)
+
+    def register_plugin(self, plugin: ContextPluginV1) -> None:
+        """Registers a new plugin with the context engine."""
+        self._plugins.append(plugin)
+
+        # Sync hooks
+        for hook_name in ['before_retrieval', 'after_retrieval', 'on_context_update', 'before_write', 'after_write']:
+            if hasattr(plugin, hook_name):
+                self.hook_registry.register_hook(hook_name, getattr(plugin, hook_name))
+
+        # Async and common lifecycle hooks
+        for hook_name in ['bootstrap', 'ingest', 'assemble', 'compact']:
+            if hasattr(plugin, hook_name):
+                self.hook_registry.register_hook(hook_name, getattr(plugin, hook_name))
+
+        logging.debug(f"Registered plugin: {plugin.__class__.__name__}")
+
+    def add_plugin(self, plugin: ContextPluginV1) -> None:
+        """Alias for register_plugin for compatibility."""
+        self.register_plugin(plugin)
+
+    async def bootstrap_all(self, config: Dict[str, Any]) -> None:
+        """Initialize all plugins using the hook registry."""
+        config_with_hooks: Dict[str, Any] = dict(config)
+        config_with_hooks["hook_registry"] = self.hook_registry
+        await self.hook_registry.trigger_broadcast_async('bootstrap', config_with_hooks)
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Run content through ingest hook of all plugins using the hook registry."""
+        return await self.hook_registry.trigger_hook_async('ingest', content, metadata)
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Assemble context using all plugins via the hook registry."""
+        if 'assemble' not in self.hook_registry._hooks or not self.hook_registry._hooks['assemble']:
+            return "\n".join([str(item) for item in context_items])
+        return await self.hook_registry.trigger_broadcast_async('assemble', context_items, metadata)
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact context through all plugins using the hook registry."""
+        current_items = await self.hook_registry.trigger_hook_async('compact', context_items, metadata)
+
+        limit = metadata.get("limit", 10)
+        if current_items and len(current_items) > limit and self.llm is not None:
+            logging.info("Context length exceeds limit after plugins. Using ContextEngine built-in fallback compression.")
+            to_summarize = current_items[:2]
+            remaining = current_items[2:]
+
+            combined_text = "\n".join([f"- {getattr(e, 'content', str(e))}" for e in to_summarize])
+            prompt = f"Please summarize the following context:\n{combined_text}"
+
+            try:
+                summary_content = await self.llm.chat_completion([
+                    {"role": "system", "content": "You compress memory context. Return only the summary text."},
+                    {"role": "user", "content": prompt}
+                ], temperature=0.3)
+
+                # Mock memory entry to represent summarized data
+                class MinimalMemoryEntry:
+                    def __init__(self, content: str):
+                        self.content = content
+
+                summary_entry = MinimalMemoryEntry(content=summary_content.strip())
+                current_items = [summary_entry] + remaining
+            except Exception as e:
+                logging.error(f"ContextEngine fallback compaction failed: {e}")
+                current_items = current_items[1:]
+        elif current_items and len(current_items) > limit:
+            logging.warning("No LLM available for fallback compaction, dropping oldest item.")
+            current_items = current_items[1:]
+
+        return current_items if current_items is not None else []
+
+    def retrieve_context(self, query: str, user_id: int, base_retrieval_func: Callable[[str, int], List[Any]]) -> List[Any]:
+        """Retrieves context by executing lifecycle hooks before and after."""
+        current_query: str = self.hook_registry.trigger_hook('before_retrieval', query, user_id)
+        if current_query is None:
+            current_query = query
+
+        context: List[Any] = base_retrieval_func(current_query, user_id)
+
+        updated_context = self.hook_registry.trigger_hook('after_retrieval', context, current_query, user_id)
+        if updated_context is None:
+            updated_context = context
+
+        return updated_context
+
+    def update_context(self, new_context: Any, user_id: int) -> None:
+        """Triggers the on_context_update hook for all registered plugins."""
+        self.hook_registry.trigger_hook('on_context_update', new_context, user_id)
+
+    def write_context(self, context: Any, user_id: int) -> None:
+        """Writes context by executing lifecycle hooks before and after."""
+        current_context: Any = self.hook_registry.trigger_hook('before_write', context, user_id)
+        if current_context is None:
+            current_context = context
+
+        self.update_context(current_context, user_id)
+        self.hook_registry.trigger_hook('after_write', current_context, user_id)

--- a/tests/test_context_engine_v1.py
+++ b/tests/test_context_engine_v1.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.memory.context_engine_v1 import ContextEngineV1, ContextPluginV1
+
+class DummyPlugin(ContextPluginV1):
+    def __init__(self):
+        self.bootstrap_called = False
+        self.ingest_called = False
+        self.assemble_called = False
+        self.compact_called = False
+        self.before_retrieval_called = False
+        self.after_retrieval_called = False
+        self.before_write_called = False
+        self.after_write_called = False
+        self.on_context_update_called = False
+
+    async def bootstrap(self, config):
+        self.bootstrap_called = True
+
+    async def ingest(self, content, metadata):
+        self.ingest_called = True
+        return content + " ingested"
+
+    async def assemble(self, context_items, metadata):
+        self.assemble_called = True
+        return " assembled"
+
+    async def compact(self, context_items, metadata):
+        self.compact_called = True
+        return context_items
+
+    def before_retrieval(self, query, user_id):
+        self.before_retrieval_called = True
+        return query + " modified"
+
+    def after_retrieval(self, context, query, user_id):
+        self.after_retrieval_called = True
+        return context + ["added"]
+
+    def before_write(self, context, user_id):
+        self.before_write_called = True
+        return context
+
+    def after_write(self, context, user_id):
+        self.after_write_called = True
+
+    def on_context_update(self, new_context, user_id):
+        self.on_context_update_called = True
+
+@pytest.mark.asyncio
+async def test_context_engine_v1_hooks():
+    plugin = DummyPlugin()
+    engine = ContextEngineV1(plugins=[plugin])
+
+    await engine.bootstrap_all({"test": "config"})
+    assert plugin.bootstrap_called
+
+    res_ingest = await engine.ingest("test", {})
+    assert plugin.ingest_called
+    assert res_ingest == "test ingested"
+
+    res_assemble = await engine.assemble(["item1"], {})
+    assert plugin.assemble_called
+    assert res_assemble == " assembled"
+
+    res_compact = await engine.compact(["item1"], {})
+    assert plugin.compact_called
+    assert res_compact == ["item1"]
+
+    base_retrieval = MagicMock(return_value=["item1"])
+    res_retrieval = engine.retrieve_context("query", 1, base_retrieval)
+    assert plugin.before_retrieval_called
+    assert plugin.after_retrieval_called
+    assert res_retrieval == ["item1", "added"]
+    base_retrieval.assert_called_with("query modified", 1)
+
+    engine.write_context("context_data", 1)
+    assert plugin.before_write_called
+    assert plugin.on_context_update_called
+    assert plugin.after_write_called
+
+@pytest.mark.asyncio
+async def test_context_engine_v1_fallback_compaction():
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "compressed_test"
+
+    engine = ContextEngineV1(llm=mock_llm)
+    items = ["item1", "item2", "item3"]
+    res = await engine.compact(items, {"limit": 2})
+
+    assert len(res) == 2
+    assert res[0].content == "compressed_test"
+    assert res[1] == "item3"
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Implements a plugin-based Context Engine capable of running structured lifecycle hooks via `HookRegistry` based on the OpenClaw Context Engine paradigm.

Also adds 2 new AI trending tasks to the backlog.

---
*PR created automatically by Jules for task [11453855082502404084](https://jules.google.com/task/11453855082502404084) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `ContextEngineV1` with plugin-based lifecycle hooks for context management
> - Adds [`context_engine_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/392/files#diff-58a9e27ded35ac34994ab111584ac1e05797f959a6918b5ed63b5e62888b3862) with a `ContextPluginV1` protocol defining async and sync lifecycle hooks: `bootstrap`, `ingest`, `assemble`, `compact`, `before_retrieval`, `after_retrieval`, `before_write`, `after_write`, and `on_context_update`.
> - `ContextEngineV1` manages registered plugins via a `HookRegistry`, broadcasting hooks at each stage of the retrieval, write, and compaction flows.
> - Compaction enforces an item limit (default 10); when exceeded and an LLM is provided, the oldest items are summarized into a `MinimalMemoryEntry` via `llm.chat_completion` before being prepended to the remaining context.
> - Tests in [`tests/test_context_engine_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/392/files#diff-c9c199515e0d8a3dcd863538266e52fdcfcf4b6dd1ced75d2c5ddf3885a38651) cover hook invocation order and LLM-based fallback compaction using `AsyncMock`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1869389.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->