### PR TITLE
feat(agents): enforce strict policies for evaluator subagent

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6840,7 +6840,7 @@
     },
     {
       "id": "claude-evaluator-subagent-policy",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "Claude Evaluator Subagent Policy Enforcement",
@@ -14310,6 +14310,57 @@
         "Routine builder identifies routine patterns across episodic records.",
         "Generates procedural routines correctly.",
         "Tests mock memory to verify extraction logic."
+      ]
+    },
+    {
+      "id": "602790d1-4a47-4ca0-98c8-743101b3fe34",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Agent Scheduled Tasks Export Integration",
+      "description": "Inspired by Hermes Agent Cron scheduler: implement scheduled task export configuration for easier multi-platform deployment without altering cron files.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_export_v1.py",
+        "tests/test_cron_export_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Export routine formats tasks accurately.",
+        "Tests verify export schemas."
+      ]
+    },
+    {
+      "id": "c639a867-2e61-43c5-aac4-0f20995f7a93",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Canvas Visualization V2",
+      "description": "Inspired by OpenClaw Canvas Live Visualization: create a module to serialize Context Engine state to a live JSON payload for front-end rendering.",
+      "allowed_paths": [
+        "magda_agent/telemetry/context_canvas_v2.py",
+        "tests/test_context_canvas_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Serialization converts context engine state accurately.",
+        "Tests mock engine and test JSON structure."
+      ]
+    },
+    {
+      "id": "689bf4c3-d060-4f17-aae1-3fa0bed483b0",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Agent Peer Authentication V2",
+      "description": "Inspired by A2A standard trend for agent-to-agent delegation: implement robust token-based peer authentication for discovered agent cards.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth_v2.py",
+        "tests/test_a2a_auth_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Peer authentication accurately verifies tokens.",
+        "Tests mock incoming A2A requests and test rejection/acceptance."
       ]
     }
   ]

--- a/magda_agent/agents/evaluator_policy.py
+++ b/magda_agent/agents/evaluator_policy.py
@@ -1,0 +1,101 @@
+import logging
+from typing import Dict, Any, List, Optional, Protocol
+
+class EvaluatorProtocol(Protocol):
+    """
+    Protocol defining the expected interface for an evaluator sub-agent.
+    """
+    async def evaluate_generator_output(self, generator_output: str, user_request: str) -> Dict[str, Any]:
+        ...
+
+class PolicyEnforcedEvaluator:
+    """
+    Wraps an Evaluator agent to strictly enforce system policies on the generator's output.
+    Inspired by Claude Agent SDK Subagent policy patterns.
+    """
+    def __init__(self, evaluator_agent: EvaluatorProtocol):
+        """
+        Initializes the PolicyEnforcedEvaluator.
+
+        Args:
+            evaluator_agent (EvaluatorProtocol): The underlying evaluator sub-agent (e.g., EvaluatorAgentV3).
+        """
+        self.evaluator = evaluator_agent
+
+    async def evaluate_generator_output(
+        self,
+        generator_output: str,
+        user_request: str,
+        policies: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Evaluates the output produced by the Generator Agent and enforces strict system constraints.
+
+        Args:
+            generator_output (str): The text or code output generated.
+            user_request (str): The initial user request or context.
+            policies (Optional[List[str]]): A list of strict policies to enforce.
+                                            Format: 'forbidden:<string>', 'must_contain:<string>', or 'max_length:<int>'.
+
+        Returns:
+            Dict[str, Any]: Parsed JSON representing the critique and feedback containing keys:
+                - score (int): 1-10 evaluation score.
+                - approved (bool): Whether the output is acceptable and passes all policies.
+                - feedback (str): Detailed, actionable critique including any policy violations.
+        """
+        policies = policies or []
+
+        # 1. Enforce strict local policies first
+        violations = self._check_policies(generator_output, policies)
+        if violations:
+            logging.warning(f"Output rejected due to policy violations: {violations}")
+            return {
+                "score": 0,
+                "approved": False,
+                "feedback": f"Policy Violation: Output failed to comply with strict system constraints. Violations: {', '.join(violations)}"
+            }
+
+        # 2. Delegate to the underlying LLM evaluator
+        try:
+            return await self.evaluator.evaluate_generator_output(generator_output, user_request)
+        except Exception as e:
+            logging.error(f"Underlying evaluation failed: {e}")
+            return {
+                "score": 0,
+                "approved": False,
+                "feedback": f"Evaluation error: {str(e)}"
+            }
+
+    def _check_policies(self, output: str, policies: List[str]) -> List[str]:
+        """
+        Checks the output against the specified strict policies.
+
+        Args:
+            output (str): The generator output.
+            policies (List[str]): List of policy strings.
+
+        Returns:
+            List[str]: A list of policy violation messages. Empty if no violations.
+        """
+        violations = []
+        for policy in policies:
+            policy_lower = policy.lower()
+            if policy_lower.startswith("forbidden:"):
+                term = policy_lower[len("forbidden:"):].strip()
+                if term in output.lower():
+                    violations.append(f"Contains forbidden term: '{term}'")
+            elif policy_lower.startswith("must_contain:"):
+                term = policy_lower[len("must_contain:"):].strip()
+                if term not in output.lower():
+                    violations.append(f"Missing required term: '{term}'")
+            elif policy_lower.startswith("max_length:"):
+                try:
+                    max_len = int(policy_lower[len("max_length:"):].strip())
+                    if len(output) > max_len:
+                        violations.append(f"Exceeds maximum length of {max_len} characters")
+                except ValueError:
+                    logging.warning(f"Invalid max_length policy: {policy}")
+            else:
+                logging.debug(f"Unsupported strict policy format ignored: {policy}")
+
+        return violations

--- a/tests/test_evaluator_policy.py
+++ b/tests/test_evaluator_policy.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import AsyncMock
+from typing import Dict, Any
+
+from magda_agent.agents.evaluator_policy import PolicyEnforcedEvaluator
+
+class MockEvaluator:
+    """Mock underlying evaluator."""
+    def __init__(self, expected_response: Dict[str, Any]):
+        self.evaluate_generator_output = AsyncMock(return_value=expected_response)
+
+
+@pytest.mark.asyncio
+async def test_policy_enforced_evaluator_passes_policies():
+    """Test that output passing policies is delegated to the LLM evaluator."""
+    expected_response = {"score": 9, "approved": True, "feedback": "Great output."}
+    mock_evaluator = MockEvaluator(expected_response=expected_response)
+
+    policy_evaluator = PolicyEnforcedEvaluator(evaluator_agent=mock_evaluator)
+
+    output = "This is a clean and compliant output that contains the mandatory_term."
+    policies = ["must_contain:mandatory_term", "max_length:200"]
+
+    result = await policy_evaluator.evaluate_generator_output(
+        generator_output=output,
+        user_request="Write a clean output.",
+        policies=policies
+    )
+
+    assert result == expected_response
+    mock_evaluator.evaluate_generator_output.assert_called_once_with(output, "Write a clean output.")
+
+@pytest.mark.asyncio
+async def test_policy_enforced_evaluator_fails_forbidden():
+    """Test that output containing forbidden terms is rejected without calling the LLM evaluator."""
+    mock_evaluator = MockEvaluator(expected_response={"score": 10, "approved": True, "feedback": "Should not be called."})
+
+    policy_evaluator = PolicyEnforcedEvaluator(evaluator_agent=mock_evaluator)
+
+    output = "This output contains a malicious_script."
+    policies = ["forbidden:malicious_script"]
+
+    result = await policy_evaluator.evaluate_generator_output(
+        generator_output=output,
+        user_request="Write an output.",
+        policies=policies
+    )
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Policy Violation" in result["feedback"]
+    assert "forbidden term" in result["feedback"]
+
+    mock_evaluator.evaluate_generator_output.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_policy_enforced_evaluator_fails_missing_term():
+    """Test that output missing required terms is rejected."""
+    mock_evaluator = MockEvaluator(expected_response={"score": 10, "approved": True, "feedback": "Should not be called."})
+
+    policy_evaluator = PolicyEnforcedEvaluator(evaluator_agent=mock_evaluator)
+
+    output = "This output missed the required term."
+    policies = ["must_contain:mandatory_term"]
+
+    result = await policy_evaluator.evaluate_generator_output(
+        generator_output=output,
+        user_request="Write an output.",
+        policies=policies
+    )
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Missing required term" in result["feedback"]
+
+    mock_evaluator.evaluate_generator_output.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_policy_enforced_evaluator_fails_max_length():
+    """Test that output exceeding max length is rejected."""
+    mock_evaluator = MockEvaluator(expected_response={"score": 10, "approved": True, "feedback": "Should not be called."})
+
+    policy_evaluator = PolicyEnforcedEvaluator(evaluator_agent=mock_evaluator)
+
+    output = "This output is way too long. " * 10
+    policies = ["max_length:20"]
+
+    result = await policy_evaluator.evaluate_generator_output(
+        generator_output=output,
+        user_request="Write a short output.",
+        policies=policies
+    )
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Exceeds maximum length" in result["feedback"]
+
+    mock_evaluator.evaluate_generator_output.assert_not_called()


### PR DESCRIPTION
This PR implements strict policy enforcement rules for the Evaluator subagent, inspired by the Claude Agent SDK Planner/Generator/Evaluator pattern. It introduces a new `PolicyEnforcedEvaluator` class that wraps any evaluator implementing the `EvaluatorProtocol`. It validates outputs against system constraints (`forbidden`, `must_contain`, `max_length`) locally, rejecting violations instantly. If policies pass, it delegates evaluation to the underlying LLM evaluator.

Additionally:
- Full AsyncMock test coverage added in `tests/test_evaluator_policy.py`.
- `agent_tasks.json` has been updated to mark this task as done and add three new contextually relevant todo tasks inspired by current AI trends.

---
*PR created automatically by Jules for task [4646238393116714195](https://jules.google.com/task/4646238393116714195) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce strict local policies for the evaluator subagent before delegation
> - Adds [`PolicyEnforcedEvaluator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/419/files#diff-a5fdef8d5f07a813eeca44a5824a4e9d167ca57dedcaa33318bbd03973cc3a53), a wrapper class that runs local policy checks on generator outputs before calling the underlying evaluator agent.
> - Supports three policy types: `forbidden:<string>` (banned terms), `must_contain:<string>` (required terms), and `max_length:<int>` (output length cap).
> - On policy violation, returns a structured rejection (`score=0`, `approved=False`) without calling the underlying evaluator; exceptions from the underlying evaluator are also caught and returned as structured errors.
> - Adds an async pytest suite in [`tests/test_evaluator_policy.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/419/files#diff-55b26dd90c06438435575a97b14d4947d21c72d8ce6abea96d395ff4cdc864e0) covering delegation, forbidden terms, missing required terms, and max-length violations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a0e6a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->