### PR TITLE
OpenClaw Canvas Memory Visualization

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7163,7 +7163,7 @@
     },
     {
       "id": "openclaw-canvas-memory-visualization-59894892",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Memory Visualization",
@@ -15333,6 +15333,57 @@
       "acceptance": [
         "Extracts implicit/explicit signals securely.",
         "Tests mock RL metric updates."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-dynamic-registry-v9",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Dynamic Registry v9",
+      "description": "Inspired by MCP standard trend: Implement an advanced registry to dynamically load and unload MCP Action Tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_registry_v9.py",
+        "tests/test_mcp_registry_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Registry dynamically loads tools",
+        "Tests verify load/unload logic"
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-visualization-v4",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw RL Canvas Metrics Visualization v4",
+      "description": "Inspired by OpenClaw trends: Stream RL performance metrics to the Canvas Live Visualization.",
+      "allowed_paths": [
+        "magda_agent/visualization/rl_canvas_metrics_v4.py",
+        "tests/test_rl_canvas_metrics_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL metrics are streamed to Canvas",
+        "Tests mock WebSocket and check payload"
+      ]
+    },
+    {
+      "id": "claude-subagent-teams-isolation-v8",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Subagent Teams Isolation v8",
+      "description": "Inspired by Claude Agent SDK: Ensure git worktree isolation for hierarchical subagent spawns.",
+      "allowed_paths": [
+        "magda_agent/architecture/teams_isolation_v8.py",
+        "tests/test_teams_isolation_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents operate in isolated worktrees",
+        "Tests check path isolation logic"
       ]
     }
   ]

--- a/magda_agent/visualization/memory_canvas.py
+++ b/magda_agent/visualization/memory_canvas.py
@@ -1,0 +1,105 @@
+import json
+import logging
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+class MemoryCanvasVisualizer:
+    """
+    Formats Magda's internal memory state into a structured JSON dictionary
+    suitable for streaming to a live OpenClaw-inspired Canvas UI.
+    """
+
+    def __init__(self, memory_system: Any) -> None:
+        """
+        Initializes the visualizer with a reference to the agent's memory system.
+
+        Args:
+            memory_system: The memory system component containing working, episodic, semantic, and procedural memory.
+        """
+        self.memory_system = memory_system
+
+    def get_formatted_memory_state(self, user_id: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Retrieves and formats the agent's memory state into a structured dictionary.
+
+        Args:
+            user_id: Optional user identifier to filter state (e.g., for memory retrieval).
+
+        Returns:
+            Dict[str, Any]: A dictionary representing the agent's current memory state.
+        """
+        state: Dict[str, Any] = {
+            "working": {},
+            "episodic": {},
+            "semantic": {},
+            "procedural": {}
+        }
+
+        if not self.memory_system:
+            return state
+
+        try:
+            # Working memory
+            if hasattr(self.memory_system, 'working_memory') and self.memory_system.working_memory:
+                wm = self.memory_system.working_memory
+
+                user_id_int = None
+                if user_id is not None:
+                    try:
+                        user_id_int = int(user_id)
+                    except ValueError:
+                        pass
+
+                entries = []
+                if hasattr(wm, 'get_entries'):
+                    entries = wm.get_entries(user_id=user_id_int)
+                elif hasattr(wm, 'items'):
+                    entries = getattr(wm, 'items', [])
+
+                count = len(entries)
+                summary = wm.get_summary(user_id=user_id_int) if hasattr(wm, 'get_summary') else None
+
+                state["working"] = {
+                    "count": count,
+                    "summary": summary
+                }
+
+            # Episodic memory
+            if hasattr(self.memory_system, 'episodic') and self.memory_system.episodic:
+                state["episodic"] = {
+                    "status": "active"
+                }
+
+            # Semantic memory
+            if hasattr(self.memory_system, 'semantic') and self.memory_system.semantic:
+                state["semantic"] = {
+                    "status": "active"
+                }
+
+            # Procedural memory
+            if hasattr(self.memory_system, 'procedural') and self.memory_system.procedural:
+                proc = self.memory_system.procedural
+                skills_count = len(getattr(proc, 'skills', {})) if hasattr(proc, 'skills') else 0
+                state["procedural"] = {
+                    "status": "active",
+                    "skills_count": skills_count
+                }
+
+        except Exception as e:
+            logger.error(f"Error formatting memory canvas state: {e}")
+            state["error"] = str(e)
+
+        return state
+
+    def get_memory_state_json(self, user_id: Optional[str] = None) -> str:
+        """
+        Returns the formatted memory state as a JSON string.
+
+        Args:
+            user_id: Optional user identifier.
+
+        Returns:
+            str: JSON-encoded string of the agent memory state.
+        """
+        return json.dumps(self.get_formatted_memory_state(user_id=user_id))

--- a/tests/test_memory_canvas.py
+++ b/tests/test_memory_canvas.py
@@ -1,0 +1,81 @@
+import pytest
+import json
+from unittest.mock import MagicMock
+from magda_agent.visualization.memory_canvas import MemoryCanvasVisualizer
+
+def test_memory_canvas_visualizer_formatting():
+    """Test that the MemoryCanvasVisualizer correctly formats the agent's memory state."""
+
+    # Mock Memory System
+    mock_memory_system = MagicMock()
+
+    # Mock Working Memory
+    mock_working = MagicMock()
+    mock_working.get_entries.return_value = [1, 2, 3, 4]
+    mock_working.get_summary.return_value = "Working memory summary content"
+    mock_memory_system.working_memory = mock_working
+
+    # Mock Episodic Memory
+    mock_memory_system.episodic = MagicMock()
+
+    # Mock Semantic Memory
+    mock_memory_system.semantic = MagicMock()
+
+    # Mock Procedural Memory
+    mock_procedural = MagicMock()
+    mock_procedural.skills = {"skill1": "impl1", "skill2": "impl2", "skill3": "impl3"}
+    mock_memory_system.procedural = mock_procedural
+
+    # Create visualizer and get state
+    visualizer = MemoryCanvasVisualizer(mock_memory_system)
+    state = visualizer.get_formatted_memory_state(user_id="123")
+
+    # Assertions
+    assert "working" in state
+    assert state["working"]["count"] == 4
+    assert state["working"]["summary"] == "Working memory summary content"
+
+    assert "episodic" in state
+    assert state["episodic"]["status"] == "active"
+
+    assert "semantic" in state
+    assert state["semantic"]["status"] == "active"
+
+    assert "procedural" in state
+    assert state["procedural"]["status"] == "active"
+    assert state["procedural"]["skills_count"] == 3
+
+    assert "error" not in state
+
+    # Test JSON output
+    json_str = visualizer.get_memory_state_json(user_id="123")
+    json_data = json.loads(json_str)
+    assert json_data == state
+
+def test_memory_canvas_visualizer_empty_system():
+    """Test handling of None memory system."""
+    visualizer = MemoryCanvasVisualizer(None)
+    state = visualizer.get_formatted_memory_state()
+
+    assert state["working"] == {}
+    assert state["episodic"] == {}
+    assert state["semantic"] == {}
+    assert state["procedural"] == {}
+    assert "error" not in state
+
+def test_memory_canvas_visualizer_missing_components():
+    """Test handling when some memory components are missing."""
+    mock_memory_system = MagicMock()
+    mock_memory_system.working_memory = None
+    mock_memory_system.episodic = None
+    mock_memory_system.semantic = None
+    mock_memory_system.procedural = None
+
+    visualizer = MemoryCanvasVisualizer(mock_memory_system)
+    state = visualizer.get_formatted_memory_state()
+
+    assert state["working"] == {}
+    assert state["episodic"] == {}
+    assert state["semantic"] == {}
+    assert state["procedural"] == {}
+    assert "error" not in state


### PR DESCRIPTION
Implements MemoryCanvasVisualizer to stream memory structures (Working, Episodic, Semantic, Procedural) to OpenClaw Canvas UI. Closes task openclaw-canvas-memory-visualization-59894892.

---
*PR created automatically by Jules for task [17643742494724693038](https://jules.google.com/task/17643742494724693038) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MemoryCanvasVisualizer` class to format agent memory state for live visualization
> - Adds [memory_canvas.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/440/files#diff-7d707cf8d00ac2797af4e987003d2608f5cd862bbd272baa04b9221f36eb3af2) with `MemoryCanvasVisualizer`, which wraps an agent memory system and exposes `get_formatted_memory_state` and `get_memory_state_json` methods.
> - `get_formatted_memory_state` returns a structured dict with working (count, summary), episodic (status), semantic (status), and procedural (status, skills_count) keys, gracefully handling missing components and surfacing errors via an `"error"` field.
> - Three unit tests cover a fully mocked memory system, a `None` system, and a system with all components set to `None`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d0ba21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

----
## Summary by Gitar

- **New visualization module:**
  - Added `MemoryCanvasVisualizer` to format and stream agent memory state (Working, Episodic, Semantic, Procedural) via `memory_canvas.py`.
- **Task management:**
  - Updated `agent_tasks.json` to mark the visualization task as done and added placeholders for three upcoming tasks related to MCP tools, RL metrics, and subagent isolation.
- **Testing:**
  - Added `test_memory_canvas.py` with full coverage for state formatting, edge cases, and empty memory system handling.


<sub>This will update automatically on new commits.</sub>