### PR TITLE
feat(memory): Implement paginate_explicit_memory_blocks in VirtualContextManagerV2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6789,7 +6789,7 @@
     },
     {
       "id": "openclaw-virtual-context-manager-v2-i9j0k1l2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Virtual Context Manager for MemorySystem v2",
@@ -14156,6 +14156,57 @@
       "acceptance": [
         "Agent discovery correctly resolves and parses Agent Cards.",
         "Tests mock network responses and evaluate validation."
+      ]
+    },
+    {
+      "id": "hermes-agent-nightly-backups-bb325590",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Agent Scheduled Nightly Backups",
+      "description": "Inspired by Hermes Agent Cron scheduler: implement a nightly backup cron job for episodic memory dumps.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_backups_v3.py",
+        "tests/test_cron_backups_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron job successfully schedules nightly episodic memory backup.",
+        "Tests verify scheduling."
+      ]
+    },
+    {
+      "id": "claude-subagent-dependency-graph-0641a915",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Subagent Dependency Graph V2",
+      "description": "Inspired by Claude Agent SDK Task system with dependency graphs.",
+      "allowed_paths": [
+        "magda_agent/architecture/dependency_graph_v2.py",
+        "tests/test_dependency_graph_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dependency graph validates subagent task execution order.",
+        "Tests simulate subagent dependency validation."
+      ]
+    },
+    {
+      "id": "mcp-action-tools-export-v2-58dbbdbc",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tools Export Compatibility V2",
+      "description": "Inspired by MCP compatibility standard: Ensure skills can be natively exported as MCP tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_export_v8.py",
+        "tests/test_mcp_export_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be exported as MCP tools accurately.",
+        "Tests verify export JSON schema format."
       ]
     }
   ]

--- a/magda_agent/memory/virtual_context_v2.py
+++ b/magda_agent/memory/virtual_context_v2.py
@@ -130,6 +130,48 @@ class VirtualContextManagerV2:
             await working_memory.add(entry)
             logging.debug(f"Paged in explicit memory entry for user {user_id}: {event_text[:30]}...")
 
+    async def paginate_explicit_memory_blocks(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, block_size: int = 2) -> None:
+        """
+        Divides the working memory into explicit blocks of a given size and pages them out to episodic memory.
+
+        Args:
+            working_memory: The WorkingMemory instance to page out from.
+            episodic_memory: The EpisodicMemory instance to page out into.
+            user_id: The ID of the user.
+            block_size: The number of entries per block to paginate.
+        """
+        entries = working_memory.get_entries(user_id=user_id)
+        if not entries:
+            return
+
+        to_remove = entries[:- (len(entries) % block_size)] if len(entries) % block_size != 0 else entries
+        if not to_remove:
+            return
+
+        blocks = [to_remove[i:i + block_size] for i in range(0, len(to_remove), block_size)]
+
+        for block in blocks:
+            for entry in block:
+                metadata = {
+                    "paged_out_explicitly": True,
+                    "importance": entry.importance,
+                    "pad_p": entry.emotional_state.pleasure,
+                    "pad_a": entry.emotional_state.arousal,
+                    "pad_d": entry.emotional_state.dominance
+                }
+                if entry.tags:
+                    metadata["tags"] = ",".join(entry.tags)
+
+                episodic_memory.store_event(
+                    text=entry.content,
+                    metadata=metadata,
+                    user_id=user_id
+                )
+                logging.debug(f"Paged out memory entry {entry.id} in block explicitly for user {user_id}")
+
+            for entry in block:
+                working_memory.remove(entry.id, user_id=user_id)
+
     def get_token_length(self, entries: List['MemoryEntry']) -> int:
         """
         Calculates a heuristic token length for the given memory entries.

--- a/tests/test_virtual_context_v2.py
+++ b/tests/test_virtual_context_v2.py
@@ -40,6 +40,32 @@ async def test_virtual_context_v2_page_out_explicit() -> None:
     assert episodic_events[0]["metadata"]["paged_out_explicitly"] == True
 
 @pytest.mark.asyncio
+async def test_virtual_context_v2_paginate_explicit_memory_blocks() -> None:
+    wm = WorkingMemory(limit=10)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v2_paginate_out"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV2()
+
+    state = PADState(0, 0, 0)
+
+    for i in range(5):
+        await wm.add(MemoryEntry(f"Item {i}", 0.5, state, user_id=1))
+
+    assert len(wm.get_entries(user_id=1)) == 5
+
+    await vcm.paginate_explicit_memory_blocks(wm, em, user_id=1, block_size=2)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 1
+    assert entries[0].content == "Item 4"
+
+    episodic_events = em.get_all_events(user_id=1)
+    assert len(episodic_events) == 4
+    assert episodic_events[0]["metadata"]["paged_out_explicitly"] == True
+
+
+@pytest.mark.asyncio
 async def test_virtual_context_v2_page_in_explicit() -> None:
     wm = WorkingMemory(limit=5)
     em = EpisodicMemory(persist_directory=":memory:")


### PR DESCRIPTION
This PR implements explicit memory pagination for `VirtualContextManagerV2`. It allows partitioning short-term working memory into distinct blocks and paging them out to episodic memory, while preserving metadata (`PADState`, `tags`). 

Additionally, it adds mock-based tests to verify correct memory limits, and appends three new AI agent trend-inspired tasks to the system backlog.

---
*PR created automatically by Jules for task [367757189817800373](https://jules.google.com/task/367757189817800373) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `paginate_explicit_memory_blocks` in `VirtualContextManagerV2`
> - Adds a new async method to [virtual_context_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/416/files#diff-c812571519b22b4e3bcd132e466dbdfa27e0d261841a9ca82cd6ae751ab12631) that partitions a user's working memory entries into fixed-size blocks and pages complete blocks out to episodic memory.
> - Each paged-out entry is stored with metadata: `paged_out_explicitly` flag, importance, PAD values, and comma-separated tags. Incomplete trailing blocks remain in working memory.
> - Adds a corresponding async test in [test_virtual_context_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/416/files#diff-90340335fdde24cfd34074f174cc77235ea950b51b8604f140db0d4b431cfa1d) verifying block-based pagination with 5 entries and block size 2.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38048aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->