### PR TITLE
feat: Agent Teams Subagent Git Worktree Isolation v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6874,7 +6874,7 @@
     },
     {
       "id": "agent-teams-subagent-isolation-v2-49252226",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "high",
       "title": "Agent Teams Subagent Git Worktree Isolation v2",
@@ -14412,6 +14412,57 @@
       "acceptance": [
         "Active tokens are managed centrally.",
         "Tests mock token exchange verification."
+      ]
+    },
+    {
+      "id": "aider-post-merge-smoke-tests-v2-1234abcd",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "low",
+      "title": "Aider Style Post-Merge Smoke Tests V2",
+      "description": "Inspired by SWE-bench Aider evaluation trends: Update the post-merge smoke testing pipeline to provide more robust analysis of agent-generated code.",
+      "allowed_paths": [
+        "magda_agent/evaluation/smoke_tester_v2.py",
+        "tests/test_smoke_tester_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Smoke tester V2 is implemented and can detect syntax and import errors.",
+        "Tests verify that incorrect files trigger validation errors."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-live-reflection-v2-5678efgh",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Reflection Tracing V2",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend: Create a reflection telemetry exporter to stream V2 reflection events to a Canvas interface.",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_reflection_v2.py",
+        "tests/test_canvas_reflection_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "V2 reflection exporter is implemented.",
+        "Tests mock data correctly matching Canvas payload."
+      ]
+    },
+    {
+      "id": "letta-virtual-context-routine-builder-v2-9012ijkl",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Letta Virtual Context Routine Builder V2",
+      "description": "Inspired by MemGPT/Letta patterns: Build an advanced routine generator hook V2 that dynamically builds procedural memory from virtual context streams.",
+      "allowed_paths": [
+        "magda_agent/memory/letta_routine_v2.py",
+        "tests/test_letta_routine_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "V2 routine builder hook is written.",
+        "Tests correctly extract routines into procedural memory."
       ]
     }
   ]

--- a/magda_agent/agents/isolation_v2.py
+++ b/magda_agent/agents/isolation_v2.py
@@ -1,0 +1,94 @@
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from typing import Optional, Dict
+
+class GitWorktreeIsolationV2:
+    """
+    Manages strict git worktree isolation and context separation for subagents.
+    Inspired by Claude Agent Teams trend.
+    """
+    def __init__(self, base_dir: str = "/tmp/magda_team_worktrees_v2") -> None:
+        """
+        Initializes the isolation manager.
+
+        Args:
+            base_dir: The base directory where worktrees will be created.
+        """
+        self.base_dir = base_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.active_contexts: Dict[str, str] = {}
+
+    async def setup_isolation(self, agent_id: str, branch_name: Optional[str] = None) -> str:
+        """
+        Sets up an isolated git worktree environment for a subagent.
+
+        Args:
+            agent_id: A unique identifier for the subagent.
+            branch_name: Optional branch name. If not provided, creates a detached worktree.
+
+        Returns:
+            The path to the isolated worktree environment.
+        """
+        unique_suffix = str(uuid.uuid4())[:8]
+        env_path = os.path.join(self.base_dir, f"subagent_{agent_id}_{unique_suffix}")
+
+        if branch_name:
+            cmd = ["git", "worktree", "add", "-b", branch_name, env_path, "HEAD"]
+        else:
+            cmd = ["git", "worktree", "add", "-d", env_path, "HEAD"]
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                error_msg = stderr.decode().strip()
+                logging.error(f"Failed to create isolated environment for {agent_id}: {error_msg}")
+                raise RuntimeError(f"Git worktree creation failed: {error_msg}")
+
+            logging.info(f"Created isolated environment for {agent_id} at {env_path}")
+            self.active_contexts[agent_id] = env_path
+            return env_path
+        except Exception as e:
+            logging.error(f"Error executing git worktree add for {agent_id}: {e}")
+            raise
+
+    async def teardown_isolation(self, agent_id: str) -> None:
+        """
+        Tears down and removes an isolated git worktree environment.
+
+        Args:
+            agent_id: The unique identifier for the subagent.
+        """
+        env_path = self.active_contexts.get(agent_id)
+        if not env_path:
+            logging.warning(f"No active isolation context found for agent {agent_id}")
+            return
+
+        cmd = ["git", "worktree", "remove", "--force", env_path]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                logging.error(f"Failed to remove isolated environment for {agent_id}: {stderr.decode().strip()}")
+            else:
+                logging.info(f"Removed isolated environment for {agent_id} at {env_path}")
+        except Exception as e:
+            logging.error(f"Error executing git worktree remove for {agent_id}: {e}")
+        finally:
+            if os.path.exists(env_path):
+                try:
+                    shutil.rmtree(env_path)
+                except Exception as ex:
+                    logging.error(f"Could not delete worktree folder for {agent_id}: {ex}")
+            self.active_contexts.pop(agent_id, None)

--- a/tests/test_isolation_v2.py
+++ b/tests/test_isolation_v2.py
@@ -1,0 +1,129 @@
+import pytest
+import asyncio
+from unittest.mock import patch, AsyncMock, MagicMock
+import os
+from magda_agent.agents.isolation_v2 import GitWorktreeIsolationV2
+
+@pytest.fixture
+def isolation_manager():
+    return GitWorktreeIsolationV2(base_dir="/tmp/test_magda_worktrees_v2")
+
+@pytest.mark.asyncio
+async def test_setup_isolation_success(isolation_manager):
+    agent_id = "test_agent_123"
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec, \
+         patch("uuid.uuid4", return_value="12345678-abcd"):
+
+        env_path = await isolation_manager.setup_isolation(agent_id)
+
+        assert "subagent_test_agent_123_12345678" in env_path
+        assert agent_id in isolation_manager.active_contexts
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "git"
+        assert args[1] == "worktree"
+        assert args[2] == "add"
+        assert args[3] == "-d"
+        assert args[4] == env_path
+        assert args[5] == "HEAD"
+
+@pytest.mark.asyncio
+async def test_setup_isolation_with_branch(isolation_manager):
+    agent_id = "test_agent_branch"
+    branch_name = "feature-branch"
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec, \
+         patch("uuid.uuid4", return_value="12345678-abcd"):
+
+        env_path = await isolation_manager.setup_isolation(agent_id, branch_name)
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "git"
+        assert args[1] == "worktree"
+        assert args[2] == "add"
+        assert args[3] == "-b"
+        assert args[4] == branch_name
+        assert args[5] == env_path
+        assert args[6] == "HEAD"
+
+@pytest.mark.asyncio
+async def test_setup_isolation_failure(isolation_manager):
+    agent_id = "test_agent_fail"
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"git error output")
+    mock_process.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+        with pytest.raises(RuntimeError, match="Git worktree creation failed"):
+            await isolation_manager.setup_isolation(agent_id)
+
+        assert agent_id not in isolation_manager.active_contexts
+
+@pytest.mark.asyncio
+async def test_teardown_isolation_success(isolation_manager):
+    agent_id = "test_agent_rm"
+    env_path = "/tmp/test_magda_worktrees_v2/subagent_test_agent_rm_12345678"
+    isolation_manager.active_contexts[agent_id] = env_path
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec, \
+         patch("os.path.exists", return_value=True), \
+         patch("shutil.rmtree") as mock_rmtree:
+
+        await isolation_manager.teardown_isolation(agent_id)
+
+        assert agent_id not in isolation_manager.active_contexts
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "git"
+        assert args[1] == "worktree"
+        assert args[2] == "remove"
+        assert args[3] == "--force"
+        assert args[4] == env_path
+
+        mock_rmtree.assert_called_once_with(env_path)
+
+@pytest.mark.asyncio
+async def test_teardown_isolation_not_found(isolation_manager):
+    agent_id = "test_agent_not_found"
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        await isolation_manager.teardown_isolation(agent_id)
+        mock_exec.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_teardown_isolation_git_failure(isolation_manager, caplog):
+    agent_id = "test_agent_fail_rm"
+    env_path = "/tmp/test_magda_worktrees_v2/subagent_test_agent_fail_rm_12345678"
+    isolation_manager.active_contexts[agent_id] = env_path
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"git remove error")
+    mock_process.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process), \
+         patch("os.path.exists", return_value=True), \
+         patch("shutil.rmtree") as mock_rmtree:
+
+        await isolation_manager.teardown_isolation(agent_id)
+
+        assert agent_id not in isolation_manager.active_contexts
+        assert "Failed to remove isolated environment" in caplog.text
+        # Cleanup should still be attempted
+        mock_rmtree.assert_called_once_with(env_path)


### PR DESCRIPTION
Implements strict subagent context isolation based on Git Worktrees according to Claude Agent Teams trend. Marks the relevant task done in `agent_tasks.json` and adds 3 new tasks reflecting current AI trends.

---
*PR created automatically by Jules for task [13748173132543853958](https://jules.google.com/task/13748173132543853958) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git worktree-based isolation for agent team subagents
> - Introduces [`GitWorktreeIsolationV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/421/files#diff-a35e3084df1f7527c8041dd9c00cf48287b08cb795c43d6414dd40e992560dbc), which creates a dedicated git worktree per subagent using a UUID-suffixed path, supporting both detached and branch modes.
> - `setup_isolation` runs `git worktree add` asynchronously and records the path in an in-memory `active_contexts` map; raises `RuntimeError` on git failure.
> - `teardown_isolation` runs `git worktree remove --force` and falls back to `shutil.rmtree` if the directory still exists, then clears the agent's entry from `active_contexts`.
> - Adds [tests/test_isolation_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/421/files#diff-3648cffcd0b8478aba4086574e0a98adf82168374c9bbc4a1804953604c6f040) with async tests covering success, branch mode, git failure, and missing-context teardown scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb6dccc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->