### PR TITLE
feat: implement OpenClaw RL metrics system

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7112,7 +7112,7 @@
     },
     {
       "id": "openclaw-rl-metrics-v1-4b8afd35",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL Metrics System",
@@ -15197,6 +15197,40 @@
       "acceptance": [
         "A2A Discovery matches capabilities using Agent Cards v3.",
         "Tests verify mock discovery."
+      ]
+    },
+    {
+      "id": "mcp-server-health-monitor-v2",
+      "area": "skills",
+      "risk": "low",
+      "status": "todo",
+      "title": "MCP Server Health Monitor v2",
+      "description": "Inspired by MCP standard trend: Implement a background health monitoring system that periodically pings registered MCP servers and logs their latency and availability.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_health_monitor.py",
+        "tests/test_mcp_health_monitor.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Health monitor correctly pings MCP servers and logs status",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "a2a-peer-delegation-timeout-v1",
+      "area": "multi-agent",
+      "risk": "medium",
+      "status": "todo",
+      "title": "A2A Peer Delegation Timeout",
+      "description": "Inspired by A2A Protocol standard: Implement timeout and automatic retry logic for long-running peer-to-peer delegation tasks to improve reliability.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_timeout.py",
+        "tests/test_a2a_timeout.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Delegation tasks timeout appropriately and retry based on policy",
+        "Tests mock network failure and verify retry logic"
       ]
     }
   ]

--- a/magda_agent/learning/metrics.py
+++ b/magda_agent/learning/metrics.py
@@ -1,0 +1,75 @@
+import logging
+from typing import Optional, Dict, Any
+from magda_agent.metacognition.tracker import QualityTracker
+from magda_agent.learning.interactive_feedback import InteractiveFeedbackFormatter
+
+class RLMetricsSystem:
+    """
+    OpenClaw RL Metrics System.
+    Captures longitudinal quality updates based on next-state signals (user replies).
+    """
+    def __init__(self, quality_tracker: QualityTracker) -> None:
+        """
+        Initializes the RL Metrics System.
+
+        Args:
+            quality_tracker (QualityTracker): Tracker to log metrics longitudinally.
+        """
+        self.quality_tracker = quality_tracker
+        self.formatter = InteractiveFeedbackFormatter()
+
+    def capture_next_state_signal(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: Optional[str],
+        tool_output: Optional[str] = None
+    ) -> None:
+        """
+        Analyzes the user's reply as a next-state signal and logs RL metrics.
+
+        Args:
+            user_reply (str): The user's reply text.
+            action_context (str): The context of the action that was taken.
+            user_id (Optional[str]): The user's ID.
+            tool_output (Optional[str], optional): The output of the tool, if any. Defaults to None.
+        """
+        if not user_reply:
+            return
+
+        signal_text = user_reply
+        if tool_output:
+            signal_text += f" [Tool Output: {tool_output}]"
+
+        feedback_signals = self.formatter.parse_corrections(signal_text)
+
+        explicit_score = feedback_signals.get("explicit_score")
+        implicit_sentiment = feedback_signals.get("implicit_sentiment", 0.0)
+        is_correction = feedback_signals.get("is_correction", False)
+
+        metadata: Dict[str, Any] = {
+            "user_id": user_id,
+            "action_context": action_context,
+            "is_correction": is_correction
+        }
+
+        # Log explicit score if available
+        if explicit_score is not None:
+            self.quality_tracker.log_metric("rl_explicit_score", explicit_score, metadata)
+            logging.info(f"RLMetricsSystem: Logged rl_explicit_score={explicit_score} for user {user_id}")
+
+        # Log implicit sentiment
+        self.quality_tracker.log_metric("rl_implicit_sentiment", implicit_sentiment, metadata)
+        logging.info(f"RLMetricsSystem: Logged rl_implicit_sentiment={implicit_sentiment} for user {user_id}")
+
+        # Calculate a combined quality score (0-100)
+        if explicit_score is not None:
+            quality_score = explicit_score * 10
+        else:
+            # Map sentiment [-1.0, 1.0] to [0, 100], base 50
+            quality_score = 50 + (implicit_sentiment * 50)
+            if is_correction:
+                quality_score = max(0.0, quality_score - 20)
+
+        self.quality_tracker.log_metric("rl_quality_score", quality_score, metadata)
+        logging.info(f"RLMetricsSystem: Logged rl_quality_score={quality_score} for user {user_id}")

--- a/tests/test_rl_metrics.py
+++ b/tests/test_rl_metrics.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.metrics import RLMetricsSystem
+from magda_agent.metacognition.tracker import QualityTracker
+
+@pytest.fixture
+def mock_quality_tracker():
+    """Provides a mocked QualityTracker."""
+    return MagicMock(spec=QualityTracker)
+
+@pytest.fixture
+def rl_metrics_system(mock_quality_tracker):
+    """Provides an RLMetricsSystem instance with a mocked tracker."""
+    return RLMetricsSystem(quality_tracker=mock_quality_tracker)
+
+def test_capture_next_state_signal_empty(rl_metrics_system, mock_quality_tracker):
+    """Test that empty replies are ignored."""
+    rl_metrics_system.capture_next_state_signal("", "context", "user_1")
+    mock_quality_tracker.log_metric.assert_not_called()
+
+def test_capture_next_state_signal_explicit_score(rl_metrics_system, mock_quality_tracker):
+    """Test capturing an explicit score."""
+    reply = "I give this a 8.5/10, good job."
+    rl_metrics_system.capture_next_state_signal(reply, "test_action", "user_1")
+
+    # Check explicit score log
+    mock_quality_tracker.log_metric.assert_any_call(
+        "rl_explicit_score",
+        8.5,
+        {"user_id": "user_1", "action_context": "test_action", "is_correction": False}
+    )
+
+    # Check quality score log (8.5 * 10 = 85.0)
+    mock_quality_tracker.log_metric.assert_any_call(
+        "rl_quality_score",
+        85.0,
+        {"user_id": "user_1", "action_context": "test_action", "is_correction": False}
+    )
+
+def test_capture_next_state_signal_positive_implicit(rl_metrics_system, mock_quality_tracker):
+    """Test capturing positive implicit sentiment."""
+    reply = "That is perfect, thanks!"
+    rl_metrics_system.capture_next_state_signal(reply, "test_action", "user_2")
+
+    # Extract args of the log_metric calls
+    calls = mock_quality_tracker.log_metric.call_args_list
+
+    # Should have logged rl_implicit_sentiment and rl_quality_score
+    assert len(calls) == 2
+
+    sentiment_call = calls[0]
+    assert sentiment_call[0][0] == "rl_implicit_sentiment"
+    assert sentiment_call[0][1] > 0.0  # sentiment should be positive
+
+    quality_call = calls[1]
+    assert quality_call[0][0] == "rl_quality_score"
+    assert quality_call[0][1] > 50.0  # quality should be > 50
+
+def test_capture_next_state_signal_correction(rl_metrics_system, mock_quality_tracker):
+    """Test capturing a negative correction."""
+    reply = "No, that is wrong, fix it."
+    rl_metrics_system.capture_next_state_signal(reply, "test_action", "user_3")
+
+    # Check for correction and sentiment logs
+    calls = mock_quality_tracker.log_metric.call_args_list
+    assert len(calls) == 2
+
+    sentiment_call = calls[0]
+    assert sentiment_call[0][0] == "rl_implicit_sentiment"
+    assert sentiment_call[0][1] < 0.0  # sentiment should be negative
+
+    quality_call = calls[1]
+    assert quality_call[0][0] == "rl_quality_score"
+    # Quality should be significantly lower (starts at 50, -sentiment penalty, -correction penalty)
+    assert quality_call[0][1] < 50.0
+
+def test_capture_next_state_signal_with_tool_output(rl_metrics_system, mock_quality_tracker):
+    """Test with tool output included."""
+    reply = "perfect"
+    tool_out = "Some expected result"
+    rl_metrics_system.capture_next_state_signal(reply, "test_action", "user_4", tool_output=tool_out)
+
+    calls = mock_quality_tracker.log_metric.call_args_list
+    assert len(calls) == 2
+    assert calls[0][0][0] == "rl_implicit_sentiment"
+    assert calls[1][0][0] == "rl_quality_score"
+
+    # Verify metadata is correct
+    assert calls[0][0][2]["user_id"] == "user_4"


### PR DESCRIPTION
This PR implements the OpenClaw RL metrics system as described in the `openclaw-rl-metrics-v1-4b8afd35` task.

**Changes:**
1. Created `magda_agent/learning/metrics.py` with the `RLMetricsSystem` class. It uses the existing `QualityTracker` and `InteractiveFeedbackFormatter` to log explicit scores, implicit sentiments, and quality scores derived from next-state signals (user replies).
2. Added unit tests in `tests/test_rl_metrics.py` mocking the database interactions to verify correct logging and scoring behaviors.
3. Updated `agent_tasks.json` to mark the original task as "done".
4. Appended two new "todo" tasks based on current AI trends (MCP server health monitoring and A2A peer delegation timeouts).

All regression tests (1285 passed) run cleanly, and `scripts/validate_agent_tasks.py` passes successfully.

---
*PR created automatically by Jules for task [18050906243376211228](https://jules.google.com/task/18050906243376211228) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLMetricsSystem` to capture and log RL metrics from user feedback
> - Adds [`RLMetricsSystem`](https://github.com/kazah4359-lgtm/Magda-agent/pull/437/files#diff-0e6b9461695fc2886506a5e682ffe591d34d01959dceb76ea1aac2260e52633d) which wires a `QualityTracker` and `InteractiveFeedbackFormatter` to parse user replies and log RL metrics.
> - The `capture_next_state_signal` method logs `rl_implicit_sentiment` and `rl_quality_score` on every non-empty reply, and `rl_explicit_score` when an explicit score is detected; quality score maps sentiment `[-1,1]` to `[0,100]` centered at 50, with a -20 penalty for corrections.
> - Adds [tests/test_rl_metrics.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/437/files#diff-6dbcaf7fe8e7a49b7d06574ef2d1321a130c0ba120f112f67ecc92d6a8f4b491) with five tests covering empty replies, explicit scores, implicit sentiment, correction penalties, and tool output inclusion using a mocked `QualityTracker`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2f946f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->