### PR TITLE
Implement OpenClaw A2A Orchestration Streaming

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7214,7 +7214,7 @@
     },
     {
       "id": "openclaw-a2a-orchestration-streaming-v1-4fa9de5b",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "OpenClaw A2A Orchestration Streaming v1",
@@ -15486,6 +15486,57 @@
       "acceptance": [
         "Skills can be exported as MCP tools",
         "Tests pass"
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-importer-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Skill Marketplace Importer V1",
+      "description": "Inspired by Hermes trends: Implement an importer to load external agentskills.io standard formats into Magda.",
+      "allowed_paths": [
+        "magda_agent/skills/agentskills_importer.py",
+        "tests/test_agentskills_importer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Importer reads valid agentskills.io schemas.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-subagent-teams-isolation-v9",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Subagent Teams Isolation v9",
+      "description": "Inspired by Claude Agent Teams: Ensure git worktree isolation for hierarchical subagent spawns (v9 iteration).",
+      "allowed_paths": [
+        "magda_agent/architecture/teams_isolation_v9.py",
+        "tests/test_teams_isolation_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents operate in isolated worktrees",
+        "Tests check path isolation logic"
+      ]
+    },
+    {
+      "id": "openai-agents-runtime-tool-concurrency-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI Agents Runtime Tool Concurrency",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement runtime function tool concurrency for executing multiple tools in parallel.",
+      "allowed_paths": [
+        "magda_agent/skills/tool_concurrency_v2.py",
+        "tests/test_tool_concurrency_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tools are executed concurrently using asyncio.gather.",
+        "Tests verify parallel execution."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_orchestration.py
+++ b/magda_agent/integration/a2a_orchestration.py
@@ -1,0 +1,76 @@
+import asyncio
+import logging
+from typing import Dict, Any, List, AsyncGenerator, Optional
+
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_security import A2ASecurityContext
+from magda_agent.integration.a2a_streaming import A2AStreamingDelegatorV2
+
+class A2AOrchestratorStream:
+    """
+    Coordinates peer-to-peer delegation streams to multiple agents asynchronously,
+    inspired by OpenClaw trends for streaming A2A orchestration.
+    """
+    def __init__(self, security_context: Optional[A2ASecurityContext] = None, timeout: float = 60.0) -> None:
+        """
+        Initializes the A2AOrchestratorStream.
+
+        Args:
+            security_context: Optional security context to pass to the delegator.
+            timeout: Configurable timeout for each delegation stream.
+        """
+        self.security_context = security_context or A2ASecurityContext()
+        self.delegator = A2AStreamingDelegatorV2(security_context=self.security_context, timeout=timeout)
+
+    async def _stream_from_agent(self, agent: AgentCardV3, plan_context: Dict[str, Any], queue: asyncio.Queue) -> None:
+        """
+        Streams updates from a single agent and places them in an asyncio queue.
+
+        Args:
+            agent: The target AgentCardV3 representing the peer.
+            plan_context: The task context to delegate.
+            queue: The asyncio Queue to put updates into.
+        """
+        try:
+            async for chunk in self.delegator.stream_delegation_v2(agent, plan_context):
+                await queue.put({"agent_name": agent.name, "chunk": chunk})
+        except Exception as e:
+            logging.error(f"Error streaming from agent {agent.name}: {e}")
+            await queue.put({"agent_name": agent.name, "chunk": {"error": str(e)}})
+
+    async def broadcast_plan_stream(self, target_agents: List[AgentCardV3], plan_context: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+        """
+        Broadcasts a plan to multiple agents and yields their chunked updates concurrently.
+
+        Args:
+            target_agents: A list of target AgentCardV3 objects.
+            plan_context: The context to delegate.
+
+        Yields:
+            A dictionary containing the agent_name and the chunk received.
+        """
+        if not target_agents:
+            logging.warning("No target agents provided for broadcast.")
+            return
+
+        queue: asyncio.Queue = asyncio.Queue()
+        tasks = []
+
+        for agent in target_agents:
+            task = asyncio.create_task(self._stream_from_agent(agent, plan_context, queue))
+            tasks.append(task)
+
+        active_tasks = len(tasks)
+
+        while active_tasks > 0 or not queue.empty():
+            try:
+                # Wait for the next item or a small timeout to check task completion
+                item = await asyncio.wait_for(queue.get(), timeout=0.1)
+                yield item
+                queue.task_done()
+            except asyncio.TimeoutError:
+                # Re-evaluate active tasks
+                active_tasks = sum(1 for t in tasks if not t.done())
+
+        # Ensure all tasks are awaited to propagate any unhandled exceptions (though they should be caught in _stream_from_agent)
+        await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_a2a_orchestration.py
+++ b/tests/test_a2a_orchestration.py
@@ -1,0 +1,99 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch
+from typing import AsyncGenerator, Dict, Any, List
+
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_orchestration import A2AOrchestratorStream
+from magda_agent.integration.a2a_security import A2ASecurityContext
+
+@pytest.fixture
+def target_agents() -> List[AgentCardV3]:
+    """Provides a list of dummy target agent cards."""
+    return [
+        AgentCardV3(
+            agent_id="agent-1",
+            name="Worker1",
+            description="Worker agent 1",
+            capabilities=["math"],
+            endpoints={"rpc": "http://10.0.0.1:8080/rpc"}
+        ),
+        AgentCardV3(
+            agent_id="agent-2",
+            name="Worker2",
+            description="Worker agent 2",
+            capabilities=["search"],
+            endpoints={"rpc": "http://10.0.0.2:8080/rpc"}
+        )
+    ]
+
+@pytest.mark.asyncio
+async def test_broadcast_plan_stream_success(target_agents: List[AgentCardV3]) -> None:
+    """Tests successful broadcast of a plan stream to multiple agents."""
+    orchestrator = A2AOrchestratorStream(timeout=10.0)
+
+    # Mock the delegator to return specific streams based on the agent name
+    async def mock_stream_delegation_v2(agent: AgentCardV3, plan_context: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+        if agent.name == "Worker1":
+            yield {"status": "processing", "progress": 50}
+            await asyncio.sleep(0.01)
+            yield {"status": "completed", "result": "Worker1_done"}
+        elif agent.name == "Worker2":
+            await asyncio.sleep(0.01)
+            yield {"status": "started"}
+            yield {"status": "completed", "result": "Worker2_done"}
+
+    with patch.object(orchestrator.delegator, 'stream_delegation_v2', side_effect=mock_stream_delegation_v2):
+        chunks = []
+        async for item in orchestrator.broadcast_plan_stream(target_agents, {"task": "do_work"}):
+            chunks.append(item)
+
+        assert len(chunks) == 4
+        # Since it's concurrent, we just verify all expected chunks are present
+        worker1_chunks = [c["chunk"] for c in chunks if c["agent_name"] == "Worker1"]
+        worker2_chunks = [c["chunk"] for c in chunks if c["agent_name"] == "Worker2"]
+
+        assert len(worker1_chunks) == 2
+        assert worker1_chunks[0]["status"] == "processing"
+        assert worker1_chunks[1]["result"] == "Worker1_done"
+
+        assert len(worker2_chunks) == 2
+        assert worker2_chunks[0]["status"] == "started"
+        assert worker2_chunks[1]["result"] == "Worker2_done"
+
+@pytest.mark.asyncio
+async def test_broadcast_plan_stream_with_error(target_agents: List[AgentCardV3]) -> None:
+    """Tests broadcast when one agent stream raises an exception."""
+    orchestrator = A2AOrchestratorStream(timeout=10.0)
+
+    async def mock_stream_delegation_v2(agent: AgentCardV3, plan_context: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+        if agent.name == "Worker1":
+            yield {"status": "processing"}
+            raise Exception("Network failure")
+        elif agent.name == "Worker2":
+            yield {"status": "completed"}
+
+    with patch.object(orchestrator.delegator, 'stream_delegation_v2', side_effect=mock_stream_delegation_v2):
+        chunks = []
+        async for item in orchestrator.broadcast_plan_stream(target_agents, {"task": "do_work"}):
+            chunks.append(item)
+
+        worker1_chunks = [c["chunk"] for c in chunks if c["agent_name"] == "Worker1"]
+        worker2_chunks = [c["chunk"] for c in chunks if c["agent_name"] == "Worker2"]
+
+        assert len(worker1_chunks) == 2
+        assert worker1_chunks[0]["status"] == "processing"
+        assert "error" in worker1_chunks[1]
+        assert "Network failure" in worker1_chunks[1]["error"]
+
+        assert len(worker2_chunks) == 1
+        assert worker2_chunks[0]["status"] == "completed"
+
+@pytest.mark.asyncio
+async def test_broadcast_plan_stream_empty_agents() -> None:
+    """Tests broadcast with an empty list of agents."""
+    orchestrator = A2AOrchestratorStream()
+    chunks = []
+    async for item in orchestrator.broadcast_plan_stream([], {"task": "do_work"}):
+        chunks.append(item)
+    assert len(chunks) == 0


### PR DESCRIPTION
Implements the `openclaw-a2a-orchestration-streaming-v1-4fa9de5b` task:

- Adds `A2AOrchestratorStream` in `magda_agent/integration/a2a_orchestration.py` to stream updates from multiple agents concurrently using `A2AStreamingDelegatorV2` and `asyncio.Queue`.
- Adds tests in `tests/test_a2a_orchestration.py` using `pytest` and `AsyncMock`.
- Updates `agent_tasks.json` to mark the current task as done and appends 3 new trend-inspired tasks (Hermes Marketplace Importer, Claude Subagent Isolation v9, and OpenAI Runtime Tool Concurrency).
- Follows all specific constraints, including type hints, docstrings, and strict formatting.

---
*PR created automatically by Jules for task [1640929720221809729](https://jules.google.com/task/1640929720221809729) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `A2AOrchestratorStream` for concurrent A2A agent plan broadcasting with streaming
> - Adds [a2a_orchestration.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/443/files#diff-7fbc00f3962511a7c244f90f468982fd7533b7e7ee2b13beafbdcf77ca9340e3) with `A2AOrchestratorStream`, which concurrently delegates a plan to multiple agents via `A2AStreamingDelegatorV2` and yields interleaved `{'agent_name': <name>, 'chunk': <chunk>}` dicts as they arrive.
> - Each agent runs in its own `asyncio.Task`; exceptions are caught and enqueued as error chunks rather than aborting the broadcast.
> - Includes async pytest tests covering multi-agent streaming, per-agent error propagation, and empty agent list behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ccc3f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->