### PR TITLE
feat(safety): implement MCP Kernel Taint Tracking Context Integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -14365,7 +14365,7 @@
     },
     {
       "id": "3f400a74-15eb-4d21-80e1-e4017b730b4f",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Kernel Taint Tracking Context Integration",
@@ -14616,6 +14616,57 @@
       "acceptance": [
         "Logger intercepts outputs and redacts PII.",
         "Tests verify PII masking."
+      ]
+    },
+    {
+      "id": "openclaw-mcp-subagent-router-plugin-v1",
+      "title": "OpenClaw MCP Subagent Router Plugin",
+      "area": "architecture",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by OpenClaw gateway patterns: Build a subagent routing plugin using MCP to delegate user prompts efficiently.",
+      "allowed_paths": [
+        "magda_agent/architecture/mcp_router_plugin_v1.py",
+        "tests/test_mcp_router_plugin_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Router routes inputs accurately.",
+        "Tests mock MCP routing endpoints."
+      ]
+    },
+    {
+      "id": "a2a-secure-payload-validation-v2",
+      "title": "A2A Secure Payload Validation",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by A2A Protocol standard trends: Enhance the payload validation to ensure secure agent-to-agent communication payloads.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_payload_validation_v2.py",
+        "tests/test_a2a_payload_validation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Payloads are securely validated.",
+        "Tests verify correct rejection of invalid payloads."
+      ]
+    },
+    {
+      "id": "virtual-context-semantic-pruning-v3",
+      "title": "Virtual Context Semantic Pruning",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by Letta context patterns: Implement a semantic pruning hook for virtual context, removing decayed short-term entries dynamically.",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_pruning_v3.py",
+        "tests/test_semantic_pruning_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Semantic pruning effectively removes irrelevant context.",
+        "Tests mock decay metrics logic."
       ]
     }
   ]

--- a/magda_agent/safety/taint_context_v6.py
+++ b/magda_agent/safety/taint_context_v6.py
@@ -1,0 +1,20 @@
+"""MCP Kernel Taint Tracking Context Integration.
+
+Integrates TaintTrackerV2 with WorkingMemory.
+"""
+from typing import List, Dict, Optional, Callable, Awaitable, Any
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+from magda_agent.safety.taint_tracking_v2 import TaintTrackerV2
+
+class TaintedWorkingMemory(WorkingMemory):
+    """Working memory that tracks tainted data."""
+    def __init__(self, limit: int = 10, context_engine: Optional[Any] = None, tracker: Optional[TaintTrackerV2] = None):
+        super().__init__(limit=limit, context_engine=context_engine)
+        self.tracker = tracker if tracker is not None else TaintTrackerV2()
+
+    async def add(self, entry: MemoryEntry, summarizer: Optional[Callable[[List[MemoryEntry]], Awaitable[MemoryEntry]]] = None) -> None:
+        """Add a memory entry to the active working memory, propagating taint."""
+        if self.tracker.is_tainted(entry.content):
+            if "tainted" not in entry.tags:
+                entry.tags.append("tainted")
+        await super().add(entry, summarizer)

--- a/tests/test_taint_context_v6.py
+++ b/tests/test_taint_context_v6.py
@@ -1,0 +1,31 @@
+"""Tests for TaintedWorkingMemory integration."""
+import pytest
+from magda_agent.emotions.engine import PADState
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.safety.taint_tracking_v2 import TaintTrackerV2
+from magda_agent.safety.taint_context_v6 import TaintedWorkingMemory
+
+@pytest.mark.asyncio
+async def test_tainted_working_memory():
+    """Test that taint tags propagate to working memory entries."""
+    tracker = TaintTrackerV2()
+    memory = TaintedWorkingMemory(tracker=tracker)
+
+    # Test tainted entry
+    tainted_str = tracker.taint("malicious_payload", "user_input")
+    state = PADState()
+    entry1 = MemoryEntry(content=tainted_str, importance=0.8, emotional_state=state)
+
+    await memory.add(entry1)
+
+    assert "tainted" in entry1.tags
+    assert len(memory.get_entries()) == 1
+
+    # Test untainted entry
+    untainted_str = "normal_payload"
+    entry2 = MemoryEntry(content=untainted_str, importance=0.5, emotional_state=state)
+
+    await memory.add(entry2)
+
+    assert "tainted" not in entry2.tags
+    assert len(memory.get_entries()) == 2


### PR DESCRIPTION
Implements MCP Kernel Taint Tracking Context Integration.

- Adds `TaintedWorkingMemory` subclass integrating `TaintTrackerV2`.
- Overrides `add` to tag memory entries as 'tainted' if `entry.content` originates from a tainted source.
- Adds asynchronous pytest test covering both tainted and non-tainted scenarios.
- Updates `agent_tasks.json`, marking current task 'done' and appending three new trend-inspired tasks (OpenClaw, A2A, Letta Virtual Context).

---
*PR created automatically by Jules for task [10211587936603328593](https://jules.google.com/task/10211587936603328593) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add taint tracking to `TaintedWorkingMemory` via `TaintTrackerV2` integration
> - Introduces [`TaintedWorkingMemory`](https://github.com/kazah4359-lgtm/Magda-agent/pull/425/files#diff-385468d3d7b91e2142eded478e86e2edcd880d920313f4e18bdaf9b5e4d5708a), a `WorkingMemory` subclass that wraps `TaintTrackerV2` to detect tainted content at write time.
> - Overrides the `add` method to check entry content against the tracker and append a `"tainted"` tag before delegating to the base class if taint is detected.
> - Adds an async pytest in [`tests/test_taint_context_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/425/files#diff-b0ccf5a6b7b9bd1369b7923d061181c2be7747d3c9ff7073ef67560eeb77ffc7) covering tainted tagging, entry count preservation, and clean-input pass-through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55d1d00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->