### PR TITLE
feat: Implement OpenClaw Context Compression v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7282,7 +7282,7 @@
     },
     {
       "id": "openclaw-context-compression-v3",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Compression v3",
@@ -15657,6 +15657,57 @@
       "risk": "medium",
       "area": "integration",
       "status": "todo"
+    },
+    {
+      "id": "agent-teams-isolation-v9-f1a2b3c4",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Agent Teams Isolation V9",
+      "description": "Inspired by Claude Agent SDK: Ensure git worktree isolation for hierarchical subagent spawns (v9).",
+      "allowed_paths": [
+        "magda_agent/architecture/teams_isolation_v9.py",
+        "tests/test_teams_isolation_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents operate in isolated worktrees",
+        "Tests check path isolation logic"
+      ]
+    },
+    {
+      "id": "a2a-discovery-agent-cards-v4-e5d6c7b8",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "low",
+      "title": "A2A Discovery Agent Cards V4",
+      "description": "Inspired by A2A standard: Implement Agent Cards generation for peer-to-peer agent discovery in a multi-agent network (v4).",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_agent_cards_v4.py",
+        "tests/test_a2a_agent_cards_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Generates valid A2A Agent Cards.",
+        "Tests verify format."
+      ]
+    },
+    {
+      "id": "acs-guardrails-policy-v8-a1b2c3d4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Compliance Policy Guardrails V8",
+      "description": "Inspired by ACS trends: Enhance the existing ACS guard architecture with a centralized policy validation layer prior to tool execution (v8).",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guardrails_v8.py",
+        "tests/test_acs_guardrails_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS Guardrails V8 is implemented and integrates dynamically before tool actions.",
+        "Tests verify policy enforcement rules via AsyncMock."
+      ]
     }
   ]
 }

--- a/magda_agent/memory/compression_v3.py
+++ b/magda_agent/memory/compression_v3.py
@@ -1,0 +1,98 @@
+import logging
+from typing import List
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.working import MemoryEntry
+
+class OpenClawContextCompressorV3:
+    """
+    OpenClaw-inspired context compressor v3 that selectively retrieves memories.
+    It preserves the most important items (critical memories) and compresses
+    the remaining ones when the context size exceeds the limit.
+    """
+    def __init__(self, llm: LLMClient, threshold: float = 0.8) -> None:
+        """
+        Initialize the OpenClawContextCompressorV3.
+
+        Args:
+            llm: The LLM client used for summarizing text.
+            threshold: The importance threshold. Memories with importance >= threshold
+                       are considered critical and will not be compressed.
+        """
+        self.llm = llm
+        self.threshold = threshold
+
+    async def compress_and_retrieve(self, memories: List[MemoryEntry], query: str, max_tokens: int = 1000) -> List[MemoryEntry]:
+        """
+        Filters memories based on the query and selectively compresses them.
+        Critical memories (importance >= threshold) are preserved as is.
+        Non-critical memories are compressed if the total context size exceeds max_tokens.
+
+        Args:
+            memories: A list of memory entries to process.
+            query: The search query to filter relevance.
+            max_tokens: Simulated token limit for the context.
+
+        Returns:
+            A list containing critical memories and a compressed summary of non-critical memories (if any).
+        """
+        query_lower = query.lower()
+        query_words = set(query_lower.split())
+
+        filtered = []
+        for m in memories:
+            content_lower = m.content.lower()
+            # Basic exact match or word match
+            if query_lower in content_lower or any(len(word) > 3 and word in content_lower for word in query_words):
+                filtered.append(m)
+
+        if not filtered:
+            return []
+
+        critical_memories = [m for m in filtered if m.importance >= self.threshold]
+        non_critical_memories = [m for m in filtered if m.importance < self.threshold]
+
+        combined_text = "\n".join(m.content for m in filtered)
+
+        # If the total text is within the limit, return all filtered memories
+        if len(combined_text) <= max_tokens * 4:
+            return filtered
+
+        result = []
+        result.extend(critical_memories)
+
+        if non_critical_memories:
+            non_critical_text = "\n".join(m.content for m in non_critical_memories)
+
+            logging.info("Compressing non-critical text to fit context limits v3.")
+            prompt = f"Summarize the following text related to '{query}', maintaining key points:\n\n{non_critical_text}"
+            messages = [
+                {"role": "system", "content": "You are a context compression engine. Return only the compressed text."},
+                {"role": "user", "content": prompt}
+            ]
+
+            try:
+                compressed_text = await self.llm.chat_completion(messages, temperature=0.3)
+                compressed_text = compressed_text.strip()
+            except Exception as e:
+                logging.error(f"Failed to compress text v3: {e}")
+                compressed_text = non_critical_text
+
+            avg_importance = sum(m.importance for m in non_critical_memories) / len(non_critical_memories)
+            first = non_critical_memories[0]
+
+            # Combine tags from non-critical entries
+            all_tags = set()
+            for m in non_critical_memories:
+                if m.tags:
+                    all_tags.update(m.tags)
+
+            summary_entry = MemoryEntry(
+                content=compressed_text,
+                importance=avg_importance,
+                emotional_state=first.emotional_state,
+                tags=list(all_tags),
+                user_id=first.user_id
+            )
+            result.append(summary_entry)
+
+        return result

--- a/tests/test_compression_v3.py
+++ b/tests/test_compression_v3.py
@@ -1,0 +1,87 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.memory.compression_v3 import OpenClawContextCompressorV3
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+@pytest.fixture
+def mock_llm():
+    """Provides a mock LLM client."""
+    llm = MagicMock()
+    llm.chat_completion = AsyncMock(return_value="Compressed summary of non-critical memories.")
+    return llm
+
+@pytest.fixture
+def compressor(mock_llm):
+    """Provides a configured OpenClawContextCompressorV3 instance."""
+    return OpenClawContextCompressorV3(llm=mock_llm, threshold=0.8)
+
+@pytest.mark.asyncio
+async def test_compress_and_retrieve_under_limit(compressor, mock_llm) -> None:
+    """Tests that entries under the token limit are not compressed."""
+    entries = [
+        MemoryEntry(content="Small entry related to query", importance=0.5, emotional_state=PADState(0,0,0)),
+    ]
+
+    result = await compressor.compress_and_retrieve(entries, query="query", max_tokens=1000)
+
+    assert len(result) == 1
+    assert result == entries
+    mock_llm.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compress_and_retrieve_critical_kept(compressor, mock_llm) -> None:
+    """Tests that critical memories are kept uncompressed while others are compressed."""
+    # Create entries that will exceed the max_tokens when combined.
+    # We will use a very low max_tokens to force compression.
+    entries = [
+        MemoryEntry(content="Critical memory about query. " * 50, importance=0.9, emotional_state=PADState(0,0,0)),
+        MemoryEntry(content="Non-critical detail 1 about query.", importance=0.5, emotional_state=PADState(0,0,0)),
+        MemoryEntry(content="Non-critical detail 2 about query.", importance=0.6, emotional_state=PADState(0,0,0)),
+    ]
+
+    # max_tokens=10 means max 40 chars. The combined text will exceed this.
+    result = await compressor.compress_and_retrieve(entries, query="query", max_tokens=10)
+
+    assert len(result) == 2
+
+    critical = [m for m in result if m.importance >= 0.8]
+    assert len(critical) == 1
+    assert critical[0].content.startswith("Critical memory about query.")
+
+    compressed = [m for m in result if m.importance < 0.8]
+    assert len(compressed) == 1
+    assert compressed[0].content == "Compressed summary of non-critical memories."
+    assert compressed[0].importance == 0.55
+
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_compress_and_retrieve_no_match(compressor, mock_llm) -> None:
+    """Tests that entries not matching the query are filtered out."""
+    entries = [
+        MemoryEntry(content="This is about apples.", importance=0.5, emotional_state=PADState(0,0,0)),
+        MemoryEntry(content="This is about bananas.", importance=0.5, emotional_state=PADState(0,0,0)),
+    ]
+
+    result = await compressor.compress_and_retrieve(entries, query="oranges", max_tokens=1000)
+
+    assert len(result) == 0
+    mock_llm.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compress_and_retrieve_llm_failure(compressor, mock_llm) -> None:
+    """Tests fallback behavior when LLM compression fails."""
+    mock_llm.chat_completion.side_effect = Exception("LLM Error")
+
+    entries = [
+        MemoryEntry(content="Non-critical detail 1 about query.", importance=0.5, emotional_state=PADState(0,0,0)),
+        MemoryEntry(content="Non-critical detail 2 about query.", importance=0.6, emotional_state=PADState(0,0,0)),
+    ]
+
+    result = await compressor.compress_and_retrieve(entries, query="query", max_tokens=5)
+
+    assert len(result) == 1
+    assert "Non-critical detail 1" in result[0].content
+    assert "Non-critical detail 2" in result[0].content


### PR DESCRIPTION
Implemented OpenClaw Context Compression v3 as requested in agent_tasks.json. This includes adding magda_agent/memory/compression_v3.py, unit tests in tests/test_compression_v3.py, modifying agent_tasks.json to mark the task as done, and adding 3 new fully formulated todo tasks based on current AI agent trends.

---
*PR created automatically by Jules for task [1085651403626536464](https://jules.google.com/task/1085651403626536464) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `OpenClawContextCompressorV3` for LLM-based context compression
> - Adds [`compression_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/447/files#diff-d1368b33783c81bb866fd1f58e47b7dbc11487710311c80421b7ac4845ee53bf) with `OpenClawContextCompressorV3`, which filters memories by query match, preserves entries above an importance threshold, and uses an LLM to summarize the rest into a single `MemoryEntry` when total content exceeds a character-based token limit.
> - Falls back to concatenated raw text if the LLM call fails, ensuring compression always completes.
> - Adds [`tests/test_compression_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/447/files#diff-48b954244b202cb296714e4f6e0898a87c43eae51b51e0ff1e77ce1fefe1d94e) covering under-limit passthrough, critical retention with summarization, empty-match filtering, and LLM failure fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab704de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->