### PR TITLE
Implement OpenClaw Local-First Context Engine

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6823,7 +6823,7 @@
     },
     {
       "id": "openclaw-local-first-context-engine",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Local-First Context Engine",
@@ -14258,6 +14258,58 @@
       "acceptance": [
         "Smoke tester correctly identifies syntax and import errors post-merge.",
         "Tests evaluate mock code files with syntax errors."
+      ]
+    },
+    {
+      "id": "4d3e907f-d2e9-44f1-b4f8-f9b4733e731a",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Reflection Tracing",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend: Create a reflection telemetry export module to broadcast subconsciousness events dynamically to a live dashboard.",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_reflection_v1.py",
+        "tests/test_canvas_reflection_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Reflection telemetry broadcaster implemented and broadcasts reflection events.",
+        "Tests verify event payloads format matches Canvas UI."
+      ]
+    },
+    {
+      "id": "1a68b69f-2238-495c-9a7c-57c1447a365c",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Server Taint Context Isolation",
+      "description": "Inspired by MCPKernel Sandboxing trends: Enhance MCP Server export functionality with taint isolation to prevent tainted responses from polluting memory.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_taint_context_v1.py",
+        "tests/test_mcp_taint_context_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tags propagate correctly to exported tool responses.",
+        "Tests verify responses carry taint flag appropriately."
+      ]
+    },
+    {
+      "id": "81d7564a-5ff7-4a2b-9e9f-4776e139f832",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Letta Virtual Context Routine Builder",
+      "description": "Inspired by MemGPT/Letta patterns: Create a context manager hook to automatically extract routine patterns from episodic memory and populate procedural memory.",
+      "allowed_paths": [
+        "magda_agent/memory/letta_routine_v1.py",
+        "tests/test_letta_routine_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Routine builder identifies routine patterns across episodic records.",
+        "Generates procedural routines correctly.",
+        "Tests mock memory to verify extraction logic."
       ]
     }
   ]

--- a/magda_agent/memory/context_engine_local.py
+++ b/magda_agent/memory/context_engine_local.py
@@ -1,0 +1,76 @@
+import logging
+from typing import List, Any, Dict, Optional
+from magda_agent.memory.context_engine import ContextEngine, ContextPlugin
+from magda_agent.memory.working import MemoryEntry
+
+class LocalFirstContextEngine(ContextEngine):
+    """
+    LocalFirstContextEngine extends ContextEngine by gracefully falling back
+    to a local LLM if the primary external LLM fails during context compaction.
+    """
+    def __init__(self, plugins: Optional[List[ContextPlugin]] = None, llm: Optional[Any] = None, local_llm: Optional[Any] = None) -> None:
+        """
+        Initialize the LocalFirstContextEngine with optional plugins, primary LLM, and fallback local LLM.
+        """
+        super().__init__(plugins=plugins, llm=llm)
+        self.local_llm = local_llm
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        Compact context through all plugins using the hook registry.
+        If limits are exceeded, attempt compression using the primary LLM.
+        If the primary LLM fails, fall back to the local LLM.
+        If the local LLM fails or is absent, truncate the context.
+        """
+        current_items = await self.hook_registry.trigger_hook_async('compact', context_items, metadata)
+
+        limit = metadata.get("limit", 10)
+        if len(current_items) <= limit:
+            return current_items
+
+        # We need compaction
+        to_summarize = current_items[:2]
+        remaining = current_items[2:]
+        combined_text = "\n".join([f"- {getattr(e, 'content', str(e))}" for e in to_summarize])
+        prompt = f"Please summarize the following short-term memory context into a concise summary while maintaining key facts and semantic links:\n{combined_text}"
+
+        first = to_summarize[0] if to_summarize else None
+        avg_importance = sum(getattr(e, 'importance', 0.5) for e in to_summarize) / max(1, len(to_summarize))
+        tags = list(set(t for e in to_summarize if isinstance(getattr(e, 'tags', []), list) for t in getattr(e, 'tags', [])))
+
+        async def _attempt_compression(target_llm: Any) -> Optional[MemoryEntry]:
+            if target_llm is None:
+                return None
+            try:
+                summary_content = await target_llm.chat_completion([
+                    {"role": "system", "content": "You compress memory context. Return only the summary text."},
+                    {"role": "user", "content": prompt}
+                ], temperature=0.3)
+
+                return MemoryEntry(
+                    content=summary_content.strip(),
+                    importance=avg_importance,
+                    emotional_state=getattr(first, 'emotional_state', None) if first else None,
+                    tags=tags,
+                    user_id=getattr(first, 'user_id', None) if first else None
+                )
+            except Exception as e:
+                logging.error(f"Compression attempt failed: {e}")
+                return None
+
+        logging.info("Context length exceeds limit. Using LocalFirstContextEngine fallback compression.")
+
+        # Try primary LLM
+        summary_entry = await _attempt_compression(self.llm)
+
+        # Try local LLM if primary failed
+        if summary_entry is None and self.local_llm is not None:
+            logging.info("Primary LLM failed or absent. Falling back to local LLM.")
+            summary_entry = await _attempt_compression(self.local_llm)
+
+        # Truncate if both failed
+        if summary_entry is None:
+            logging.warning("Both external and local LLMs failed or were absent. Dropping oldest item.")
+            return current_items[1:]
+
+        return [summary_entry] + remaining

--- a/tests/test_context_engine_local.py
+++ b/tests/test_context_engine_local.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.memory.context_engine_local import LocalFirstContextEngine
+from magda_agent.memory.working import MemoryEntry
+
+@pytest.mark.asyncio
+async def test_local_first_context_engine_fallback_to_local_llm() -> None:
+    """Tests that LocalFirstContextEngine falls back to the local LLM if the primary LLM fails."""
+
+    primary_llm = AsyncMock()
+    primary_llm.chat_completion.side_effect = Exception("Primary API down")
+
+    local_llm = AsyncMock()
+    local_llm.chat_completion.return_value = "local summary"
+
+    engine = LocalFirstContextEngine(llm=primary_llm, local_llm=local_llm)
+
+    entry1 = MagicMock(spec=MemoryEntry)
+    entry1.content = "content1"
+    entry1.importance = 0.5
+    entry1.tags = ["tag1"]
+
+    entry2 = MagicMock(spec=MemoryEntry)
+    entry2.content = "content2"
+    entry2.importance = 0.5
+    entry2.tags = ["tag2"]
+
+    items = [entry1, entry2]
+    # Limit is 1, so compaction will trigger
+    compacted = await engine.compact(items, {"limit": 1})
+
+    assert primary_llm.chat_completion.called
+    assert local_llm.chat_completion.called
+    assert len(compacted) == 1
+    assert compacted[0].content == "local summary"
+    assert set(compacted[0].tags) == {"tag1", "tag2"}
+
+@pytest.mark.asyncio
+async def test_local_first_context_engine_fallback_to_truncation() -> None:
+    """Tests that LocalFirstContextEngine truncates if both LLMs fail."""
+
+    primary_llm = AsyncMock()
+    primary_llm.chat_completion.side_effect = Exception("Primary API down")
+
+    local_llm = AsyncMock()
+    local_llm.chat_completion.side_effect = Exception("Local API down")
+
+    engine = LocalFirstContextEngine(llm=primary_llm, local_llm=local_llm)
+
+    entry1 = MagicMock(spec=MemoryEntry)
+    entry1.content = "content1"
+
+    entry2 = MagicMock(spec=MemoryEntry)
+    entry2.content = "content2"
+
+    items = [entry1, entry2]
+    # Limit is 1, so compaction will trigger
+    compacted = await engine.compact(items, {"limit": 1})
+
+    assert primary_llm.chat_completion.called
+    assert local_llm.chat_completion.called
+
+    # Should drop the oldest item (entry1)
+    assert len(compacted) == 1
+    assert compacted[0] == entry2
+
+@pytest.mark.asyncio
+async def test_local_first_context_engine_primary_llm_succeeds() -> None:
+    """Tests that LocalFirstContextEngine uses the primary LLM if it succeeds."""
+
+    primary_llm = AsyncMock()
+    primary_llm.chat_completion.return_value = "primary summary"
+
+    local_llm = AsyncMock()
+
+    engine = LocalFirstContextEngine(llm=primary_llm, local_llm=local_llm)
+
+    entry1 = MagicMock(spec=MemoryEntry)
+    entry1.content = "content1"
+
+    entry2 = MagicMock(spec=MemoryEntry)
+    entry2.content = "content2"
+
+    items = [entry1, entry2]
+    # Limit is 1, so compaction will trigger
+    compacted = await engine.compact(items, {"limit": 1})
+
+    assert primary_llm.chat_completion.called
+    assert not local_llm.chat_completion.called
+
+    assert len(compacted) == 1
+    assert compacted[0].content == "primary summary"


### PR DESCRIPTION
Implemented the `LocalFirstContextEngine` module based on the "OpenClaw Local-First Context Engine" task. It inherits from `ContextEngine` and overrides the `compact` method to gracefully fall back to a `local_llm` when the primary external LLM fails, and ultimately truncates context if both fail. Included comprehensive async tests with mock LLM calls. The `agent_tasks.json` manifest was updated to reflect task completion and augmented with three new tasks inspired by June 2026 AI Agent trends.

---
*PR created automatically by Jules for task [11659165998611833696](https://jules.google.com/task/11659165998611833696) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `LocalFirstContextEngine` with primary/local LLM fallback and truncation compaction
> - Adds [LocalFirstContextEngine](https://github.com/kazah4359-lgtm/Magda-agent/pull/418/files#diff-3c88f626f29e8152d5e4b89d2590988a4e42439a027ef9addcd2048f4cbd9402), a `ContextEngine` subclass that compacts context by first attempting summarization with a primary LLM, then falling back to a local LLM, and finally dropping the oldest item if both fail.
> - The `compact()` method runs plugin hooks before compaction, merges importance scores and tags from the two oldest items, and builds a summarization prompt for whichever LLM is available.
> - Tests cover all three paths: primary LLM success, fallback to local LLM, and fallback to truncation.
> - Behavioral Change: when both LLMs fail, the oldest context item is silently dropped rather than raising an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3c6244.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->