### PR TITLE
feat: Implement ACS Runtime Tool Validation v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7265,7 +7265,7 @@
     },
     {
       "id": "acs-runtime-tool-validation-v5",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "ACS Runtime Tool Validation v5",
@@ -15623,6 +15623,40 @@
         "Procedural memory tracks RL signals accurately.",
         "Tests mock learning signals and verify updates."
       ]
+    },
+    {
+      "id": "mcp-action-tool-concurrency-v11",
+      "title": "MCP Action Tool Concurrency v11",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement robust runtime concurrency for multiple MCP tool executions using asyncio.gather with error boundary isolation.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_v11.py",
+        "tests/test_mcp_concurrency_v11.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tools execute concurrently",
+        "Exceptions are isolated"
+      ],
+      "risk": "medium",
+      "area": "skills",
+      "status": "todo"
+    },
+    {
+      "id": "a2a-discovery-mesh-telemetry-v3",
+      "title": "A2A Discovery Mesh Telemetry v3",
+      "description": "Inspired by A2A Protocol trend: Implement distributed telemetry broadcasting over the A2A mesh network.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mesh_telemetry_v3.py",
+        "tests/test_a2a_mesh_telemetry_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry is broadcasted",
+        "Tests verify mock payloads"
+      ],
+      "risk": "medium",
+      "area": "integration",
+      "status": "todo"
     }
   ]
 }

--- a/magda_agent/safety/acs_validation_v5.py
+++ b/magda_agent/safety/acs_validation_v5.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Dict, Any, Tuple
+
+
+class ACSValidationV5:
+    """
+    ACS Validation V5.
+    Implements runtime tool validation checks to block potentially destructive actions
+    before execution.
+    """
+
+    def __init__(self) -> None:
+        """Initializes the ACSValidationV5 instance."""
+        self.logger = logging.getLogger(__name__)
+
+    def validate_tool_call(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Validates the tool call specified in the workflow_data.
+
+        Args:
+            workflow_data: A dictionary containing at least 'tool' and 'kwargs' keys.
+
+        Returns:
+            A tuple containing a boolean indicating if the tool is safe to execute,
+            and a string explaining the reason.
+        """
+        tool = workflow_data.get("tool")
+        kwargs = workflow_data.get("kwargs", {})
+
+        if not tool:
+            return False, "Validation failed: 'tool' field is missing or empty."
+
+        if not isinstance(kwargs, dict):
+            return False, "Validation failed: 'kwargs' must be a dictionary."
+
+        # Block specific destructive tools entirely
+        destructive_tools = {"rm", "format", "delete_database", "shutdown"}
+        if tool in destructive_tools:
+            return False, f"Validation failed: Tool '{tool}' is considered destructive and blocked."
+
+        # Block potentially dangerous payloads for execution tools
+        execution_tools = {"system_execute_code", "run_in_bash_session"}
+        if tool in execution_tools:
+            command = str(kwargs.get("command", "")).lower()
+            code = str(kwargs.get("code", "")).lower()
+            payload = command + " " + code
+
+            # Simple heuristic for destructive payloads
+            dangerous_patterns = ["rm -rf", "mkfs", "dd if=", "> /dev/sda", "drop table"]
+            for pattern in dangerous_patterns:
+                if pattern in payload:
+                    return False, f"Validation failed: Tool '{tool}' contains dangerous pattern '{pattern}'."
+
+        # Allow if no checks failed
+        return True, "Validation passed: Tool is considered safe."

--- a/tests/test_acs_validation_v5.py
+++ b/tests/test_acs_validation_v5.py
@@ -1,0 +1,77 @@
+import pytest
+from magda_agent.safety.acs_validation_v5 import ACSValidationV5
+
+
+@pytest.fixture
+def acs_validator() -> ACSValidationV5:
+    """Fixture to provide an instance of ACSValidationV5."""
+    return ACSValidationV5()
+
+
+def test_acs_validation_v5_safe_tool(acs_validator: ACSValidationV5) -> None:
+    """Tests that a safe tool call passes validation."""
+    workflow_data = {
+        "tool": "read_file",
+        "kwargs": {"filepath": "config.yaml"}
+    }
+    passed, reason = acs_validator.validate_tool_call(workflow_data)
+    assert passed is True
+    assert "Validation passed" in reason
+
+    workflow_data_safe_execute = {
+        "tool": "system_execute_code",
+        "kwargs": {"command": "ls -l"}
+    }
+    passed, reason = acs_validator.validate_tool_call(workflow_data_safe_execute)
+    assert passed is True
+    assert "Validation passed" in reason
+
+
+def test_acs_validation_v5_destructive_tool(acs_validator: ACSValidationV5) -> None:
+    """Tests that potentially destructive tool calls are blocked."""
+    # Test blocked tool
+    workflow_data_blocked_tool = {
+        "tool": "rm",
+        "kwargs": {"target": "important_file.txt"}
+    }
+    passed, reason = acs_validator.validate_tool_call(workflow_data_blocked_tool)
+    assert passed is False
+    assert "is considered destructive and blocked" in reason
+
+    # Test dangerous pattern in execute tool
+    workflow_data_dangerous_pattern = {
+        "tool": "run_in_bash_session",
+        "kwargs": {"command": "rm -rf /"}
+    }
+    passed, reason = acs_validator.validate_tool_call(workflow_data_dangerous_pattern)
+    assert passed is False
+    assert "contains dangerous pattern 'rm -rf'" in reason
+
+    # Test dangerous pattern in code payload
+    workflow_data_dangerous_code = {
+        "tool": "system_execute_code",
+        "kwargs": {"code": "DROP TABLE users;"}
+    }
+    passed, reason = acs_validator.validate_tool_call(workflow_data_dangerous_code)
+    assert passed is False
+    assert "contains dangerous pattern 'drop table'" in reason
+
+
+def test_acs_validation_v5_invalid_input(acs_validator: ACSValidationV5) -> None:
+    """Tests validation with missing or invalid input."""
+    # Missing tool
+    workflow_data_missing_tool = {
+        "kwargs": {"path": "/"}
+    }
+    passed, reason = acs_validator.validate_tool_call(workflow_data_missing_tool)
+    assert passed is False
+    assert "'tool' field is missing or empty" in reason
+
+    # Invalid kwargs
+    workflow_data_invalid_kwargs = {
+        "tool": "ls",
+        "kwargs": "not a dict"
+    }
+    passed, reason = acs_validator.validate_tool_call(workflow_data_invalid_kwargs)
+    assert passed is False
+    assert "'kwargs' must be a dictionary" in reason


### PR DESCRIPTION
Implements the ACSValidationV5 class to validate runtime tool execution and block potentially destructive actions before execution. Also appends 2 new trend-inspired tasks to agent_tasks.json.

---
*PR created automatically by Jules for task [11560017306599735681](https://jules.google.com/task/11560017306599735681) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ACSValidationV5` runtime safety validator for tool calls
> - Introduces [`acs_validation_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/446/files#diff-7baa74d75dfebbf8c161d36ac3314b8188040479b13230cec6b8894e89c1f200) with `ACSValidationV5.validate_tool_call`, which rejects tool calls missing a `tool` name, with non-dict `kwargs`, matching a blocklist of destructive tools (`rm`, `format`, `delete_database`, `shutdown`), or containing dangerous patterns (`rm -rf`, `mkfs`, `dd if=`, `> /dev/sda`, `drop table`) in execution tool payloads.
> - Adds tests in [`test_acs_validation_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/446/files#diff-8c006fb48baa03bb2662b133d8b51ab56f5f4f5a5a02b0ef6365ce92e37eb1fe) covering safe inputs, destructive tool blocking, dangerous pattern detection, and invalid input rejection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6c27aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->