### PR TITLE
feat(agents): implement claude multi-agent spawning v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6637,7 +6637,7 @@
     },
     {
       "id": "claude-multi-agent-spawning-v3",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "Claude multi-agent spawning v3",
@@ -13793,6 +13793,57 @@
       "acceptance": [
         "Procedural memories are isolated and recall correctly.",
         "Tests mock DB logic."
+      ]
+    },
+    {
+      "id": "96c3b83b-8572-42d7-9ec1-e4041374df51",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Discovery Agent Card Broadcaster V4",
+      "description": "Inspired by A2A standard trend: Implement an agent discovery component that periodically broadcasts the agent's capabilities via Agent Card formatting over network.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v4.py",
+        "tests/test_a2a_discovery_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent capabilities are broadcasted correctly.",
+        "Tests verify payload format."
+      ]
+    },
+    {
+      "id": "f5a908a1-4008-47a8-8cb1-60faf53ff94a",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Dynamic Verification Sandbox Hook V2",
+      "description": "Inspired by MCP policy layer trends: Implement a dynamic execution hook for intercepting and sandboxing external MCP action tools during runtime.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_sandbox_hook_v2.py",
+        "tests/test_mcp_sandbox_hook_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Hook intercepts and sandboxes external calls.",
+        "Tests mock hook behavior."
+      ]
+    },
+    {
+      "id": "69833305-d25f-4b77-9472-65747ad0e5f4",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "MemGPT Virtual Context Compression Trigger V3",
+      "description": "Inspired by MemGPT virtual context trend: Introduce a subagent trigger specifically responsible for periodic context compression of long dialogue history.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_compression_trigger_v3.py",
+        "tests/test_virtual_compression_trigger_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trigger initiates compression when context exceeds threshold.",
+        "Tests verify threshold detection and compression call."
       ]
     }
   ]

--- a/magda_agent/agents/multi_agent_manager_v3.py
+++ b/magda_agent/agents/multi_agent_manager_v3.py
@@ -1,0 +1,57 @@
+import asyncio
+from typing import List, Dict, Optional
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+
+
+class MultiAgentManagerV3:
+    """
+    Manager for spawning and orchestrating multiple subagents concurrently.
+    Inspired by Claude Agent Teams.
+    """
+
+    def __init__(self, llm: LLMClient):
+        """
+        Initializes the MultiAgentManagerV3.
+
+        Args:
+            llm (LLMClient): The LLMClient instance to provide to subagents.
+        """
+        self.llm = llm
+
+    def spawn_subagent(self, system_prompt: Optional[str] = None, use_isolation: bool = False) -> SubAgent:
+        """
+        Spawns a single subagent with the given system prompt.
+
+        Args:
+            system_prompt (Optional[str]): The system prompt to configure the subagent with.
+            use_isolation (bool): Whether the subagent should run in an isolated environment.
+
+        Returns:
+            SubAgent: The configured SubAgent instance.
+        """
+        return SubAgent(llm=self.llm, system_prompt=system_prompt, use_isolation=use_isolation)
+
+    async def run_parallel_tasks(self, tasks: List[Dict[str, str]], context: str, use_isolation: bool = False) -> List[str]:
+        """
+        Runs multiple tasks in parallel using spawned subagents.
+
+        Args:
+            tasks (List[Dict[str, str]]): A list of dictionaries, where each dictionary
+                                          contains 'task' (required) and 'system_prompt' (optional).
+            context (str): The shared parent context to provide to all subagents.
+            use_isolation (bool): Whether the subagents should run in isolated environments.
+
+        Returns:
+            List[str]: A list of results from each executed subagent task.
+        """
+        coroutines = []
+        for task_info in tasks:
+            task_desc = task_info.get('task', '')
+            system_prompt = task_info.get('system_prompt')
+            subagent = self.spawn_subagent(system_prompt=system_prompt, use_isolation=use_isolation)
+            coroutines.append(subagent.execute(task=task_desc, context=context))
+
+        results = await asyncio.gather(*coroutines)
+        return list(results)

--- a/plan.txt
+++ b/plan.txt
@@ -1,0 +1,22 @@
+1. Read the required documents. I've read `AGENTS.md`, `docs/cognitive_architecture.md`, `docs/jules_autonomous_loop.md`, `docs/codex_worker_plan.md`, `docs/trends.md`.
+2. I found the first task with status "todo":
+`id`: `claude-multi-agent-spawning-v3`
+`title`: `Claude multi-agent spawning v3`
+`allowed_paths`:
+- `magda_agent/agents/multi_agent_manager_v3.py`
+- `tests/test_multi_agent_manager_v3.py`
+- `agent_tasks.json`
+
+3. Implement `magda_agent/agents/multi_agent_manager_v3.py`.
+It should have a `MultiAgentManagerV3` class with methods to spawn subagents, assign tasks, and gather results, potentially running concurrently via asyncio. It should accept an `LLMClient` to give to the `SubAgent`s.
+
+4. Implement `tests/test_multi_agent_manager_v3.py`.
+Use `pytest_asyncio` and `AsyncMock` to mock `LLMClient.chat_completion`. Ensure testing concurrent spawning.
+
+5. Update `agent_tasks.json` to mark `claude-multi-agent-spawning-v3` as "done".
+
+6. Generate 2-3 NEW "todo" tasks in `agent_tasks.json` based on the trends read. Use explicit UUIDs, low/medium risk.
+
+7. Update `backlog.md` if the task exists there. Let's check `backlog.md` for `Claude multi-agent spawning v3`.
+
+8. Pre-commit check using `python scripts/validate_agent_tasks.py agent_tasks.json` and running pytest.

--- a/tests/test_multi_agent_manager_v3.py
+++ b/tests/test_multi_agent_manager_v3.py
@@ -1,0 +1,50 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, patch
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.multi_agent_manager_v3 import MultiAgentManagerV3
+from magda_agent.agents.sub_agent import SubAgent
+
+@pytest.fixture
+def mock_llm_client():
+    llm = LLMClient(api_key="test-key")
+    llm.chat_completion = AsyncMock()
+    llm.chat_completion.return_value = "Mocked subagent response"
+    return llm
+
+@pytest.fixture
+def mock_subagent_compressor():
+    with patch("magda_agent.agents.sub_agent.SubagentContextCompressor") as mock:
+        compressor_instance = mock.return_value
+        compressor_instance.compress_context = AsyncMock(side_effect=lambda ctx: ctx)
+        yield compressor_instance
+
+def test_spawn_subagent(mock_llm_client, mock_subagent_compressor):
+    manager = MultiAgentManagerV3(llm=mock_llm_client)
+    subagent = manager.spawn_subagent(system_prompt="Test Prompt", use_isolation=False)
+
+    assert isinstance(subagent, SubAgent)
+    assert subagent.llm == mock_llm_client
+    assert subagent.system_prompt == "Test Prompt"
+    assert subagent.use_isolation is False
+
+@pytest.mark.asyncio
+async def test_run_parallel_tasks(mock_llm_client, mock_subagent_compressor):
+    manager = MultiAgentManagerV3(llm=mock_llm_client)
+    tasks = [
+        {"task": "Task 1", "system_prompt": "Prompt 1"},
+        {"task": "Task 2", "system_prompt": "Prompt 2"}
+    ]
+    context = "Shared Context"
+
+    # Mocking chat_completion on LLMClient
+    mock_llm_client.chat_completion.side_effect = ["Response 1", "Response 2"]
+
+    results = await manager.run_parallel_tasks(tasks, context, use_isolation=False)
+
+    assert len(results) == 2
+    assert "Response" in results[0]
+    assert "Response" in results[1]
+
+    assert mock_llm_client.chat_completion.call_count == 2


### PR DESCRIPTION
This PR completes the `claude-multi-agent-spawning-v3` task by implementing the `MultiAgentManagerV3` component. 

Key changes:
- `magda_agent/agents/multi_agent_manager_v3.py`: Implementation of `MultiAgentManagerV3` capable of spawning concurrent `SubAgent`s.
- `tests/test_multi_agent_manager_v3.py`: Mocked tests to ensure `MultiAgentManagerV3` functionality.
- `agent_tasks.json`: Marked task as `done` and added 3 new explicitly structured low/medium risk `todo` tasks based on upcoming 2026 AI trends (`A2A Discovery Agent Card Broadcaster V4`, `MCP Dynamic Verification Sandbox Hook V2`, `MemGPT Virtual Context Compression Trigger V3`).

---
*PR created automatically by Jules for task [5917646928744222305](https://jules.google.com/task/5917646928744222305) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MultiAgentManagerV3` to spawn and run SubAgent tasks concurrently
> - Adds [`multi_agent_manager_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/406/files#diff-8b5c46b7a3e1d5487394bdb7060f34a87cb08d05f0e47a708f04e00db8f2df49) with `MultiAgentManagerV3`, which accepts an `LLMClient` and exposes `spawn_subagent` (factory for configured `SubAgent` instances) and `run_parallel_tasks` (runs tasks concurrently via `asyncio.gather`).
> - Adds unit and async tests in [`tests/test_multi_agent_manager_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/406/files#diff-d0b7ba0927c5cb2efebeca303256927513abf6781cdaae608ec8bc51ba34a426) covering subagent creation and parallel task execution with mocked `LLMClient`.
> - Updates `agent_tasks.json` with three new TODO tasks and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7301d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->