### PR TITLE
feat: OpenClaw Multi-Agent Canvas Extension

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6505,7 +6505,7 @@
     },
     {
       "id": "openclaw-multi-agent-canvas-v1",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Multi-Agent Canvas Extension",
@@ -13377,6 +13377,57 @@
       "acceptance": [
         "RL parameter tuner correctly updates learning rates.",
         "Tests verify learning rate adjustment logic."
+      ]
+    },
+    {
+      "id": "mcp-agent-action-tools-audit-v1-68f664a0-eec9-49f9-ab30-330a32f42c16",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Agent Action Tools Audit V1",
+      "description": "Inspired by MCP Standard trend: Add audit trail logging specifically for MCP action tools to track tool usage frequency and execution results.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_audit_v1.py",
+        "tests/test_mcp_audit_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audit trail logs MCP tool invocations.",
+        "Tests verify logging occurs correctly."
+      ]
+    },
+    {
+      "id": "agent-teams-parallel-subagents-v4-228d45c3-ed5c-4968-a69d-8e0b61e3425b",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Agent Teams Parallel Subagents V4",
+      "description": "Inspired by Agent Teams isolation trend: Implement parallel execution manager for subagents operating in isolated git worktrees.",
+      "allowed_paths": [
+        "magda_agent/architecture/parallel_execution_v4.py",
+        "tests/test_parallel_execution_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents execute concurrently in their respective worktrees.",
+        "Tests verify concurrency and isolation."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-skills-metrics-v2-3fd53530-b2f2-4fa2-a905-96e6577ec73c",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Canvas Skills Metrics V2",
+      "description": "Inspired by OpenClaw Canvas Live Visualization: Broadcast dynamic skill adjustments and learning metrics over websocket.",
+      "allowed_paths": [
+        "magda_agent/learning/canvas_skills_metrics_v2.py",
+        "tests/test_canvas_skills_metrics_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill metrics are correctly formatted into websocket payloads.",
+        "Tests verify format."
       ]
     }
   ]

--- a/magda_agent/visualization/multi_agent_stream.py
+++ b/magda_agent/visualization/multi_agent_stream.py
@@ -1,0 +1,68 @@
+import json
+import logging
+from typing import Dict, Any
+
+from magda_agent.architecture.agent_teams_v3 import AgentTeamManagerV3
+
+logger = logging.getLogger(__name__)
+
+class MultiAgentStreamServer:
+    """
+    Formats multi-agent isolation metrics and active agent states into a structured
+    JSON payload suitable for streaming to a live OpenClaw-inspired Canvas UI.
+    """
+
+    def __init__(self, team_manager: AgentTeamManagerV3) -> None:
+        """
+        Initialize the stream server formatter.
+
+        Args:
+            team_manager (AgentTeamManagerV3): The team manager coordinating agents.
+        """
+        self.team_manager = team_manager
+
+    def get_formatted_state(self) -> Dict[str, Any]:
+        """
+        Retrieves active agents and their isolated worktrees to broadcast status.
+
+        Returns:
+            Dict[str, Any]: A dictionary representing the active multi-agent cluster.
+        """
+        state: Dict[str, Any] = {
+            "agents": [],
+            "isolation_metrics": {
+                "active_worktrees": 0,
+                "base_dir": ""
+            }
+        }
+
+        try:
+            isolation = self.team_manager.isolation_manager
+
+            if isolation:
+                state["isolation_metrics"]["base_dir"] = isolation.base_dir
+
+                for agent_id, env_path in isolation.active_worktrees.items():
+                    agent_info = {
+                        "agent_id": agent_id,
+                        "worktree": env_path,
+                        "status": "active"
+                    }
+                    state["agents"].append(agent_info)
+
+                state["isolation_metrics"]["active_worktrees"] = len(state["agents"])
+
+        except Exception as e:
+            logger.error(f"Error formatting multi-agent canvas state: {e}")
+            state["error"] = str(e)
+
+        return state
+
+    def get_state_json(self) -> str:
+        """
+        Returns the formatted multi-agent state as a JSON string.
+
+        Returns:
+            str: JSON-encoded string of the multi-agent state.
+        """
+        return json.dumps(self.get_formatted_state())

--- a/tests/test_multi_agent_stream.py
+++ b/tests/test_multi_agent_stream.py
@@ -1,0 +1,60 @@
+import json
+from unittest.mock import MagicMock
+
+from magda_agent.architecture.agent_teams_v3 import AgentTeamManagerV3, AgentWorktreeIsolationV3
+from magda_agent.visualization.multi_agent_stream import MultiAgentStreamServer
+
+def test_get_multi_agent_state_json_empty():
+    mock_isolation = MagicMock(spec=AgentWorktreeIsolationV3)
+    mock_isolation.base_dir = "/mock/base"
+    mock_isolation.active_worktrees = {}
+
+    mock_team_manager = MagicMock(spec=AgentTeamManagerV3)
+    mock_team_manager.isolation_manager = mock_isolation
+
+    server = MultiAgentStreamServer(team_manager=mock_team_manager)
+    state_json = server.get_state_json()
+    state = json.loads(state_json)
+
+    assert state["isolation_metrics"]["base_dir"] == "/mock/base"
+    assert state["isolation_metrics"]["active_worktrees"] == 0
+    assert len(state["agents"]) == 0
+
+def test_get_multi_agent_state_json_with_agents():
+    mock_isolation = MagicMock(spec=AgentWorktreeIsolationV3)
+    mock_isolation.base_dir = "/mock/base"
+    mock_isolation.active_worktrees = {
+        "agent-1": "/mock/base/agent-1-env",
+        "agent-2": "/mock/base/agent-2-env"
+    }
+
+    mock_team_manager = MagicMock(spec=AgentTeamManagerV3)
+    mock_team_manager.isolation_manager = mock_isolation
+
+    server = MultiAgentStreamServer(team_manager=mock_team_manager)
+    state_json = server.get_state_json()
+    state = json.loads(state_json)
+
+    assert state["isolation_metrics"]["base_dir"] == "/mock/base"
+    assert state["isolation_metrics"]["active_worktrees"] == 2
+    assert len(state["agents"]) == 2
+
+    agent_ids = [agent["agent_id"] for agent in state["agents"]]
+    assert "agent-1" in agent_ids
+    assert "agent-2" in agent_ids
+
+    agent_1 = next(agent for agent in state["agents"] if agent["agent_id"] == "agent-1")
+    assert agent_1["worktree"] == "/mock/base/agent-1-env"
+    assert agent_1["status"] == "active"
+
+def test_get_multi_agent_state_json_error_handling():
+    mock_team_manager = MagicMock(spec=AgentTeamManagerV3)
+    # Simulate an error by having accessing isolation_manager raise an exception
+    type(mock_team_manager).isolation_manager = property(lambda self: (_ for _ in ()).throw(ValueError("Mock Exception")))
+
+    server = MultiAgentStreamServer(team_manager=mock_team_manager)
+    state_json = server.get_state_json()
+    state = json.loads(state_json)
+
+    assert "error" in state
+    assert "Mock Exception" in state["error"]


### PR DESCRIPTION
This PR implements the task `openclaw-multi-agent-canvas-v1`. It adds a `MultiAgentStreamServer` that interfaces with `AgentTeamManagerV3` and `AgentWorktreeIsolationV3` to collect active agent data and format it into a WebSocket-compatible JSON stream. Thorough testing via mocks has been added to ensure correct operation. The agent's task queue (`agent_tasks.json`) was successfully processed: the implemented task marked as "done" and 3 new tasks added inspired by recent trends in MCP standard, Agent Teams parallel execution, and OpenClaw RL metrics.

---
*PR created automatically by Jules for task [429276068090213749](https://jules.google.com/task/429276068090213749) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MultiAgentStreamServer` to stream multi-agent isolation state as JSON
> - Adds [`MultiAgentStreamServer`](https://github.com/kazah4359-lgtm/Magda-agent/pull/396/files#diff-bf51c4886c7401969ca9447d2b15d1afade306cdbae879f56755a38b4d44b7dd) with two methods: `get_formatted_state` builds a dict of isolation `base_dir`, active worktree count, and agent list; `get_state_json` serializes it to a JSON string.
> - Reads state from `AgentTeamManagerV3.isolation_manager`, iterating `active_worktrees` to populate per-agent entries with worktree path and status.
> - Errors during state collection are caught and embedded as an `'error'` key in the returned dict rather than propagating.
> - Three unit tests in [`tests/test_multi_agent_stream.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/396/files#diff-ed12dc75c6fad7beaef3cc43fc925e9c1989fe70fb799bdab087560aa238d913) cover the empty, populated, and error-handling paths using mocked isolation managers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f13c279.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->