### PR TITLE
Integrate OpenClaw-RL behavioral and skill weights into the cognitive loop

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6522,7 +6522,7 @@
     },
     {
       "id": "openclaw-online-rl-integration-v1",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw Online RL Integration",

--- a/magda_agent/agents/planner_agent.py
+++ b/magda_agent/agents/planner_agent.py
@@ -13,7 +13,14 @@ class PlannerAgent:
 
 
 
-    async def plan(self, user_input: str, user_id: Optional[str] = None, mental_state: Optional[MentalState] = None) -> List[Dict[str, Any]]:
+    async def plan(
+        self,
+        user_input: str,
+        user_id: Optional[str] = None,
+        mental_state: Optional[MentalState] = None,
+        behavior_weights: Optional[Dict[str, float]] = None,
+        skill_weights: Optional[Dict[str, float]] = None
+    ) -> List[Dict[str, Any]]:
         """
         Generates a plan based on the user input.
         If a plan step requires a capability available on an external agent, it delegates the sub-plan.
@@ -23,7 +30,13 @@ class PlannerAgent:
 
         current_plan = self.planner.get_current_plan(user_id=user_id)
         if not current_plan:
-            await self.planner.generate_plan(user_input, user_id=user_id, mental_state=mental_state)
+            await self.planner.generate_plan(
+                user_input,
+                user_id=user_id,
+                mental_state=mental_state,
+                behavior_weights=behavior_weights,
+                skill_weights=skill_weights
+            )
             current_plan = self.planner.get_current_plan(user_id=user_id)
 
         # Retrieve plan and automatically delegate steps if an A2A Delegator is available

--- a/magda_agent/agents/triad_coordinator.py
+++ b/magda_agent/agents/triad_coordinator.py
@@ -28,12 +28,20 @@ class TriadCoordinator:
         message_builder: Optional[Callable[[str], List[Dict[str, Any]]]] = None,
         pre_generation_hook: Optional[Callable[[], None]] = None,
         policies: Optional[List[str]] = None,
-        mental_state: Optional[Any] = None
+        mental_state: Optional[Any] = None,
+        behavior_weights: Optional[Dict[str, float]] = None,
+        skill_weights: Optional[Dict[str, float]] = None
     ) -> str:
         """
         Executes the triad flow: Plan -> Execute -> Generate -> Evaluate.
         """
-        await self.planner_agent.plan(user_input, user_id=user_id, mental_state=mental_state)
+        await self.planner_agent.plan(
+            user_input,
+            user_id=user_id,
+            mental_state=mental_state,
+            behavior_weights=behavior_weights,
+            skill_weights=skill_weights
+        )
         plan_str = await self.generator_agent.execute_plan(user_input, user_id=user_id)
 
         messages = []
@@ -44,6 +52,12 @@ class TriadCoordinator:
             pre_generation_hook()
 
         response = await self.generator_agent.generate_response(messages)
+
+        # Trigger learning from immediate outcome if possible
+        if hasattr(self.generator_agent, 'planner') and self.generator_agent.planner:
+            completed = self.generator_agent.planner.get_completed_steps(user_id=user_id)
+            # This is a bit of a placeholder, actual next-state signal usually comes in next turn
+            # but we can at least log or consolidate here.
 
         await self.evaluator_agent.evaluate(user_input, response, user_id=user_id, policies=policies)
 

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -137,7 +137,7 @@ class Consciousness:
             a_delta = min(0.1, score * 0.1)
             self.emotions.update(p_delta=0.0, a_delta=a_delta, d_delta=0.0, user_id=None)
 
-    async def process_input(self, user_input: str, user_id: Optional[int] = None) -> str:
+    async def process_input(self, user_input: str, user_id: Optional[str] = None) -> str:
         logging.info(f"Consciousness processing: {user_input}")
         if self.tracer:
             self.tracer.add_step("input_received", {"user_input": user_input, "user_id": user_id})
@@ -387,6 +387,14 @@ class Consciousness:
         # Actually, passing it evaluated before `coordinate()` is fine since the state is already loaded.
         policies = self.planner.get_user_state(user_id).current_constraints if self.planner else None
 
+        # Retrieve weights from user model if available
+        behavior_weights = None
+        skill_weights = None
+        if self.user_model and user_id is not None:
+            model_data = self.user_model.get_model(user_id)
+            behavior_weights = model_data.get("behavior_weights")
+            skill_weights = model_data.get("skill_weights")
+
         try:
             response = await coordinator.coordinate(
                 user_input,
@@ -394,7 +402,9 @@ class Consciousness:
                 message_builder=message_builder,
                 pre_generation_hook=pre_generation_hook,
                 policies=policies,
-                mental_state=self.mental_states._get_state(user_id)
+                mental_state=self.mental_states._get_state(user_id),
+                behavior_weights=behavior_weights,
+                skill_weights=skill_weights
             )
         except ActionIgnored as e:
             return str(e)

--- a/magda_agent/emotions/style_adapter.py
+++ b/magda_agent/emotions/style_adapter.py
@@ -55,6 +55,19 @@ class StyleAdapter:
             if "short_answers" in preferences and preferences["short_answers"]:
                 style_instructions.append("- User strictly prefers very short, bulleted answers.")
 
+        # Behavior Weight Modifications
+        if user_model and "behavior_weights" in user_model:
+            bw = user_model["behavior_weights"]
+            if bw.get("verbosity", 1.0) > 1.3:
+                style_instructions.append("- High verbosity mode: Provide detailed, thorough explanations.")
+            elif bw.get("verbosity", 1.0) < 0.7:
+                style_instructions.append("- Low verbosity mode: Be as brief and concise as possible.")
+
+            if bw.get("directness", 1.0) > 1.3:
+                style_instructions.append("- High directness mode: Get straight to the point, avoid preamble.")
+            elif bw.get("directness", 1.0) < 0.7:
+                style_instructions.append("- Low directness mode: Use polite softeners and structured introductions.")
+
         if len(style_instructions) > 1:
             return "\n".join(style_instructions)
         return ""

--- a/magda_agent/learning/openclaw_rl.py
+++ b/magda_agent/learning/openclaw_rl.py
@@ -36,7 +36,7 @@ class OpenClawInteractiveLearner:
         self,
         user_reply: str,
         action_context: str,
-        user_id: int,
+        user_id: Optional[str],
         tool_output: Optional[str] = None,
         skills_used: Optional[List[str]] = None
     ) -> None:
@@ -65,8 +65,14 @@ class OpenClawInteractiveLearner:
         if p_shift > 0.0:
             # Positive signal, reinforce the habits explicitly
             skills: List[str] = skills_used or ["rl_skill"]
+
+            # Update skill weights
+            skill_weights = model_data.setdefault("skill_weights", {})
             for skill in skills:
+                current_w = skill_weights.get(skill, 1.0)
+                skill_weights[skill] = min(2.0, current_w + p_shift * 0.2)
                 self.habit_tracker.record_usage(input_text=action_context, skill_used=skill, evaluation_score=10.0, user_id=user_id)
+
             logging.info(f"OpenClaw-RL: Positive signal received (p_shift={p_shift:.2f}). Reinforced habits: {skills}")
 
             # Adjust communication style towards friendly if not present
@@ -75,6 +81,13 @@ class OpenClawInteractiveLearner:
 
         elif p_shift < 0.0:
             logging.info(f"OpenClaw-RL: Negative signal received (p_shift={p_shift:.2f}).")
+
+            # Update skill weights (penalty)
+            if skills_used:
+                skill_weights = model_data.setdefault("skill_weights", {})
+                for skill in skills_used:
+                    current_w = skill_weights.get(skill, 1.0)
+                    skill_weights[skill] = max(0.1, current_w + p_shift * 0.2)
 
             # Directive signal: generate recovery lesson for significant negative feedback
             if p_shift <= -0.2 and self.recovery_lessons:

--- a/magda_agent/planning/planner.py
+++ b/magda_agent/planning/planner.py
@@ -120,7 +120,14 @@ class Planner:
     def paused_plan(self, value: Optional[Dict[str, Any]]) -> None:
         self.get_user_state().paused_plan = value
 
-    async def generate_plan(self, user_input: str, user_id: int = None, mental_state: Optional[MentalState] = None) -> List[Dict[str, Any]]:
+    async def generate_plan(
+        self,
+        user_input: str,
+        user_id: Optional[str] = None,
+        mental_state: Optional[MentalState] = None,
+        behavior_weights: Optional[Dict[str, float]] = None,
+        skill_weights: Optional[Dict[str, float]] = None
+    ) -> List[Dict[str, Any]]:
         logging.info("Generating plan for input")
         state = self.get_user_state(user_id)
         skills_desc = self.skills.get_skills_summary()
@@ -151,6 +158,27 @@ class Planner:
 
             if bias_instructions:
                 system_prompt += "\n\nCognitive Bias Modifiers:\n" + "\n".join(bias_instructions)
+
+        if behavior_weights:
+            weight_instructions = ["\n\nBehavioral Parameters:"]
+            if behavior_weights.get("exploration", 1.0) > 1.3:
+                weight_instructions.append("- High exploration mode: Prefer new or complex tools, suggest experimental steps.")
+            elif behavior_weights.get("exploration", 1.0) < 0.7:
+                weight_instructions.append("- Low exploration mode: Stick to proven, safe tools and standard procedures.")
+
+            if behavior_weights.get("directness", 1.0) > 1.3:
+                weight_instructions.append("- High directness: Prioritize efficient, minimal-step plans.")
+            elif behavior_weights.get("directness", 1.0) < 0.7:
+                weight_instructions.append("- Low directness: Include extra verification and safety checkpoints in the plan.")
+
+            if len(weight_instructions) > 1:
+                system_prompt += "\n".join(weight_instructions)
+
+        if skill_weights:
+            top_skills = sorted(skill_weights.items(), key=lambda x: x[1], reverse=True)[:3]
+            preferred = [s for s, w in top_skills if w > 1.2]
+            if preferred:
+                system_prompt += f"\n\nHighly weighted skills for this user: {', '.join(preferred)}. Prefer using these if appropriate."
 
         if self.habit_tracker:
             suggested_strategy = self.habit_tracker.suggest_strategy(user_input, user_id=user_id)

--- a/tests/test_openclaw_rl.py
+++ b/tests/test_openclaw_rl.py
@@ -143,3 +143,68 @@ async def test_openclaw_rl_dynamic_behavior_weights(mock_habit_tracker: MagicMoc
     assert weights2["exploration"] <= 2.0
     assert weights2["verbosity"] <= 2.0
     assert weights2["directness"] >= 0.5
+
+@pytest.mark.asyncio
+async def test_openclaw_rl_integration_weights_to_planner(mock_habit_tracker: MagicMock, mock_mirror_neurons: MagicMock, user_model: UserModel) -> None:
+    """Tests that learned weights are correctly passed to the Planner through Consciousness."""
+    from magda_agent.consciousness.core import Consciousness
+    from magda_agent.llm_client import LLMClient
+    from magda_agent.emotions.engine import EmotionalEngine
+    from magda_agent.memory.storage import MemorySystem
+    from magda_agent.skills.registry import SkillRegistry
+    from magda_agent.planning.planner import Planner
+    from unittest.mock import AsyncMock
+
+    # Setup mocks
+    llm = MagicMock(spec=LLMClient)
+    llm.chat_completion = AsyncMock(return_value=json.dumps({
+        "goal": "test", "constraints": [], "risk": "low", "steps": [], "acceptance": []
+    }))
+    llm.get_system_prompt.return_value = "System prompt"
+
+    emotions = MagicMock(spec=EmotionalEngine)
+    memory = MagicMock(spec=MemorySystem)
+    memory.working_memory = MagicMock()
+    memory.working_memory.get_entries.return_value = []
+    memory.episodic_memory = MagicMock()
+    memory.episodic_memory.recall_events.return_value = []
+    memory.retrieve_relevant.return_value = []
+    skills = MagicMock(spec=SkillRegistry)
+    planner = Planner(llm=llm, skills=skills)
+
+    learner = OpenClawInteractiveLearner(mock_habit_tracker, mock_mirror_neurons, user_model)
+
+    # Initialize Consciousness
+    consciousness = Consciousness(
+        llm=llm,
+        emotions=emotions,
+        memory=memory,
+        skills=skills,
+        planner=planner,
+        user_model=user_model,
+        openclaw_rl=learner
+    )
+
+    # Simulate feedback to set weights
+    # p_shift=0.8, a_shift=0.8, d_shift=0.8
+    mock_mirror_neurons.empathize.return_value = (0.8, 0.8, 0.8)
+    await consciousness.process_input("You are doing a great job!", user_id=123)
+
+    # Verify weights were set in user model
+    model_data = user_model.get_model(123)
+    assert model_data["behavior_weights"]["exploration"] > 1.3
+
+    # Reset chat_completion mock to track the call during next process_input
+    llm.chat_completion.reset_mock()
+
+    # Process next input, which should trigger plan generation with weights
+    await consciousness.process_input("What is the next task?", user_id=123)
+
+    # Verify generate_plan was called with behavior_weights (via llm.chat_completion tracking in Planner)
+    # The system prompt generated in Planner.generate_plan should contain "High exploration mode"
+    # Note: chat_completion is called twice: once for planning, once for response generation.
+    # We want to check the planning call.
+    plan_call = next(c for c in llm.chat_completion.call_args_list if "Prefrontal Cortex" in c[0][0][0]["content"])
+    system_msg = plan_call[0][0][0]["content"]
+    assert "High exploration mode" in system_msg
+    assert "Behavioral Parameters:" in system_msg

--- a/tests/test_three_agent.py
+++ b/tests/test_three_agent.py
@@ -14,7 +14,13 @@ async def test_planner_agent():
     plan = await agent.plan("test input")
 
     assert plan == [{"step": 1}]
-    mock_planner.generate_plan.assert_called_once_with("test input", user_id=None, mental_state=None)
+    mock_planner.generate_plan.assert_called_once_with(
+        "test input",
+        user_id=None,
+        mental_state=None,
+        behavior_weights=None,
+        skill_weights=None
+    )
 
 @pytest.mark.asyncio
 async def test_generator_agent():

--- a/tests/test_triad_coordinator.py
+++ b/tests/test_triad_coordinator.py
@@ -28,7 +28,13 @@ async def test_triad_coordinator():
     )
 
     assert res == "final response"
-    planner.plan.assert_called_once_with("hello", user_id="123", mental_state=None)
+    planner.plan.assert_called_once_with(
+        "hello",
+        user_id="123",
+        mental_state=None,
+        behavior_weights=None,
+        skill_weights=None
+    )
     generator.execute_plan.assert_called_once_with("hello", user_id="123")
     message_builder.assert_called_once_with("plan string")
     pre_hook.assert_called_once()


### PR DESCRIPTION
The OpenClaw-RL pattern for online reinforcement learning was partially implemented but not fully integrated into the agent's decision-making process. These changes ensure that the weights learned from user feedback (captured as PAD emotion shifts) actually influence the agent's planning and response style.

Key changes:
1.  **OpenClawInteractiveLearner**: Now updates `skill_weights` in the `UserModel` data based on positive/negative feedback.
2.  **Planner**: The `generate_plan` method now adds specific instructions to its system prompt based on `behavior_weights` (e.g., "High exploration mode") and `skill_weights` (e.g., "Highly weighted skills: ...").
3.  **StyleAdapter**: Uses `behavior_weights` from the user model to add styling instructions like "High verbosity mode" or "High directness mode" to the final response generation prompt.
4.  **Consciousness**: Wired these components together, ensuring that weights are retrieved from the persistent user model and passed through the `TriadCoordinator` to the relevant agents.
5.  **Standardization**: Updated method signatures to use `Optional[str]` for `user_id` consistently, addressing potential type mismatch issues.
6.  **Testing**: Added an end-to-end integration test in `tests/test_openclaw_rl.py` that verifies user feedback correctly updates weights which then appear in the Planner's system prompt.

This completes task `openclaw-online-rl-integration-v1`.

---
*PR created automatically by Jules for task [1255371697258115758](https://jules.google.com/task/1255371697258115758) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Integrate OpenClaw-RL behavioral and skill weights into the cognitive planning loop
> - [`Planner.generate_plan`](https://github.com/kazah4359-lgtm/Magda-agent/pull/397/files#diff-0dba6309dba5da62981c561d46f8b9e2e8128b6e7c999b43517c44d1e5735abb) now accepts `behavior_weights` and `skill_weights`, injecting a "Behavioral Parameters" section into the system prompt to bias LLM output toward exploration/directness preferences and high-weight skills (>1.2 threshold).
> - [`OpenClawInteractiveLearner.process_next_state_signal`](https://github.com/kazah4359-lgtm/Magda-agent/pull/397/files#diff-97cf6ce0be050f90c1268294aaba45efca5e6d006d2802e9455ecce9876f92e0) now maintains per-skill weights in the user model, incrementing or penalizing weights based on signal polarity and persisting changes via `user_model.save_model`.
> - [`StyleAdapter.get_style_prompt`](https://github.com/kazah4359-lgtm/Magda-agent/pull/397/files#diff-b0bd4018cb892a041282fcc908bf3d36c0dadfe8b63c81eaafdb55456c8b1457) now reads `behavior_weights` from the user model to append verbosity and directness instructions to the style prompt.
> - [`TriadCoordinator.coordinate`](https://github.com/kazah4359-lgtm/Magda-agent/pull/397/files#diff-2ae3e2134b4c8f9c4190bbcba7c298444eedf7d8c9005fe1d5c4ddeb58f0799e) and [`PlannerAgent.plan`](https://github.com/kazah4359-lgtm/Magda-agent/pull/397/files#diff-c2d3c6926ef8cf2969d786a148f211ab242d429f61933ea6f0ca646557f7df5f) thread `behavior_weights` and `skill_weights` through the call chain from coordinator to planner.
> - Behavioral Change: LLM planning prompts and response style prompts now vary per-user based on learned RL weights, replacing previously static prompts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52d0f3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->