### PR TITLE
Add MCP Kernel Taint Tracking Sandbox v1

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6908,7 +6908,7 @@
     },
     {
       "id": "mcp-kernel-taint-tracking-v1-9876",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Kernel Taint Tracking Sandbox v1",
@@ -14514,6 +14514,57 @@
       "acceptance": [
         "Concurrency guardrail allows independent tool runs.",
         "Tests simulate parallel asynchronous function tool executions."
+      ]
+    },
+    {
+      "id": "agent-teams-parallel-subagents-v6",
+      "title": "Agent Teams Parallel Subagents V6",
+      "area": "architecture",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by Agent Teams isolation trend: Implement parallel execution manager for subagents operating in isolated git worktrees.",
+      "allowed_paths": [
+        "magda_agent/architecture/parallel_execution_v6.py",
+        "tests/test_parallel_execution_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents execute concurrently in their respective worktrees.",
+        "Tests verify concurrency and isolation."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-skill-marketplace-poller-v2",
+      "title": "MCP Dynamic Skill Marketplace Poller V2",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by agentskills.io standard: Implement a background cron job that periodically syncs with the agentskills.io marketplace.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_marketplace_poller_v2.py",
+        "tests/test_mcp_marketplace_poller_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Poller accurately parses agentskills.io JSON formats",
+        "Tests mock network calls"
+      ]
+    },
+    {
+      "id": "openclaw-memory-compaction-cron-v2",
+      "title": "OpenClaw Memory Compaction Cron V2",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by OpenClaw virtual context: Implement a cron job that automatically compacts episodic memory overnight.",
+      "allowed_paths": [
+        "magda_agent/scheduler/memory_compaction_cron_v2.py",
+        "tests/test_memory_compaction_cron_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory compaction job runs on schedule.",
+        "Tests mock cron execution."
       ]
     }
   ]

--- a/magda_agent/safety/mcp_kernel_sandbox.py
+++ b/magda_agent/safety/mcp_kernel_sandbox.py
@@ -1,0 +1,46 @@
+"""MCP Kernel Taint Tracking Sandbox v1.
+
+Provides a sandbox execution environment for MCP tools with taint tracking.
+"""
+from typing import Any, Callable, Dict
+
+from magda_agent.safety.taint_tracking_v2 import (
+    TaintTrackerV2,
+    SandboxExecutionEnvironmentV2,
+    PolicyViolationError,
+)
+
+class MCPKernelSandbox:
+    """Sandbox execution environment with taint tracking capabilities inspired by MCPKernel."""
+
+    def __init__(self) -> None:
+        """Initialize the MCPKernelSandbox."""
+        self.tracker = TaintTrackerV2()
+        self.sandbox = SandboxExecutionEnvironmentV2(self.tracker)
+
+    def execute(self, tool_func: Callable[..., Any], inputs: Dict[str, Any], is_sensitive: bool = False) -> Any:
+        """
+        Executes a tool within the sandbox boundary.
+
+        Args:
+            tool_func: The function to execute.
+            inputs: A dictionary of inputs to pass to the function.
+            is_sensitive: If True, execution will fail if inputs contain tainted data.
+
+        Returns:
+            The result of the tool execution, appropriately tainted if inputs were tainted.
+
+        Raises:
+            PolicyViolationError: If is_sensitive is True and inputs contain tainted data.
+            RuntimeError: If the tool execution fails.
+        """
+        if is_sensitive and self.tracker.is_tainted(inputs):
+            origins = self.tracker.get_origins(inputs)
+            raise PolicyViolationError(f"Tainted input to sensitive tool call from origins: {origins}")
+
+        try:
+            return self.sandbox.execute(tool_func, **inputs)
+        except PolicyViolationError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Sandbox execution failed: {str(e)}")

--- a/tests/test_mcp_kernel_sandbox.py
+++ b/tests/test_mcp_kernel_sandbox.py
@@ -1,0 +1,74 @@
+"""Tests for MCP Kernel Taint Tracking Sandbox v1."""
+
+import pytest
+
+from magda_agent.safety.mcp_kernel_sandbox import MCPKernelSandbox
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError, is_tainted, mark_tainted
+
+def sample_sensitive_tool(data: str) -> str:
+    """A sample sensitive tool."""
+    return f"Processed {data}"
+
+def sample_safe_tool(data: str) -> str:
+    """A sample non-sensitive tool."""
+    return f"Safe {data}"
+
+def test_safe_inputs_accepted() -> None:
+    """Test that a non-sensitive tool accepts safe data and returns untainted result."""
+    sandbox = MCPKernelSandbox()
+
+    safe_data = {"data": "alice"}
+
+    result = sandbox.execute(sample_safe_tool, safe_data, is_sensitive=False)
+
+    assert "Safe alice" in result
+    assert not is_tainted(result)
+
+def test_taint_propagation_non_sensitive() -> None:
+    """Test that a non-sensitive tool accepts tainted data and propagates the taint."""
+    sandbox = MCPKernelSandbox()
+
+    tainted_string = sandbox.tracker.taint("DROP TABLE users;", "user_input")
+    tainted_data = {"data": tainted_string}
+
+    result = sandbox.execute(sample_safe_tool, tainted_data, is_sensitive=False)
+
+    assert "Safe DROP TABLE users;" in result
+    assert is_tainted(result)
+    assert "user_input" in sandbox.tracker.get_origins(result)
+
+def test_sensitive_tool_tainted_input() -> None:
+    """Test that a sensitive tool rejects tainted data and raises PolicyViolationError."""
+    sandbox = MCPKernelSandbox()
+
+    tainted_string = sandbox.tracker.taint("DROP TABLE users;", "malicious_user")
+    tainted_data = {"data": tainted_string}
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        sandbox.execute(sample_sensitive_tool, tainted_data, is_sensitive=True)
+
+    assert "malicious_user" in str(exc_info.value)
+    assert "Tainted input to sensitive tool call from origins" in str(exc_info.value)
+
+def test_sensitive_tool_untainted_input() -> None:
+    """Test that a sensitive tool accepts untainted data and returns untainted result."""
+    sandbox = MCPKernelSandbox()
+
+    safe_data = {"data": "alice"}
+
+    result = sandbox.execute(sample_sensitive_tool, safe_data, is_sensitive=True)
+
+    assert "Processed alice" in result
+    assert not is_tainted(result)
+
+def test_tool_execution_error() -> None:
+    """Test that runtime errors in tool execution are wrapped in RuntimeError."""
+    sandbox = MCPKernelSandbox()
+
+    def failing_tool(data: str) -> str:
+        raise ValueError("Tool failed")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        sandbox.execute(failing_tool, {"data": "alice"}, is_sensitive=False)
+
+    assert "Sandbox execution failed: Tool failed" in str(exc_info.value)


### PR DESCRIPTION
Implements the MCPKernelSandbox class which wraps SandboxExecutionEnvironmentV2 and TaintTrackerV2 to securely execute tools, enforcing taint tracking for sensitive tools. Also marks the task as done in agent_tasks.json and appends 3 new tasks based on recent trends.

---
*PR created automatically by Jules for task [17852441813953182110](https://jules.google.com/task/17852441813953182110) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPKernelSandbox` class with taint tracking and policy enforcement
> - Adds [`MCPKernelSandbox`](https://github.com/kazah4359-lgtm/Magda-agent/pull/423/files#diff-88378552add8576955929f50186d817c6a7b88d3dce3e76595c16a7aadc0045a) which wires `TaintTrackerV2` and `SandboxExecutionEnvironmentV2` to execute tool functions with taint-aware policy checks.
> - When `is_sensitive=True`, `execute()` raises `PolicyViolationError` if any input is tainted, including origin details; non-policy exceptions are wrapped as `RuntimeError`.
> - Adds unit tests in [`tests/test_mcp_kernel_sandbox.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/423/files#diff-fb902b51bddab8f4e15168184388776af54879dc87c9c573711516e64ddd7dd8) covering safe inputs, taint propagation, sensitive-tool rejection, and exception wrapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69600a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->