### PR TITLE
Implement ParallelSubagentSpawnerV5 for agent teams and update task manifest

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6737,7 +6737,7 @@
     },
     {
       "id": "agent-teams-subagent-spawning-v5-6806",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "high",
       "title": "Agent Teams Parallel Subagent Spawning",
@@ -14054,6 +14054,40 @@
       "acceptance": [
         "Guardrail correctly blocks excessive MCP tool requests.",
         "Tests verify the token-bucket logic implementation."
+      ]
+    },
+    {
+      "id": "openclaw-rl-context-b7616d3b",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Online RL Implementation",
+      "description": "Inspired by OpenClaw RL trends: Implement online reinforcement learning from user feedback dynamically integrated into the context engine.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl_context_v2.py",
+        "tests/test_online_rl_context_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Online learning module accurately updates context retrieval weights based on feedback.",
+        "Tests use AsyncMock and verify weight adjustment algorithms without real LLM usage."
+      ]
+    },
+    {
+      "id": "acs-guardrails-policy-f8f43db8",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Compliance Policy Guardrails V7",
+      "description": "Inspired by ACS trends: Enhance the existing ACS guard architecture with a centralized policy validation layer prior to tool execution.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guardrails_v7.py",
+        "tests/test_acs_guardrails_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS Guardrails V7 is implemented and integrates dynamically before tool actions.",
+        "Tests verify policy enforcement rules via AsyncMock."
       ]
     }
   ]

--- a/magda_agent/agents/parallel_subagents_v5.py
+++ b/magda_agent/agents/parallel_subagents_v5.py
@@ -1,0 +1,74 @@
+import asyncio
+import logging
+import uuid
+from typing import List, Dict, Any, Optional
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.architecture.agent_teams_v3 import AgentWorktreeIsolationV3
+
+class ParallelSubagentSpawnerV5:
+    """
+    Manages spawning parallel subagents, utilizing Git worktree isolation
+    to prevent cross-contamination between tasks. Inspired by Claude Agent Teams.
+    """
+
+    def __init__(self, llm: LLMClient, isolation_manager: Optional[AgentWorktreeIsolationV3] = None):
+        """
+        Initialize the ParallelSubagentSpawnerV5.
+
+        Args:
+            llm: The Language Model client for subagents.
+            isolation_manager: Manager for Git worktree isolation. If not provided, a new one is created.
+        """
+        self.llm = llm
+        self.isolation_manager = isolation_manager or AgentWorktreeIsolationV3()
+
+    async def run_parallel_tasks(self, tasks: List[Dict[str, str]], base_context: str, use_isolation: bool = True) -> List[str]:
+        """
+        Run multiple tasks concurrently using spawned subagents, with optional isolated Git worktrees.
+
+        Args:
+            tasks: A list of dictionaries, each containing 'description' and optionally 'system_prompt'.
+            base_context: The shared context string.
+            use_isolation: If True, each subagent gets a dedicated Git worktree.
+
+        Returns:
+            A list containing the results of each task execution.
+        """
+        logging.info(f"ParallelSubagentSpawnerV5 spawning {len(tasks)} tasks (isolation={use_isolation}).")
+
+        async def execute_isolated_task(task_info: Dict[str, str]) -> str:
+            agent_id = str(uuid.uuid4())[:8]
+            task_desc = task_info.get("description", "")
+            system_prompt = task_info.get("system_prompt", "You are an isolated Sub-Agent executing a task.")
+
+            subagent = SubAgent(llm=self.llm, system_prompt=system_prompt, use_isolation=False) # We handle isolation here externally
+            worktree_path = None
+            task_context = base_context
+
+            if use_isolation:
+                try:
+                    worktree_path = await self.isolation_manager.create_worktree(agent_id=agent_id)
+                    task_context += f"\n\nIsolated Git Worktree Path: {worktree_path}"
+                    logging.info(f"Agent {agent_id} using worktree {worktree_path}")
+                except Exception as e:
+                    logging.error(f"Failed to create worktree for agent {agent_id}: {e}")
+                    return f"Error: Failed to create isolated worktree - {e}"
+
+            try:
+                result = await subagent.execute(task=task_desc, context=task_context)
+                return result
+            except Exception as e:
+                logging.error(f"Task execution failed for agent {agent_id}: {e}")
+                return f"Error: Task execution failed - {e}"
+            finally:
+                if use_isolation and worktree_path:
+                    try:
+                        await self.isolation_manager.remove_worktree(agent_id=agent_id)
+                    except Exception as e:
+                        logging.error(f"Failed to clean up worktree for agent {agent_id}: {e}")
+
+        coroutines = [execute_isolated_task(task) for task in tasks]
+        results = await asyncio.gather(*coroutines)
+        return list(results)

--- a/tests/test_parallel_subagents_v5.py
+++ b/tests/test_parallel_subagents_v5.py
@@ -1,0 +1,56 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, patch
+
+from magda_agent.agents.parallel_subagents_v5 import ParallelSubagentSpawnerV5
+
+@pytest_asyncio.fixture
+def mock_llm_client():
+    client = AsyncMock()
+    # Need to mock the chat_completion inside SubAgent.execute which uses llm.chat_completion
+    # Since Subagent calls llm.chat_completion
+    client.chat_completion = AsyncMock(return_value="Mocked response")
+    return client
+
+@pytest_asyncio.fixture
+def mock_isolation_manager():
+    manager = AsyncMock()
+    manager.create_worktree = AsyncMock(return_value="/tmp/mock_worktree")
+    manager.remove_worktree = AsyncMock()
+    return manager
+
+@pytest.mark.asyncio
+async def test_parallel_spawning_success(mock_llm_client, mock_isolation_manager):
+    spawner = ParallelSubagentSpawnerV5(llm=mock_llm_client, isolation_manager=mock_isolation_manager)
+    tasks = [
+        {"description": "Task 1", "system_prompt": "Sys 1"},
+        {"description": "Task 2"}
+    ]
+
+    with patch("magda_agent.agents.sub_agent.SubAgent.execute", new_callable=AsyncMock) as mock_execute:
+        mock_execute.side_effect = ["Result 1", "Result 2"]
+        results = await spawner.run_parallel_tasks(tasks=tasks, base_context="Base context", use_isolation=False)
+
+        assert results == ["Result 1", "Result 2"]
+        assert mock_execute.call_count == 2
+
+        # Verify isolation was NOT called
+        mock_isolation_manager.create_worktree.assert_not_called()
+        mock_isolation_manager.remove_worktree.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_worktree_isolation_mocked(mock_llm_client, mock_isolation_manager):
+    spawner = ParallelSubagentSpawnerV5(llm=mock_llm_client, isolation_manager=mock_isolation_manager)
+    tasks = [{"description": "Isolated Task"}]
+
+    with patch("magda_agent.agents.sub_agent.SubAgent.execute", new_callable=AsyncMock) as mock_execute:
+        mock_execute.return_value = "Isolated Result"
+        results = await spawner.run_parallel_tasks(tasks=tasks, base_context="Base", use_isolation=True)
+
+        assert results == ["Isolated Result"]
+        assert mock_isolation_manager.create_worktree.call_count == 1
+        assert mock_isolation_manager.remove_worktree.call_count == 1
+
+        # Verify context included worktree path
+        call_args = mock_execute.call_args[1]
+        assert "Base\n\nIsolated Git Worktree Path: /tmp/mock_worktree" in call_args['context']


### PR DESCRIPTION
Implements parallel subagent spawning using Git worktree isolation as requested in task `agent-teams-subagent-spawning-v5-6806`. It handles spawning subagents concurrently, passing contexts safely, and cleaning up worktrees after task execution or failure.

It also updates `agent_tasks.json` to mark the current task as done and generates 2 new AI-trend inspired tasks with unique UUIDs and specific acceptance criteria based on the June 2026 AI Trends file. Tests have been written utilizing AsyncMock to avoid real API/Git calls, and the full test suite and JSON validators have run and passed cleanly.

---
*PR created automatically by Jules for task [16277557364774243998](https://jules.google.com/task/16277557364774243998) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ParallelSubagentSpawnerV5` to run subagent tasks concurrently with optional Git worktree isolation
> - Adds [`parallel_subagents_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/413/files#diff-3cb65d796ccca8a3bd0156770514afb3fbb8a3a69734226483cb40c8fbf526ff) with `ParallelSubagentSpawnerV5`, which accepts a list of task descriptions and runs them concurrently via `asyncio.gather`.
> - When `use_isolation=True`, each task gets its own Git worktree via `AgentWorktreeIsolationV3`, with the worktree path appended to the task context and cleanup guaranteed in a `finally` block.
> - Errors during worktree creation or task execution are caught and returned as error strings rather than raising, so one failure does not abort the batch.
> - Updates [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/413/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) to mark one task as done and add two new tasks under `learning` and `safety` domains.
> - Adds async tests in [`tests/test_parallel_subagents_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/413/files#diff-94c885cebcb67e64f488cb82df06b3cbc0ce6296ad73ee8788359ee4b03b86b6) covering both isolated and non-isolated execution paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4ac2e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->