### PR TITLE
feat: Implement Agent-generated code longitudinal tracker

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10380,7 +10380,7 @@
     },
     {
       "id": "b074131c-9004-48dc-9d88-feb29e8ba1c2",
-      "status": "todo",
+      "status": "done",
       "area": "metacognition",
       "risk": "low",
       "title": "Agent-generated code longitudinal tracker",
@@ -13691,6 +13691,57 @@
         "Reward propagator tracks execution hierarchies using context metadata.",
         "Implicit feedback properly trickles down and modulates weights across parallel subagents.",
         "Tests verify weight adjustments through the propagation graph using simulated feedback."
+      ]
+    },
+    {
+      "id": "eae22bdf-ac48-486d-ba69-38dbb06ecf2a",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "A2A Distributed Telemetry Collection v8",
+      "description": "Inspired by A2A standard trend: Create a module that collects sub-agent telemetry events and broadcasts them over the A2A network.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_distributed_v8.py",
+        "tests/test_a2a_distributed_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry module tracks distributed events.",
+        "Tests mock A2A broadcasting and verify payload generation."
+      ]
+    },
+    {
+      "id": "34786d8b-7329-4f97-b93e-ada7d9ab06ac",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Concurrency v4",
+      "description": "Inspired by MCP runtime concurrency trend: Safely execute MCP action tools concurrently.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_v4.py",
+        "tests/test_mcp_concurrency_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Action tools run concurrently.",
+        "Tests mock execution."
+      ]
+    },
+    {
+      "id": "ef032098-856e-4e96-8e46-383cfbd55bbd",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Virtual Context Compression V4",
+      "description": "Inspired by MemGPT context management trend: Context engine plugin for context compression.",
+      "allowed_paths": [
+        "magda_agent/memory/context_plugin_v4.py",
+        "tests/test_context_plugin_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin handles context compression.",
+        "Tests mock memory stores."
       ]
     }
   ]

--- a/magda_agent/metacognition/longitudinal_tracker.py
+++ b/magda_agent/metacognition/longitudinal_tracker.py
@@ -1,0 +1,89 @@
+import sqlite3
+import json
+from typing import Dict, Any, List, Optional
+import os
+
+
+class LongitudinalTracker:
+    """
+    A longitudinal tracker for agent-generated code.
+    Records PR outcomes and test failures in an SQLite database.
+    """
+    def __init__(self, db_path: str = "longitudinal_metrics.db", max_entries: int = 1000):
+        """
+        Initializes the LongitudinalTracker.
+
+        Args:
+            db_path (str): The path to the SQLite database file.
+            max_entries (int): The maximum number of entries to store.
+        """
+        self.db_path = db_path
+        self.max_entries = max_entries
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the SQLite database schema."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS pr_metrics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    pr_id TEXT NOT NULL,
+                    outcome TEXT NOT NULL,
+                    test_failures INTEGER NOT NULL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+            conn.commit()
+
+    def record_pr_outcome(self, pr_id: str, outcome: str, test_failures: int) -> None:
+        """
+        Records the outcome of a PR and its test failures.
+
+        Args:
+            pr_id (str): The identifier of the Pull Request.
+            outcome (str): The outcome of the PR (e.g., 'success', 'failure').
+            test_failures (int): The number of test failures in the PR.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                INSERT INTO pr_metrics (pr_id, outcome, test_failures)
+                VALUES (?, ?, ?)
+            ''', (pr_id, outcome, test_failures))
+
+            # Enforce bounds
+            cursor.execute('''
+                DELETE FROM pr_metrics
+                WHERE id NOT IN (
+                    SELECT id FROM pr_metrics
+                    ORDER BY id DESC
+                    LIMIT ?
+                )
+            ''', (self.max_entries,))
+
+            conn.commit()
+
+    def get_summary(self) -> Dict[str, Any]:
+        """
+        Retrieves a summary of the longitudinal metrics.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing total PRs, success rate, and total test failures.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute('SELECT COUNT(*), SUM(CASE WHEN outcome = "success" THEN 1 ELSE 0 END), SUM(test_failures) FROM pr_metrics')
+            row = cursor.fetchone()
+
+            total_prs = row[0] if row[0] is not None else 0
+            successful_prs = row[1] if row[1] is not None else 0
+            total_failures = row[2] if row[2] is not None else 0
+
+            success_rate = (successful_prs / total_prs) * 100 if total_prs > 0 else 0.0
+
+            return {
+                "total_prs": total_prs,
+                "success_rate": round(success_rate, 2),
+                "total_test_failures": total_failures
+            }

--- a/tests/test_longitudinal_tracker.py
+++ b/tests/test_longitudinal_tracker.py
@@ -1,0 +1,85 @@
+import pytest
+import sqlite3
+import os
+from magda_agent.metacognition.longitudinal_tracker import LongitudinalTracker
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    """Fixture to provide a temporary database path for tests."""
+    db_path = tmp_path / "test_metrics.db"
+    yield str(db_path)
+
+
+def test_tracker_initialization(temp_db):
+    """Test that the tracker initializes the database correctly."""
+    tracker = LongitudinalTracker(db_path=temp_db)
+
+    assert os.path.exists(temp_db)
+
+    # Verify the table exists
+    with sqlite3.connect(temp_db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='pr_metrics'")
+        assert cursor.fetchone() is not None
+
+
+def test_record_pr_outcome(temp_db):
+    """Test recording PR outcomes."""
+    tracker = LongitudinalTracker(db_path=temp_db)
+
+    tracker.record_pr_outcome("PR-1", "success", 0)
+    tracker.record_pr_outcome("PR-2", "failure", 5)
+
+    with sqlite3.connect(temp_db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT pr_id, outcome, test_failures FROM pr_metrics ORDER BY id")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 2
+        assert rows[0] == ("PR-1", "success", 0)
+        assert rows[1] == ("PR-2", "failure", 5)
+
+
+def test_get_summary(temp_db):
+    """Test the summary method."""
+    tracker = LongitudinalTracker(db_path=temp_db)
+
+    # Empty DB
+    summary = tracker.get_summary()
+    assert summary["total_prs"] == 0
+    assert summary["success_rate"] == 0.0
+    assert summary["total_test_failures"] == 0
+
+    # Add data
+    tracker.record_pr_outcome("PR-1", "success", 0)
+    tracker.record_pr_outcome("PR-2", "failure", 3)
+    tracker.record_pr_outcome("PR-3", "success", 0)
+
+    summary = tracker.get_summary()
+    assert summary["total_prs"] == 3
+    assert summary["success_rate"] == 66.67
+    assert summary["total_test_failures"] == 3
+
+
+def test_bounded_storage(temp_db):
+    """Test that the tracker respects the max_entries limit."""
+    tracker = LongitudinalTracker(db_path=temp_db, max_entries=2)
+
+    tracker.record_pr_outcome("PR-1", "success", 0)
+    tracker.record_pr_outcome("PR-2", "failure", 3)
+    tracker.record_pr_outcome("PR-3", "success", 0)
+
+    with sqlite3.connect(temp_db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT pr_id FROM pr_metrics ORDER BY id")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 2
+        assert rows[0][0] == "PR-2"
+        assert rows[1][0] == "PR-3"
+
+    summary = tracker.get_summary()
+    assert summary["total_prs"] == 2
+    assert summary["success_rate"] == 50.0
+    assert summary["total_test_failures"] == 3


### PR DESCRIPTION
This PR fulfills the task `b074131c-9004-48dc-9d88-feb29e8ba1c2`.

It implements a background metric collector (`LongitudinalTracker`) that analyzes the success rate and test failures of the agent's PRs over time to identify brittle generated code. The metrics are stored in a bounded SQLite table.

The PR includes unit tests for all methods (initialization, bounded storage, data logging, summary logic). 

It also adds 3 new tasks to `agent_tasks.json` as per the autonomous operation requirements.

---
*PR created automatically by Jules for task [2984442985084523003](https://jules.google.com/task/2984442985084523003) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SQLite-backed `LongitudinalTracker` for PR metrics in agent metacognition
> - Adds [longitudinal_tracker.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/404/files#diff-37851e6a4aa5343aed708f549c4fb54b7402684f71da21e9a47b1f4f0377b8a7) with a `LongitudinalTracker` class that persists PR outcomes (success/failure, test failure counts) to a SQLite database.
> - `record_pr_outcome` inserts rows into a `pr_metrics` table and prunes entries beyond a configurable `max_entries` limit.
> - `get_summary` returns aggregate stats: total PRs, success rate, and total test failures.
> - Adds [tests/test_longitudinal_tracker.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/404/files#diff-7ec7f2fd254071edfe983b2d502502b7c29a4904445988ad25f2f0b5f12ff946) covering initialization, insertion, summarization, and pruning using a temporary SQLite database.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f5d102.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->