### PR TITLE
Update agent_tasks.json: complete task and add new ones

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6686,7 +6686,7 @@
     },
     {
       "id": "openclaw-rl-next-state-signals-v1-d14a492a",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Next-State Signals capture",
@@ -13898,6 +13898,60 @@
         "Router evaluates task complexity and matches it to a peer agent via Agent Card capabilities.",
         "Task is delegated successfully if a match is found.",
         "Tests verify matching logic and mock delegation payload."
+      ]
+    },
+    {
+      "id": "a2a-discovery-agent-card-validation-v5-6af99633",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Agent Card Dynamic Validation V5",
+      "description": "Inspired by the A2A standard trend in docs/trends.md: Implement dynamic JSON schema validation for incoming Agent Cards during network discovery to ensure enterprise-ready interoperability and security.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v5.py",
+        "tests/test_a2a_discovery_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2ADiscovery applies strict schema validation to discovered Agent Cards.",
+        "Invalid or malformed Agent Cards are rejected and logged.",
+        "Tests verify schema validation with valid and mock invalid cards."
+      ]
+    },
+    {
+      "id": "acs-guard-checkpoint-runtime-v7-4e1d186a",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Agent Control Specification Runtime Guard V7",
+      "description": "Inspired by the ACS standard trend from docs/trends.md: Introduce a robust ACS runtime validation guardrail module that intercepts all tool executions, evaluating them against 5 validation checkpoints for policy adherence.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_runtime_v7.py",
+        "tests/test_acs_guard_runtime_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACSGuard evaluates tool executions against predefined runtime policies.",
+        "Execution is blocked if any of the ACS validation checkpoints fail.",
+        "Pytest verification with mock executions ensures blocks and passes correctly."
+      ]
+    },
+    {
+      "id": "agent-teams-git-worktree-isolation-v4-6cee8930",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Agent Teams Git Worktree Isolation V4",
+      "description": "Inspired by the Claude Agent SDK pattern in docs/trends.md: Develop a mechanism to spawn independent Git worktrees for parallel Agent Teams, preventing merge conflicts across concurrent generation tasks.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_v4.py",
+        "tests/test_agent_teams_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "AgentTeamManager creates independent Git worktrees for assigned sub-agents.",
+        "Sub-agents operate within their isolated worktrees successfully.",
+        "Mock tests confirm worktree creation and isolation."
       ]
     }
   ]

--- a/plan.txt
+++ b/plan.txt
@@ -1,22 +1,7 @@
-1. Read the required documents. I've read `AGENTS.md`, `docs/cognitive_architecture.md`, `docs/jules_autonomous_loop.md`, `docs/codex_worker_plan.md`, `docs/trends.md`.
-2. I found the first task with status "todo":
-`id`: `claude-multi-agent-spawning-v3`
-`title`: `Claude multi-agent spawning v3`
-`allowed_paths`:
-- `magda_agent/agents/multi_agent_manager_v3.py`
-- `tests/test_multi_agent_manager_v3.py`
-- `agent_tasks.json`
-
-3. Implement `magda_agent/agents/multi_agent_manager_v3.py`.
-It should have a `MultiAgentManagerV3` class with methods to spawn subagents, assign tasks, and gather results, potentially running concurrently via asyncio. It should accept an `LLMClient` to give to the `SubAgent`s.
-
-4. Implement `tests/test_multi_agent_manager_v3.py`.
-Use `pytest_asyncio` and `AsyncMock` to mock `LLMClient.chat_completion`. Ensure testing concurrent spawning.
-
-5. Update `agent_tasks.json` to mark `claude-multi-agent-spawning-v3` as "done".
-
-6. Generate 2-3 NEW "todo" tasks in `agent_tasks.json` based on the trends read. Use explicit UUIDs, low/medium risk.
-
-7. Update `backlog.md` if the task exists there. Let's check `backlog.md` for `Claude multi-agent spawning v3`.
-
-8. Pre-commit check using `python scripts/validate_agent_tasks.py agent_tasks.json` and running pytest.
+1. We need to implement `openclaw-rl-next-state-signals-v1-d14a492a` task.
+2. The current implementation in `magda_agent/learning/online_rl.py` and `tests/test_online_rl.py` is fully implemented and passes all the tests!
+3. The only required steps:
+- Mark the task `openclaw-rl-next-state-signals-v1-d14a492a` as completed ("done") in `agent_tasks.json`.
+- Add 2-3 NEW "todo" tasks to `agent_tasks.json` inspired by docs/trends.md.
+- Ensure `agent_tasks.json` passes validation with `python scripts/validate_agent_tasks.py agent_tasks.json`.
+- Commit the changes and submit.


### PR DESCRIPTION
This PR updates the `agent_tasks.json` file. It marks the `openclaw-rl-next-state-signals-v1-d14a492a` task as completed since the related logic in `magda_agent/learning/online_rl.py` and its tests in `tests/test_online_rl.py` have already been fully implemented. In addition, it appends 3 new tasks to the backlog based on current trends observed in `docs/trends.md`.

---
*PR created automatically by Jules for task [12825204843007894806](https://jules.google.com/task/12825204843007894806) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add three new tasks and mark one task as done in `agent_tasks.json`
> - Marks task `openclaw-rl-next-state-signals-v1-d14a492a` as `done` in [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/409/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205).
> - Appends three new `todo` tasks: `a2a-discovery-agent-card-validation-v5-6af99633`, `acs-guard-checkpoint-runtime-v7-4e1d186a`, and `agent-teams-git-worktree-isolation-v4-6cee8930`, each with area, risk, allowed_paths, and acceptance criteria.
> - Updates [plan.txt](https://github.com/kazah4359-lgtm/Magda-agent/pull/409/files#diff-e74802dd92c7421316b3a3f023197ec08cffd054cb1c91cdb70c9a7eda7fa864) to reflect the new plan focused on these task additions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b4968c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->