### PR TITLE
Mark A2A Discovery v2 task as done and add new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7129,7 +7129,7 @@
     },
     {
       "id": "a2a-discovery-v2-8142d1f8",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery v2 (Agent Cards)",
@@ -15231,6 +15231,57 @@
       "acceptance": [
         "Delegation tasks timeout appropriately and retry based on policy",
         "Tests mock network failure and verify retry logic"
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-exporter-v1",
+      "title": "Hermes Skill Marketplace Exporter V1",
+      "description": "Inspired by Hermes trends: Implement an exporter to translate Magda skills into the open agentskills.io standard format for sharing in external marketplaces.",
+      "area": "skills",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/skills/agentskills_exporter.py",
+        "tests/test_agentskills_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter outputs valid agentskills.io schemas.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-subagent-compression-v1",
+      "title": "Claude Subagent Context Compression V1",
+      "description": "Inspired by Claude Agent Teams: Implement specialized context compression when spawning subagents to ensure they only receive minimal, relevant task context.",
+      "area": "architecture",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/subagent_compression.py",
+        "tests/test_subagent_compression.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context is successfully compressed before subagent delegation.",
+        "Tests mock compression logic and verify subagent inputs."
+      ]
+    },
+    {
+      "id": "openclaw-live-canvas-telemetry-v1",
+      "title": "OpenClaw Live Canvas Telemetry V1",
+      "description": "Inspired by OpenClaw trends: Implement live canvas telemetry to stream real-time agent execution state to an external dashboard.",
+      "area": "visualization",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_telemetry.py",
+        "tests/test_canvas_telemetry.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent execution states are correctly streamed as telemetry data.",
+        "Tests verify telemetry formatting."
       ]
     }
   ]


### PR DESCRIPTION
The A2A Discovery V2 task implementation was already completed (code in `magda_agent/integration/a2a_discovery_v2.py` and passing tests in `tests/test_a2a_discovery_v2.py`). 

This PR performs the following manifest updates:
1. Marks `a2a-discovery-v2-8142d1f8` as `done`.
2. Appends three new AI trend-inspired tasks to the backlog.

---
*PR created automatically by Jules for task [12533957761447992388](https://jules.google.com/task/12533957761447992388) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark A2A Discovery v2 task as done and add three new tasks to agent_tasks.json
> Updates [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/438/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) to reflect current task state: marks the A2A Discovery v2 task as `done` and appends three new `todo` tasks: `hermes-skill-marketplace-exporter-v1`, `claude-subagent-compression-v1`, and `openclaw-live-canvas-telemetry-v1`. Each new task includes metadata, allowed file paths, and acceptance criteria.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a47f45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->