### PR TITLE
feat(agents): implement Agent Teams Git Worktree Isolation v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6976,7 +6976,7 @@
     },
     {
       "id": "claude-agent-teams-subagent-isolation-v3-56a1b5e7",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "high",
       "title": "Agent Teams Subagent Git Worktree Isolation v3",
@@ -14806,6 +14806,40 @@
       "acceptance": [
         "Subagents execute concurrently in their respective worktrees.",
         "Tests verify concurrency and isolation."
+      ]
+    },
+    {
+      "id": "openclaw-rl-habit-integrator-2b516875",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Habit Integrator",
+      "description": "Implement an OnlineRLIntegrator inspired by OpenClaw-RL that dynamically adjusts habit weights based on next-state signals from user replies.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl.py",
+        "tests/test_online_rl.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "OnlineRLIntegrator adjusts habit weights accurately.",
+        "Tests verify weight adjustment logic."
+      ]
+    },
+    {
+      "id": "marketplace-skill-exporter-c9363a92",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Marketplace Skill Exporter for agentskills.io",
+      "description": "Implement a MarketplaceExporter that dynamically exports Magda's registered skills to the open agentskills.io standard by extracting JSON schemas.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_exporter.py",
+        "tests/test_marketplace_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MarketplaceExporter generates valid agentskills.io JSON definitions.",
+        "Tests confirm extraction of schema."
       ]
     }
   ]

--- a/magda_agent/agents/isolation_v3.py
+++ b/magda_agent/agents/isolation_v3.py
@@ -1,0 +1,94 @@
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from typing import Optional, Dict
+
+class AgentWorktreeIsolationV3:
+    """
+    Manages strict git worktree isolation and context separation for subagents.
+    Inspired by Claude Agent Teams trend.
+    """
+    def __init__(self, base_dir: str = "/tmp/magda_team_worktrees_v3") -> None:
+        """
+        Initializes the isolation manager.
+
+        Args:
+            base_dir: The base directory where worktrees will be created.
+        """
+        self.base_dir = base_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.active_contexts: Dict[str, str] = {}
+
+    async def setup_isolation(self, agent_id: str, branch_name: Optional[str] = None) -> str:
+        """
+        Sets up an isolated git worktree environment for a subagent.
+
+        Args:
+            agent_id: A unique identifier for the subagent.
+            branch_name: Optional branch name. If not provided, creates a detached worktree.
+
+        Returns:
+            The path to the isolated worktree environment.
+        """
+        unique_suffix = str(uuid.uuid4())[:8]
+        env_path = os.path.join(self.base_dir, f"subagent_{agent_id}_{unique_suffix}")
+
+        if branch_name:
+            cmd = ["git", "worktree", "add", "-b", branch_name, env_path, "HEAD"]
+        else:
+            cmd = ["git", "worktree", "add", "-d", env_path, "HEAD"]
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                error_msg = stderr.decode().strip()
+                logging.error(f"Failed to create isolated environment for {agent_id}: {error_msg}")
+                raise RuntimeError(f"Git worktree creation failed: {error_msg}")
+
+            logging.info(f"Created isolated environment for {agent_id} at {env_path}")
+            self.active_contexts[agent_id] = env_path
+            return env_path
+        except Exception as e:
+            logging.error(f"Error executing git worktree add for {agent_id}: {e}")
+            raise
+
+    async def teardown_isolation(self, agent_id: str) -> None:
+        """
+        Tears down and removes an isolated git worktree environment.
+
+        Args:
+            agent_id: The unique identifier for the subagent.
+        """
+        env_path = self.active_contexts.get(agent_id)
+        if not env_path:
+            logging.warning(f"No active isolation context found for agent {agent_id}")
+            return
+
+        cmd = ["git", "worktree", "remove", "--force", env_path]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                logging.error(f"Failed to remove isolated environment for {agent_id}: {stderr.decode().strip()}")
+            else:
+                logging.info(f"Removed isolated environment for {agent_id} at {env_path}")
+        except Exception as e:
+            logging.error(f"Error executing git worktree remove for {agent_id}: {e}")
+        finally:
+            if os.path.exists(env_path):
+                try:
+                    shutil.rmtree(env_path)
+                except Exception as ex:
+                    logging.error(f"Could not delete worktree folder for {agent_id}: {ex}")
+            self.active_contexts.pop(agent_id, None)

--- a/tests/test_isolation_v3.py
+++ b/tests/test_isolation_v3.py
@@ -1,0 +1,135 @@
+import pytest
+import asyncio
+from unittest.mock import patch, AsyncMock, MagicMock
+import os
+from magda_agent.agents.isolation_v3 import AgentWorktreeIsolationV3
+
+@pytest.fixture
+def isolation_manager() -> AgentWorktreeIsolationV3:
+    """Returns a configured instance for testing."""
+    return AgentWorktreeIsolationV3(base_dir="/tmp/test_magda_worktrees_v3")
+
+@pytest.mark.asyncio
+async def test_setup_isolation_success(isolation_manager: AgentWorktreeIsolationV3) -> None:
+    """Tests setup isolation success."""
+    agent_id = "test_agent_123"
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec, \
+         patch("uuid.uuid4", return_value="12345678-abcd"):
+
+        env_path = await isolation_manager.setup_isolation(agent_id)
+
+        assert "subagent_test_agent_123_12345678" in env_path
+        assert agent_id in isolation_manager.active_contexts
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "git"
+        assert args[1] == "worktree"
+        assert args[2] == "add"
+        assert args[3] == "-d"
+        assert args[4] == env_path
+        assert args[5] == "HEAD"
+
+@pytest.mark.asyncio
+async def test_setup_isolation_with_branch(isolation_manager: AgentWorktreeIsolationV3) -> None:
+    """Tests setup isolation with branch."""
+    agent_id = "test_agent_branch"
+    branch_name = "feature-branch"
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec, \
+         patch("uuid.uuid4", return_value="12345678-abcd"):
+
+        env_path = await isolation_manager.setup_isolation(agent_id, branch_name)
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "git"
+        assert args[1] == "worktree"
+        assert args[2] == "add"
+        assert args[3] == "-b"
+        assert args[4] == branch_name
+        assert args[5] == env_path
+        assert args[6] == "HEAD"
+
+@pytest.mark.asyncio
+async def test_setup_isolation_failure(isolation_manager: AgentWorktreeIsolationV3) -> None:
+    """Tests setup isolation failure."""
+    agent_id = "test_agent_fail"
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"git error output")
+    mock_process.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+        with pytest.raises(RuntimeError, match="Git worktree creation failed"):
+            await isolation_manager.setup_isolation(agent_id)
+
+        assert agent_id not in isolation_manager.active_contexts
+
+@pytest.mark.asyncio
+async def test_teardown_isolation_success(isolation_manager: AgentWorktreeIsolationV3) -> None:
+    """Tests teardown isolation success."""
+    agent_id = "test_agent_rm"
+    env_path = "/tmp/test_magda_worktrees_v3/subagent_test_agent_rm_12345678"
+    isolation_manager.active_contexts[agent_id] = env_path
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec, \
+         patch("os.path.exists", return_value=True), \
+         patch("shutil.rmtree") as mock_rmtree:
+
+        await isolation_manager.teardown_isolation(agent_id)
+
+        assert agent_id not in isolation_manager.active_contexts
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args[0]
+        assert args[0] == "git"
+        assert args[1] == "worktree"
+        assert args[2] == "remove"
+        assert args[3] == "--force"
+        assert args[4] == env_path
+
+        mock_rmtree.assert_called_once_with(env_path)
+
+@pytest.mark.asyncio
+async def test_teardown_isolation_not_found(isolation_manager: AgentWorktreeIsolationV3) -> None:
+    """Tests teardown isolation not found."""
+    agent_id = "test_agent_not_found"
+
+    with patch("asyncio.create_subprocess_exec") as mock_exec:
+        await isolation_manager.teardown_isolation(agent_id)
+        mock_exec.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_teardown_isolation_git_failure(isolation_manager: AgentWorktreeIsolationV3, caplog: pytest.LogCaptureFixture) -> None:
+    """Tests teardown isolation git failure."""
+    agent_id = "test_agent_fail_rm"
+    env_path = "/tmp/test_magda_worktrees_v3/subagent_test_agent_fail_rm_12345678"
+    isolation_manager.active_contexts[agent_id] = env_path
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"git remove error")
+    mock_process.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process), \
+         patch("os.path.exists", return_value=True), \
+         patch("shutil.rmtree") as mock_rmtree:
+
+        await isolation_manager.teardown_isolation(agent_id)
+
+        assert agent_id not in isolation_manager.active_contexts
+        assert "Failed to remove isolated environment" in caplog.text
+        mock_rmtree.assert_called_once_with(env_path)


### PR DESCRIPTION
Implements Subagent spawning with strict Git Worktree isolation via `AgentWorktreeIsolationV3`.
- Completes `agent_tasks.json` task `claude-agent-teams-subagent-isolation-v3-56a1b5e7`.
- Appends new "todo" tasks for OpenClaw-RL Habit Integrator and Marketplace Skill Exporter.
- Avoids shell injection vulnerabilities.
- Maintains isolated tests using `unittest.mock.patch` with type hints and docstrings.

---
*PR created automatically by Jules for task [3265633265176630531](https://jules.google.com/task/3265633265176630531) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AgentWorktreeIsolationV3` class for git worktree isolation of subagents
> - Introduces [`isolation_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/429/files#diff-fb6bf11df9fb9b8577c3c3b00da86059c8e34e4f63414c72f1d1d28f03972106) with `AgentWorktreeIsolationV3`, which creates and removes isolated git worktrees per subagent using `git worktree add/remove` via `asyncio.create_subprocess_exec`.
> - Each worktree is assigned a unique path based on `agent_id` and a UUID suffix; active contexts are tracked in-memory and cleaned up on teardown, including a `shutil.rmtree` fallback if git removal fails.
> - Supports both detached and branch-based worktree modes via an optional `branch_name` parameter on `setup_isolation`.
> - Adds [`tests/test_isolation_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/429/files#diff-f0a2a44bd4d8fa823ec9fc12bc2d61b818a54a32da1813d461ff6bf933d307ba) with async tests covering success, branch, failure, and missing-context scenarios using mocked subprocesses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a81c4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->