### PR TITLE
feat: implement webarena navigation skills v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7299,7 +7299,7 @@
     },
     {
       "id": "webarena-navigation-skills-v2-2aa4a776",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "WebArena Navigation Skill Integration v2",
@@ -15707,6 +15707,57 @@
       "acceptance": [
         "ACS Guardrails V8 is implemented and integrates dynamically before tool actions.",
         "Tests verify policy enforcement rules via AsyncMock."
+      ]
+    },
+    {
+      "id": "openclaw-rl-interactive-learning-v15",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Interactive Learning v15",
+      "description": "Implement interactive feedback processing for OpenClaw-RL.",
+      "allowed_paths": [
+        "magda_agent/learning/interactive_rl_v15.py",
+        "tests/test_interactive_rl_v15.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Feedback processed correctly",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "a2a-enterprise-integration-v15",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Enterprise Integration v15",
+      "description": "Implement A2A enterprise tracing and authentication.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_enterprise_v15.py",
+        "tests/test_a2a_enterprise_v15.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tracing enabled",
+        "Auth works"
+      ]
+    },
+    {
+      "id": "mcp-action-tool-concurrency-v15",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Concurrency v15",
+      "description": "Enhance MCP execution engine to support concurrent dynamic tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_v15.py",
+        "tests/test_mcp_concurrency_v15.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Parallel tools execute successfully",
+        "Tests pass"
       ]
     }
   ]

--- a/magda_agent/skills/web_navigation_v2.py
+++ b/magda_agent/skills/web_navigation_v2.py
@@ -1,6 +1,6 @@
 """
 Web navigation skill v2 (WebArena inspired).
-Provides capabilities to load a URL, click on elements, type text, scroll, and submit forms.
+Provides capabilities to load a URL, click on elements, type text, hover, clear, scroll, and submit forms.
 """
 import ipaddress
 import logging
@@ -105,6 +105,21 @@ def type_text(element_id: str, text: str) -> str:
     logging.info(f"Typing '{text}' into element: {element_id}")
     return json.dumps({"status": "success", "action": "type", "element_id": element_id, "text": text})
 
+
+def hover_element(element_id: str) -> str:
+    """
+    Simulates a hover action on a specific element identified by element_id.
+    """
+    logging.info(f"Hovering element: {element_id}")
+    return json.dumps({"status": "success", "action": "hover", "element_id": element_id})
+
+def clear_text(element_id: str) -> str:
+    """
+    Simulates clearing text from a specific element identified by element_id.
+    """
+    logging.info(f"Clearing text from element: {element_id}")
+    return json.dumps({"status": "success", "action": "clear", "element_id": element_id})
+
 def scroll(direction: str) -> str:
     """
     Simulates scrolling the viewport.
@@ -139,6 +154,17 @@ def web_navigate_v2(action: str, **kwargs: Any) -> str:
         if not element_id or text is None:
             return json.dumps({"status": "error", "message": "'element_id' and 'text' are required for type action."})
         return type_text(str(element_id), str(text))
+
+    elif action == 'hover':
+        element_id = kwargs.get('element_id')
+        if not element_id:
+            return json.dumps({"status": "error", "message": "'element_id' is required for hover action."})
+        return hover_element(str(element_id))
+    elif action == 'clear':
+        element_id = kwargs.get('element_id')
+        if not element_id:
+            return json.dumps({"status": "error", "message": "'element_id' is required for clear action."})
+        return clear_text(str(element_id))
     elif action == 'scroll':
         direction = kwargs.get('direction', 'down')
         return scroll(str(direction))

--- a/tests/test_web_navigation_v2.py
+++ b/tests/test_web_navigation_v2.py
@@ -2,7 +2,7 @@ import socket
 import pytest
 import json
 from unittest.mock import patch, MagicMock
-from magda_agent.skills.web_navigation_v2 import load_url, click_element, type_text, scroll, submit_form, web_navigate_v2
+from magda_agent.skills.web_navigation_v2 import load_url, click_element, type_text, hover_element, clear_text, scroll, submit_form, web_navigate_v2
 
 @patch('urllib.request.urlopen')
 
@@ -42,6 +42,17 @@ def test_type_text():
     assert result["status"] == "success"
     assert result["action"] == "type"
 
+
+def test_hover_element():
+    result = json.loads(hover_element("elem-1"))
+    assert result["status"] == "success"
+    assert result["action"] == "hover"
+
+def test_clear_text():
+    result = json.loads(clear_text("input-1"))
+    assert result["status"] == "success"
+    assert result["action"] == "clear"
+
 def test_scroll():
     result = json.loads(scroll("down"))
     assert result["status"] == "success"
@@ -63,4 +74,7 @@ def test_web_navigate_v2_errors():
     assert "required" in web_navigate_v2("click")
     assert "required" in web_navigate_v2("type", element_id="1")
     assert "required" in web_navigate_v2("submit")
+
+    assert "required" in web_navigate_v2("hover")
+    assert "required" in web_navigate_v2("clear")
     assert "Unknown" in web_navigate_v2("invalid_action")


### PR DESCRIPTION
Implement WebArena navigation v2 and update agent_tasks

---
*PR created automatically by Jules for task [3886864198219076337](https://jules.google.com/task/3886864198219076337) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **Web navigation improvements:**
  - Added `hover` and `clear` support to `web_navigation_v2.py` and updated `web_navigate_v2` dispatcher.
  - Included corresponding unit tests for new navigation actions in `test_web_navigation_v2.py`.
- **Task management:**
  - Marked `webarena-navigation-skills-v2` as completed in `agent_tasks.json`.
  - Added new pending tasks for `OpenClaw RL Interactive Learning`, `A2A Enterprise Integration`, and `MCP Action Tool Concurrency`.

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `hover_element` and `clear_text` actions to web navigation v2 skills
> - Adds `hover_element` and `clear_text` functions to [`web_navigation_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/448/files#diff-cf7cc9b91cb4c8a78e6607517166e940858ee193378a7912f99e963ddc9ba072), each returning a success JSON response with the given `element_id`.
> - Extends the `web_navigate_v2` action router to dispatch `'hover'` and `'clear'` actions, returning an error JSON when `element_id` is missing.
> - Adds tests in [`test_web_navigation_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/448/files#diff-db0a7a92f073e7116abc1f2104008bca07686b179758cb587616fd202d409615) covering success and missing-parameter error cases for both new actions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 918d0ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->