### PR TITLE
feat: implement ACS Guardrails Runtime Policy v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6605,7 +6605,7 @@
     },
     {
       "id": "acs-guardrail-runtime-v5-e48c3980",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "high",
       "title": "ACS Guardrails Runtime Policy v5",
@@ -13637,6 +13637,60 @@
       "acceptance": [
         "Agent falls back to a neutral response on output validation failure.",
         "Tests mock a denied validation and assert the fallback path is taken."
+      ]
+    },
+    {
+      "id": "2d0966fd-8abe-4b49-8ac8-73aa7d00068a",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Magentic-One Task Dependency Resolution Engine v4",
+      "description": "Inspired by Magentic-One and Agent Teams trends: Implement an orchestration router component that topologically sorts DAG-based execution plans and routes independent sub-tasks concurrently to subagents in isolated git worktrees.",
+      "allowed_paths": [
+        "magda_agent/architecture/dependency_router_v4.py",
+        "tests/test_dependency_router_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Orchestrator correctly resolves sub-task dependencies using a topological sort.",
+        "Independent tasks are grouped for parallel execution.",
+        "Tests verify DAG resolution logic with mocked subagent workflows."
+      ]
+    },
+    {
+      "id": "640fdf1f-cd6c-4543-9eb5-dbaffad4e745",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "MemGPT Semantic Cluster Virtual Context Pager v2",
+      "description": "Inspired by MemGPT/Letta patterns and Context Compression trends: Introduce a Context Engine plugin that applies local embeddings clustering on episodic memories, automatically evicting or compressing entire redundant thematic clusters to maintain token constraints.",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_pager_v2.py",
+        "tests/test_semantic_pager_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pager identifies redundant thematic clusters across episodic records.",
+        "Evicts or summarizes related records concurrently when threshold is hit.",
+        "Tests mock local embeddings to verify proper cluster eviction logic."
+      ]
+    },
+    {
+      "id": "6d8ad2d6-3cec-40d9-b1bf-68c2995ab826",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Online Reward Propagator v6",
+      "description": "Inspired by OpenClaw-RL implicit feedback trends: Develop an online reinforcement learning propagator that dynamically traces sub-agent execution paths, assigning positive or negative PAD feedback signals recursively up the hierarchy of delegated actions based on user replies.",
+      "allowed_paths": [
+        "magda_agent/learning/reward_propagator_v6.py",
+        "tests/test_reward_propagator_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Reward propagator tracks execution hierarchies using context metadata.",
+        "Implicit feedback properly trickles down and modulates weights across parallel subagents.",
+        "Tests verify weight adjustments through the propagation graph using simulated feedback."
       ]
     }
   ]

--- a/magda_agent/safety/acs_guard_v5.py
+++ b/magda_agent/safety/acs_guard_v5.py
@@ -78,17 +78,11 @@ class ACSGuardV5:
         """
         Checkpoint 3: Tool Policy.
         Checks if the tool complies with defined policies using the PolicyLayer.
+        Delegates to ACSRuntimeGuardV5.
         """
-        tool = workflow_data.get("tool")
-        if tool == "forbidden_tool":
-            return False, f"Tool policy failed: tool '{tool}' is forbidden."
-
-        kwargs = workflow_data.get("kwargs", {})
-        allow, explanation = self.policy_layer.evaluate(tool, **kwargs)
-        if not allow:
-            return False, f"Tool policy failed: {explanation}"
-
-        return True, "Tool policy Passed."
+        from magda_agent.safety.acs_runtime_v5 import ACSRuntimeGuardV5
+        guard = ACSRuntimeGuardV5(policy_layer=self.policy_layer)
+        return guard.evaluate(workflow_data)
 
     def checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
         """

--- a/magda_agent/safety/acs_runtime_v5.py
+++ b/magda_agent/safety/acs_runtime_v5.py
@@ -1,0 +1,47 @@
+import logging
+from typing import Dict, Any, Tuple, Optional
+from magda_agent.safety.policy import PolicyLayer
+
+class ACSRuntimeGuardV5:
+    """
+    ACS Checkpoint 3 (Runtime Safety) policy framework.
+    Evaluates tool calls dynamically using the underlying PolicyLayer.
+    """
+
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None) -> None:
+        self.logger = logging.getLogger(__name__)
+        self.policy_layer = policy_layer or PolicyLayer()
+
+    def checkpoint_3_tool_policy(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Validates the tool call using the policy layer.
+
+        Args:
+            workflow_data: The context data including 'tool' and 'kwargs'.
+
+        Returns:
+            Tuple[bool, str]: (Passed, Reason)
+        """
+        tool = workflow_data.get("tool")
+        if not tool:
+            return False, "Tool policy failed: missing 'tool' field."
+
+        if tool == "forbidden_tool":
+            return False, f"Tool policy failed: tool '{tool}' is explicitly forbidden."
+
+        kwargs = workflow_data.get("kwargs", {})
+        if not isinstance(kwargs, dict):
+            return False, "Tool policy failed: 'kwargs' must be a dictionary."
+
+        allow, explanation = self.policy_layer.evaluate(tool, **kwargs)
+        if not allow:
+            return False, f"Tool policy failed: {explanation}"
+
+        return True, "Tool policy passed."
+
+    def evaluate(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Main entry point for evaluating runtime safety.
+        Delegates to checkpoint_3_tool_policy.
+        """
+        return self.checkpoint_3_tool_policy(workflow_data)

--- a/tests/test_acs_guard_v5.py
+++ b/tests/test_acs_guard_v5.py
@@ -70,7 +70,7 @@ def test_checkpoint_3_tool_policy(acs_guard: ACSGuardV5, mock_policy_layer: Magi
     # Fail - forbidden_tool
     passed, reason = acs_guard.checkpoint_3_tool_policy({"tool": "forbidden_tool"})
     assert not passed
-    assert "is forbidden" in reason
+    assert "is explicitly forbidden" in reason
 
     # Fail - PolicyLayer denial
     mock_policy_layer.evaluate.return_value = (False, "Policy denial")
@@ -167,7 +167,7 @@ def test_intercept_action(acs_guard: ACSGuardV5, mock_audit_trail: MagicMock) ->
     mock_audit_trail.log_call.assert_called_with(
         tool_name="forbidden_tool",
         kwargs={},
-        why="ACS Checkpoint 3 Failed: Tool policy failed: tool 'forbidden_tool' is forbidden.",
+        why="ACS Checkpoint 3 Failed: Tool policy failed: tool 'forbidden_tool' is explicitly forbidden.",
         result="blocked",
         duration=0.0
     )

--- a/tests/test_acs_runtime_v5.py
+++ b/tests/test_acs_runtime_v5.py
@@ -1,0 +1,39 @@
+import pytest
+from magda_agent.safety.acs_runtime_v5 import ACSRuntimeGuardV5
+
+class MockPolicyLayer:
+    def evaluate(self, tool: str, **kwargs) -> tuple[bool, str]:
+        if tool == "mock_safe_tool":
+            return True, "Safe."
+        if tool == "mock_unsafe_tool":
+            return False, "Unsafe operation."
+        return False, "Unknown tool."
+
+@pytest.fixture
+def guard():
+    return ACSRuntimeGuardV5(policy_layer=MockPolicyLayer())
+
+def test_missing_tool(guard):
+    passed, reason = guard.evaluate({"action": "execute", "kwargs": {}})
+    assert not passed
+    assert "missing 'tool' field" in reason
+
+def test_forbidden_tool(guard):
+    passed, reason = guard.evaluate({"tool": "forbidden_tool", "kwargs": {}})
+    assert not passed
+    assert "explicitly forbidden" in reason
+
+def test_invalid_kwargs(guard):
+    passed, reason = guard.evaluate({"tool": "mock_safe_tool", "kwargs": "invalid"})
+    assert not passed
+    assert "'kwargs' must be a dictionary" in reason
+
+def test_safe_tool(guard):
+    passed, reason = guard.evaluate({"tool": "mock_safe_tool", "kwargs": {}})
+    assert passed
+    assert "Tool policy passed" in reason
+
+def test_unsafe_tool(guard):
+    passed, reason = guard.evaluate({"tool": "mock_unsafe_tool", "kwargs": {}})
+    assert not passed
+    assert "Tool policy failed: Unsafe operation." in reason


### PR DESCRIPTION
This PR implements the `ACSRuntimeGuardV5` component as specified in the `acs-guardrail-runtime-v5-e48c3980` task.

**Changes:**
1.  **Implementation:** Created `magda_agent/safety/acs_runtime_v5.py` which houses the `ACSRuntimeGuardV5` class. This class implements the core logic for the ACS Checkpoint 3 (Runtime Safety), validating tool calls dynamically using the `PolicyLayer`.
2.  **Testing:** Created comprehensive unit tests in `tests/test_acs_runtime_v5.py` utilizing a mocked `PolicyLayer` to ensure isolation and verify behavior under various scenarios (missing tool, forbidden tool, invalid kwargs, safe/unsafe tool executions).
3.  **Integration:** Integrated `ACSRuntimeGuardV5` into the broader architecture by patching `ACSGuardV5.checkpoint_3_tool_policy` in `magda_agent/safety/acs_guard_v5.py` to delegate its logic to the new `ACSRuntimeGuardV5` instance.
4.  **Task Manifest Updates:** Marked the target task `acs-guardrail-runtime-v5-e48c3980` as `done` in `agent_tasks.json`. Added 3 new tasks (`todo`) to the manifest based on June 2026 AI Agent Trends (Magentic-One Task Dependency Resolution, MemGPT Semantic Cluster Virtual Context Pager, and OpenClaw-RL Online Reward Propagator).
5.  **Quality Checks:** Ran `scripts/validate_agent_tasks.py` and the full `pytest` suite to ensure no regressions were introduced. Removed all temporary execution scripts from the workspace.

---
*PR created automatically by Jules for task [8702470960643252110](https://jules.google.com/task/8702470960643252110) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement ACS Guardrails Runtime Policy v5 via `ACSRuntimeGuardV5`
> - Extracts checkpoint 3 tool policy logic from [`ACSGuardV5`](https://github.com/kazah4359-lgtm/Magda-agent/pull/403/files#diff-5ba2388ae117cb14555d4621c705b6f0a28ea1a39a765c16bb2172955f3c3b6c) into a new [`ACSRuntimeGuardV5`](https://github.com/kazah4359-lgtm/Magda-agent/pull/403/files#diff-f9404f9f1569b82b623296cb4b632089836967551eabd72e0f725c35d0433c26) class with an `evaluate` method.
> - `ACSRuntimeGuardV5` validates that `tool` is present, rejects explicitly forbidden tools, ensures `kwargs` is a dict, and delegates to `PolicyLayer.evaluate`.
> - Behavioral Change: failure messages now use 'is explicitly forbidden' instead of 'is forbidden', and new validation errors are raised for missing `tool` and non-dict `kwargs`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5506d69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->