### PR TITLE
Implement MCPKernelRuntimeV3 for taint tracking proxy

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7146,7 +7146,7 @@
     },
     {
       "id": "mcp-kernel-runtime-v3-629cf94c",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Kernel Runtime v3",
@@ -15282,6 +15282,57 @@
       "acceptance": [
         "Agent execution states are correctly streamed as telemetry data.",
         "Tests verify telemetry formatting."
+      ]
+    },
+    {
+      "id": "mcp-tool-exporter-v4-1111",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Tool Exporter V4",
+      "description": "Inspired by MCP standards trend: Extract Python functions into MCP tools, producing valid schemas dynamically.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_exporter_v4.py",
+        "tests/test_mcp_exporter_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Generates valid MCP JSON schemas from standard python functions using type hints.",
+        "Tests cover argument and docstring extraction."
+      ]
+    },
+    {
+      "id": "agent-team-spawn-v2-2222",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Agent Team Spawner V2",
+      "description": "Inspired by Anthropic Claude Agent Teams trend: create a system for dynamically spawning sub-agents securely.",
+      "allowed_paths": [
+        "magda_agent/agents/team_spawner_v2.py",
+        "tests/test_team_spawner_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Provides an interface to initialize and execute isolated sub-agents.",
+        "Tests cover successful agent isolation and lifecycle hooks."
+      ]
+    },
+    {
+      "id": "online-learning-feedback-v4-3333",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online Learning Feedback V4",
+      "description": "Inspired by OpenClaw-RL trend: Capture user feedback signals automatically from dialogue for self-improvement.",
+      "allowed_paths": [
+        "magda_agent/learning/online_feedback_v4.py",
+        "tests/test_online_feedback_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Extracts implicit/explicit signals securely.",
+        "Tests mock RL metric updates."
       ]
     }
   ]

--- a/magda_agent/safety/mcp_kernel_runtime_v3.py
+++ b/magda_agent/safety/mcp_kernel_runtime_v3.py
@@ -1,0 +1,144 @@
+"""
+MCP Kernel Runtime V3.
+
+Inspired by MCPKernel taint tracking trend: this module provides a runtime proxy
+that enforces taint policies for tool calls.
+"""
+
+import inspect
+from functools import wraps
+from typing import Any, Callable, Dict, Optional, Coroutine
+
+from magda_agent.safety.mcp_taint_policy import MCPTaintPolicyEngine
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError
+
+
+class MCPKernelRuntimeV3:
+    """
+    Acts as a runtime proxy enforcing taint policy for tool calls.
+    """
+
+    def __init__(self, policy_engine: Optional[MCPTaintPolicyEngine] = None) -> None:
+        """
+        Initializes the MCPKernelRuntimeV3.
+
+        Args:
+            policy_engine: The policy engine used for evaluating data streams.
+                If not provided, a new one is created.
+        """
+        self.policy_engine = policy_engine or MCPTaintPolicyEngine()
+
+    def execute_tool(
+        self,
+        tool_func: Callable[..., Any],
+        inputs: Dict[str, Any],
+        is_sensitive: bool = False,
+        is_trusted: bool = False,
+    ) -> Any:
+        """
+        Evaluates the input stream, executes the tool, and evaluates the output stream.
+
+        Args:
+            tool_func: The actual tool function to execute if permitted.
+            inputs: A dictionary of inputs to pass to the tool.
+            is_sensitive: If True, the tool is considered sensitive and execution will
+                fail if inputs contain any tainted data.
+            is_trusted: If True, the output is considered trusted and execution will
+                succeed even if it contains tainted data.
+
+        Returns:
+            The result of the tool execution if permitted.
+
+        Raises:
+            PolicyViolationError: If input/output policies are violated.
+        """
+        # 1. Evaluate Input Stream
+        self.policy_engine.evaluate_stream(inputs, is_sensitive=is_sensitive)
+
+        # 2. Execute Tool
+        # We handle coroutine vs sync inside runtime_proxy, but we also support direct calls
+        if inspect.iscoroutinefunction(tool_func):
+            async def async_wrapper() -> Any:
+                result = await tool_func(**inputs)
+                self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+                return result
+            return async_wrapper()
+
+        result = tool_func(**inputs)
+
+        # Handle synchronous execution returning an awaitable (e.g. from wrapper)
+        if inspect.isawaitable(result):
+            async def async_result_wrapper() -> Any:
+                awaited_result = await result
+                self.policy_engine.evaluate_output_stream(awaited_result, is_trusted=is_trusted)
+                return awaited_result
+            return async_result_wrapper()
+
+        # 3. Evaluate Output Stream
+        self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+
+        return result
+
+    def runtime_proxy(self, is_sensitive: bool = False, is_trusted: bool = False) -> Callable:
+        """
+        A decorator to wrap a tool function with the MCPKernelRuntimeV3.
+
+        Args:
+            is_sensitive: If True, the tool is considered sensitive.
+            is_trusted: If True, the output is considered trusted.
+
+        Returns:
+            The decorated tool function.
+        """
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            @wraps(func)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                # To be generic, combine args and kwargs into an inputs dictionary
+                # For simplicity, we just package everything into a dict.
+                # Real MCP tools often take named parameters (kwargs).
+                # We'll map args to positional indices if necessary.
+
+                sig = inspect.signature(func)
+                bound_args = sig.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+                inputs = dict(bound_args.arguments)
+
+                # Check inputs
+                self.policy_engine.evaluate_stream(inputs, is_sensitive=is_sensitive)
+
+                result = func(*args, **kwargs)
+
+                # Check if the synchronous wrapper returned a coroutine
+                if inspect.isawaitable(result):
+                     async def async_eval() -> Any:
+                         awaited_result = await result
+                         self.policy_engine.evaluate_output_stream(awaited_result, is_trusted=is_trusted)
+                         return awaited_result
+                     return async_eval()
+
+                # Check output
+                self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+
+                return result
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                sig = inspect.signature(func)
+                bound_args = sig.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+                inputs = dict(bound_args.arguments)
+
+                # Check inputs
+                self.policy_engine.evaluate_stream(inputs, is_sensitive=is_sensitive)
+
+                result = await func(*args, **kwargs)
+
+                # Check output
+                self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+
+                return result
+
+            return async_wrapper if inspect.iscoroutinefunction(func) else sync_wrapper
+
+        return decorator

--- a/tests/test_mcp_kernel_runtime_v3.py
+++ b/tests/test_mcp_kernel_runtime_v3.py
@@ -1,0 +1,125 @@
+"""Tests for the MCPKernelRuntimeV3 module."""
+
+import pytest
+
+from magda_agent.safety.mcp_kernel_runtime_v3 import MCPKernelRuntimeV3
+from magda_agent.safety.mcp_taint_policy import MCPTaintPolicyEngine
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError, TaintTrackerV2
+
+
+@pytest.fixture
+def runtime() -> MCPKernelRuntimeV3:
+    """Fixture providing an MCPKernelRuntimeV3 instance."""
+    return MCPKernelRuntimeV3()
+
+
+def test_execute_tool_sensitive_rejects_tainted_input(runtime: MCPKernelRuntimeV3) -> None:
+    """Test that a sensitive tool rejects tainted input."""
+    def sample_tool(data: str) -> str:
+        return f"Processed {data}"
+
+    tracker = runtime.policy_engine.tracker
+    tainted_input = tracker.taint({"data": "untrusted"}, "malicious_source")
+
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call"):
+        runtime.execute_tool(sample_tool, inputs=tainted_input, is_sensitive=True)
+
+
+def test_execute_tool_non_sensitive_accepts_tainted_input(runtime: MCPKernelRuntimeV3) -> None:
+    """Test that a non-sensitive tool accepts tainted input."""
+    def sample_tool(data: str) -> str:
+        return f"Processed {data}"
+
+    tracker = runtime.policy_engine.tracker
+    # Input is tainted but not the string itself to bypass simple tests, let's taint a string.
+    tainted_str = tracker.taint("untrusted", "malicious_source")
+
+    # We execute and return the tainted string
+    def sample_tool_2(data: str) -> str:
+        return data
+
+    inputs = {"data": tainted_str}
+
+    # Tool is not sensitive and output is untrusted. We should fail output validation
+    # since output is tainted and tool is untrusted.
+    with pytest.raises(PolicyViolationError, match="Tainted output from untrusted tool call"):
+         runtime.execute_tool(sample_tool_2, inputs=inputs, is_sensitive=False, is_trusted=False)
+
+
+def test_execute_tool_untrusted_rejects_tainted_output(runtime: MCPKernelRuntimeV3) -> None:
+    """Test that an untrusted tool rejects tainted output."""
+    def sample_tool() -> str:
+        return runtime.policy_engine.tracker.taint("secret", "db")
+
+    with pytest.raises(PolicyViolationError, match="Tainted output from untrusted tool call"):
+        runtime.execute_tool(sample_tool, inputs={}, is_sensitive=False, is_trusted=False)
+
+
+def test_execute_tool_trusted_accepts_tainted_output(runtime: MCPKernelRuntimeV3) -> None:
+    """Test that a trusted tool accepts tainted output."""
+    def sample_tool() -> str:
+        return runtime.policy_engine.tracker.taint("secret", "db")
+
+    result = runtime.execute_tool(sample_tool, inputs={}, is_sensitive=False, is_trusted=True)
+    assert runtime.policy_engine.tracker.is_tainted(result)
+
+
+def test_runtime_proxy_sync(runtime: MCPKernelRuntimeV3) -> None:
+    """Test the runtime_proxy decorator with a synchronous function."""
+
+    @runtime.runtime_proxy(is_sensitive=True, is_trusted=False)
+    def my_sync_tool(a: str, b: str = "default") -> str:
+        return f"{a} {b}"
+
+    # Clean inputs -> clean output
+    res = my_sync_tool("hello")
+    assert res == "hello default"
+
+    # Tainted input -> rejected because sensitive
+    tainted_input = runtime.policy_engine.tracker.taint("bad", "source")
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call"):
+        my_sync_tool(tainted_input)
+
+    @runtime.runtime_proxy(is_sensitive=False, is_trusted=False)
+    def my_tainted_tool() -> str:
+         return runtime.policy_engine.tracker.taint("secret", "db")
+
+    # Tainted output -> rejected because untrusted
+    with pytest.raises(PolicyViolationError, match="Tainted output from untrusted tool call"):
+        my_tainted_tool()
+
+
+@pytest.mark.asyncio
+async def test_runtime_proxy_async(runtime: MCPKernelRuntimeV3) -> None:
+    """Test the runtime_proxy decorator with an asynchronous function."""
+
+    @runtime.runtime_proxy(is_sensitive=True, is_trusted=False)
+    async def my_async_tool(a: str, b: str = "default") -> str:
+        return f"{a} {b}"
+
+    # Clean inputs -> clean output
+    res = await my_async_tool("hello")
+    assert res == "hello default"
+
+    # Tainted input -> rejected because sensitive
+    tainted_input = runtime.policy_engine.tracker.taint("bad", "source")
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call"):
+        await my_async_tool(tainted_input)
+
+    @runtime.runtime_proxy(is_sensitive=False, is_trusted=True)
+    async def my_trusted_async_tool() -> str:
+         return runtime.policy_engine.tracker.taint("secret", "db")
+
+    # Tainted output -> accepted because trusted
+    res2 = await my_trusted_async_tool()
+    assert runtime.policy_engine.tracker.is_tainted(res2)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_async(runtime: MCPKernelRuntimeV3) -> None:
+    """Test execute_tool directly with an asynchronous function."""
+    async def sample_tool() -> str:
+        return "async clean"
+
+    res = await runtime.execute_tool(sample_tool, inputs={}, is_sensitive=False, is_trusted=False)
+    assert res == "async clean"


### PR DESCRIPTION
Implements the `MCPKernelRuntimeV3` module which acts as a runtime proxy enforcing taint policy for tool calls, inspired by the MCPKernel taint tracking trend.

- Created `magda_agent/safety/mcp_kernel_runtime_v3.py` with `execute_tool` and a `runtime_proxy` decorator that supports both synchronous and asynchronous functions.
- Integrated `MCPTaintPolicyEngine` to actively evaluate and enforce input and output data stream taint tracking.
- Implemented comprehensive `pytest` test suite covering sync/async, untrusted tools, and sensitive inputs in `tests/test_mcp_kernel_runtime_v3.py`.
- Processed task `mcp-kernel-runtime-v3-629cf94c` by marking it `done`.
- Autonomously replenished the `agent_tasks.json` manifest with 3 new task cards inspired by current trends: MCP Exporter V4, Agent Team Spawner V2, and Online Learning Feedback V4.

---
*PR created automatically by Jules for task [15544725565937310379](https://jules.google.com/task/15544725565937310379) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `MCPKernelRuntimeV3` for taint-tracking proxy on tool calls
> - Adds [`MCPKernelRuntimeV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/439/files#diff-dea459670515b0054feecce4fd5dcd6f01d04815a4e68aa75a21718d75165631) as a runtime proxy that enforces taint policy on tool inputs and outputs using `MCPTaintPolicyEngine`, raising `PolicyViolationError` on violations.
> - Provides two execution paths: `execute_tool` for direct invocation and `runtime_proxy` as a decorator factory, both supporting sync and async functions.
> - Adds a [test module](https://github.com/kazah4359-lgtm/Magda-agent/pull/439/files#diff-fdff8ea8af356e95a7bbf27aad481783a0cbbc017fad3903ba88d0d08979b0a8) covering input/output taint rejection, `is_sensitive`/`is_trusted` semantics, and sync/async decorator behavior.
> - Risk: sync functions wrapped by `runtime_proxy` may return a coroutine if the underlying function yields an awaitable, which callers must handle explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee7570a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->