### PR TITLE
feat: Implement OpenClaw Semantic Memory Compaction V4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13279,7 +13279,7 @@
     },
     {
       "id": "045f5265-421f-4035-bde4-cc3a35ca53ed",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Semantic Memory Compaction V4",
@@ -13516,6 +13516,42 @@
         "MCP tools run in isolated context namespace.",
         "Taint tracker effectively blocks unsafe data transitions.",
         "Tests use mocked tool executions to verify isolation."
+      ]
+    },
+    {
+      "id": "8a857a8b-360a-4a5a-aff1-9d05fdd8ece1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "MemGPT Virtual Context Integration V2",
+      "description": "Inspired by MemGPT virtual context patterns: Create a context manager that swaps episodic memories in and out of the active LLM context based on token limits.",
+      "allowed_paths": [
+        "magda_agent/memory/memgpt_virtual_context_v2.py",
+        "tests/test_memgpt_virtual_context_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context manager enforces token limits.",
+        "Episodic memories are correctly swapped.",
+        "Tests verify virtual context swapping logic."
+      ]
+    },
+    {
+      "id": "cc58a34c-3f1a-41aa-9db6-ddff979cb589",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Prempti Tool Interception Logger V1",
+      "description": "Inspired by Prempti (Falco): Implement a low-level logger that intercepts all dynamic tool executions and records metadata into the AuditTrail before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/prempti_logger_v1.py",
+        "tests/test_prempti_logger_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Logger intercepts tool calls.",
+        "AuditTrail receives pre-execution logs.",
+        "Tests verify logging logic without executing the actual tool."
       ]
     }
   ]

--- a/magda_agent/memory/semantic_compaction_v4.py
+++ b/magda_agent/memory/semantic_compaction_v4.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Optional, List, Dict, Any
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.memory.semantic import SemanticMemory
+from magda_agent.llm_client import LLMClient
+
+logger = logging.getLogger(__name__)
+
+class SemanticCompactionV4:
+    """
+    OpenClaw Semantic Memory Compaction V4
+    Inspired by OpenClaw trends: Implement semantic memory compaction that runs periodically via cron, clustering related events.
+    """
+    def __init__(
+        self,
+        episodic_memory: EpisodicMemory,
+        semantic_memory: SemanticMemory,
+        llm_client: LLMClient,
+        batch_size: int = 10,
+        cluster_prompt: Optional[str] = None
+    ):
+        """
+        Initializes the SemanticCompactionV4.
+
+        Args:
+            episodic_memory: The episodic memory instance to read events from.
+            semantic_memory: The semantic memory instance to store clustered facts.
+            llm_client: The LLM client to use for clustering/summarization.
+            batch_size: Minimum number of events required to trigger compaction.
+            cluster_prompt: Optional custom prompt template for clustering.
+        """
+        self.episodic_memory = episodic_memory
+        self.semantic_memory = semantic_memory
+        self.llm_client = llm_client
+        self.batch_size = batch_size
+        self.cluster_prompt = cluster_prompt or (
+            "Analyze the following episodic memory events and extract the core semantic facts. "
+            "Cluster related events and provide a concise summary of the key facts learned. "
+            "Return the facts as a simple text list, one fact per line.\n\nEvents:\n{events}"
+        )
+
+    async def run_compaction(self) -> SemanticCompactionV4:
+        """
+        Fetches non-decayed events, clusters them using LLM, stores as semantic facts,
+        and decays the original events.
+        """
+        logger.info("Starting Semantic Memory Compaction V4")
+
+        events = self.episodic_memory.get_all_events(include_decayed=False, limit=self.batch_size * 2)
+        if not events or len(events) < self.batch_size:
+            logger.info(f"Not enough events for compaction. Found {len(events)}, require {self.batch_size}.")
+            return
+
+        events_to_compact = events[:self.batch_size]
+        event_texts = [f"- {e['text']}" for e in events_to_compact]
+        events_str = "\n".join(event_texts)
+
+        prompt = self.cluster_prompt.format(events=events_str)
+
+        logger.info(f"Clustering {len(events_to_compact)} events.")
+
+        try:
+            # We use chat_completion directly or generate?
+            # guidelines say we should use generate or chat_completion? LLMClient has both, both async.
+            response = await self.llm_client.generate(prompt)
+
+            if response.startswith("Error:"):
+                logger.error(f"LLM Error during compaction: {response}")
+                return
+
+            # Store the facts
+            facts = [fact.strip("- *").strip() for fact in response.split("\n") if fact.strip()]
+            for fact in facts:
+                if fact:
+                    self.semantic_memory.store_fact(fact, metadata={"source": "compaction_v4"})
+                    logger.debug(f"Stored compacted fact: {fact}")
+
+            # Decay original events
+            for event in events_to_compact:
+                self.episodic_memory.decay_event(event["id"])
+
+            logger.info("Semantic compaction completed successfully.")
+
+        except Exception as e:
+            logger.error(f"Error during semantic compaction: {e}", exc_info=True)
+
+
+def register_compaction_cron(
+    scheduler,
+    episodic_memory: EpisodicMemory,
+    semantic_memory: SemanticMemory,
+    llm_client: LLMClient,
+    cron_expr: str = "0 2 * * *" # Daily at 2 AM
+) -> SemanticCompactionV4:
+    """
+    Registers the compaction process with HermesCronSchedulerV3.
+    """
+    compactor = SemanticCompactionV4(episodic_memory, semantic_memory, llm_client)
+
+    @scheduler.task(cron_expr, name="semantic_compaction_v4")
+    async def compact_task():
+        await compactor.run_compaction()
+
+    return compactor

--- a/magda_agent/memory/semantic_compaction_v4.py
+++ b/magda_agent/memory/semantic_compaction_v4.py
@@ -39,7 +39,7 @@ class SemanticCompactionV4:
             "Return the facts as a simple text list, one fact per line.\n\nEvents:\n{events}"
         )
 
-    async def run_compaction(self) -> SemanticCompactionV4:
+    async def run_compaction(self) -> None:
         """
         Fetches non-decayed events, clusters them using LLM, stores as semantic facts,
         and decays the original events.
@@ -91,7 +91,7 @@ def register_compaction_cron(
     semantic_memory: SemanticMemory,
     llm_client: LLMClient,
     cron_expr: str = "0 2 * * *" # Daily at 2 AM
-) -> SemanticCompactionV4:
+) -> "SemanticCompactionV4":
     """
     Registers the compaction process with HermesCronSchedulerV3.
     """

--- a/tests/test_semantic_compaction_v4.py
+++ b/tests/test_semantic_compaction_v4.py
@@ -1,0 +1,92 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import MagicMock, AsyncMock, call
+from magda_agent.memory.semantic_compaction_v4 import SemanticCompactionV4, register_compaction_cron
+
+@pytest_asyncio.fixture
+async def compactor_setup():
+    episodic_mock = MagicMock()
+    semantic_mock = MagicMock()
+    llm_mock = MagicMock()
+    llm_mock.generate = AsyncMock()
+
+    compactor = SemanticCompactionV4(
+        episodic_memory=episodic_mock,
+        semantic_memory=semantic_mock,
+        llm_client=llm_mock,
+        batch_size=2
+    )
+    return compactor, episodic_mock, semantic_mock, llm_mock
+
+@pytest.mark.asyncio
+async def test_compaction_not_enough_events(compactor_setup):
+    compactor, episodic_mock, _, llm_mock = compactor_setup
+
+    # Return fewer events than batch_size (2)
+    episodic_mock.get_all_events.return_value = [{"id": "1", "text": "event1", "metadata": {}}]
+
+    await compactor.run_compaction()
+
+    episodic_mock.get_all_events.assert_called_once()
+    llm_mock.generate.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compaction_success(compactor_setup):
+    compactor, episodic_mock, semantic_mock, llm_mock = compactor_setup
+
+    # Return enough events
+    events = [
+        {"id": "1", "text": "event1", "metadata": {}},
+        {"id": "2", "text": "event2", "metadata": {}},
+        {"id": "3", "text": "event3", "metadata": {}}
+    ]
+    episodic_mock.get_all_events.return_value = events
+
+    # Mock LLM response
+    llm_mock.generate.return_value = "- Fact 1\n- Fact 2"
+
+    await compactor.run_compaction()
+
+    # Check LLM called
+    llm_mock.generate.assert_called_once()
+
+    # Check facts stored
+    assert semantic_mock.store_fact.call_count == 2
+    semantic_mock.store_fact.assert_any_call("Fact 1", metadata={"source": "compaction_v4"})
+    semantic_mock.store_fact.assert_any_call("Fact 2", metadata={"source": "compaction_v4"})
+
+    # Check original events decayed (only batch_size=2 events should be decayed)
+    assert episodic_mock.decay_event.call_count == 2
+    episodic_mock.decay_event.assert_any_call("1")
+    episodic_mock.decay_event.assert_any_call("2")
+
+@pytest.mark.asyncio
+async def test_compaction_llm_error(compactor_setup):
+    compactor, episodic_mock, semantic_mock, llm_mock = compactor_setup
+
+    events = [
+        {"id": "1", "text": "event1", "metadata": {}},
+        {"id": "2", "text": "event2", "metadata": {}},
+    ]
+    episodic_mock.get_all_events.return_value = events
+
+    llm_mock.generate.return_value = "Error: Some API issue"
+
+    await compactor.run_compaction()
+
+    llm_mock.generate.assert_called_once()
+    semantic_mock.store_fact.assert_not_called()
+    episodic_mock.decay_event.assert_not_called()
+
+def test_register_compaction_cron():
+    scheduler_mock = MagicMock()
+    scheduler_mock.task.return_value = lambda x: x
+
+    episodic_mock = MagicMock()
+    semantic_mock = MagicMock()
+    llm_mock = MagicMock()
+
+    compactor = register_compaction_cron(scheduler_mock, episodic_mock, semantic_mock, llm_mock)
+
+    assert isinstance(compactor, SemanticCompactionV4)
+    scheduler_mock.task.assert_called_once_with("0 2 * * *", name="semantic_compaction_v4")


### PR DESCRIPTION
Implemented `SemanticCompactionV4` which periodically clusters non-decayed events from `EpisodicMemory` into facts via `LLMClient`, stores them into `SemanticMemory`, decays the processed episodic events, and integrated it with `HermesCronSchedulerV3`. I have also added tests to `tests/test_semantic_compaction_v4.py` using `pytest` and `unittest.mock`, correctly utilizing async features for the `LLMClient`. `agent_tasks.json` has been updated to mark this task as "done", and two new trend-inspired tasks (MemGPT Virtual Context Integration V2 and Prempti Tool Interception Logger V1) have been appended with unique UUIDs.

---
*PR created automatically by Jules for task [1818258778829635065](https://jules.google.com/task/1818258778829635065) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SemanticCompactionV4` class to compact episodic memory into semantic facts via LLM
> - Adds [`semantic_compaction_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/400/files#diff-cd45b9ae5b848a38a791ac7121a9b48364a2bf5b7966293bbb7201b190a5ba6d) with `SemanticCompactionV4`, which pulls non-decayed episodic events in batches, sends them to an LLM, and stores the returned lines as semantic facts tagged with `{source: 'compaction_v4'}`.
> - After successful compaction, the source batch of events is decayed; LLM responses prefixed with `'Error:'` are rejected and cause the batch to be skipped.
> - Adds `register_compaction_cron` to schedule compaction as a daily cron job (default `0 2 * * *`) on a provided scheduler.
> - Adds async tests covering the skip-on-small-batch, success, LLM-error, and cron-registration cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f664ad4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->