### PR TITLE
Implement MCP Concurrent Action Tool Execution V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6857,7 +6857,7 @@
     },
     {
       "id": "mcp-action-tool-concurrency-v2-a9a0b782",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP concurrent action tool execution v2",
@@ -14361,6 +14361,57 @@
       "acceptance": [
         "Peer authentication accurately verifies tokens.",
         "Tests mock incoming A2A requests and test rejection/acceptance."
+      ]
+    },
+    {
+      "id": "3f400a74-15eb-4d21-80e1-e4017b730b4f",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Kernel Taint Tracking Context Integration",
+      "description": "Inspired by MCPKernel Sandboxing trends: Expand taint tracking to seamlessly integrate with working memory context.",
+      "allowed_paths": [
+        "magda_agent/safety/taint_context_v6.py",
+        "tests/test_taint_context_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tags propagate correctly to working memory context.",
+        "Tests verify working memory entries carry taint flag correctly."
+      ]
+    },
+    {
+      "id": "4d78fb0f-566e-4a65-965c-10a9bb2fee26",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Habit Decay Parameterization",
+      "description": "Inspired by OpenClaw-RL trend: Add adjustable time decay parameters to learned habits based on explicit feedback loops.",
+      "allowed_paths": [
+        "magda_agent/learning/habit_decay_v2.py",
+        "tests/test_habit_decay_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Habit decay is configurable.",
+        "Decay tests simulate adjustable parameters."
+      ]
+    },
+    {
+      "id": "60cfa7dd-4b71-457d-b396-4c3d49f037b5",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Workflow Auth Delegation Manager V3",
+      "description": "Inspired by A2A Protocol standard trends: Upgrade active authentication token manager for A2A mesh network peers.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth_delegation_v3.py",
+        "tests/test_a2a_auth_delegation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Active tokens are managed centrally.",
+        "Tests mock token exchange verification."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_router_v2_concurrency.py
+++ b/magda_agent/skills/mcp_router_v2_concurrency.py
@@ -1,0 +1,94 @@
+import asyncio
+import inspect
+import logging
+from typing import Dict, Any, List, Callable, Coroutine
+
+
+class MCPConcurrentRouterV2:
+    """
+    Router that handles concurrent execution of tools with server prefixes,
+    according to MCP standard trends.
+    It can route multiple tool calls concurrently.
+    """
+
+    def __init__(self) -> None:
+        """Initializes the MCP Concurrent Router V2."""
+        # Maps server name to a routing function that handles that server's tools
+        self.server_handlers: Dict[str, Callable[[str, Dict[str, Any]], Any]] = {}
+
+    def register_server(self, server_name: str, handler: Callable[[str, Dict[str, Any]], Any]) -> None:
+        """
+        Registers a handler for a specific server prefix.
+
+        Args:
+            server_name (str): The prefix used to identify the server.
+            handler (Callable): Function that takes (tool_name, tool_arguments) and returns a result.
+        """
+        self.server_handlers[server_name] = handler
+        logging.info(f"Registered MCP server handler for prefix: {server_name}")
+
+    def _route_tool(self, tool_call_name: str, arguments: Dict[str, Any]) -> Any:
+        """
+        Routes a single tool call by its prefixed name.
+
+        Args:
+            tool_call_name (str): The full tool name, e.g., 'weather_server_get_forecast'.
+            arguments (Dict[str, Any]): The arguments for the tool call.
+
+        Returns:
+            Any: The result of the routed tool execution.
+
+        Raises:
+            ValueError: If the tool name does not contain a prefix, or if the server prefix is unknown.
+        """
+        if "_" not in tool_call_name:
+            raise ValueError(f"Tool name '{tool_call_name}' must be prefixed with a server name (e.g., 'server_tool').")
+
+        matched_server = None
+        matched_tool = None
+
+        for server_name in sorted(self.server_handlers.keys(), key=len, reverse=True):
+            prefix = f"{server_name}_"
+            if tool_call_name.startswith(prefix):
+                matched_server = server_name
+                matched_tool = tool_call_name[len(prefix):]
+                break
+
+        if not matched_server:
+            raise ValueError(f"No registered MCP server handler found for tool: {tool_call_name}")
+
+        handler = self.server_handlers[matched_server]
+        return handler(matched_tool, arguments)
+
+    async def execute_concurrently(self, tool_calls: List[Dict[str, Any]]) -> List[Any]:
+        """
+        Executes a list of tool calls concurrently.
+        Each element in tool_calls must have 'name' and 'kwargs'.
+
+        Args:
+            tool_calls (List[Dict[str, Any]]): List of tool calls to execute.
+
+        Returns:
+            List[Any]: A list of results corresponding to the input tool calls.
+        """
+        tasks = []
+        for call in tool_calls:
+            name = call.get("name")
+            kwargs = call.get("kwargs", {})
+
+            if not name:
+                tasks.append(asyncio.to_thread(lambda: "Error: Tool name is missing."))
+                continue
+
+            async def wrap_execution(n: str = name, k: Dict[str, Any] = kwargs) -> Any:
+                try:
+                    res = await asyncio.to_thread(self._route_tool, n, k)
+                    if inspect.isawaitable(res):
+                        return await res
+                    return res
+                except Exception as e:
+                    return f"Error executing tool '{n}': {e}"
+
+            tasks.append(wrap_execution())
+
+        return await asyncio.gather(*tasks)

--- a/tests/test_mcp_router_v2_concurrency.py
+++ b/tests/test_mcp_router_v2_concurrency.py
@@ -1,0 +1,69 @@
+import asyncio
+import time
+import pytest
+from magda_agent.skills.mcp_router_v2_concurrency import MCPConcurrentRouterV2
+
+def slow_sync_handler(tool_name: str, arguments: dict) -> str:
+    """A mock handler that takes 0.1 seconds to execute synchronously."""
+    time.sleep(0.1)
+    return f"Executed {tool_name} with {arguments}"
+
+async def slow_async_handler(tool_name: str, arguments: dict) -> str:
+    """A mock handler that takes 0.1 seconds to execute asynchronously."""
+    await asyncio.sleep(0.1)
+    return f"Async executed {tool_name} with {arguments}"
+
+def error_handler(tool_name: str, arguments: dict) -> str:
+    """A mock handler that always raises an exception."""
+    raise RuntimeError("Intentional error for testing")
+
+@pytest.mark.asyncio
+async def test_concurrent_execution_timing_and_results():
+    """Test that concurrent execution runs multiple tools in parallel, saving time."""
+    router = MCPConcurrentRouterV2()
+    router.register_server("weather", slow_sync_handler)
+    router.register_server("asyncweather", slow_async_handler)
+
+    tool_calls = [
+        {"name": "weather_get_forecast", "kwargs": {"location": "London"}},
+        {"name": "weather_get_temperature", "kwargs": {"location": "London"}},
+        {"name": "asyncweather_get_wind", "kwargs": {"location": "London"}},
+    ]
+
+    start_time = time.monotonic()
+    results = await router.execute_concurrently(tool_calls)
+    end_time = time.monotonic()
+
+    duration = end_time - start_time
+
+    # If executed sequentially, it would take ~0.3 seconds.
+    # Concurrently, it should take slightly more than 0.1 seconds.
+    assert duration < 0.25, f"Execution took too long: {duration}s"
+
+    assert len(results) == 3
+    assert "Executed get_forecast" in results[0]
+    assert "Executed get_temperature" in results[1]
+    assert "Async executed get_wind" in results[2]
+
+@pytest.mark.asyncio
+async def test_error_handling():
+    """Test that errors during execution are caught and returned as strings."""
+    router = MCPConcurrentRouterV2()
+    router.register_server("failing", error_handler)
+
+    tool_calls = [
+        {"name": "failing_tool", "kwargs": {}},
+        {"name": "missingprefix", "kwargs": {}},
+        {"name": "unknown_tool", "kwargs": {}},
+        {"kwargs": {}}  # missing name
+    ]
+
+    results = await router.execute_concurrently(tool_calls)
+
+    assert len(results) == 4
+    assert "Error executing tool 'failing_tool'" in results[0]
+    assert "Intentional error for testing" in results[0]
+
+    assert "must be prefixed with a server name" in results[1]
+    assert "No registered MCP server handler found" in results[2]
+    assert "Error: Tool name is missing." in results[3]


### PR DESCRIPTION
This PR implements the task `mcp-action-tool-concurrency-v2-a9a0b782` by adding `MCPConcurrentRouterV2`. This enables concurrent execution of multiple MCP action tools at runtime, saving time. Test coverage has been added. `agent_tasks.json` is updated and validated successfully. 3 new tasks based on AI trends have been generated.

---
*PR created automatically by Jules for task [4256823510370783458](https://jules.google.com/task/4256823510370783458) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add concurrent MCP tool execution router with server-prefix dispatch
> - Adds [`MCPConcurrentRouterV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/420/files#diff-c786c656508dc3037cc0b53a9fb5057a8631ca6fe1fb737ebc11919a9ebb606b) which routes tool calls by matching server prefixes in tool names (e.g. `server_tool`) to registered handler callables.
> - `execute_concurrently` runs a batch of tool calls in parallel using `asyncio.gather`, dispatching sync handlers via `asyncio.to_thread` and awaiting async handlers directly.
> - Failures in individual calls are caught and returned as error strings rather than raising, so one failed call does not abort the batch.
> - Adds a corresponding test suite covering timing, sync/async handler routing, and error cases (unknown prefix, missing name, handler exceptions).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46af386.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->