### PR TITLE
feat: implement OpenClaw-RL interactive feedback formatter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7044,7 +7044,7 @@
     },
     {
       "id": "openclaw-rl-interactive-feedback-v1-uuid",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Interactive Feedback Formatter",
@@ -14993,6 +14993,57 @@
       "acceptance": [
         "Dashboard exposes metrics correctly.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v4-uuid",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Exporter V4",
+      "description": "Inspired by MCP standardization trends: Implement an exporter to automatically extract JSON schemas from Magda's registered skills for exposing them as MCP action tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_exporter.py",
+        "tests/test_mcp_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter generates valid MCP JSON definitions.",
+        "Tests confirm extraction logic."
+      ]
+    },
+    {
+      "id": "a2a-discovery-agent-cards-v3-uuid",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "low",
+      "title": "A2A Discovery Agent Cards V3",
+      "description": "Inspired by A2A standard: Implement Agent Cards generation for peer-to-peer agent discovery in a multi-agent network.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_agent_cards.py",
+        "tests/test_a2a_agent_cards.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Generates valid A2A Agent Cards.",
+        "Tests verify format."
+      ]
+    },
+    {
+      "id": "context-engine-plugin-interface-v5-uuid",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Plugin Interface V5",
+      "description": "Inspired by OpenClaw architecture: Implement a Context Engine plugin interface with lifecycle hooks (on_load, on_unload) for dynamic memory management.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_plugin.py",
+        "tests/test_context_engine_plugin.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Interface handles dynamic plugin loading/unloading.",
+        "Tests mock plugin lifecycle hooks."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -233,3 +233,4 @@
 * [x] FEATURE: MCP Dynamic Action Tool v7 (mcp-dynamic-action-tool-v7)
 - [x] a2a-enterprise-integration-v8: A2A Enterprise Integration v8
 * [x] FEATURE: MCP Kernel Taint Tracking Policy Engine (mcp-kernel-sandbox-taint-policy-v1-uuid)
+* [x] FEATURE: OpenClaw-RL Interactive Feedback Formatter (openclaw-rl-interactive-feedback-v1-uuid)

--- a/magda_agent/learning/interactive_feedback.py
+++ b/magda_agent/learning/interactive_feedback.py
@@ -1,0 +1,66 @@
+import re
+from typing import Dict, Any, Optional
+
+class InteractiveFeedbackFormatter:
+    """
+    Formatter to extract explicit and implicit feedback signals from user text.
+    Inspired by OpenClaw-RL interactive learning.
+    """
+    def __init__(self) -> None:
+        """
+        Initializes the InteractiveFeedbackFormatter.
+        """
+        pass
+
+    def parse_corrections(self, text: str) -> Dict[str, Any]:
+        """
+        Parses user text to extract corrections and feedback signals.
+
+        Args:
+            text (str): The user's input text to be parsed.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing feedback signals:
+                - is_correction (bool): True if a correction was detected.
+                - explicit_score (Optional[float]): Extracted explicit score (0-10), if any.
+                - implicit_sentiment (float): Calculated implicit sentiment (-1.0 to 1.0).
+        """
+        if not text:
+            return {
+                "is_correction": False,
+                "explicit_score": None,
+                "implicit_sentiment": 0.0
+            }
+
+        text_lower = text.lower()
+
+        # Detect corrections
+        correction_keywords = ["no", "actually", "instead", "wrong", "fix", "incorrect"]
+        is_correction = any(re.search(rf'\b{kw}\b', text_lower) for kw in correction_keywords)
+
+        # Extract explicit score (e.g., 8/10 or 8.5 / 10)
+        explicit_score: Optional[float] = None
+        score_match = re.search(r'(\d+(?:\.\d+)?)\s*/\s*10', text_lower)
+        if score_match:
+            try:
+                score = float(score_match.group(1))
+                if 0 <= score <= 10:
+                    explicit_score = score
+            except ValueError:
+                pass
+
+        # Calculate implicit sentiment based on keywords
+        positive_keywords = ["good", "great", "awesome", "perfect", "thanks", "correct", "yes"]
+        negative_keywords = ["bad", "terrible", "awful", "incorrect", "wrong", "no", "stupid"]
+
+        pos_count = sum(1 for kw in positive_keywords if re.search(rf'\b{kw}\b', text_lower))
+        neg_count = sum(1 for kw in negative_keywords if re.search(rf'\b{kw}\b', text_lower))
+
+        sentiment = float(pos_count - neg_count) * 0.5
+        implicit_sentiment = max(min(sentiment, 1.0), -1.0)
+
+        return {
+            "is_correction": is_correction,
+            "explicit_score": explicit_score,
+            "implicit_sentiment": implicit_sentiment
+        }

--- a/tests/test_interactive_feedback.py
+++ b/tests/test_interactive_feedback.py
@@ -1,0 +1,55 @@
+import pytest
+from typing import Any, Dict
+from magda_agent.learning.interactive_feedback import InteractiveFeedbackFormatter
+
+def test_parse_corrections_explicit_score() -> None:
+    """Tests if explicit score is correctly extracted."""
+    formatter = InteractiveFeedbackFormatter()
+
+    result = formatter.parse_corrections("This is okay, maybe 7.5/10.")
+    assert result["explicit_score"] == 7.5
+
+    result2 = formatter.parse_corrections("I give it 10 / 10!")
+    assert result2["explicit_score"] == 10.0
+
+    result3 = formatter.parse_corrections("Score is 11/10")
+    # Should not capture out of bounds, though regex captures it, our logic discards if > 10.
+    assert result3["explicit_score"] is None
+
+def test_parse_corrections_implicit_sentiment() -> None:
+    """Tests if implicit sentiment is correctly calculated."""
+    formatter = InteractiveFeedbackFormatter()
+
+    result = formatter.parse_corrections("Good job, thanks!")
+    # 'good', 'thanks' -> 2 positive
+    assert result["implicit_sentiment"] == 1.0
+
+    result2 = formatter.parse_corrections("This is terrible and bad.")
+    # 'terrible', 'bad' -> 2 negative
+    assert result2["implicit_sentiment"] == -1.0
+
+    result3 = formatter.parse_corrections("It is good but bad")
+    # 1 positive, 1 negative -> 0.0
+    assert result3["implicit_sentiment"] == 0.0
+
+def test_parse_corrections_is_correction() -> None:
+    """Tests if corrections are correctly detected."""
+    formatter = InteractiveFeedbackFormatter()
+
+    result = formatter.parse_corrections("No, actually it's this.")
+    assert result["is_correction"] is True
+
+    result2 = formatter.parse_corrections("Please fix the typo.")
+    assert result2["is_correction"] is True
+
+    result3 = formatter.parse_corrections("Great, thanks!")
+    assert result3["is_correction"] is False
+
+def test_parse_corrections_empty() -> None:
+    """Tests behavior with empty string."""
+    formatter = InteractiveFeedbackFormatter()
+    result = formatter.parse_corrections("")
+
+    assert result["is_correction"] is False
+    assert result["explicit_score"] is None
+    assert result["implicit_sentiment"] == 0.0


### PR DESCRIPTION
This PR introduces the `InteractiveFeedbackFormatter`, which is part of the OpenClaw-RL Interactive Learning feature. It parses natural language corrections and feedback to extract boolean corrections, explicit scores, and implicit sentiment analysis based on keywords.

It also updates the `agent_tasks.json` manifest by completing the `openclaw-rl-interactive-feedback-v1-uuid` task and introducing three new trend-inspired tasks (MCP, A2A, and Context Engine). The corresponding task entry is also appended to `backlog.md`. All tests pass successfully and type hints/docstrings are rigorously applied.

---
*PR created automatically by Jules for task [14175579374613540970](https://jules.google.com/task/14175579374613540970) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `InteractiveFeedbackFormatter` class to parse correction signals from user text
> - Introduces [`interactive_feedback.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/433/files#diff-3aeb695e9adae9a7fe70a2277ec7bb126cbf787061ad27f13be508e0cfb8f15e) with `InteractiveFeedbackFormatter`, which parses user text for correction intent, explicit numeric scores (e.g. `7.5/10`, validated to 0–10), and implicit sentiment (keyword-counted, clamped to [-1.0, 1.0]).
> - Returns a structured dict with `is_correction`, `explicit_score`, and `implicit_sentiment` keys.
> - Adds [`tests/test_interactive_feedback.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/433/files#diff-f596935b06df5bb0af90d4b1eb07e87e36ac203f779d1bfc0badb4c32b5bf6c1) covering empty input, correction detection, explicit score extraction with range validation, and sentiment clamping.
> - Updates `backlog.md` and `agent_tasks.json` to mark the feature complete and add three new backlog tasks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5cc7b6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->