### PR TITLE
Implement A2A Agent Discovery v3 parsing capabilities

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6573,7 +6573,7 @@
     },
     {
       "id": "a2a-agent-discovery-v3-89076f63",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Agent Discovery v3",
@@ -13552,6 +13552,57 @@
         "Logger intercepts tool calls.",
         "AuditTrail receives pre-execution logs.",
         "Tests verify logging logic without executing the actual tool."
+      ]
+    },
+    {
+      "id": "7fb16e93-1c84-4e9e-b85f-42b18bc3f423",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Magentic-One Multi-Agent Orchestration V3",
+      "description": "Inspired by Magentic-One pattern from Microsoft: Build an orchestration layer that efficiently routes tasks to parallel subagents and merges state natively.",
+      "allowed_paths": [
+        "magda_agent/architecture/magentic_one_v3.py",
+        "tests/test_magentic_one_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Orchestrator can route tasks among multiple sub-agents.",
+        "Tests verify task routing."
+      ]
+    },
+    {
+      "id": "3a7bb365-8d58-4c05-bfba-cf78ee024091",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Tool Runtime Execution Policy Sandbox V4",
+      "description": "Inspired by MCP sandboxing trends: Introduce a tight runtime policy evaluator sandbox to intercept action tools preventing unverified side-effects.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_policy_sandbox_v4.py",
+        "tests/test_mcp_policy_sandbox_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP action tools trigger the sandbox policy.",
+        "Tests verify valid executions and blocked executions."
+      ]
+    },
+    {
+      "id": "d11098fc-9600-4fb2-a17b-68efa4eab388",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Workflow Auth Delegation Tokens",
+      "description": "Inspired by A2A Protocol standard trends: Manage active authentication tokens when passing tasks over A2A mesh network to peers.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth_delegation.py",
+        "tests/test_a2a_auth_delegation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tasks delegate securely via active token.",
+        "Tests verify A2A requests over mock token exchange."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_discovery_v3.py
+++ b/magda_agent/integration/a2a_discovery_v3.py
@@ -1,0 +1,50 @@
+from typing import Dict, List, Optional
+import json
+import logging
+from magda_agent.integration.a2a_discovery import AgentCard
+
+class A2ADiscoveryV3:
+    """
+    Implements A2A Agent Discovery v3 logic using the new standard.
+    This class handles the parsing and management of AgentCards.
+    """
+    def __init__(self):
+        """
+        Initializes the A2ADiscoveryV3 registry.
+        """
+        self._discovered_agents: Dict[str, AgentCard] = {}
+
+    def parse_and_register_cards(self, raw_cards: List[str]) -> List[AgentCard]:
+        """
+        Parses a list of JSON string representations of Agent Cards
+        and registers them in the internal store.
+
+        Args:
+            raw_cards: A list of JSON strings representing AgentCards.
+
+        Returns:
+            A list of successfully parsed AgentCard objects.
+        """
+        successfully_parsed = []
+        for card_json in raw_cards:
+            try:
+                card = AgentCard.from_json(card_json)
+                self._discovered_agents[card.agent_id] = card
+                successfully_parsed.append(card)
+                logging.info(f"Successfully parsed and registered AgentCard for agent_id: {card.agent_id}")
+            except (json.JSONDecodeError, TypeError, ValueError, KeyError) as e:
+                logging.error(f"Failed to parse Agent Card. Error: {str(e)}, Raw Data: {card_json}")
+
+        return successfully_parsed
+
+    def get_agent_card(self, agent_id: str) -> Optional[AgentCard]:
+        """
+        Retrieves a registered AgentCard by its agent_id.
+        """
+        return self._discovered_agents.get(agent_id)
+
+    def get_all_agents(self) -> List[AgentCard]:
+        """
+        Returns a list of all discovered agents.
+        """
+        return list(self._discovered_agents.values())

--- a/tests/test_a2a_discovery_v3.py
+++ b/tests/test_a2a_discovery_v3.py
@@ -1,0 +1,66 @@
+import pytest
+import json
+from dataclasses import asdict
+from magda_agent.integration.a2a_discovery import AgentCard
+from magda_agent.integration.a2a_discovery_v3 import A2ADiscoveryV3
+
+@pytest.fixture
+def valid_card():
+    return AgentCard(
+        agent_id="test-agent-001",
+        name="TestAgent",
+        description="A test agent",
+        capabilities=["test", "parse"],
+        endpoints={"rpc": "http://localhost:8080"}
+    )
+
+def test_parse_and_register_valid_cards(valid_card):
+    discovery = A2ADiscoveryV3()
+
+    valid_json = valid_card.to_json()
+
+    parsed_cards = discovery.parse_and_register_cards([valid_json])
+
+    assert len(parsed_cards) == 1
+    assert parsed_cards[0].agent_id == "test-agent-001"
+    assert parsed_cards[0].name == "TestAgent"
+
+    # Verify it was registered
+    registered_card = discovery.get_agent_card("test-agent-001")
+    assert registered_card is not None
+    assert registered_card.name == "TestAgent"
+
+    all_agents = discovery.get_all_agents()
+    assert len(all_agents) == 1
+
+def test_parse_invalid_json():
+    discovery = A2ADiscoveryV3()
+
+    invalid_json = '{"agent_id": "missing_quotes}'
+
+    parsed_cards = discovery.parse_and_register_cards([invalid_json])
+
+    assert len(parsed_cards) == 0
+    assert len(discovery.get_all_agents()) == 0
+
+def test_parse_missing_required_fields():
+    discovery = A2ADiscoveryV3()
+
+    missing_fields_json = '{"agent_id": "test-agent-002", "name": "Agent"}' # missing description, capabilities, endpoints
+
+    parsed_cards = discovery.parse_and_register_cards([missing_fields_json])
+
+    assert len(parsed_cards) == 0
+    assert len(discovery.get_all_agents()) == 0
+
+def test_parse_mixed_valid_and_invalid(valid_card):
+    discovery = A2ADiscoveryV3()
+
+    valid_json = valid_card.to_json()
+    invalid_json = '{"broken": json}'
+
+    parsed_cards = discovery.parse_and_register_cards([invalid_json, valid_json])
+
+    assert len(parsed_cards) == 1
+    assert parsed_cards[0].agent_id == "test-agent-001"
+    assert len(discovery.get_all_agents()) == 1


### PR DESCRIPTION
This PR implements the A2A Agent Discovery v3 feature based on the new standard. It adds the `A2ADiscoveryV3` class to handle parsing and registration of `AgentCard` objects.

Changes include:
- `magda_agent/integration/a2a_discovery_v3.py`: Implementation of `A2ADiscoveryV3`.
- `tests/test_a2a_discovery_v3.py`: Pytest suite to verify valid JSON parsing and robust error handling for edge cases.
- `agent_tasks.json`: Marked the current task as `done` and generated 3 new tasks (`Magentic-One Multi-Agent Orchestration V3`, `MCP Tool Runtime Execution Policy Sandbox V4`, and `A2A Workflow Auth Delegation Tokens`) according to current AI trends.

---
*PR created automatically by Jules for task [12945496865441651382](https://jules.google.com/task/12945496865441651382) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A Agent Discovery v3 parsing and registry via `A2ADiscoveryV3`
> - Adds [`A2ADiscoveryV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/401/files#diff-fd1ec7ea5c0dbd302dcb1adb58ac34badce86ba2131ed00d6f55802bf2ea159d) with an in-memory registry of `AgentCard` instances, keyed by `agent_id`.
> - `parse_and_register_cards` accepts a list of JSON strings, registers valid cards, logs errors for invalid entries without raising, and returns only successfully parsed cards.
> - `get_agent_card` and `get_all_agents` provide retrieval from the registry.
> - Adds [tests](https://github.com/kazah4359-lgtm/Magda-agent/pull/401/files#diff-28aa33873f7dfbf3e94189d7f0b5bc4baf634888eca3d188f15e24d6d77d77bd) covering valid input, invalid JSON, missing required fields, and mixed valid/invalid input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ee507c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->