### PR TITLE
MCP Compatibility Export

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6754,7 +6754,7 @@
     },
     {
       "id": "mcp-compatibility-export-v1-a1b2c3d4",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Compatibility Export",
@@ -14088,6 +14088,40 @@
       "acceptance": [
         "ACS Guardrails V7 is implemented and integrates dynamically before tool actions.",
         "Tests verify policy enforcement rules via AsyncMock."
+      ]
+    },
+    {
+      "id": "9d27c5fc-0ce1-4476-b12a-b13b32e3e37a",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Agent Teams Distributed Tracing V9",
+      "description": "Inspired by Claude Agent SDK Agent Teams and enterprise tracing trends: Implement distributed tracing that propagates OpenTelemetry context across sub-agents running in isolated Git worktrees, allowing full visibility into parallel tasks.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_tracing_v9.py",
+        "tests/test_agent_teams_tracing_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tracing context propagates to spawned sub-agents.",
+        "Tests mock sub-agent spans and verify trace IDs match."
+      ]
+    },
+    {
+      "id": "78af6406-b0ef-4b72-822e-be43e41edb3e",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Policy Interceptor V8",
+      "description": "Inspired by MCP action tool growth and ACS safety standard: Add a centralized runtime policy interceptor specifically tailored for dynamic MCP tools to validate payloads before execution.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_policy_interceptor_v8.py",
+        "tests/test_mcp_policy_interceptor_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy interceptor intercepts MCP tool calls.",
+        "Tests verify valid inputs pass and tainted inputs are blocked."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_export.py
+++ b/magda_agent/skills/mcp_export.py
@@ -1,0 +1,119 @@
+import inspect
+from typing import Dict, Any, List
+from magda_agent.skills.registry import SkillRegistry
+
+class MCPExporter:
+    """
+    MCP Server adapter for Magda's SkillRegistry.
+    Exposes Magda skills as MCP-compatible tools.
+    """
+    def __init__(self, registry: SkillRegistry) -> None:
+        self.registry = registry
+
+    from typing import Callable
+
+    def _get_json_schema(self, func: Callable) -> Dict[str, Any]:
+        """
+        Extracts JSON schema parameters from the function signature.
+        """
+        if hasattr(func, "__mcp_schema__"):
+            return getattr(func, "__mcp_schema__")
+
+        sig = inspect.signature(func)
+        properties = {}
+        required = []
+
+        for name, param in sig.parameters.items():
+            if name in ('self', 'kwargs', 'args'):
+                continue
+
+            param_type = "string"
+            if param.annotation is not inspect.Parameter.empty:
+                if param.annotation is int:
+                    param_type = "integer"
+                elif param.annotation is float:
+                    param_type = "number"
+                elif param.annotation is bool:
+                    param_type = "boolean"
+                elif param.annotation is list or param.annotation is List:
+                    param_type = "array"
+                elif param.annotation is dict or param.annotation is Dict:
+                    param_type = "object"
+
+            properties[name] = {"type": param_type}
+
+            if param.default is inspect.Parameter.empty:
+                required.append(name)
+
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": required
+        }
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists all registered skills as MCP-compatible tool definitions.
+        """
+        tools = []
+        for name, func in self.registry.skills.items():
+            description = self.registry.descriptions.get(name, "")
+            schema = self._get_json_schema(func)
+            tools.append({
+                "name": name,
+                "description": description,
+                "inputSchema": schema
+            })
+        return tools
+
+    async def call_tool_async(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Invokes an async skill via the MCP protocol format.
+        """
+        if not self.registry.has_skill(name):
+            return {
+                "content": [{"type": "text", "text": f"Error: Tool '{name}' not found."}],
+                "isError": True
+            }
+
+        try:
+            result = self.registry.execute_skill(name, **arguments)
+            if inspect.isawaitable(result):
+                try:
+                    result = await result
+                except Exception as e:
+                    return {
+                        "content": [{"type": "text", "text": f"Error executing async tool {name}: {e}"}],
+                        "isError": True
+                    }
+            return {
+                "content": [{"type": "text", "text": str(result)}],
+                "isError": False
+            }
+        except Exception as e:
+            return {
+                "content": [{"type": "text", "text": f"Error executing tool {name}: {e}"}],
+                "isError": True
+            }
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Invokes a skill via the MCP protocol format.
+        """
+        if not self.registry.has_skill(name):
+            return {
+                "content": [{"type": "text", "text": f"Error: Tool '{name}' not found."}],
+                "isError": True
+            }
+
+        try:
+            result = self.registry.execute_skill(name, **arguments)
+            return {
+                "content": [{"type": "text", "text": str(result)}],
+                "isError": False
+            }
+        except Exception as e:
+            return {
+                "content": [{"type": "text", "text": f"Error executing tool {name}: {e}"}],
+                "isError": True
+            }

--- a/tests/test_mcp_export.py
+++ b/tests/test_mcp_export.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock
-from magda_agent.integration.mcp_export import MCPExporter
+from magda_agent.skills.mcp_export import MCPExporter
 
 @pytest.fixture
 def mock_registry():


### PR DESCRIPTION
Implement MCP compatibility export functionality by moving `magda_agent/integration/mcp_export.py` to `magda_agent/skills/mcp_export.py` and adjusting the relevant imports. Added two new tasks related to tracing and MCP policies.

---
*PR created automatically by Jules for task [1711121377852465897](https://jules.google.com/task/1711121377852465897) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPExporter` class to expose registered skills as MCP-compatible tools
> - Introduces [mcp_export.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/414/files#diff-6c04862b977c757af22496c7b2a41250c52af66ab73ec44c12933fa3a337a508) with a new `MCPExporter` class that wraps a `SkillRegistry` and adapts its skills into MCP tool definitions.
> - `list_tools()` iterates the registry and returns tool descriptors with names, descriptions, and JSON schemas derived from function signatures (or a `__mcp_schema__` attribute if declared).
> - `call_tool()` and `call_tool_async()` invoke skills via `registry.execute_skill` and return standardized `{ content, isError }` response dicts, handling both sync and awaitable results.
> - Updates the import path in [test_mcp_export.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/414/files#diff-ad98900cec5441ed168a17024479f9628cbda16275fbbe67d49a88b47c4efce4) from `magda_agent.integration.mcp_export` to `magda_agent.skills.mcp_export`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e39f8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->