### PR TITLE
feat: Hermes Persistent Memory Marketplace

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7197,7 +7197,7 @@
     },
     {
       "id": "hermes-persistent-memory-marketplace-v1-28a4370c",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Hermes Persistent Memory Marketplace v1",
@@ -15435,6 +15435,57 @@
       "acceptance": [
         "Subagents operate in isolated worktrees",
         "Tests check path isolation logic"
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugin-interface-v1-11a22b3c",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Plugin Interface",
+      "description": "Implement a Context Engine plugin interface with lifecycle hooks inspired by OpenClaw trends.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_plugin.py",
+        "tests/test_context_engine_plugin.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin interface is defined",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "claude-agent-teams-subagent-spawning-v3-22c33d4e",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude Agent Teams Subagent Spawning v3",
+      "description": "Implement subagent spawning for parallel tasks with git worktree isolation inspired by Claude Agent Teams.",
+      "allowed_paths": [
+        "magda_agent/agents/subagent_spawning_v3.py",
+        "tests/test_subagent_spawning_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents can be spawned in isolated worktrees",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "mcp-agent-skills-export-v2-33d44e5f",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Agent Skills Export v2",
+      "description": "Export Magda skills as MCP-compatible JSON-RPC tools inspired by MCP trends.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_export_v2.py",
+        "tests/test_mcp_export_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skills can be exported as MCP tools",
+        "Tests pass"
       ]
     }
   ]

--- a/magda_agent/memory/marketplace.py
+++ b/magda_agent/memory/marketplace.py
@@ -1,0 +1,66 @@
+import logging
+from typing import List, Dict, Any
+
+def export_episodic_to_marketplace_format(events: List[Dict[str, Any]], author_id: str = "magda") -> Dict[str, Any]:
+    """
+    Export a list of episodic memory events to the Hermes marketplace standard JSON format.
+
+    Args:
+        events: A list of episodic memory event dictionaries. Each should have 'id', 'text', and optional 'metadata'.
+        author_id: The identifier for the agent creating the export. Defaults to "magda".
+
+    Returns:
+        A dictionary representing the marketplace JSON structure containing the memory events.
+    """
+    try:
+        marketplace_events = []
+        for event in events:
+            marketplace_events.append({
+                "event_id": event.get("id", ""),
+                "text": event.get("text", ""),
+                "metadata": event.get("metadata", {}),
+                "timestamp": event.get("metadata", {}).get("timestamp", None)
+            })
+
+        return {
+            "version": "1.0",
+            "author_id": author_id,
+            "events": marketplace_events
+        }
+    except Exception as e:
+        logging.error(f"Error exporting episodic memory to marketplace format: {e}")
+        return {"version": "1.0", "author_id": author_id, "events": []}
+
+def import_episodic_from_marketplace_format(marketplace_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Import episodic memory events from the Hermes marketplace standard JSON format.
+
+    Args:
+        marketplace_data: A dictionary representing the marketplace JSON structure.
+
+    Returns:
+        A list of episodic memory event dictionaries compatible with the local system.
+    """
+    try:
+        if not isinstance(marketplace_data, dict) or "events" not in marketplace_data:
+            logging.error("Invalid marketplace data format. Must be a dict with an 'events' key.")
+            return []
+
+        events = []
+        for marketplace_event in marketplace_data.get("events", []):
+            event = {
+                "id": marketplace_event.get("event_id", ""),
+                "text": marketplace_event.get("text", ""),
+                "metadata": marketplace_event.get("metadata", {})
+            }
+            # Maintain timestamp if it was present explicitly in the marketplace event
+            if "timestamp" in marketplace_event and marketplace_event["timestamp"] is not None:
+                if "timestamp" not in event["metadata"]:
+                    event["metadata"]["timestamp"] = marketplace_event["timestamp"]
+
+            events.append(event)
+
+        return events
+    except Exception as e:
+        logging.error(f"Error importing episodic memory from marketplace format: {e}")
+        return []

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -112,3 +112,68 @@ async def test_search_marketplace_skills(mock_get):
     names = [r["name"] for r in results2]
     assert "calculator" in names
     assert "math_helper" in names
+
+
+from magda_agent.memory.marketplace import export_episodic_to_marketplace_format, import_episodic_from_marketplace_format
+
+def test_export_episodic_to_marketplace_format():
+    events = [
+        {
+            "id": "mem-1",
+            "text": "User wants a pizza",
+            "metadata": {"timestamp": 1234567890, "user_id": 42}
+        },
+        {
+            "id": "mem-2",
+            "text": "User likes mushrooms",
+            "metadata": {"user_id": 42}
+        }
+    ]
+
+    result = export_episodic_to_marketplace_format(events, author_id="magda_test")
+
+    assert result["version"] == "1.0"
+    assert result["author_id"] == "magda_test"
+    assert len(result["events"]) == 2
+
+    assert result["events"][0]["event_id"] == "mem-1"
+    assert result["events"][0]["text"] == "User wants a pizza"
+    assert result["events"][0]["metadata"] == {"timestamp": 1234567890, "user_id": 42}
+    assert result["events"][0]["timestamp"] == 1234567890
+
+    assert result["events"][1]["event_id"] == "mem-2"
+    assert result["events"][1]["text"] == "User likes mushrooms"
+    assert result["events"][1]["metadata"] == {"user_id": 42}
+    assert result["events"][1]["timestamp"] is None
+
+def test_import_episodic_from_marketplace_format():
+    marketplace_data = {
+        "version": "1.0",
+        "author_id": "other_agent",
+        "events": [
+            {
+                "event_id": "ext-1",
+                "text": "User hates olives",
+                "metadata": {"source": "external"},
+                "timestamp": 987654321
+            },
+            {
+                "event_id": "ext-2",
+                "text": "User loves cheese",
+                "metadata": {}
+            }
+        ]
+    }
+
+    result = import_episodic_from_marketplace_format(marketplace_data)
+
+    assert len(result) == 2
+
+    assert result[0]["id"] == "ext-1"
+    assert result[0]["text"] == "User hates olives"
+    assert result[0]["metadata"]["source"] == "external"
+    assert result[0]["metadata"]["timestamp"] == 987654321
+
+    assert result[1]["id"] == "ext-2"
+    assert result[1]["text"] == "User loves cheese"
+    assert "timestamp" not in result[1]["metadata"]


### PR DESCRIPTION
This PR resolves the `hermes-persistent-memory-marketplace-v1-28a4370c` task by introducing a standard memory export format inspired by Hermes Agent. It allows agents to share episodic memory via a standardized JSON interface. Tests evaluate parsing integrity and new trend-inspired tasks have been appended to the task backlog.

---
*PR created automatically by Jules for task [14389835770235978321](https://jules.google.com/task/14389835770235978321) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Hermes marketplace export/import functions for episodic memory
> - Adds `export_episodic_to_marketplace_format` in [`marketplace.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/442/files#diff-fd6e0ee82ce69ebdf797957ebdc86cca30da302be0257f9757dba2ac76588448) that converts local episodic event dicts into the Hermes marketplace JSON shape, including `event_id`, `text`, `metadata`, and `timestamp` fields.
> - Adds `import_episodic_from_marketplace_format` that maps Hermes marketplace events back to local episodic dicts, preserving explicit timestamps where present.
> - Both functions include error handling that logs failures and returns safe fallback values (empty events list or empty list).
> - Adds tests in [`test_marketplace.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/442/files#diff-b658411584973233e8e31c0d568d23cc2e9871be9c7b54cba05b3f6bace19d5f) covering round-trip behavior and timestamp handling for both functions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 287e51f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->