### PR TITLE
feat: Context Engine Plugin Lifecycle Hooks v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6589,7 +6589,7 @@
     },
     {
       "id": "context-engine-plugin-lifecycle-v2-28520349",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "low",
       "title": "Context Engine Plugin Lifecycle Hooks v2",
@@ -13603,6 +13603,40 @@
       "acceptance": [
         "Tasks delegate securely via active token.",
         "Tests verify A2A requests over mock token exchange."
+      ]
+    },
+    {
+      "id": "e7fb872a-ebce-4600-acca-7d6ba7ac4739",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Hierarchical Delegation Telemetry Exporter v2",
+      "description": "Inspired by Magentic-One and Agent Teams: Expose telemetry data on parallel sub-agent communication for live visualization tools.",
+      "allowed_paths": [
+        "magda_agent/architecture/hierarchical_delegation_telemetry_v2.py",
+        "tests/test_hierarchical_delegation_telemetry_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agent message traffic is captured by the telemetry exporter.",
+        "Tests mock message passing and verify export payloads."
+      ]
+    },
+    {
+      "id": "3aea55f9-c46a-4e15-973e-819f9c57cb7f",
+      "status": "todo",
+      "area": "safety",
+      "risk": "low",
+      "title": "ACS Control Fallback Strategy v5",
+      "description": "Inspired by ACS runtime safety controls: Implement a graceful fallback strategy when a tool's output validation is denied by the state check.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_fallback_v5.py",
+        "tests/test_acs_fallback_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent falls back to a neutral response on output validation failure.",
+        "Tests mock a denied validation and assert the fallback path is taken."
       ]
     }
   ]

--- a/magda_agent/memory/context_engine_lifecycle_v2.py
+++ b/magda_agent/memory/context_engine_lifecycle_v2.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Dict, Any, Optional
+from magda_agent.memory.context_engine_v1 import ContextEngineV1, ContextPluginV1
+
+class ContextPluginLifecycleV2(ContextPluginV1):
+    """
+    Protocol extending ContextPluginV1 to include lifecycle hooks
+    for dynamically loading and unloading plugins.
+    """
+
+    async def on_load(self, config: Dict[str, Any]) -> None:
+        """Called when the plugin is dynamically loaded."""
+        pass
+
+    async def on_unload(self) -> None:
+        """Called when the plugin is dynamically unloaded."""
+        pass
+
+class ContextEngineLifecycleV2(ContextEngineV1):
+    """
+    Extends ContextEngineV1 to support dynamic loading and unloading
+    of plugins at runtime with lifecycle hooks.
+    """
+
+    async def load_plugin(self, plugin: ContextPluginLifecycleV2, config: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Dynamically loads a plugin, registers its hooks, and calls its on_load hook.
+        """
+        if config is None:
+            config = {}
+
+        self.register_plugin(plugin)
+
+        if hasattr(plugin, 'on_load'):
+            await plugin.on_load(config)
+
+        logging.info(f"Dynamically loaded plugin: {plugin.__class__.__name__}")
+
+    async def unload_plugin(self, plugin: ContextPluginLifecycleV2) -> None:
+        """
+        Dynamically unloads a plugin, calls its on_unload hook, and unregisters its hooks.
+        """
+        if plugin not in self._plugins:
+            logging.warning(f"Plugin {plugin.__class__.__name__} is not registered.")
+            return
+
+        if hasattr(plugin, 'on_unload'):
+            await plugin.on_unload()
+
+        self._plugins.remove(plugin)
+
+        # Remove plugin's hooks from the registry
+        for hook_type, callbacks in self.hook_registry._hooks.items():
+            # We need to iterate carefully to remove the correct bound methods
+            # related to this plugin instance.
+            hooks_to_remove = []
+            for cb in callbacks:
+                # Check if the callback is a bound method of the plugin instance
+                if hasattr(cb, '__self__') and cb.__self__ is plugin:
+                    hooks_to_remove.append(cb)
+
+            for cb in hooks_to_remove:
+                callbacks.remove(cb)
+
+        logging.info(f"Dynamically unloaded plugin: {plugin.__class__.__name__}")

--- a/tests/test_context_engine_lifecycle_v2.py
+++ b/tests/test_context_engine_lifecycle_v2.py
@@ -1,0 +1,50 @@
+import pytest
+from typing import Dict, Any
+from magda_agent.memory.context_engine_lifecycle_v2 import ContextEngineLifecycleV2, ContextPluginLifecycleV2
+
+class DummyLifecyclePlugin(ContextPluginLifecycleV2):
+    def __init__(self):
+        self.on_load_called = False
+        self.on_unload_called = False
+        self.config_received = None
+        self.before_retrieval_called = False
+
+    async def on_load(self, config: Dict[str, Any]) -> None:
+        self.on_load_called = True
+        self.config_received = config
+
+    async def on_unload(self) -> None:
+        self.on_unload_called = True
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Modify query before retrieval."""
+        self.before_retrieval_called = True
+        return query + " modified"
+
+@pytest.mark.asyncio
+async def test_lifecycle_hooks() -> None:
+    """Test load and unload hooks correctly manipulate the plugin list and registry."""
+    plugin = DummyLifecyclePlugin()
+    engine = ContextEngineLifecycleV2()
+
+    # Load plugin
+    await engine.load_plugin(plugin, {"test_key": "test_value"})
+    assert plugin.on_load_called is True
+    assert plugin.config_received == {"test_key": "test_value"}
+    assert plugin in engine._plugins
+
+    # Test hook registry was updated
+    res = engine.retrieve_context("query", 1, lambda q, u: [q])
+    assert plugin.before_retrieval_called is True
+    assert res == ["query modified"]
+
+    # Unload plugin
+    await engine.unload_plugin(plugin)
+    assert plugin.on_unload_called is True
+    assert plugin not in engine._plugins
+
+    # Verify hooks are removed
+    plugin.before_retrieval_called = False # reset
+    res = engine.retrieve_context("query", 1, lambda q, u: [q])
+    assert plugin.before_retrieval_called is False
+    assert res == ["query"]


### PR DESCRIPTION
Closes the `context-engine-plugin-lifecycle-v2-28520349` task by implementing lifecycle hooks for dynamically loading and unloading plugins into the Context Engine. Added 2 new AI-trend inspired tasks to the backlog.

---
*PR created automatically by Jules for task [1547326028487516065](https://jules.google.com/task/1547326028487516065) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lifecycle hooks `on_load`/`on_unload` to Context Engine plugin system
> - Introduces `ContextPluginLifecycleV2` protocol in [`context_engine_lifecycle_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/402/files#diff-675ecdc6e9a080e6357b52387847a1e957bcc7b116797e46543fae032cdb62a4), extending `ContextPluginV1` with async `on_load(config)` and `on_unload()` hooks.
> - Adds `ContextEngineLifecycleV2` engine with `load_plugin` and `unload_plugin` methods that invoke these hooks and manage hook registry cleanup.
> - On unload, the engine purges all bound method callbacks belonging to the removed plugin from the hook registry.
> - Test coverage in [`test_context_engine_lifecycle_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/402/files#diff-902198614afae512734bc32659d3fa7c9d5c0d31c0706f567909485ee86174fd) validates load/unload behavior and hook cleanup end-to-end.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9418f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->