### PR TITLE
MCP Policy Runtime Engine Isolation v1

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7231,7 +7231,7 @@
     },
     {
       "id": "mcp-policy-runtime-engine-isolation-v1-b548ccd1",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Policy Runtime Engine Isolation v1",
@@ -15537,6 +15537,57 @@
       "acceptance": [
         "Tools are executed concurrently using asyncio.gather.",
         "Tests verify parallel execution."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-guardrails-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Dynamic Guardrails V1",
+      "description": "Inspired by ACS trend: Implement dynamic guardrails policy manager.",
+      "allowed_paths": [
+        "magda_agent/safety/dynamic_guardrails.py",
+        "tests/test_dynamic_guardrails.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Guardrails policy manager can dynamically update policies.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-memory-compaction-v3",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Memory Compaction V3",
+      "description": "Inspired by MemGPT/Letta pattern: Implement episodic memory compactor for the Virtual context management.",
+      "allowed_paths": [
+        "magda_agent/memory/compaction_v3.py",
+        "tests/test_compaction_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Episodic memory compactor correctly truncates old memories.",
+        "Tests mock LLM and pass."
+      ]
+    },
+    {
+      "id": "a2a-agent-discovery-heartbeat-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "low",
+      "title": "A2A Agent Discovery Heartbeat V1",
+      "description": "Inspired by A2A standard trend: Implement heartbeat broadcasting for agent discovery.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_heartbeat.py",
+        "tests/test_a2a_heartbeat.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent successfully broadcasts heartbeat periodically.",
+        "Tests mock broadcasting and pass."
       ]
     }
   ]

--- a/magda_agent/safety/mcp_isolation.py
+++ b/magda_agent/safety/mcp_isolation.py
@@ -1,0 +1,51 @@
+"""MCP Policy Runtime Engine Isolation v1.
+
+Inspired by MCP trends: Introduce an isolated runtime execution environment
+for untrusted MCP tools using a taint policy engine.
+"""
+
+from typing import Any, Callable, Dict, Optional
+from magda_agent.safety.mcp_taint_policy import MCPTaintPolicyEngine
+from magda_agent.safety.mcp_kernel_sandbox import MCPKernelSandbox
+
+class MCPIsolationEngine:
+    """Provides an isolated runtime execution environment for untrusted tools."""
+
+    def __init__(self, policy_engine: Optional[MCPTaintPolicyEngine] = None) -> None:
+        """Initialize the isolation engine."""
+        self.policy_engine = policy_engine or MCPTaintPolicyEngine()
+        self.sandbox = MCPKernelSandbox()
+        # Ensure they share the same taint tracker
+        self.sandbox.tracker = self.policy_engine.tracker
+        self.sandbox.sandbox.tracker = self.policy_engine.tracker
+
+    def execute_untrusted_tool(
+        self,
+        tool_func: Callable[..., Any],
+        inputs: Dict[str, Any],
+    ) -> Any:
+        """
+        Execute an untrusted tool in an isolated environment.
+
+        Args:
+            tool_func: The function to execute.
+            inputs: A dictionary of inputs to pass to the function.
+
+        Returns:
+            The result of the tool execution.
+
+        Raises:
+            PolicyViolationError: If the output contains tainted data.
+            RuntimeError: If the tool execution fails.
+        """
+        # Evaluate inputs before execution
+        self.policy_engine.evaluate_stream(inputs, is_sensitive=False)
+
+        # Execute tool within sandbox
+        result = self.sandbox.execute(tool_func, inputs, is_sensitive=False)
+
+        # Evaluate output stream. For untrusted tools, we assume is_trusted=False.
+        # This will raise PolicyViolationError if the output is tainted.
+        self.policy_engine.evaluate_output_stream(result, is_trusted=False)
+
+        return result

--- a/tests/test_mcp_isolation.py
+++ b/tests/test_mcp_isolation.py
@@ -1,0 +1,28 @@
+import pytest
+from magda_agent.safety.mcp_isolation import MCPIsolationEngine
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError
+
+def test_mcp_isolation_engine_safe_execution() -> None:
+    """Test that a safe tool executes successfully."""
+    engine = MCPIsolationEngine()
+
+    def safe_tool(data: str) -> str:
+        return f"Processed: {data}"
+
+    result = engine.execute_untrusted_tool(safe_tool, {"data": "clean_data"})
+    assert result == "Processed: clean_data"
+
+def test_mcp_isolation_engine_blocks_tainted_output() -> None:
+    """Test that untrusted tool outputs are correctly blocked in isolation mode."""
+    engine = MCPIsolationEngine()
+
+    # Simulate a tool that receives tainted input
+    def malicious_tool(data: str) -> str:
+        return data
+
+    tainted_input = engine.policy_engine.tracker.taint("secret_data", "source1")
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        engine.execute_untrusted_tool(malicious_tool, {"data": tainted_input})
+
+    assert "Tainted output from untrusted tool call" in str(exc_info.value)


### PR DESCRIPTION
Implements mcp-policy-runtime-engine-isolation-v1-b548ccd1 by creating an MCPIsolationEngine and updates agent_tasks.json with 3 new AI agent trend tasks.

---
*PR created automatically by Jules for task [1262905081040121265](https://jules.google.com/task/1262905081040121265) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPIsolationEngine` to run untrusted MCP tools in a sandboxed, taint-tracked policy runtime
> - Adds [`MCPIsolationEngine`](https://github.com/kazah4359-lgtm/Magda-agent/pull/444/files#diff-55d4353cc08f7016a6c6c76796e94cc973d973953353ca86709bf1e36330ec2a) which wires `MCPTaintPolicyEngine` and `MCPKernelSandbox` together, sharing a single taint tracker across both.
> - `execute_untrusted_tool` evaluates input taint, runs the tool inside the sandbox, then validates output taint — raising `PolicyViolationError` if output is tainted.
> - Adds two tests in [`tests/test_mcp_isolation.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/444/files#diff-51c80f58582e0e77cb49d608682cf3ff5d3b8e3f27feec52042265e41cd9b845): one for safe tool execution and one asserting `PolicyViolationError` is raised for tainted output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab8abe4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->