### PR TITLE
feat: Implement A2A task delegation streaming v2 and update agent_tasks.json

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7061,7 +7061,7 @@
     },
     {
       "id": "a2a-task-delegation-streaming-v2-uuid",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Task Delegation Streaming Interface v2",
@@ -15044,6 +15044,57 @@
       "acceptance": [
         "Interface handles dynamic plugin loading/unloading.",
         "Tests mock plugin lifecycle hooks."
+      ]
+    },
+    {
+      "id": "openclaw-rl-habit-integrator-v11",
+      "title": "OpenClaw RL Habit Integrator V11",
+      "description": "Inspired by OpenClaw trends: Implement an online reinforcement learning integrator to adjust habit weights from user dialogue signals.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v11.py",
+        "tests/test_openclaw_rl_v11.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL integrator correctly updates habit weights.",
+        "Tests mock RL behavior and user signals."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-isolation-v6",
+      "title": "Claude Agent Teams Isolation V6",
+      "description": "Inspired by Claude Agent Teams trend: Implement strict Git worktree isolation for subagent spawning in a multi-agent architecture.",
+      "area": "architecture",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_isolation_v6.py",
+        "tests/test_agent_teams_isolation_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents execute in isolated git worktrees.",
+        "Tests verify path isolation."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-telemetry-v10",
+      "title": "MCP Dynamic Tool Telemetry V10",
+      "description": "Inspired by MCP runtime concurrency trend: Implement dynamic tool telemetry to trace tool performance metrics during execution.",
+      "area": "skills",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_telemetry_v10.py",
+        "tests/test_mcp_telemetry_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry correctly records tool call metrics.",
+        "Tests confirm metrics collection."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_streaming.py
+++ b/magda_agent/integration/a2a_streaming.py
@@ -67,3 +67,67 @@ class A2AStreamingDelegator:
         except Exception as e:
             logging.error(f"Streaming delegation failed: {e}")
             yield {"error": str(e)}
+
+
+class A2AStreamingDelegatorV2(A2AStreamingDelegator):
+    """
+    V2 Implementation of the streaming interface for A2A peer-to-peer task delegation.
+    Enhances long-horizon task coordination by supporting configurable timeouts and retries.
+    """
+    def __init__(self, security_context: Optional[A2ASecurityContext] = None, timeout: float = 60.0) -> None:
+        """
+        Initializes the V2 streaming delegator.
+
+        Args:
+            security_context: Optional security context for token generation.
+            timeout: Configurable timeout for long-horizon task streaming.
+        """
+        super().__init__(security_context)
+        self.timeout = timeout
+
+    async def stream_delegation_v2(self, target_agent: AgentCardV3, plan_context: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+        """
+        Delegates a task to a peer agent using enhanced V2 configuration.
+
+        Args:
+            target_agent: The target AgentCardV3 representing the peer.
+            plan_context: The task context to delegate.
+
+        Yields:
+            Chunked update dictionaries received from the peer.
+        """
+        logging.info(f"Initiating V2 streaming delegation to Agent: {target_agent.name} with timeout {self.timeout}")
+        endpoint = target_agent.endpoints.get("rpc")
+        if not endpoint:
+            yield {"error": f"Agent {target_agent.name} missing rpc endpoint"}
+            return
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "stream_subplan_v2",
+            "params": {"context": plan_context}
+        }
+
+        headers: Dict[str, str] = {}
+        A2ATracer.inject_headers(headers)
+
+        if self.security_context:
+            token = self.security_context.generate_token()
+            headers["Authorization"] = f"Bearer {token}"
+            self.security_context.trace_action("stream_delegation_v2", {"target_agent": target_agent.name})
+
+        try:
+            async with httpx.AsyncClient() as client:
+                async with client.stream("POST", endpoint, json=payload, headers=headers, timeout=self.timeout) as response:
+                    response.raise_for_status()
+                    async for chunk in response.aiter_lines():
+                        if chunk:
+                            try:
+                                data = json.loads(chunk)
+                                yield data
+                            except json.JSONDecodeError:
+                                yield {"error": "Failed to decode chunk", "raw": chunk}
+        except Exception as e:
+            logging.error(f"V2 Streaming delegation failed: {e}")
+            yield {"error": str(e)}

--- a/tests/test_a2a_streaming.py
+++ b/tests/test_a2a_streaming.py
@@ -16,14 +16,27 @@ def target_agent() -> AgentCardV3:
         endpoints={"rpc": "http://192.168.1.10:8080/rpc"}
     )
 
+from typing import Any, AsyncGenerator, Type, Optional
+from types import TracebackType
+
 class MockAsyncContextManager:
-    def __init__(self, return_value):
+    """A mock context manager for async tests."""
+    def __init__(self, return_value: Any) -> None:
+        """Initialize mock context manager.
+        Args:
+            return_value: The value to return when entering the context.
+        """
         self.return_value = return_value
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Any:
+        """Enter the async context.
+        Returns:
+            The configured return value.
+        """
         return self.return_value
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> None:
+        """Exit the async context."""
         pass
 
 @pytest.mark.asyncio
@@ -35,7 +48,11 @@ async def test_stream_delegation_success(target_agent: AgentCardV3) -> None:
     mock_response = AsyncMock()
     mock_response.raise_for_status = MagicMock()
 
-    async def mock_aiter_lines():
+    async def mock_aiter_lines() -> AsyncGenerator[str, None]:
+        """Provides simulated chunked responses.
+        Yields:
+            A simulated response line string.
+        """
         yield json.dumps({"status": "processing", "progress": 50})
         yield "" # empty chunk should be ignored
         yield "invalid json chunk"
@@ -44,7 +61,12 @@ async def test_stream_delegation_success(target_agent: AgentCardV3) -> None:
     mock_response.aiter_lines = mock_aiter_lines
 
     class MockClient:
-        def stream(self, *args, **kwargs):
+        """A mock HTTP client."""
+        def stream(self, *args: Any, **kwargs: Any) -> MockAsyncContextManager:
+            """Mocks the HTTP stream response context.
+            Returns:
+                A mock context manager containing the mock response.
+            """
             return MockAsyncContextManager(mock_response)
 
     with patch('httpx.AsyncClient', return_value=MockAsyncContextManager(MockClient())):
@@ -78,10 +100,13 @@ async def test_stream_delegation_http_error(target_agent: AgentCardV3) -> None:
     delegator = A2AStreamingDelegator()
 
     class ErrorContextManager:
-        async def __aenter__(self):
+        """A context manager to simulate an error upon entering context."""
+        async def __aenter__(self) -> Any:
+            """Raises an Exception on enter."""
             raise Exception("Connection Refused")
 
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
+        async def __aexit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> None:
+            """Exit the async context."""
             pass
 
     with patch('httpx.AsyncClient', return_value=ErrorContextManager()):
@@ -92,3 +117,34 @@ async def test_stream_delegation_http_error(target_agent: AgentCardV3) -> None:
         assert len(chunks) == 1
         assert "error" in chunks[0]
         assert "Connection Refused" in chunks[0]["error"]
+
+from magda_agent.integration.a2a_streaming import A2AStreamingDelegatorV2
+
+@pytest.mark.asyncio
+async def test_stream_delegation_v2_success(target_agent: AgentCardV3) -> None:
+    """Tests successful V2 streaming delegation with chunked updates."""
+    security_context = A2ASecurityContext()
+    delegator = A2AStreamingDelegatorV2(security_context=security_context, timeout=120.0)
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+
+    async def mock_aiter_lines() -> AsyncGenerator[str, None]:
+        yield json.dumps({"status": "v2_processing", "progress": 10})
+        yield json.dumps({"status": "v2_completed", "result": "done"})
+
+    mock_response.aiter_lines = mock_aiter_lines
+
+    class MockClientV2:
+        def stream(self, *args: Any, **kwargs: Any) -> MockAsyncContextManager:
+            assert kwargs.get("timeout") == 120.0
+            return MockAsyncContextManager(mock_response)
+
+    with patch('httpx.AsyncClient', return_value=MockAsyncContextManager(MockClientV2())):
+        chunks = []
+        async for chunk in delegator.stream_delegation_v2(target_agent, {"task": "test_v2"}):
+            chunks.append(chunk)
+
+        assert len(chunks) == 2
+        assert chunks[0]["status"] == "v2_processing"
+        assert chunks[1]["status"] == "v2_completed"


### PR DESCRIPTION
This PR addresses the A2A Task Delegation Streaming v2 task, implementing a `A2AStreamingDelegatorV2` class that supports configurable timeouts, fixing test typing and docstrings, marking the task done, and appending 3 new AI-trend tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [6454576437743218486](https://jules.google.com/task/6454576437743218486) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `A2AStreamingDelegatorV2` with configurable timeout and JSON-RPC `stream_subplan_v2` support
> - Adds [`A2AStreamingDelegatorV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/434/files#diff-ead8a1bcd96c4a8a12110645eb5d92d2ec2234454c11fe7f0227446768a95d42) subclassing the existing delegator, with a configurable timeout (default 60s) and optional `A2ASecurityContext` for Authorization header injection.
> - The new `stream_delegation_v2` method calls the `stream_subplan_v2` JSON-RPC method, yielding parsed JSON chunks and structured error objects on missing `rpc` endpoint, JSON decode failures, or request exceptions.
> - Adds a corresponding test [`test_stream_delegation_v2_success`](https://github.com/kazah4359-lgtm/Magda-agent/pull/434/files#diff-c940a3603260c6ca98e15938adc409c2903e7077004b8e14042d045bd47ede22) verifying timeout propagation and chunk handling; existing tests receive type annotations and docstrings with no behavioral changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eac293b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->