### PR TITLE
feat: Implement OpenClaw Local-First Context Engine v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -6993,7 +6993,7 @@
     },
     {
       "id": "openclaw-local-first-context-engine-v2-618a2738",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Local-First Context Engine v2",
@@ -14840,6 +14840,57 @@
       "acceptance": [
         "MarketplaceExporter generates valid agentskills.io JSON definitions.",
         "Tests confirm extraction of schema."
+      ]
+    },
+    {
+      "id": "acs-runtime-safety-controls-v1-9871ab",
+      "title": "ACS Runtime Safety Controls",
+      "area": "safety",
+      "status": "todo",
+      "risk": "high",
+      "description": "Inspired by Microsoft ACS 2026 standard, implement runtime safety controls acting as guardrails for tool execution.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_controls.py",
+        "tests/test_acs_controls.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS controls successfully guard tool execution.",
+        "Tests confirm rejected invalid tools."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-isolation-v2-8756cd",
+      "title": "Claude Agent Teams Isolation",
+      "area": "architecture",
+      "status": "todo",
+      "risk": "medium",
+      "description": "Inspired by Claude Agent SDK Agent Teams, implement multi-agent delegation with strict git worktree isolation.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams.py",
+        "tests/test_agent_teams.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agents can spawn with isolated worktrees.",
+        "Tests verify worktree paths."
+      ]
+    },
+    {
+      "id": "hermes-skill-creation-loop-v3-1245ef",
+      "title": "Hermes Skill Creation Loop",
+      "area": "learning",
+      "status": "todo",
+      "risk": "medium",
+      "description": "Inspired by Hermes self-improving loop, implement a module to automatically generate skills from repeated user workflows.",
+      "allowed_paths": [
+        "magda_agent/learning/skill_loop.py",
+        "tests/test_skill_loop.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be generated from past interactions.",
+        "Tests verify schema creation."
       ]
     }
   ]

--- a/magda_agent/memory/context_engine_local_v2.py
+++ b/magda_agent/memory/context_engine_local_v2.py
@@ -1,0 +1,83 @@
+import logging
+from typing import List, Any, Dict, Optional
+from magda_agent.memory.context_engine_local import LocalFirstContextEngine
+from magda_agent.memory.context_engine import ContextPlugin
+
+class LocalFirstContextEngineV2(LocalFirstContextEngine):
+    """
+    LocalFirstContextEngineV2 extends LocalFirstContextEngine by gracefully
+    falling back to a local LLM if the primary external LLM fails during context compaction,
+    expanding on previous v1.
+    """
+    def __init__(self, plugins: Optional[List[ContextPlugin]] = None, llm: Optional[Any] = None, local_llm: Optional[Any] = None) -> None:
+        """
+        Initialize the LocalFirstContextEngineV2 with optional plugins, primary LLM, and fallback local LLM.
+        """
+        super().__init__(plugins=plugins, llm=llm, local_llm=local_llm)
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        Compact context through all plugins using the hook registry.
+        If limits are exceeded, attempt compression using the primary LLM.
+        If the primary LLM fails, fall back to the local LLM gracefully.
+        If the local LLM fails or is absent, truncate the context.
+        """
+        # Trigger 'compact' hooks
+        current_items = await self.hook_registry.trigger_hook_async('compact', context_items, metadata)
+
+        limit = metadata.get("limit", 10)
+        if len(current_items) <= limit:
+            return current_items
+
+        # We need compaction
+        to_summarize = current_items[:2]
+        remaining = current_items[2:]
+        combined_text = "\n".join([f"- {getattr(e, 'content', str(e))}" for e in to_summarize])
+        prompt = f"Please summarize the following short-term memory context into a concise summary while maintaining key facts and semantic links:\n{combined_text}"
+
+        first = to_summarize[0] if to_summarize else None
+        avg_importance = sum(getattr(e, 'importance', 0.5) for e in to_summarize) / max(1, len(to_summarize))
+        tags = list(set(t for e in to_summarize if isinstance(getattr(e, 'tags', []), list) for t in getattr(e, 'tags', [])))
+        user_id = getattr(first, 'user_id', None) if first else None
+        emotional_state = getattr(first, 'emotional_state', None) if first else None
+
+        async def _attempt_compression(target_llm: Any) -> Optional[Any]:
+            if target_llm is None:
+                return None
+            try:
+                summary_content = await target_llm.chat_completion([
+                    {"role": "system", "content": "You compress memory context. Return only the summary text."},
+                    {"role": "user", "content": prompt}
+                ], temperature=0.3)
+
+                from magda_agent.memory.working import MemoryEntry
+                return MemoryEntry(
+                    content=summary_content.strip(),
+                    importance=avg_importance,
+                    emotional_state=emotional_state,
+                    tags=tags,
+                    user_id=user_id
+                )
+            except Exception as e:
+                logging.error(f"Compression attempt failed: {e}")
+                return None
+
+        logging.info("Context length exceeds limit. Using LocalFirstContextEngineV2 fallback compression.")
+
+        summary_entry = None
+
+        # Try primary LLM
+        if self.llm is not None:
+            summary_entry = await _attempt_compression(self.llm)
+
+        # Try local LLM if primary failed
+        if summary_entry is None and self.local_llm is not None:
+            logging.info("Primary LLM failed or absent. Falling back to local LLM.")
+            summary_entry = await _attempt_compression(self.local_llm)
+
+        # Truncate if both failed
+        if summary_entry is None:
+            logging.warning("Both external and local LLMs failed or were absent. Dropping oldest item.")
+            return current_items[1:]
+
+        return [summary_entry] + remaining

--- a/tests/test_context_engine_local_v2.py
+++ b/tests/test_context_engine_local_v2.py
@@ -1,0 +1,86 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from typing import List, Any
+from magda_agent.memory.context_engine_local_v2 import LocalFirstContextEngineV2
+from magda_agent.memory.working import MemoryEntry
+
+from magda_agent.emotions.engine import PADState
+
+@pytest.fixture
+def memory_entries() -> List[MemoryEntry]:
+    return [
+        MemoryEntry(content="Item 1", importance=0.8, emotional_state=PADState(0.0, 0.0, 0.0), user_id=1),
+        MemoryEntry(content="Item 2", importance=0.6, emotional_state=PADState(0.0, 0.0, 0.0), user_id=1),
+        MemoryEntry(content="Item 3", importance=0.5, emotional_state=PADState(0.0, 0.0, 0.0), user_id=1)
+    ]
+
+@pytest.mark.asyncio
+async def test_primary_llm_success(memory_entries: List[MemoryEntry]) -> None:
+    """Test that primary LLM successfully compacts when limit is exceeded."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "Summary of 1 and 2"
+    mock_local_llm = AsyncMock()
+
+    engine = LocalFirstContextEngineV2(llm=mock_llm, local_llm=mock_local_llm)
+    metadata = {"limit": 2}
+
+    compacted = await engine.compact(memory_entries, metadata)
+
+    assert len(compacted) == 2
+    assert compacted[0].content == "Summary of 1 and 2"
+    assert compacted[1].content == "Item 3"
+
+    mock_llm.chat_completion.assert_awaited_once()
+    mock_local_llm.chat_completion.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_local_fallback_success(memory_entries: List[MemoryEntry]) -> None:
+    """Test that it falls back to local_llm if primary llm fails."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.side_effect = Exception("Primary API Error")
+    mock_local_llm = AsyncMock()
+    mock_local_llm.chat_completion.return_value = "Local summary"
+
+    engine = LocalFirstContextEngineV2(llm=mock_llm, local_llm=mock_local_llm)
+    metadata = {"limit": 2}
+
+    compacted = await engine.compact(memory_entries, metadata)
+
+    assert len(compacted) == 2
+    assert compacted[0].content == "Local summary"
+    assert compacted[1].content == "Item 3"
+
+    mock_llm.chat_completion.assert_awaited_once()
+    mock_local_llm.chat_completion.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_both_llms_fail_truncation(memory_entries: List[MemoryEntry]) -> None:
+    """Test that it truncates the oldest item if both llms fail."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.side_effect = Exception("Primary API Error")
+    mock_local_llm = AsyncMock()
+    mock_local_llm.chat_completion.side_effect = Exception("Local API Error")
+
+    engine = LocalFirstContextEngineV2(llm=mock_llm, local_llm=mock_local_llm)
+    metadata = {"limit": 2}
+
+    compacted = await engine.compact(memory_entries, metadata)
+
+    assert len(compacted) == 2
+    assert compacted[0].content == "Item 2"
+    assert compacted[1].content == "Item 3"
+
+    mock_llm.chat_completion.assert_awaited_once()
+    mock_local_llm.chat_completion.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_no_llms_truncation(memory_entries: List[MemoryEntry]) -> None:
+    """Test that it truncates the oldest item if both llms are None."""
+    engine = LocalFirstContextEngineV2(llm=None, local_llm=None)
+    metadata = {"limit": 2}
+
+    compacted = await engine.compact(memory_entries, metadata)
+
+    assert len(compacted) == 2
+    assert compacted[0].content == "Item 2"
+    assert compacted[1].content == "Item 3"


### PR DESCRIPTION
- Creates `magda_agent/memory/context_engine_local_v2.py` implementing `LocalFirstContextEngineV2`.
- Adds comprehensive pytest tests checking primary API fallback to local API, and truncation on double failure.
- Appends 3 new tasks into `agent_tasks.json`:
  1. ACS Runtime Safety Controls
  2. Claude Agent Teams Isolation
  3. Hermes Skill Creation Loop

---
*PR created automatically by Jules for task [14283414806747418335](https://jules.google.com/task/14283414806747418335) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `LocalFirstContextEngineV2` with LLM-based context compaction and truncation fallback
> - Adds [`LocalFirstContextEngineV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/430/files#diff-3f2ab3546a3153dda4d5543e7822b6e204e7fdc57f9c70ff899d7a298877caae) extending `LocalFirstContextEngine` with a `compact` method that summarizes the oldest context entries using a primary LLM.
> - Falls back to a local LLM if the primary returns `None` or raises, and drops the oldest entry if both LLMs fail or are absent.
> - Summaries preserve averaged importance, union of tags, and selected user/emotional state from the compacted entries.
> - Adds [tests](https://github.com/kazah4359-lgtm/Magda-agent/pull/430/files#diff-ad33d944cdb622ca2fcb2cebea7d02ed0e07d75c7d5f25724859ea10e081f88f) covering primary success, local fallback, dual failure, and no-LLM truncation paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66e43fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->