### PR TITLE
Implement A2A Task Delegation Streaming Interface

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7010,7 +7010,7 @@
     },
     {
       "id": "a2a-task-delegation-streaming-v1-uuid",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Task Delegation Streaming Interface",
@@ -14891,6 +14891,57 @@
       "acceptance": [
         "Skills can be generated from past interactions.",
         "Tests verify schema creation."
+      ]
+    },
+    {
+      "id": "openclaw-rl-fallback-recovery-v2",
+      "title": "OpenClaw RL Fallback Recovery",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by OpenClaw trends: Implement fallback recovery mechanism for online RL habit weight adjustments when next-state feedback signals are ambiguous.",
+      "allowed_paths": [
+        "magda_agent/learning/fallback_recovery.py",
+        "tests/test_fallback_recovery.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Fallback recovery prevents inaccurate habit weight modifications.",
+        "Tests confirm fallback logic on ambiguous signals."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-concurrency-sync-v12",
+      "title": "MCP Dynamic Tool Concurrency Sync",
+      "area": "skills",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by MCP runtime concurrency: Add dynamic tool concurrent synchronization across the agent network to ensure state consistency during parallel MCP action execution.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_sync.py",
+        "tests/test_mcp_concurrency_sync.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP concurrency sync maintains state consistency during parallel execution.",
+        "Tests mock concurrent tool executions."
+      ]
+    },
+    {
+      "id": "claude-subagent-teams-isolation-v3-unique",
+      "title": "Claude Subagent Teams Isolation",
+      "area": "multi-agent",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by Claude Agent Teams: Enhance git worktree isolation for subagents executing parallel MCP tool actions.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_isolation.py",
+        "tests/test_agent_teams_isolation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worktree isolation handles nested subagent spawning.",
+        "Tests verify nested subagent paths."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_streaming.py
+++ b/magda_agent/integration/a2a_streaming.py
@@ -1,0 +1,69 @@
+import logging
+import json
+from typing import Dict, Any, AsyncGenerator, Optional
+import httpx
+
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_security import A2ASecurityContext
+from magda_agent.integration.a2a_tracing import A2ATracer
+
+class A2AStreamingDelegator:
+    """
+    Implements a streaming interface for A2A peer-to-peer task delegation,
+    supporting long-horizon task coordination via chunked updates.
+    """
+    def __init__(self, security_context: Optional[A2ASecurityContext] = None) -> None:
+        """
+        Initializes the streaming delegator.
+
+        Args:
+            security_context: Optional security context for token generation.
+        """
+        self.security_context = security_context or A2ASecurityContext()
+
+    async def stream_delegation(self, target_agent: AgentCardV3, plan_context: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+        """
+        Delegates a task to a peer agent and streams the chunked updates back.
+
+        Args:
+            target_agent: The target AgentCardV3 representing the peer.
+            plan_context: The task context to delegate.
+
+        Yields:
+            Chunked update dictionaries received from the peer.
+        """
+        logging.info(f"Initiating streaming delegation to Agent: {target_agent.name}")
+        endpoint = target_agent.endpoints.get("rpc")
+        if not endpoint:
+            yield {"error": f"Agent {target_agent.name} missing rpc endpoint"}
+            return
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "stream_subplan",
+            "params": {"context": plan_context}
+        }
+
+        headers: Dict[str, str] = {}
+        A2ATracer.inject_headers(headers)
+
+        if self.security_context:
+            token = self.security_context.generate_token()
+            headers["Authorization"] = f"Bearer {token}"
+            self.security_context.trace_action("stream_delegation", {"target_agent": target_agent.name})
+
+        try:
+            async with httpx.AsyncClient() as client:
+                async with client.stream("POST", endpoint, json=payload, headers=headers, timeout=30.0) as response:
+                    response.raise_for_status()
+                    async for chunk in response.aiter_lines():
+                        if chunk:
+                            try:
+                                data = json.loads(chunk)
+                                yield data
+                            except json.JSONDecodeError:
+                                yield {"error": "Failed to decode chunk", "raw": chunk}
+        except Exception as e:
+            logging.error(f"Streaming delegation failed: {e}")
+            yield {"error": str(e)}

--- a/tests/test_a2a_streaming.py
+++ b/tests/test_a2a_streaming.py
@@ -1,0 +1,94 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, patch, MagicMock
+from magda_agent.integration.a2a_streaming import A2AStreamingDelegator
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_security import A2ASecurityContext
+
+@pytest.fixture
+def target_agent() -> AgentCardV3:
+    """Provides a dummy target agent card."""
+    return AgentCardV3(
+        agent_id="agent-v3-001",
+        name="TargetAgent",
+        description="Worker for testing",
+        capabilities=["code_execution"],
+        endpoints={"rpc": "http://192.168.1.10:8080/rpc"}
+    )
+
+class MockAsyncContextManager:
+    def __init__(self, return_value):
+        self.return_value = return_value
+
+    async def __aenter__(self):
+        return self.return_value
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+@pytest.mark.asyncio
+async def test_stream_delegation_success(target_agent: AgentCardV3) -> None:
+    """Tests successful streaming delegation with chunked updates."""
+    security_context = A2ASecurityContext()
+    delegator = A2AStreamingDelegator(security_context=security_context)
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+
+    async def mock_aiter_lines():
+        yield json.dumps({"status": "processing", "progress": 50})
+        yield "" # empty chunk should be ignored
+        yield "invalid json chunk"
+        yield json.dumps({"status": "completed", "result": "done"})
+
+    mock_response.aiter_lines = mock_aiter_lines
+
+    class MockClient:
+        def stream(self, *args, **kwargs):
+            return MockAsyncContextManager(mock_response)
+
+    with patch('httpx.AsyncClient', return_value=MockAsyncContextManager(MockClient())):
+        chunks = []
+        async for chunk in delegator.stream_delegation(target_agent, {"task": "test"}):
+            chunks.append(chunk)
+
+        assert len(chunks) == 3
+        assert chunks[0]["status"] == "processing"
+        assert "error" in chunks[1]
+        assert chunks[1]["raw"] == "invalid json chunk"
+        assert chunks[2]["result"] == "done"
+
+@pytest.mark.asyncio
+async def test_stream_delegation_missing_endpoint(target_agent: AgentCardV3) -> None:
+    """Tests streaming delegation when the endpoint is missing."""
+    target_agent.endpoints = {}
+    delegator = A2AStreamingDelegator()
+
+    chunks = []
+    async for chunk in delegator.stream_delegation(target_agent, {"task": "test"}):
+        chunks.append(chunk)
+
+    assert len(chunks) == 1
+    assert "error" in chunks[0]
+    assert "missing" in chunks[0]["error"]
+
+@pytest.mark.asyncio
+async def test_stream_delegation_http_error(target_agent: AgentCardV3) -> None:
+    """Tests streaming delegation when an HTTP error occurs."""
+    delegator = A2AStreamingDelegator()
+
+    class ErrorContextManager:
+        async def __aenter__(self):
+            raise Exception("Connection Refused")
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    with patch('httpx.AsyncClient', return_value=ErrorContextManager()):
+        chunks = []
+        async for chunk in delegator.stream_delegation(target_agent, {"task": "test"}):
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        assert "error" in chunks[0]
+        assert "Connection Refused" in chunks[0]["error"]


### PR DESCRIPTION
Implement A2A Task Delegation Streaming Interface

- Added A2AStreamingDelegator class for chunked peer-to-peer updates using httpx.AsyncClient.
- Authored pytest test cases covering successful streaming, missing endpoints, and exception handling via context manager mocks.
- Marked task a2a-task-delegation-streaming-v1-uuid as 'done' in agent_tasks.json.
- Replenished agent_tasks.json with 3 new high-quality agentic trend tasks.

---
*PR created automatically by Jules for task [11698189475912478249](https://jules.google.com/task/11698189475912478249) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `A2AStreamingDelegator` class for streaming task delegation to peer agents
> - Adds [a2a_streaming.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/431/files#diff-ead8a1bcd96c4a8a12110645eb5d92d2ec2234454c11fe7f0227446768a95d42) with `A2AStreamingDelegator`, an async generator that POSTs a JSON-RPC `stream_subplan` request to a peer agent's `rpc` endpoint and yields decoded JSON chunks.
> - Injects tracing headers via `A2ATracer` and optionally adds a Bearer token from `A2ASecurityContext`.
> - Handles missing endpoints, invalid JSON chunks, and HTTP/connection errors by yielding structured error dicts rather than raising.
> - Adds tests in [test_a2a_streaming.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/431/files#diff-c940a3603260c6ca98e15938adc409c2903e7077004b8e14042d045bd47ede22) covering the success path, missing endpoint, and HTTP error scenarios with `httpx` mocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0307e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->