### PR TITLE
feat(safety): Implement MCPTaintPolicyEngine and add new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7027,7 +7027,7 @@
     },
     {
       "id": "mcp-kernel-sandbox-taint-policy-v1-uuid",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Kernel Taint Tracking Policy Engine",
@@ -14942,6 +14942,57 @@
       "acceptance": [
         "Worktree isolation handles nested subagent spawning.",
         "Tests verify nested subagent paths."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-integration-v10",
+      "status": "todo",
+      "area": "integration",
+      "risk": "low",
+      "title": "A2A Enterprise Auth Token Delegation",
+      "description": "Implement A2A token delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_enterprise_v10.py",
+        "tests/test_a2a_enterprise_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A supports token delegation.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-semantic-context-compression",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "OpenClaw Semantic Search Context Compression",
+      "description": "Implement context compression via semantic search.",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_compression.py",
+        "tests/test_semantic_compression.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context compresses correctly.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-tool-registry-metrics-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "MCP Tool Registry Metrics Dashboard",
+      "description": "Implement MCP tool metrics dashboard.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_metrics.py",
+        "tests/test_mcp_metrics.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dashboard exposes metrics correctly.",
+        "Tests pass."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -232,3 +232,4 @@
 * [x] FEATURE: ACS Runtime Safety Controls V6 (acs-guard-runtime-safety-controls-v6)
 * [x] FEATURE: MCP Dynamic Action Tool v7 (mcp-dynamic-action-tool-v7)
 - [x] a2a-enterprise-integration-v8: A2A Enterprise Integration v8
+* [x] FEATURE: MCP Kernel Taint Tracking Policy Engine (mcp-kernel-sandbox-taint-policy-v1-uuid)

--- a/magda_agent/safety/mcp_taint_policy.py
+++ b/magda_agent/safety/mcp_taint_policy.py
@@ -1,0 +1,40 @@
+"""MCP Kernel Taint Tracking Policy Engine.
+
+Inspired by MCPKernel taint tracking + sandboxed execution.
+Provides a dynamic taint tracking policy engine to restrict untrusted tool outputs.
+"""
+
+from typing import Any, Dict
+
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError, TaintTrackerV2
+
+
+class MCPTaintPolicyEngine:
+    """Evaluates data streams against taint policies before tool execution."""
+
+    def __init__(self, tracker: TaintTrackerV2 | None = None) -> None:
+        """
+        Initialize the MCPTaintPolicyEngine.
+
+        Args:
+            tracker: An optional TaintTrackerV2 instance. If not provided, a new one is created.
+        """
+        self.tracker = tracker or TaintTrackerV2()
+
+    def evaluate_stream(self, inputs: Dict[str, Any], is_sensitive: bool = False) -> None:
+        """
+        Evaluates a stream of inputs against the taint policy.
+
+        Args:
+            inputs: A dictionary of inputs to be passed to a tool.
+            is_sensitive: If True, the tool is considered sensitive and execution will
+                fail if inputs contain any tainted data.
+
+        Raises:
+            PolicyViolationError: If is_sensitive is True and inputs contain tainted data.
+        """
+        if is_sensitive and self.tracker.is_tainted(inputs):
+            origins = self.tracker.get_origins(inputs)
+            raise PolicyViolationError(
+                f"Tainted input to sensitive tool call from origins: {origins}"
+            )

--- a/tests/test_mcp_taint_policy.py
+++ b/tests/test_mcp_taint_policy.py
@@ -1,0 +1,49 @@
+"""Tests for the MCP Kernel Taint Tracking Policy Engine."""
+
+import pytest
+
+from magda_agent.safety.mcp_taint_policy import MCPTaintPolicyEngine
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError, TaintTrackerV2
+
+
+def test_evaluate_stream_blocks_tainted_input_when_sensitive() -> None:
+    """Test that evaluate_stream raises PolicyViolationError when sensitive and inputs are tainted."""
+    tracker = TaintTrackerV2()
+    engine = MCPTaintPolicyEngine(tracker=tracker)
+
+    tainted_input = tracker.taint({"data": "untrusted"}, "malicious_source")
+
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call"):
+        engine.evaluate_stream(inputs=tainted_input, is_sensitive=True)
+
+
+def test_evaluate_stream_allows_tainted_input_when_not_sensitive() -> None:
+    """Test that evaluate_stream allows execution when inputs are tainted but tool is not sensitive."""
+    tracker = TaintTrackerV2()
+    engine = MCPTaintPolicyEngine(tracker=tracker)
+
+    tainted_input = tracker.taint({"data": "untrusted"}, "malicious_source")
+
+    # Should not raise an exception
+    engine.evaluate_stream(inputs=tainted_input, is_sensitive=False)
+
+
+def test_evaluate_stream_allows_clean_input_when_sensitive() -> None:
+    """Test that evaluate_stream allows execution for a sensitive tool when inputs are not tainted."""
+    tracker = TaintTrackerV2()
+    engine = MCPTaintPolicyEngine(tracker=tracker)
+
+    clean_input = {"data": "trusted"}
+
+    # Should not raise an exception
+    engine.evaluate_stream(inputs=clean_input, is_sensitive=True)
+
+
+def test_evaluate_stream_allows_clean_input_when_not_sensitive() -> None:
+    """Test that evaluate_stream allows execution for a non-sensitive tool when inputs are clean."""
+    engine = MCPTaintPolicyEngine()
+
+    clean_input = {"data": "trusted"}
+
+    # Should not raise an exception
+    engine.evaluate_stream(inputs=clean_input, is_sensitive=False)


### PR DESCRIPTION
This PR implements the MCP Kernel Taint Tracking Policy Engine. It evaluates data streams against taint policies using `TaintTrackerV2` and properly blocks tainted inputs for sensitive tools.

Additionally, this PR marks the related task as "done" in `agent_tasks.json`, introduces 3 new trend-inspired tasks, and updates the `backlog.md` with the new completed feature.

---
*PR created automatically by Jules for task [2978320919095882029](https://jules.google.com/task/2978320919095882029) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPTaintPolicyEngine` to block tainted inputs on sensitive tool calls
> - Adds [`MCPTaintPolicyEngine`](https://github.com/kazah4359-lgtm/Magda-agent/pull/432/files#diff-43d1aeeff12b8e2f7236ba7c3f2e4b895ff3b677e5627a7ba6b8be6e2650fd15) which composes a `TaintTrackerV2` to evaluate inputs before MCP tool execution.
> - `evaluate_stream` raises `PolicyViolationError` when `is_sensitive=True` and the input is tainted, including taint origins in the error; non-sensitive calls and clean inputs pass through silently.
> - Accepts an optional injected `TaintTrackerV2` in the constructor, defaulting to a new internal instance.
> - Tests in [`tests/test_mcp_taint_policy.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/432/files#diff-ae61720c3cdc0245042e018b6a1d24016f21f79244baf13e0c5144024a9918e1) cover tainted-sensitive (blocked), tainted-non-sensitive (allowed), and clean input cases.
> - Also adds three new task entries to `agent_tasks.json` and marks the taint policy feature as complete in `backlog.md`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9007a88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->