### PR TITLE
feat: Implement MCP Router V3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6653,7 +6653,7 @@
     },
     {
       "id": "mcp-server-prefixed-tools-v3",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Server Prefixed Tools",
@@ -13844,6 +13844,60 @@
       "acceptance": [
         "Trigger initiates compression when context exceeds threshold.",
         "Tests verify threshold detection and compression call."
+      ]
+    },
+    {
+      "id": "a961f497-7231-4129-b058-bc19f8a5ab8e",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes-inspired Dynamic Skill Optimizer V2",
+      "description": "Inspired by Hermes Agent learning loop: Create a module that observes the output of standard skills and, upon consecutive successful executions, dynamically generates an optimized, cached version of the skill to reduce token usage and latency.",
+      "allowed_paths": [
+        "magda_agent/skills/dynamic_optimizer_v2.py",
+        "tests/test_dynamic_optimizer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Optimizer detects consecutive successful executions of a skill.",
+        "Generates and registers an optimized cached version.",
+        "Tests verify detection and registration using mocked skill executions."
+      ]
+    },
+    {
+      "id": "ff002869-57a4-4a3b-a7ae-f96da0500728",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCPKernel Taint Tracking Sandbox V3",
+      "description": "Inspired by MCPKernel standard trend: Implement a runtime sandbox wrapper for MCP tool execution that tracks tainted inputs (e.g., untrusted user strings) and blocks them from reaching sensitive tool arguments (like file paths or command payloads).",
+      "allowed_paths": [
+        "magda_agent/safety/mcpkernel_sandbox_v3.py",
+        "tests/test_mcpkernel_sandbox_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox wrapper successfully tracks tainted input variables.",
+        "Execution is blocked if tainted data is passed to sensitive arguments.",
+        "Tests verify block and allow paths using mock tainted data."
+      ]
+    },
+    {
+      "id": "ffcc3daa-d337-460a-8e3d-9686ec7a1ede",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "A2A Peer Delegation Routing V2",
+      "description": "Inspired by the Agent-to-Agent (A2A) protocol trend: Implement a routing mechanism that allows Magda to evaluate a task's complexity and delegate it to a specialized peer sub-agent network using Agent Cards for capability matching.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_peer_routing_v2.py",
+        "tests/test_a2a_peer_routing_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Router evaluates task complexity and matches it to a peer agent via Agent Card capabilities.",
+        "Task is delegated successfully if a match is found.",
+        "Tests verify matching logic and mock delegation payload."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_router_v3.py
+++ b/magda_agent/skills/mcp_router_v3.py
@@ -1,0 +1,61 @@
+import logging
+from typing import Dict, Any, List, Optional, Callable
+
+class MCPRouterV3:
+    """
+    Router that handles tools with server prefixes, according to MCP standard trends.
+    It can route tool calls of the form 'server_name_tool_name' to the appropriate server handler.
+    """
+
+    def __init__(self):
+        """Initializes the MCP Router V3."""
+        # Maps server name to a routing function that handles that server's tools
+        self.server_handlers: Dict[str, Callable[[str, Dict[str, Any]], Any]] = {}
+
+    def register_server(self, server_name: str, handler: Callable[[str, Dict[str, Any]], Any]) -> None:
+        """
+        Registers a handler for a specific server prefix.
+
+        Args:
+            server_name (str): The prefix used to identify the server.
+            handler (Callable): Function that takes (tool_name, tool_arguments) and returns a result.
+        """
+        self.server_handlers[server_name] = handler
+        logging.info(f"Registered MCP server handler for prefix: {server_name}")
+
+    def route_tool(self, tool_call_name: str, arguments: Dict[str, Any]) -> Any:
+        """
+        Routes a tool call by its prefixed name.
+
+        Args:
+            tool_call_name (str): The full tool name, e.g., 'weather_server_get_forecast'.
+            arguments (Dict[str, Any]): The arguments for the tool call.
+
+        Returns:
+            Any: The result of the routed tool execution.
+
+        Raises:
+            ValueError: If the tool name does not contain a prefix, or if the server prefix is unknown.
+        """
+        if "_" not in tool_call_name:
+            raise ValueError(f"Tool name '{tool_call_name}' must be prefixed with a server name (e.g., 'server_tool').")
+
+        # We split on the first underscore only, assuming the format is <server_name>_<tool_name>
+        # Alternatively, we could iterate over registered server names to find a prefix match.
+        # Let's find the longest matching registered server prefix.
+
+        matched_server = None
+        matched_tool = None
+
+        for server_name in sorted(self.server_handlers.keys(), key=len, reverse=True):
+            prefix = f"{server_name}_"
+            if tool_call_name.startswith(prefix):
+                matched_server = server_name
+                matched_tool = tool_call_name[len(prefix):]
+                break
+
+        if not matched_server:
+            raise ValueError(f"No registered MCP server handler found for tool: {tool_call_name}")
+
+        handler = self.server_handlers[matched_server]
+        return handler(matched_tool, arguments)

--- a/tests/test_mcp_router_v3.py
+++ b/tests/test_mcp_router_v3.py
@@ -1,0 +1,48 @@
+import pytest
+from magda_agent.skills.mcp_router_v3 import MCPRouterV3
+
+def test_register_server():
+    router = MCPRouterV3()
+    def mock_handler(tool, args): pass
+
+    router.register_server("test_server", mock_handler)
+    assert "test_server" in router.server_handlers
+
+def test_route_tool_success():
+    router = MCPRouterV3()
+
+    def weather_handler(tool_name, args):
+        if tool_name == "get_forecast":
+            return f"Weather for {args.get('location')} is sunny."
+        return "Unknown weather tool"
+
+    router.register_server("weather", weather_handler)
+
+    result = router.route_tool("weather_get_forecast", {"location": "London"})
+    assert result == "Weather for London is sunny."
+
+def test_route_tool_longest_prefix():
+    router = MCPRouterV3()
+
+    router.register_server("db", lambda t, a: f"db: {t}")
+    router.register_server("db_admin", lambda t, a: f"db_admin: {t}")
+
+    # Should match db_admin, not db
+    res1 = router.route_tool("db_admin_drop_table", {})
+    assert res1 == "db_admin: drop_table"
+
+    res2 = router.route_tool("db_query", {})
+    assert res2 == "db: query"
+
+def test_route_tool_missing_prefix():
+    router = MCPRouterV3()
+
+    with pytest.raises(ValueError, match="must be prefixed with a server name"):
+        router.route_tool("noprefix", {})
+
+def test_route_tool_unknown_server():
+    router = MCPRouterV3()
+    router.register_server("weather", lambda t, a: None)
+
+    with pytest.raises(ValueError, match="No registered MCP server handler found"):
+        router.route_tool("unknown_get_data", {})


### PR DESCRIPTION
This PR introduces the `MCPRouterV3` class, addressing the `mcp-server-prefixed-tools-v3` task. It routes tools prefixed with server names (e.g., `server_toolname`) using a longest-prefix matching algorithm.

Also:
- Includes comprehensive pytest tests covering registration, routing success, longest-prefix matching, and failure conditions.
- Updates the `agent_tasks.json` backlog by marking this task as done and appending 3 new trend-inspired tasks (Hermes-inspired Optimizer, MCPKernel Taint Sandbox, A2A Peer Routing).

---
*PR created automatically by Jules for task [9706287664647490993](https://jules.google.com/task/9706287664647490993) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPRouterV3` class to route prefixed tool calls using longest-prefix matching
> - Introduces [mcp_router_v3.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/407/files#diff-7715c963f5a679f67a3648ebed8fffdb55df6f73f77e295582b356bbca00117f) with `MCPRouterV3`, a router that maps server name prefixes to handler callables and dispatches `<server>_<tool>` calls to the correct handler.
> - `register_server` stores a handler under a given prefix; `route_tool` selects the longest matching prefix, strips it, and calls the handler with `(tool_name, arguments)`.
> - Raises `ValueError` when the tool name contains no prefix or the prefix is not registered.
> - Adds tests covering registration, successful routing, longest-prefix selection, and both error cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4e9824.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->