### PR TITLE
feat: Implement OpenClaw Canvas Live Visualization WebSockets v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6891,7 +6891,7 @@
     },
     {
       "id": "openclaw-canvas-live-visualization-v2-553ba456",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw Canvas Live Visualization WebSockets v2",
@@ -14463,6 +14463,57 @@
       "acceptance": [
         "V2 routine builder hook is written.",
         "Tests correctly extract routines into procedural memory."
+      ]
+    },
+    {
+      "id": "hermes-agent-skill-improvement-v1-abcd",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Agent Experience Skill Improvement V1",
+      "description": "Inspired by Hermes Agent trend: Implement a learning module that creates and refines skills dynamically from episodic experience.",
+      "allowed_paths": [
+        "magda_agent/learning/skill_improver_v1.py",
+        "tests/test_skill_improver_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill Improver correctly distills skills from memory.",
+        "Tests mock memory extractions."
+      ]
+    },
+    {
+      "id": "claude-agent-subagent-spawning-v4-efgh",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Agent Teams Context Compression V4",
+      "description": "Inspired by Claude Agent SDK: Add context compression hooks to subagent spawner to pass highly condensed context down the hierarchy.",
+      "allowed_paths": [
+        "magda_agent/architecture/context_compression_v4.py",
+        "tests/test_context_compression_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context compression properly formats hierarchical context.",
+        "Tests verify prompt sizes are appropriately condensed."
+      ]
+    },
+    {
+      "id": "mcp-kernel-runtime-function-concurrency-v1-ijkl",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI SDK Runtime Function Tool Concurrency V1",
+      "description": "Inspired by OpenAI Agents SDK: Allow concurrent execution of independent function tool requests inside the runtime execution guardrail.",
+      "allowed_paths": [
+        "magda_agent/skills/runtime_concurrency_v4.py",
+        "tests/test_runtime_concurrency_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Concurrency guardrail allows independent tool runs.",
+        "Tests simulate parallel asynchronous function tool executions."
       ]
     }
   ]

--- a/magda_agent/visualization/server_v2.py
+++ b/magda_agent/visualization/server_v2.py
@@ -1,0 +1,67 @@
+import asyncio
+import logging
+from typing import List, Optional
+from fastapi import WebSocket, WebSocketDisconnect
+from magda_agent.consciousness.core import Consciousness
+
+logger = logging.getLogger(__name__)
+
+class CanvasServerV2:
+    """
+    WebSocket server for streaming live visualization of Magda's internal cognitive state.
+    """
+    def __init__(self, consciousness: Consciousness, interval: float = 1.0) -> None:
+        """
+        Initialize the WebSocket canvas server.
+        """
+        from magda_agent.visualization.canvas_v3 import CanvasVisualizerV3
+        self.visualizer = CanvasVisualizerV3(consciousness)
+        self.active_connections: List[WebSocket] = []
+        self.consciousness: Consciousness = consciousness
+        self.interval: float = interval
+        self._streaming_task: Optional[asyncio.Task] = None
+        self._running: bool = False
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """Accept a websocket connection and add it to the active pool."""
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info(f"Canvas client connected. Total clients: {len(self.active_connections)}")
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        """Remove a websocket connection from the pool."""
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+            logger.info(f"Canvas client disconnected. Total clients: {len(self.active_connections)}")
+
+    async def broadcast(self, message: str) -> None:
+        """Broadcast a message to all active websocket connections."""
+        disconnected: List[WebSocket] = []
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(message)
+            except Exception as e:
+                logger.error(f"Failed to send message to canvas client: {e}")
+                disconnected.append(connection)
+
+        for conn in disconnected:
+            self.disconnect(conn)
+
+    async def start_streaming(self) -> None:
+        """Start the background task that periodically broadcasts the cognitive state."""
+        self._running = True
+        logger.info("Canvas visualization streaming started.")
+        while self._running:
+            try:
+                if self.active_connections:
+                    state = self.visualizer.get_state_json()
+                    await self.broadcast(state)
+            except Exception as e:
+                logger.error(f"Error while streaming canvas state: {e}")
+            await asyncio.sleep(self.interval)
+
+    async def stop_streaming(self) -> None:
+        """Stop the background streaming task."""
+        self._running = False
+        logger.info("Canvas visualization streaming stopped.")
+        # We don't cancel the task directly here, we let the loop finish gracefully.

--- a/tests/test_visualization_server_v2.py
+++ b/tests/test_visualization_server_v2.py
@@ -1,0 +1,93 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import WebSocket
+from magda_agent.visualization.server_v2 import CanvasServerV2 as CanvasServer
+from typing import Any
+
+@pytest.fixture
+def mock_consciousness() -> MagicMock:
+    """Provides a mocked Consciousness instance."""
+    mock = MagicMock()
+    mock.emotions = None
+    mock.mental_states = None
+    mock.memory = None
+    mock.skills = None
+    mock.planner = None
+    mock.hypothalamus = None
+    mock.global_workspace = None
+    return mock
+
+@pytest.fixture
+def canvas_server(mock_consciousness: MagicMock) -> CanvasServer:
+    """Provides a CanvasServerV2 instance initialized with a mocked visualizer."""
+    with patch('magda_agent.visualization.canvas_v3.CanvasVisualizerV3') as mock_visualizer_class:
+        mock_visualizer_instance = mock_visualizer_class.return_value
+        mock_visualizer_instance.get_state_json.return_value = '{"test": "state"}'
+        server = CanvasServer(consciousness=mock_consciousness, interval=0.1)
+        # Verify the mock is being used
+        assert server.visualizer == mock_visualizer_instance
+        return server
+
+@pytest.mark.asyncio
+async def test_connect(canvas_server: CanvasServer) -> None:
+    """Test that a new websocket connection is accepted and appended to active connections."""
+    mock_ws = AsyncMock(spec=WebSocket)
+    await canvas_server.connect(mock_ws)
+    assert mock_ws in canvas_server.active_connections
+    mock_ws.accept.assert_awaited_once()
+
+def test_disconnect(canvas_server: CanvasServer) -> None:
+    """Test that a websocket is removed from active connections upon disconnect."""
+    mock_ws = MagicMock(spec=WebSocket)
+    canvas_server.active_connections.append(mock_ws)
+    canvas_server.disconnect(mock_ws)
+    assert mock_ws not in canvas_server.active_connections
+
+@pytest.mark.asyncio
+async def test_broadcast(canvas_server: CanvasServer) -> None:
+    """Test that broadcast sends the payload to all active connections."""
+    mock_ws1 = AsyncMock(spec=WebSocket)
+    mock_ws2 = AsyncMock(spec=WebSocket)
+
+    canvas_server.active_connections.extend([mock_ws1, mock_ws2])
+
+    await canvas_server.broadcast("Test Message")
+
+    mock_ws1.send_text.assert_awaited_once_with("Test Message")
+    mock_ws2.send_text.assert_awaited_once_with("Test Message")
+
+@pytest.mark.asyncio
+async def test_broadcast_disconnects_on_error(canvas_server: CanvasServer) -> None:
+    """Test that connections failing to receive broadcast are removed."""
+    mock_ws1 = AsyncMock(spec=WebSocket)
+    mock_ws2 = AsyncMock(spec=WebSocket)
+    mock_ws2.send_text.side_effect = Exception("Connection closed")
+
+    canvas_server.active_connections.extend([mock_ws1, mock_ws2])
+
+    await canvas_server.broadcast("Test Message")
+
+    mock_ws1.send_text.assert_awaited_once_with("Test Message")
+    assert mock_ws1 in canvas_server.active_connections
+    assert mock_ws2 not in canvas_server.active_connections
+
+@pytest.mark.asyncio
+async def test_start_streaming(canvas_server: CanvasServer, mock_consciousness: MagicMock) -> None:
+    """Test that start_streaming broadcasts at regular intervals."""
+    mock_ws = AsyncMock(spec=WebSocket)
+    canvas_server.active_connections.append(mock_ws)
+
+    # Run start_streaming as a background task
+    task = asyncio.create_task(canvas_server.start_streaming())
+
+    # Yield control to the event loop so the task can run
+    await asyncio.sleep(0.15)
+
+    # Stop the stream
+    await canvas_server.stop_streaming()
+    await task
+
+    # The interval is 0.1s, sleeping 0.15s should trigger at least 1 broadcast
+    assert mock_ws.send_text.await_count >= 1
+    mock_ws.send_text.assert_any_call('{"test": "state"}')


### PR DESCRIPTION
This PR addresses the `openclaw-canvas-live-visualization-v2-553ba456` todo task from `agent_tasks.json`.

Changes:
1. Created `magda_agent/visualization/server_v2.py` containing `CanvasServerV2` to broadcast streaming WebSocket messages to clients using FastAPI and `CanvasVisualizerV3`.
2. Created `tests/test_visualization_server_v2.py` implementing extensive mocked unit tests over the background broadcasting routine.
3. Marked the task as `done` in `agent_tasks.json`.
4. Extracted 3 new trend-inspired tasks to `agent_tasks.json` following the constraints in `scripts/validate_agent_tasks.py`.

---
*PR created automatically by Jules for task [10055819373226800451](https://jules.google.com/task/10055819373226800451) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CanvasServerV2` WebSocket server for live cognitive state visualization
> - Introduces [`server_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/422/files#diff-e1c2965d1df090d8421b2dc9866f6e2b80be72e51d472c3dc05a7da1c8b3f999) with `CanvasServerV2`, a WebSocket server that wraps `CanvasVisualizerV3` and periodically broadcasts JSON visualization state to all connected clients at a configurable interval.
> - Manages client lifecycle via `connect`, `disconnect`, and `broadcast` methods; clients that error during send are automatically removed from the active pool.
> - Adds async unit tests in [`tests/test_visualization_server_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/422/files#diff-73aae9066fe802e01f4fc6fc7ca498eebb080ce2ad1e9e4f9d33acfd15dca52b) covering connection, disconnection, broadcast success/failure, and start/stop streaming.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8b90e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->