### PR TITLE
feat(memory): Implement Context Engine Plugin Lifecycle Hooks v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6720,7 +6720,7 @@
     },
     {
       "id": "context-engine-plugin-lifecycle-v5-6804",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "low",
       "title": "Context Engine Plugin Lifecycle Hooks v5",
@@ -14003,6 +14003,57 @@
       "acceptance": [
         "A2A execution hook successfully evaluates tool calls through safety checkpoints.",
         "Mock executions confirm tainted peer parameters block execution."
+      ]
+    },
+    {
+      "id": "47c649d8-ed2b-40bc-99b4-122e210d7b91",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Semantic Clustering V2",
+      "description": "Inspired by MemGPT/Letta patterns: Implement an advanced context engine hook that clusters related episodic memories semantically to compress the working context effectively.",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_clustering_v2.py",
+        "tests/test_semantic_clustering_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Hook successfully clusters episodic memories based on semantic tags.",
+        "Tests mock memory stores and verify token reduction."
+      ]
+    },
+    {
+      "id": "6fed0f15-f976-4ce8-afe4-187237a11c25",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Agent Teams Worktree State Diffing V1",
+      "description": "Inspired by Claude Agent SDK Agent Teams: Implement a robust state diffing utility that evaluates isolation leaks across subagent git worktrees prior to state merges.",
+      "allowed_paths": [
+        "magda_agent/architecture/worktree_diffing_v1.py",
+        "tests/test_worktree_diffing_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Diffing utility strictly identifies cross-contamination.",
+        "Tests mock isolated worktrees and simulate leaks."
+      ]
+    },
+    {
+      "id": "8de63680-bfd0-44c1-a314-23b76d215261",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Action Tool Rate Limiting V1",
+      "description": "Inspired by MCP action tools standardization (65% growth): Introduce a strict token-bucket based rate limiting guardrail specifically tailored for MCP action tools to prevent runaway external side-effects.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_rate_limiting_v1.py",
+        "tests/test_mcp_rate_limiting_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Guardrail correctly blocks excessive MCP tool requests.",
+        "Tests verify the token-bucket logic implementation."
       ]
     }
   ]

--- a/magda_agent/memory/context_engine_lifecycle_v5.py
+++ b/magda_agent/memory/context_engine_lifecycle_v5.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Dict, Any, Optional
+from magda_agent.memory.context_engine_v1 import ContextEngineV1, ContextPluginV1
+
+class ContextPluginLifecycleV5(ContextPluginV1):
+    """
+    Protocol extending ContextPluginV1 to include lifecycle hooks
+    (on_load, on_unload) for dynamically managing plugins v5.
+    """
+
+    async def on_load(self, config: Dict[str, Any]) -> None:
+        """Called when the plugin is dynamically loaded."""
+        pass
+
+    async def on_unload(self) -> None:
+        """Called when the plugin is dynamically unloaded."""
+        pass
+
+class ContextEngineLifecycleV5(ContextEngineV1):
+    """
+    Extends ContextEngineV1 to support dynamic loading and unloading
+    of plugins at runtime with lifecycle hooks (V5).
+    """
+
+    async def load_plugin(self, plugin: ContextPluginLifecycleV5, config: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Dynamically loads a plugin, registers its hooks, and calls its on_load hook.
+        """
+        if config is None:
+            config = {}
+
+        self.register_plugin(plugin)
+
+        if hasattr(plugin, 'on_load'):
+            await plugin.on_load(config)
+
+        logging.info(f"Dynamically loaded plugin: {plugin.__class__.__name__}")
+
+    async def unload_plugin(self, plugin: ContextPluginLifecycleV5) -> None:
+        """
+        Dynamically unloads a plugin, calls its on_unload hook, and unregisters its hooks.
+        """
+        if plugin not in self._plugins:
+            logging.warning(f"Plugin {plugin.__class__.__name__} is not registered.")
+            return
+
+        if hasattr(plugin, 'on_unload'):
+            await plugin.on_unload()
+
+        self._plugins.remove(plugin)
+
+        # Remove plugin's hooks from the registry
+        for hook_type, callbacks in self.hook_registry._hooks.items():
+            # We need to iterate carefully to remove the correct bound methods
+            # related to this plugin instance.
+            hooks_to_remove = []
+            for cb in callbacks:
+                # Check if the callback is a bound method of the plugin instance
+                if hasattr(cb, '__self__') and getattr(cb, '__self__', None) is plugin:
+                    hooks_to_remove.append(cb)
+
+            for cb in hooks_to_remove:
+                callbacks.remove(cb)
+
+        logging.info(f"Dynamically unloaded plugin: {plugin.__class__.__name__}")

--- a/tests/test_context_engine_lifecycle_v5.py
+++ b/tests/test_context_engine_lifecycle_v5.py
@@ -1,0 +1,76 @@
+import pytest
+import pytest_asyncio
+from typing import Dict, Any, List
+from magda_agent.memory.context_engine_lifecycle_v5 import ContextPluginLifecycleV5, ContextEngineLifecycleV5
+
+class MockLifecyclePlugin(ContextPluginLifecycleV5):
+    """A mock plugin to test lifecycle hooks."""
+    def __init__(self):
+        self.loaded = False
+        self.unloaded = False
+        self.config = {}
+
+    async def on_load(self, config: Dict[str, Any]) -> None:
+        self.loaded = True
+        self.config = config
+
+    async def on_unload(self) -> None:
+        self.unloaded = True
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        return context
+
+@pytest_asyncio.fixture
+async def context_engine():
+    """Fixture to provide a ContextEngineLifecycleV5 instance."""
+    engine = ContextEngineLifecycleV5()
+    yield engine
+
+@pytest.mark.asyncio
+async def test_load_plugin(context_engine):
+    """Test that a plugin is correctly loaded and its on_load hook is called."""
+    plugin = MockLifecyclePlugin()
+    config = {"key": "value"}
+
+    assert not plugin.loaded
+    await context_engine.load_plugin(plugin, config)
+
+    assert plugin.loaded
+    assert plugin.config == config
+    assert plugin in context_engine._plugins
+
+@pytest.mark.asyncio
+async def test_unload_plugin(context_engine):
+    """Test that a plugin is correctly unloaded and its on_unload hook is called."""
+    plugin = MockLifecyclePlugin()
+
+    await context_engine.load_plugin(plugin)
+    assert plugin in context_engine._plugins
+    assert not plugin.unloaded
+
+    await context_engine.unload_plugin(plugin)
+
+    assert plugin.unloaded
+    assert plugin not in context_engine._plugins
+
+@pytest.mark.asyncio
+async def test_unload_unregistered_plugin(context_engine, caplog):
+    """Test that unloading an unregistered plugin logs a warning and doesn't crash."""
+    plugin = MockLifecyclePlugin()
+
+    await context_engine.unload_plugin(plugin)
+    assert "is not registered" in caplog.text
+
+@pytest.mark.asyncio
+async def test_hook_deregistration_on_unload(context_engine):
+    """Test that plugin hooks are removed from the registry when unloaded."""
+    plugin = MockLifecyclePlugin()
+    await context_engine.load_plugin(plugin)
+
+    # Verify the hook is registered
+    assert len(context_engine.hook_registry._hooks.get('before_write', [])) > 0
+
+    await context_engine.unload_plugin(plugin)
+
+    # Verify the hook is deregistered
+    assert len(context_engine.hook_registry._hooks.get('before_write', [])) == 0


### PR DESCRIPTION
This PR implements the `Context Engine Plugin Lifecycle Hooks v5` task from `agent_tasks.json`. 

It introduces a new protocol `ContextPluginLifecycleV5` extending `ContextPluginV1` with `on_load` and `on_unload` async hooks. The engine extension, `ContextEngineLifecycleV5`, provides methods to dynamically load and unload these plugins. Unloading gracefully deregisters bound methods from the underlying `HookRegistry` (`magda_agent.architecture.context_hooks_v5.HookRegistry`).

Pytest tests cover successful loading, unloading, hook deregistration, and gracefully handling the unloading of unregistered plugins.

The PR also correctly updates the task queue in `agent_tasks.json` by marking this task as done and appending 3 new relevant AI-trend inspired tasks.

---
*PR created automatically by Jules for task [3837462948546125594](https://jules.google.com/task/3837462948546125594) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lifecycle hooks to `ContextEngineLifecycleV5` for dynamic plugin load and unload
> - Adds `ContextPluginLifecycleV5`, a plugin protocol extending `ContextPluginV1` with optional async `on_load(config)` and `on_unload()` hooks in [context_engine_lifecycle_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/412/files#diff-161a3384aa35c5a5f3a34fcf9b7601207ff65db558c96c0ce79ab434b36d594d).
> - `load_plugin` registers the plugin and calls `on_load` if implemented; `unload_plugin` calls `on_unload`, removes the plugin from `_plugins`, and deregisters all its callbacks from `hook_registry`.
> - Tests in [test_context_engine_lifecycle_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/412/files#diff-ed45c99db50a0f68e53fa42d5ee1dccf47701cdab94bc05a1f11e3d5eb0d8e6a) cover load, unload, unregistered-plugin warning, and hook deregistration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2c2bc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->