### PR TITLE
Feat: Prempti Audit Logger v2 Integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6942,7 +6942,7 @@
     },
     {
       "id": "prempti-audit-logger-v2-5678",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "low",
       "title": "Prempti Audit Logger v2 Integration",
@@ -14718,6 +14718,60 @@
       "acceptance": [
         "Habit weights update in real-time from feedback.",
         "Tests verify habit scaling using mocked feedback."
+      ]
+    },
+    {
+      "id": "canvas-ui-adapter-workspace",
+      "status": "todo",
+      "area": "UI",
+      "risk": "low",
+      "title": "Canvas UI Adapter for Global Workspace",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend: Create an adapter to visually expose the current state of the Global Workspace to a connected Canvas UI.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_workspace_adapter.py",
+        "tests/test_canvas_workspace_adapter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Adapter successfully reads workspace state.",
+        "Adapter formats data correctly for websocket streaming.",
+        "Tests verify format."
+      ]
+    },
+    {
+      "id": "hierarchical-a2a-subagent-spawner",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Hierarchical A2A Subagent Spawner",
+      "description": "Inspired by Claude Agent SDK and Agent Teams trend: Allow main orchestrator to spawn A2A compliant subagents to handle complex parallel multi-step goals.",
+      "allowed_paths": [
+        "magda_agent/architecture/a2a_spawner.py",
+        "tests/test_a2a_spawner.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Spawner can instantiate a subagent successfully.",
+        "Subagent delegates via A2A.",
+        "Tests mock A2A subagent execution."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-action-tool-redactor",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Dynamic Action Tool Redactor",
+      "description": "Inspired by MCP action tools standardization trend: Develop a safety redactor module that strips PII and sensitive internal IDs from outgoing tool requests automatically.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_redactor.py",
+        "tests/test_mcp_redactor.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Redactor strips identifiable PII.",
+        "Outgoing payload avoids leaking agent private state.",
+        "Tests mock extraction and redaction correctly."
       ]
     }
   ]

--- a/magda_agent/safety/prempti_logger_v2.py
+++ b/magda_agent/safety/prempti_logger_v2.py
@@ -1,0 +1,230 @@
+import re
+import time
+import copy
+import inspect
+from functools import wraps
+from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+class PremptiAuditLoggerV2:
+    """
+    An advanced audit logger inspired by Prempti (Falco).
+    Intercepts tool calls to provide rigorous audit trails of invocations,
+    arguments, and results, while preventing data leaks through robust
+    sanitization/redaction of sensitive arguments.
+    """
+
+    # Expanded set of sensitive keys to redact
+    SENSITIVE_KEYS = {
+        "password", "secret", "key", "token", "auth", "credential",
+        "env", "api_key", "access_key", "private", "private_key"
+    }
+
+    def __init__(self) -> None:
+        """Initializes the PremptiAuditLoggerV2."""
+        self.trail: List[Dict[str, Any]] = []
+
+    def _sanitize(self, data: Any, memo: Optional[Dict[int, Any]] = None) -> Any:
+        """
+        Recursively sanitizes sensitive data from dictionaries and lists.
+        Redacts values for keys that match sensitive patterns.
+        Handles circular references via a memo dictionary.
+        """
+        if memo is None:
+            memo = {}
+
+        if id(data) in memo:
+            return "<circular reference>"
+
+        if inspect.isawaitable(data):
+            return "<awaitable>"
+
+        if isinstance(data, dict):
+            memo[id(data)] = True
+            sanitized = {}
+            for k, v in data.items():
+                k_lower = k.lower()
+
+                # Check for exact matches or word boundaries to avoid over-redacting
+                is_sensitive = False
+                for s in self.SENSITIVE_KEYS:
+                    # check if the sensitive key is present as a standalone word/stem,
+                    # allowing for trailing 's' or being surrounded by underscores/etc.
+                    # This avoids 'auth' matching 'author' but allows 'secret' matching 'secrets'
+                    if re.search(rf"(^|[^a-zA-Z]){re.escape(s)}s?([^a-zA-Z]|$)", k_lower):
+                        is_sensitive = True
+                        break
+
+                if is_sensitive:
+                    sanitized[k] = "***"
+                else:
+                    sanitized[k] = self._sanitize(v, memo)
+            return sanitized
+
+        elif isinstance(data, list):
+            memo[id(data)] = True
+            return [self._sanitize(item, memo) for item in data]
+
+        try:
+            return copy.deepcopy(data)
+        except Exception:
+            return repr(data)
+
+
+    def log_call(
+        self,
+        tool_name: str,
+        kwargs: Dict[str, Any],
+        why: str,
+        result: Any,
+        duration: float = 0.0
+    ) -> None:
+        """
+        Logs a tool call with metadata and sanitization.
+
+        Args:
+            tool_name: Name of the tool or action.
+            kwargs: Arguments passed to the tool.
+            why: Reason for the call or outcome context.
+            result: Outcome of the execution.
+            duration: Time taken in seconds.
+        """
+        entry = {
+            "timestamp": time.time(),
+            "tool_name": tool_name,
+            "kwargs": self._sanitize(kwargs, None),
+            "why": why,
+            "result": self._sanitize(result, None),
+            "duration": duration
+        }
+        self.trail.append(entry)
+
+    def intercept(
+        self,
+        tool_name: Optional[str] = None,
+        why: str = "intercepted call"
+    ) -> Callable[[F], F]:
+        """
+        A decorator to intercept a function/tool call, log its arguments,
+        execution time, and results securely.
+
+        Args:
+            tool_name (Optional[str]): The name of the tool. If not provided,
+                                       the function's __name__ is used.
+            why (str): The default reason or context for the call.
+
+        Returns:
+            Callable[[F], F]: The decorated function.
+        """
+        def decorator(func: F) -> F:
+            name_to_use = tool_name if tool_name else func.__name__
+
+            if inspect.iscoroutinefunction(func):
+                @wraps(func)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    start_time = time.time()
+                    all_args = self._extract_args(func, args, kwargs)
+                    try:
+                        result = await func(*args, **kwargs)
+                        duration = time.time() - start_time
+                        self.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=why,
+                            result=result,
+                            duration=duration
+                        )
+                        return result
+                    except Exception as e:
+                        duration = time.time() - start_time
+                        self.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=f"{why} (failed)",
+                            result=str(e),
+                            duration=duration
+                        )
+                        raise
+                return cast(F, async_wrapper)
+            else:
+                @wraps(func)
+                def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    start_time = time.time()
+                    all_args = self._extract_args(func, args, kwargs)
+                    try:
+                        result = func(*args, **kwargs)
+                        duration = time.time() - start_time
+                        self.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=why,
+                            result=result,
+                            duration=duration
+                        )
+                        return result
+                    except Exception as e:
+                        duration = time.time() - start_time
+                        self.log_call(
+                            tool_name=name_to_use,
+                            kwargs=all_args,
+                            why=f"{why} (failed)",
+                            result=str(e),
+                            duration=duration
+                        )
+                        raise
+                return cast(F, sync_wrapper)
+
+        return decorator
+
+    def _extract_args(
+        self,
+        func: Callable[..., Any],
+        args: Any,
+        kwargs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Extracts and normalizes arguments passed to a function based on its signature.
+
+        Args:
+            func (Callable): The function being called.
+            args (tuple): Positional arguments.
+            kwargs (dict): Keyword arguments.
+
+        Returns:
+            Dict[str, Any]: A dictionary of all arguments bound to their names.
+        """
+        try:
+            sig = inspect.signature(func)
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            return dict(bound.arguments)
+        except Exception:
+            # Fallback if signature parsing fails
+            return {"args": list(args), "kwargs": kwargs}
+
+    def query(
+        self,
+        tool_name: Optional[str] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Queries the audit log.
+        """
+        results = self.trail
+        if tool_name:
+            results = [e for e in results if e["tool_name"] == tool_name]
+        if start_time is not None:
+            results = [e for e in results if e["timestamp"] >= start_time]
+        if end_time is not None:
+            results = [e for e in results if e["timestamp"] <= end_time]
+        return results
+
+    def get_all(self) -> List[Dict[str, Any]]:
+        """Returns all log entries."""
+        return self.trail
+
+    def clear(self) -> None:
+        """Clears the audit log."""
+        self.trail.clear()

--- a/tests/test_prempti_logger_v2.py
+++ b/tests/test_prempti_logger_v2.py
@@ -1,0 +1,143 @@
+import pytest
+import asyncio
+from typing import Any
+from magda_agent.safety.prempti_logger_v2 import PremptiAuditLoggerV2
+
+def test_sync_interception() -> None:
+    """Test that a synchronous function can be intercepted and its arguments sanitized."""
+    logger = PremptiAuditLoggerV2()
+
+    @logger.intercept(tool_name="test_sync", why="testing sync")
+    def sync_tool(param1: str, password: str) -> str:
+        return f"{param1} and secret done"
+
+    result = sync_tool("public", password="super_secret_password")
+    assert result == "public and secret done"
+
+    logs = logger.get_all()
+    assert len(logs) == 1
+    log_entry = logs[0]
+    assert log_entry["tool_name"] == "test_sync"
+    assert log_entry["why"] == "testing sync"
+    assert log_entry["result"] == "public and secret done"
+    assert "kwargs" in log_entry
+    assert log_entry["kwargs"]["param1"] == "public"
+    assert log_entry["kwargs"]["password"] == "***"
+    assert log_entry["duration"] >= 0.0
+
+@pytest.mark.asyncio
+async def test_async_interception() -> None:
+    """Test that an asynchronous function can be intercepted and its arguments sanitized."""
+    logger = PremptiAuditLoggerV2()
+
+    @logger.intercept(why="testing async")
+    async def async_tool(data: dict) -> str:
+        await asyncio.sleep(0.01)
+        return "async done"
+
+    result = await async_tool({"public_data": "123", "api_key": "secret456"})
+    assert result == "async done"
+
+    logs = logger.get_all()
+    assert len(logs) == 1
+    log_entry = logs[0]
+    assert log_entry["tool_name"] == "async_tool"
+    assert log_entry["why"] == "testing async"
+    assert log_entry["result"] == "async done"
+
+    kwargs = log_entry["kwargs"]
+    assert "data" in kwargs
+    assert kwargs["data"]["public_data"] == "123"
+    assert kwargs["data"]["api_key"] == "***"
+    assert log_entry["duration"] >= 0.005 # Sometimes it's slightly faster or sleep yields early
+
+def test_sanitization_rules() -> None:
+    """Test the sanitization logic accurately redacts sensitive data and allows non-sensitive."""
+    logger = PremptiAuditLoggerV2()
+
+    data = {
+        "normal": "value",
+        "PASSWORD": "123",
+        "my_Secret_key": "456",
+        "nested": {
+            "token": "789",
+            "safe": "safe_val"
+        },
+        "list_of_secrets": [{"api_key": "abc"}, {"normal": "def"}],
+        "list_of_primitives_with_secret_key": ["a", "b", "c"],
+        "token_list": ["secret1", "secret2"],
+        "author": "john doe",  # Should not be redacted even though 'auth' is a sensitive keyword
+        "environment": "prod", # Should not be redacted even though 'env' is a sensitive keyword
+        "keynote": "hello"     # Should not be redacted even though 'key' is a sensitive keyword
+    }
+
+    sanitized = logger._sanitize(data)
+
+    assert sanitized["normal"] == "value"
+    assert sanitized["PASSWORD"] == "***"
+    assert sanitized["my_Secret_key"] == "***"
+
+    assert sanitized["nested"]["safe"] == "safe_val"
+    assert sanitized["nested"]["token"] == "***"
+
+    assert sanitized["list_of_secrets"] == "***"
+
+    assert sanitized["token_list"] == "***"
+
+    assert sanitized["author"] == "john doe"
+    assert sanitized["environment"] == "prod"
+    assert sanitized["keynote"] == "hello"
+
+def test_exception_logging() -> None:
+    """Test that exceptions during tool execution are correctly caught and logged."""
+    logger = PremptiAuditLoggerV2()
+
+    @logger.intercept(tool_name="error_tool", why="testing error")
+    def error_tool(token: str) -> None:
+        raise ValueError("Something went wrong")
+
+    with pytest.raises(ValueError, match="Something went wrong"):
+        error_tool("my_secret_token")
+
+    logs = logger.get_all()
+    assert len(logs) == 1
+    log_entry = logs[0]
+    assert log_entry["tool_name"] == "error_tool"
+    assert log_entry["why"] == "testing error (failed)"
+    assert log_entry["result"] == "Something went wrong"
+    assert log_entry["kwargs"]["token"] == "***"
+
+class UnpicklableObject:
+    def __init__(self, value: str):
+        self.value = value
+
+    def __deepcopy__(self, memo: dict) -> Any:
+        raise TypeError("Cannot deepcopy this object")
+
+def test_unpicklable_object_sanitization() -> None:
+    """Test that the logger does not crash when attempting to serialize unpicklable objects."""
+    logger = PremptiAuditLoggerV2()
+
+    obj = UnpicklableObject("some state")
+
+    @logger.intercept(tool_name="unpicklable_tool", why="testing unpicklable")
+    def unpicklable_tool(param1: Any) -> Any:
+        return param1
+
+    result = unpicklable_tool(obj)
+
+    logs = logger.get_all()
+    assert len(logs) == 1
+    assert "UnpicklableObject" in logs[0]["kwargs"]["param1"]
+    assert "UnpicklableObject" in logs[0]["result"]
+
+def test_circular_reference() -> None:
+    """Test that circular references do not cause infinite recursion in sanitization."""
+    logger = PremptiAuditLoggerV2()
+
+    data: Dict[str, Any] = {"hello": "world"}
+    data["self_ref"] = data
+
+    sanitized = logger._sanitize(data)
+    assert sanitized["hello"] == "world"
+    assert sanitized["self_ref"] == "<circular reference>"


### PR DESCRIPTION
Resolves task `prempti-audit-logger-v2-5678` by building an advanced audit logger to intercept tool calls and ensure rigorous audit trails without data leaks. Includes the logger implementation, tests, and updates `agent_tasks.json` with completion status and 3 new trends-inspired tasks.

---
*PR created automatically by Jules for task [5139598191661943993](https://jules.google.com/task/5139598191661943993) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PremptiAuditLoggerV2` for intercepting and sanitizing function call logs
> - Adds [prempti_logger_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/427/files#diff-a5ccdcdf158f9f38830fa260e5b45ce0a8bc19a5d4991db79b25d0e316975291) with a new `PremptiAuditLoggerV2` class that wraps sync and async functions via an `intercept` decorator, recording sanitized arguments, results, timing, and exceptions into an in-memory audit trail.
> - Sensitive keys (e.g. `password`, `token`, `api_key`) are redacted to `***`; circular references, awaitables, and uncopyable objects are handled gracefully without raising.
> - The trail supports filtered queries by tool name and time range via `query()`, plus `get_all()` and `clear()` accessors.
> - Tests in [test_prempti_logger_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/427/files#diff-ad50460e7f5c7828121627c03123b933c334e6bb876cacb3293da806b011f9f9) cover sync/async interception, sanitization edge cases (including non-redacted keys like `author`), exception logging, and circular references.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8071411.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->