### PR TITLE
feat: implement MCP runtime tool concurrency execution

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6454,7 +6454,7 @@
     },
     {
       "id": "mcp-action-tool-concurrency-v1-unique",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Runtime Tool Concurrency",
@@ -13224,6 +13224,57 @@
       "acceptance": [
         "Subagents operate in isolated worktrees.",
         "Tests verify isolation."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-evaluator-plugin-v2-a9ba9bdc-07ef-46ea-a5c8-a69fae9d45ed",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Evaluator Plugin v2",
+      "description": "Inspired by MCP standards trend: Develop an evaluator plugin that evaluates new skills against an MCP dynamic verification sandbox.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_eval_v2.py",
+        "tests/test_mcp_eval_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator plugin successfully evaluates skills in a dynamic sandbox.",
+        "Tests verify evaluation."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-live-metrics-v8-dbdf3a77-d78e-47b0-8c8a-7f683d60b2e7",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "OpenClaw RL Canvas Live Metrics v8",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend: Create an export module to broadcast memory consolidation metrics to a live dashboard.",
+      "allowed_paths": [
+        "magda_agent/skills/canvas_metrics_v8.py",
+        "tests/test_canvas_metrics_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry broadcaster implemented and broadcasts metrics.",
+        "Tests verify metric payloads format matches Canvas UI."
+      ]
+    },
+    {
+      "id": "a2a-discovery-mesh-cards-v8-0ee4892e-796f-4470-b084-0579481e265e",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Discovery Mesh Cards V8",
+      "description": "Inspired by A2A Protocol trends: Enable Agent Card broadcasting across A2A mesh network to discover agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_mesh_v8.py",
+        "tests/test_a2a_discovery_mesh_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Card broadcast is received locally.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/skills/tool_concurrency_v1.py
+++ b/magda_agent/skills/tool_concurrency_v1.py
@@ -1,0 +1,71 @@
+import asyncio
+import inspect
+from typing import Any, Dict, List, Optional
+
+
+class ConcurrentToolExecutorV1:
+    """Executes multiple skills concurrently, with dynamic handling of async skills."""
+
+    def __init__(self, registry: Any, mcp_registry: Optional[Any] = None) -> None:
+        """
+        Initialize the ConcurrentToolExecutorV1.
+
+        Args:
+            registry (Any): The main skill registry containing callable skills.
+            mcp_registry (Optional[Any]): The MCP tool registry to look up metadata.
+        """
+        self.registry = registry
+        self.mcp_registry = mcp_registry
+
+    async def execute_concurrently(self, tool_calls: List[Dict[str, Any]]) -> List[Any]:
+        """
+        Executes a list of tool calls concurrently.
+        Each element in tool_calls must have 'name' and 'kwargs'.
+
+        Args:
+            tool_calls (List[Dict[str, Any]]): The list of tool calls to execute.
+
+        Returns:
+            List[Any]: The list of results from the tool calls.
+        """
+        tasks = []
+        for call in tool_calls:
+            name = call.get("name")
+            kwargs = call.get("kwargs", {})
+
+            if not name or not hasattr(self.registry, "skills") or name not in self.registry.skills:
+                tasks.append(asyncio.to_thread(lambda n=name: f"Error: Skill '{n}' not found."))
+                continue
+
+            skill_func = self.registry.skills[name]
+
+            # Determine if the skill is async
+            is_async = False
+
+            # Check metadata from MCP registry if available
+            if self.mcp_registry and hasattr(self.mcp_registry, "get_tool"):
+                tool_metadata = self.mcp_registry.get_tool(name)
+                if tool_metadata and isinstance(tool_metadata, dict):
+                    is_async = tool_metadata.get("__is_async__", False)
+
+            # Fallback to standard inspect
+            if not is_async and inspect.iscoroutinefunction(skill_func):
+                is_async = True
+
+            async def wrap_execution(n: str = name, k: Dict[str, Any] = kwargs, is_async_skill: bool = is_async) -> Any:
+                if is_async_skill:
+                    # Execute async natively
+                    res = self.registry.execute_skill(n, **k)
+                    if inspect.isawaitable(res):
+                        return await res
+                    return res
+                else:
+                    # Run the synchronous part in a thread to unblock the event loop
+                    res = await asyncio.to_thread(self.registry.execute_skill, n, **k)
+                    if inspect.isawaitable(res):
+                        return await res
+                    return res
+
+            tasks.append(wrap_execution())
+
+        return await asyncio.gather(*tasks)

--- a/tests/test_tool_concurrency_v1.py
+++ b/tests/test_tool_concurrency_v1.py
@@ -1,50 +1,104 @@
 import pytest
 import asyncio
-import time
-from typing import Any
-from magda_agent.skills.concurrency import ConcurrentSkillExecutor
+from typing import Any, Dict, List
+from magda_agent.skills.tool_concurrency_v1 import ConcurrentToolExecutorV1
 
 class MockRegistry:
-    """Mock registry for testing concurrency."""
+    """Mock skill registry for testing."""
     def __init__(self) -> None:
-        """Initializes the mock registry."""
-        self.skills = {}
+        """Initialize mock registry with sync and async tools."""
+        self.skills: Dict[str, Any] = {
+            "sync_tool": self.sync_tool,
+            "async_tool": self.async_tool,
+        }
 
-    def register_skill(self, name: str, func: Any) -> None:
-        """Registers a skill."""
-        self.skills[name] = func
+    def sync_tool(self, arg: str) -> str:
+        """A synchronous mock tool."""
+        import time
+        time.sleep(0.1)
+        return f"sync_{arg}"
+
+    async def async_tool(self, arg: str) -> str:
+        """An asynchronous mock tool."""
+        await asyncio.sleep(0.1)
+        return f"async_{arg}"
 
     def execute_skill(self, name: str, **kwargs: Any) -> Any:
-        """Executes a skill if it exists."""
-        if name not in self.skills:
-            return f"Error: Skill '{name}' not found."
+        """Execute a skill from the registry."""
         return self.skills[name](**kwargs)
 
-def slow_sync_tool(duration: float = 0.1) -> str:
-    """A slow synchronous tool to test concurrency."""
-    time.sleep(duration)
-    return f"done {duration}"
+class MockMCPRegistry:
+    """Mock MCP registry for testing."""
+    def __init__(self) -> None:
+        """Initialize mock MCP registry with a tool marked as async."""
+        self.mcp_tools: Dict[str, Dict[str, Any]] = {
+            "mcp_async_tool": {"__is_async__": True, "name": "mcp_async_tool"}
+        }
+
+    def get_tool(self, name: str) -> Dict[str, Any]:
+        """Get tool metadata by name."""
+        return self.mcp_tools.get(name, {})
+
+class MockRegistryWithMCP(MockRegistry):
+    """Mock registry that includes an MCP tool."""
+    def __init__(self) -> None:
+        """Initialize mock registry with MCP tool."""
+        super().__init__()
+        self.skills["mcp_async_tool"] = self.mcp_async_tool
+
+    def mcp_async_tool(self, arg: str) -> Any:
+        """An MCP tool that returns a coroutine."""
+        async def inner() -> str:
+            """Inner coroutine."""
+            await asyncio.sleep(0.1)
+            return f"mcp_{arg}"
+        return inner()
 
 @pytest.mark.asyncio
-async def test_concurrent_execution_speeds_up_processing() -> None:
-    """Tests that concurrent execution is faster than sequential execution."""
+async def test_concurrent_execution_mixed() -> None:
+    """Test concurrent execution of mixed sync and async tools."""
     registry = MockRegistry()
-    registry.register_skill("slow", slow_sync_tool)
-    executor = ConcurrentSkillExecutor(registry)
+    executor = ConcurrentToolExecutorV1(registry)
 
-    start_time = time.time()
-    calls = [{"name": "slow", "kwargs": {"duration": 0.2}} for _ in range(3)]
-    results = await executor.execute_concurrently(calls)
-    end_time = time.time()
+    tool_calls: List[Dict[str, Any]] = [
+        {"name": "sync_tool", "kwargs": {"arg": "1"}},
+        {"name": "async_tool", "kwargs": {"arg": "2"}},
+        {"name": "sync_tool", "kwargs": {"arg": "3"}},
+    ]
 
-    assert results == ["done 0.2", "done 0.2", "done 0.2"]
-    assert end_time - start_time < 0.4  # Should be ~0.2s, not 0.6s
+    import time
+    start = time.time()
+    results = await executor.execute_concurrently(tool_calls)
+    end = time.time()
+
+    assert results == ["sync_1", "async_2", "sync_3"]
+    # All should take ~0.1s concurrently
+    assert end - start < 0.2
 
 @pytest.mark.asyncio
-async def test_missing_skill() -> None:
-    """Tests that missing skills are handled gracefully."""
+async def test_concurrent_execution_with_mcp_metadata() -> None:
+    """Test concurrent execution using MCP tool metadata."""
+    registry = MockRegistryWithMCP()
+    mcp_registry = MockMCPRegistry()
+    executor = ConcurrentToolExecutorV1(registry, mcp_registry)
+
+    tool_calls: List[Dict[str, Any]] = [
+        {"name": "mcp_async_tool", "kwargs": {"arg": "1"}},
+    ]
+
+    results = await executor.execute_concurrently(tool_calls)
+    assert results == ["mcp_1"]
+
+
+@pytest.mark.asyncio
+async def test_tool_not_found() -> None:
+    """Test execution when a tool is not found."""
     registry = MockRegistry()
-    executor = ConcurrentSkillExecutor(registry)
-    calls = [{"name": "missing", "kwargs": {}}]
-    results = await executor.execute_concurrently(calls)
-    assert results == ["Error: Skill 'missing' not found."]
+    executor = ConcurrentToolExecutorV1(registry)
+
+    tool_calls: List[Dict[str, Any]] = [
+        {"name": "missing_tool", "kwargs": {}},
+    ]
+
+    results = await executor.execute_concurrently(tool_calls)
+    assert results[0] == "Error: Skill 'missing_tool' not found."


### PR DESCRIPTION
This PR implements the MCP Runtime Tool Concurrency (mcp-action-tool-concurrency-v1-unique) task.
It introduces the `ConcurrentToolExecutorV1` which can execute multiple tools (sync or async) concurrently, correctly evaluating MCP async metadata and using `asyncio.to_thread()` where appropriate to keep the main event loop unblocked.

- Updated task list with new AI-trend-inspired tasks and ensured `agent_tasks.json` validation passes.
- Code has full type hints and docstrings.
- All test mock usages follow conventions without touching external real APIs.

---
*PR created automatically by Jules for task [11615974987976206027](https://jules.google.com/task/11615974987976206027) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add concurrent MCP tool execution via `ConcurrentToolExecutorV1`
> - Adds [`ConcurrentToolExecutorV1`](https://github.com/kazah4359-lgtm/Magda-agent/pull/393/files#diff-0bc3e00cdd0fd094640bb6e3a46e701a2ae69e08bcc1e01dd0b9894951737ca5) which runs multiple tool calls concurrently using `asyncio.gather`, running sync skills in a thread pool via `asyncio.to_thread` and async skills natively.
> - Detects whether a skill is async via MCP registry metadata (`__is_async__`) or `inspect.iscoroutinefunction`, with explicit error strings returned for missing skills.
> - Adds tests in [`tests/test_tool_concurrency_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/393/files#diff-43fb2e364343acbef0186ecdbd772d9f13d02140c4eb89b27b6ad25c55516741) covering mixed sync/async execution, MCP metadata-driven async detection, and missing-tool handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c79c00f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->