### PR TITLE
feat: Add MCP Kernel Taint Policy Output Evaluation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7078,7 +7078,7 @@
     },
     {
       "id": "mcp-kernel-sandbox-taint-policy-v2-uuid",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Kernel Taint Tracking Policy Engine v2",
@@ -15095,6 +15095,57 @@
       "acceptance": [
         "Telemetry correctly records tool call metrics.",
         "Tests confirm metrics collection."
+      ]
+    },
+    {
+      "id": "mcpkernel-taint-origin-graph-v1",
+      "title": "MCPKernel Taint Origin Graph",
+      "description": "Inspired by MCPKernel trends: Implement a visual or structured representation of taint origin propagation graphs to track complex data lineage across agent operations.",
+      "area": "safety",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/taint_graph.py",
+        "tests/test_taint_graph.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Origin graph accurately traces and visualizes taint sources.",
+        "Tests verify graph construction and tracking correctness."
+      ]
+    },
+    {
+      "id": "mcpkernel-sandbox-resource-limits-v1",
+      "title": "MCPKernel Sandbox Resource Limits",
+      "description": "Inspired by MCPKernel and general sandboxing trends: Add configurable resource limits (timeout, memory heuristics) to the SandboxExecutionEnvironmentV2.",
+      "area": "safety",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/sandbox_limits.py",
+        "tests/test_sandbox_limits.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Resource limits prevent tool executions from exceeding defined boundaries.",
+        "Tests mock resource exhaustion scenarios to verify enforcement."
+      ]
+    },
+    {
+      "id": "mcpkernel-policy-audit-logger-v1",
+      "title": "MCPKernel Policy Audit Logger",
+      "description": "Inspired by Prempti and ACS standards: Implement a dedicated policy audit logger to record all taint policy evaluations and violations into a structured audit trail.",
+      "area": "safety",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/policy_audit.py",
+        "tests/test_policy_audit.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy audit logger records policy evaluations and violations.",
+        "Tests ensure correct formatting and logging behavior without external side-effects."
       ]
     }
   ]

--- a/magda_agent/safety/mcp_taint_policy.py
+++ b/magda_agent/safety/mcp_taint_policy.py
@@ -38,3 +38,21 @@ class MCPTaintPolicyEngine:
             raise PolicyViolationError(
                 f"Tainted input to sensitive tool call from origins: {origins}"
             )
+
+    def evaluate_output_stream(self, output: Any, is_trusted: bool = False) -> None:
+        """
+        Evaluates a stream of outputs against the taint policy.
+
+        Args:
+            output: The output to be evaluated.
+            is_trusted: If True, the output is considered trusted and execution will
+                succeed even if it contains tainted data.
+
+        Raises:
+            PolicyViolationError: If is_trusted is False and the output contains tainted data.
+        """
+        if not is_trusted and self.tracker.is_tainted(output):
+            origins = self.tracker.get_origins(output)
+            raise PolicyViolationError(
+                f"Tainted output from untrusted tool call with origins: {origins}"
+            )

--- a/tests/test_mcp_taint_policy.py
+++ b/tests/test_mcp_taint_policy.py
@@ -47,3 +47,45 @@ def test_evaluate_stream_allows_clean_input_when_not_sensitive() -> None:
 
     # Should not raise an exception
     engine.evaluate_stream(inputs=clean_input, is_sensitive=False)
+
+
+def test_evaluate_output_stream_blocks_tainted_output_when_untrusted() -> None:
+    """Test that evaluate_output_stream raises PolicyViolationError when output is tainted and untrusted."""
+    tracker = TaintTrackerV2()
+    engine = MCPTaintPolicyEngine(tracker=tracker)
+
+    tainted_output = tracker.taint({"data": "untrusted"}, "malicious_source")
+
+    with pytest.raises(PolicyViolationError, match="Tainted output from untrusted tool call"):
+        engine.evaluate_output_stream(output=tainted_output, is_trusted=False)
+
+
+def test_evaluate_output_stream_allows_tainted_output_when_trusted() -> None:
+    """Test that evaluate_output_stream allows tainted output when it is trusted."""
+    tracker = TaintTrackerV2()
+    engine = MCPTaintPolicyEngine(tracker=tracker)
+
+    tainted_output = tracker.taint({"data": "untrusted"}, "malicious_source")
+
+    # Should not raise an exception
+    engine.evaluate_output_stream(output=tainted_output, is_trusted=True)
+
+
+def test_evaluate_output_stream_allows_clean_output_when_untrusted() -> None:
+    """Test that evaluate_output_stream allows clean output even when untrusted."""
+    engine = MCPTaintPolicyEngine()
+
+    clean_output = {"data": "trusted"}
+
+    # Should not raise an exception
+    engine.evaluate_output_stream(output=clean_output, is_trusted=False)
+
+
+def test_evaluate_output_stream_allows_clean_output_when_trusted() -> None:
+    """Test that evaluate_output_stream allows clean output when trusted."""
+    engine = MCPTaintPolicyEngine()
+
+    clean_output = {"data": "trusted"}
+
+    # Should not raise an exception
+    engine.evaluate_output_stream(output=clean_output, is_trusted=True)


### PR DESCRIPTION
Implemented the MCP Kernel Taint Tracking Policy Engine v2 task (`mcp-kernel-sandbox-taint-policy-v2-uuid`).

1. Added `evaluate_output_stream(self, output: Any, is_trusted: bool = False)` to `magda_agent/safety/mcp_taint_policy.py`. This method raises a `PolicyViolationError` when an untrusted tool attempts to return tainted output.
2. Included comprehensive pytest coverage in `tests/test_mcp_taint_policy.py` verifying all edge cases of tainted/clean and trusted/untrusted logic.
3. Added 3 new `todo` tasks to `agent_tasks.json` inspired by advanced security trends (MCPKernel Taint Origin Graph, MCPKernel Sandbox Resource Limits, and MCPKernel Policy Audit Logger).
4. Ensured `agent_tasks.json` was correctly formatted and passes the validation script. All module tests pass correctly.

---
*PR created automatically by Jules for task [14633606727338151567](https://jules.google.com/task/14633606727338151567) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `evaluate_output_stream` to `MCPTaintPolicyEngine` to block tainted untrusted outputs
> Adds `evaluate_output_stream(output, is_trusted=False)` to [`MCPTaintPolicyEngine`](https://github.com/kazah4359-lgtm/Magda-agent/pull/435/files#diff-43d1aeeff12b8e2f7236ba7c3f2e4b895ff3b677e5627a7ba6b8be6e2650fd15). The method checks whether the output is tainted via `TaintTrackerV2` and raises `PolicyViolationError` (including taint origins) when the output is tainted and `is_trusted` is `False`. Four tests cover the blocking and pass-through cases in [`tests/test_mcp_taint_policy.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/435/files#diff-ae61720c3cdc0245042e018b6a1d24016f21f79244baf13e0c5144024a9918e1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 187b6f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->