### PR TITLE
feat: Implement ASSERT Policy Driven Eval Framework v1

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6925,7 +6925,7 @@
     },
     {
       "id": "assert-policy-eval-framework-v1-4321",
-      "status": "todo",
+      "status": "done",
       "area": "metacognition",
       "risk": "medium",
       "title": "ASSERT Policy Driven Eval Framework v1",
@@ -14565,6 +14565,57 @@
       "acceptance": [
         "Memory compaction job runs on schedule.",
         "Tests mock cron execution."
+      ]
+    },
+    {
+      "id": "letta-virtual-context-advanced-sync-v3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Letta Virtual Context Advanced Sync V3",
+      "description": "Inspired by MemGPT/Letta patterns: Implement an advanced synchronization hook to push procedural memory from virtual context streams to disk in real-time.",
+      "allowed_paths": [
+        "magda_agent/memory/letta_sync_v3.py",
+        "tests/test_letta_sync_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Advanced sync hook correctly writes virtual context.",
+        "Tests mock disk writes and context updates."
+      ]
+    },
+    {
+      "id": "claude-dependency-graph-planner-v4",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Claude Dependency Graph Planner Export V2",
+      "description": "Inspired by Claude Agent SDK task system: Serialize internal dependency graphs into standard MCP task format for external observability.",
+      "allowed_paths": [
+        "magda_agent/planning/graph_exporter_v2.py",
+        "tests/test_graph_exporter_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dependency graph exports to standard MCP task format.",
+        "Tests verify JSON export schema."
+      ]
+    },
+    {
+      "id": "prempti-audit-logger-intercept-v4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Prempti Audit Logger Action Intercept V4",
+      "description": "Inspired by Prempti (Falco) trend: Implement action interception layer that intercepts standard output during skill execution to mask PII.",
+      "allowed_paths": [
+        "magda_agent/safety/prempti_intercept_v4.py",
+        "tests/test_prempti_intercept_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Logger intercepts outputs and redacts PII.",
+        "Tests verify PII masking."
       ]
     }
   ]

--- a/magda_agent/metacognition/assert_framework.py
+++ b/magda_agent/metacognition/assert_framework.py
@@ -1,0 +1,81 @@
+import json
+import logging
+from typing import Dict, Any, List
+
+from magda_agent.llm_client import LLMClient
+
+class AssertFramework:
+    """
+    ASSERT Policy Driven Evaluation Framework.
+    Evaluates an execution plan against system constraints dynamically.
+    """
+
+    def __init__(self, llm: LLMClient) -> None:
+        """
+        Initializes the AssertFramework.
+
+        Args:
+            llm: The LLM client to use for evaluation.
+        """
+        self.llm = llm
+
+    async def evaluate_plan(self, plan: List[str], policies: List[str]) -> Dict[str, Any]:
+        """
+        Evaluates a given execution plan against explicit system policies.
+
+        Args:
+            plan: A list of strings representing the steps of the execution plan.
+            policies: A list of string policies to check against.
+
+        Returns:
+            A dictionary containing 'is_compliant' (bool) and 'violations' (List[str]).
+        """
+        formatted_plan = "\n".join([f"{i+1}. {step}" for i, step in enumerate(plan)])
+        formatted_policies = "\n".join([f"- {policy}" for policy in policies])
+
+        prompt = (
+            "Evaluate the following execution plan against the provided system policies.\n"
+            "Determine if the plan violates ANY of these policies.\n\n"
+            f"Policies:\n{formatted_policies}\n\n"
+            f"Execution Plan:\n{formatted_plan}\n\n"
+            "Respond ONLY with a JSON object in this exact format:\n"
+            "{\n"
+            '  "is_compliant": true,\n'
+            '  "violations": ["Policy description if violated, else empty"]\n'
+            "}"
+        )
+
+        messages = [{"role": "system", "content": prompt}]
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.llm.chat_completion(messages, temperature=0.1)
+
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+                is_compliant = evaluation.get("is_compliant", False)
+                violations = evaluation.get("violations", [])
+
+                if not is_compliant and violations:
+                    logging.warning(f"ASSERT Framework: Plan violation detected! Violations: {violations}")
+
+                return {
+                    "is_compliant": is_compliant,
+                    "violations": violations
+                }
+
+            except json.JSONDecodeError as e:
+                logging.warning(f"ASSERT Framework JSON decoding error attempt {attempt + 1}/{max_retries}: {e}")
+                if attempt == max_retries - 1:
+                    logging.error("ASSERT Framework reached max retries. Failing closed (is_compliant=False).")
+                    return {"is_compliant": False, "violations": ["Evaluation failed due to JSON decoding error."]}
+            except Exception as e:
+                logging.error(f"ASSERT Framework failed: {e}")
+                return {"is_compliant": False, "violations": [f"Evaluation failed: {str(e)}"]}
+
+        return {"is_compliant": False, "violations": ["Unknown error"]}

--- a/tests/test_assert_framework.py
+++ b/tests/test_assert_framework.py
@@ -1,0 +1,104 @@
+import pytest
+import json
+from unittest.mock import AsyncMock
+
+from magda_agent.metacognition.assert_framework import AssertFramework
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_llm_client():
+    mock = AsyncMock(spec=LLMClient)
+    return mock
+
+@pytest.fixture
+def assert_framework(mock_llm_client):
+    return AssertFramework(llm=mock_llm_client)
+
+@pytest.mark.asyncio
+async def test_evaluate_plan_compliant(assert_framework, mock_llm_client):
+    mock_json_response = '''
+    {
+      "is_compliant": true,
+      "violations": []
+    }
+    '''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    plan = ["Run tests"]
+    policies = ["Do no harm"]
+
+    result = await assert_framework.evaluate_plan(plan, policies)
+
+    assert result["is_compliant"] is True
+    assert result["violations"] == []
+    mock_llm_client.chat_completion.assert_called_once()
+
+    # Check that prompt formatting is correct
+    call_args = mock_llm_client.chat_completion.call_args[0][0]
+    prompt = call_args[0]["content"]
+    assert "- Do no harm" in prompt
+    assert "1. Run tests" in prompt
+
+@pytest.mark.asyncio
+async def test_evaluate_plan_non_compliant(assert_framework, mock_llm_client):
+    mock_json_response = '''
+    {
+      "is_compliant": false,
+      "violations": ["Must not delete user data"]
+    }
+    '''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    plan = ["Delete user database"]
+    policies = ["Must not delete user data"]
+
+    result = await assert_framework.evaluate_plan(plan, policies)
+
+    assert result["is_compliant"] is False
+    assert result["violations"] == ["Must not delete user data"]
+
+@pytest.mark.asyncio
+async def test_evaluate_plan_json_decode_retry_success(assert_framework, mock_llm_client):
+    invalid_json = "This is not json"
+    valid_json = '''
+    {
+      "is_compliant": true,
+      "violations": []
+    }
+    '''
+
+    mock_llm_client.chat_completion.side_effect = [invalid_json, valid_json]
+
+    plan = ["Safe plan"]
+    policies = ["Safe policy"]
+
+    result = await assert_framework.evaluate_plan(plan, policies)
+
+    assert result["is_compliant"] is True
+    assert mock_llm_client.chat_completion.call_count == 2
+
+@pytest.mark.asyncio
+async def test_evaluate_plan_json_decode_failure(assert_framework, mock_llm_client):
+    invalid_json = "This is not json"
+    mock_llm_client.chat_completion.side_effect = [invalid_json, invalid_json, invalid_json]
+
+    plan = ["Safe plan"]
+    policies = ["Safe policy"]
+
+    result = await assert_framework.evaluate_plan(plan, policies)
+
+    assert result["is_compliant"] is False
+    assert "Evaluation failed due to JSON decoding error." in result["violations"][0]
+    assert mock_llm_client.chat_completion.call_count == 3
+
+@pytest.mark.asyncio
+async def test_evaluate_plan_exception(assert_framework, mock_llm_client):
+    mock_llm_client.chat_completion.side_effect = Exception("Network error")
+
+    plan = ["Safe plan"]
+    policies = ["Safe policy"]
+
+    result = await assert_framework.evaluate_plan(plan, policies)
+
+    assert result["is_compliant"] is False
+    assert "Evaluation failed: Network error" in result["violations"][0]


### PR DESCRIPTION
Implemented the ASSERT Policy Driven Eval Framework v1 as per the `agent_tasks.json`. The `AssertFramework` evaluates execution plans against explicit policies via the LLM. 

Also appended three new tasks to `agent_tasks.json` reflecting recent AI agent trends from `docs/trends.md`. All tests are passing and the validation script succeeds.

---
*PR created automatically by Jules for task [5304309517915984094](https://jules.google.com/task/5304309517915984094) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AssertFramework` class for LLM-backed policy-driven plan evaluation
> - Adds [`AssertFramework`](https://github.com/kazah4359-lgtm/Magda-agent/pull/424/files#diff-0f8df237c793a94e8b55664f8a5fe5225dd571c3eadf49b08e4a24cc26234b09) in `magda_agent.metacognition`, which takes an `LLMClient` and exposes an async `evaluate_plan(plan, policies)` method that returns `{'is_compliant': bool, 'violations': List[str]}`.
> - The method formats plan steps and policies into a prompt, calls the LLM, strips JSON code fences, and parses the response. It retries up to 3 times on `JSONDecodeError` and fails closed (`is_compliant=False`) on persistent errors or unexpected exceptions.
> - Adds full test coverage in [`tests/test_assert_framework.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/424/files#diff-49ca3d65548dd4211d6e5f76cab43d27eab98d9bfe772d9036e0a6fb15843d6f) covering compliant, non-compliant, retry-success, max-retry failure, and exception paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8c617e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->