### PR TITLE
Implement MCP Action Tool Management v8

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7316,7 +7316,7 @@
     },
     {
       "id": "mcp-action-tool-concurrency-v8-a317db1a",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP action tools support with dynamic loading",

--- a/magda_agent/mcp/action_tools_v8.py
+++ b/magda_agent/mcp/action_tools_v8.py
@@ -1,0 +1,136 @@
+import json
+import logging
+import inspect
+from typing import Dict, Any, List, Optional, Tuple
+
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.safety.policy import PolicyLayer
+
+logger = logging.getLogger(__name__)
+
+class MCPActionToolManagerV8:
+    """
+    Manages state-mutating action tools exported via MCP.
+    Protected by a PolicyLayer and integrated with SkillRegistry.
+    """
+
+    def __init__(self, registry: SkillRegistry, policy_layer: PolicyLayer) -> None:
+        """
+        Initialize the MCP Action Tool Manager.
+
+        Args:
+            registry: The SkillRegistry to execute skills.
+            policy_layer: The PolicyLayer to gate executions.
+        """
+        self.registry = registry
+        self.policy_layer = policy_layer
+        self.action_tools: Dict[str, Dict[str, Any]] = {}
+
+    def register_action_tool(self, name: str, description: str, input_schema: Dict[str, Any]) -> None:
+        """
+        Registers an action tool metadata.
+
+        Args:
+            name: The name of the tool.
+            description: A description of the tool.
+            input_schema: JSON schema for tool inputs.
+        """
+        self.action_tools[name] = {
+            "name": name,
+            "description": description,
+            "inputSchema": input_schema,
+            "is_action": True
+        }
+        logger.info(f"Registered MCP action tool: {name}")
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists all registered action tools in MCP format.
+        """
+        return list(self.action_tools.values())
+
+    async def handle_mcp_request(self, payload: str) -> str:
+        """
+        Processes a JSON-RPC 2.0 payload.
+
+        Args:
+            payload: JSON string of the request.
+
+        Returns:
+            JSON string of the response.
+        """
+        try:
+            request = json.loads(payload)
+        except json.JSONDecodeError:
+            return self._error_response(None, -32700, "Parse error")
+
+        req_id = request.get("id")
+        if request.get("jsonrpc") != "2.0":
+            return self._error_response(req_id, -32600, "Invalid Request")
+
+        method = request.get("method")
+        params = request.get("params", {})
+
+        if method == "list_tools":
+            return self._result_response(req_id, {"tools": self.list_tools()})
+
+        if method == "call_tool":
+            tool_name = params.get("name")
+            arguments = params.get("arguments", {})
+
+            if not tool_name:
+                return self._error_response(req_id, -32602, "Invalid params: 'name' is required")
+
+            if tool_name not in self.action_tools:
+                return self._error_response(req_id, -32601, f"Tool '{tool_name}' not found")
+
+            return await self._execute_tool(req_id, tool_name, arguments)
+
+        return self._error_response(req_id, -32601, f"Method '{method}' not found")
+
+    async def _execute_tool(self, req_id: Any, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """
+        Evaluates policy and executes the tool.
+        """
+        # 1. Policy Gating
+        allowed, explanation = self.policy_layer.evaluate(tool_name, **arguments)
+        if not allowed:
+            logger.warning(f"MCP Action Tool '{tool_name}' denied by policy: {explanation}")
+            return self._error_response(req_id, -32000, f"Policy violation: {explanation}")
+
+        # 2. Execution via SkillRegistry
+        try:
+            result = self.registry.execute_skill(tool_name, **arguments)
+
+            if inspect.isawaitable(result):
+                result = await result
+
+            # Wrap result in MCP content format
+            mcp_result = {
+                "content": [{"type": "text", "text": str(result)}],
+                "isError": False
+            }
+
+            # Check if SkillRegistry returned an error string
+            if isinstance(result, str) and result.startswith("Error:"):
+                mcp_result["isError"] = True
+
+            return self._result_response(req_id, mcp_result)
+
+        except Exception as e:
+            logger.error(f"Error executing MCP action tool '{tool_name}': {e}")
+            return self._error_response(req_id, -32000, f"Execution error: {str(e)}")
+
+    def _error_response(self, req_id: Any, code: int, message: str) -> str:
+        return json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": code, "message": message}
+        })
+
+    def _result_response(self, req_id: Any, result: Any) -> str:
+        return json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": result
+        })

--- a/tests/test_mcp_action_tools_v8.py
+++ b/tests/test_mcp_action_tools_v8.py
@@ -1,0 +1,148 @@
+import pytest
+import json
+import asyncio
+from magda_agent.mcp.action_tools_v8 import MCPActionToolManagerV8
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.safety.policy import PolicyLayer
+
+@pytest.fixture
+def registry():
+    reg = SkillRegistry()
+    def save_data(data: str):
+        return f"Saved: {data}"
+
+    reg.register_skill("save_data", save_data, "Saves some data")
+
+    async def async_action(val: int):
+        return f"Async: {val}"
+
+    reg.register_skill("async_action", async_action, "An async action")
+
+    return reg
+
+@pytest.fixture
+def policy_layer():
+    return PolicyLayer()
+
+@pytest.fixture
+def manager(registry, policy_layer):
+    mgr = MCPActionToolManagerV8(registry, policy_layer)
+    mgr.register_action_tool(
+        "save_data",
+        "Saves some data",
+        {"type": "object", "properties": {"data": {"type": "string"}}, "required": ["data"]}
+    )
+    mgr.register_action_tool(
+        "async_action",
+        "An async action",
+        {"type": "object", "properties": {"val": {"type": "integer"}}, "required": ["val"]}
+    )
+    return mgr
+
+def test_register_and_list_tools(manager):
+    tools = manager.list_tools()
+    assert len(tools) == 2
+    names = [t["name"] for t in tools]
+    assert "save_data" in names
+    assert "async_action" in names
+
+@pytest.mark.asyncio
+async def test_handle_list_tools_rpc(manager):
+    request = {
+        "jsonrpc": "2.0",
+        "method": "list_tools",
+        "id": "1"
+    }
+    response_str = await manager.handle_mcp_request(json.dumps(request))
+    response = json.loads(response_str)
+
+    assert response["id"] == "1"
+    assert "tools" in response["result"]
+    assert len(response["result"]["tools"]) == 2
+
+@pytest.mark.asyncio
+async def test_call_tool_success(manager):
+    request = {
+        "jsonrpc": "2.0",
+        "method": "call_tool",
+        "params": {
+            "name": "save_data",
+            "arguments": {"data": "important info"}
+        },
+        "id": "2"
+    }
+    response_str = await manager.handle_mcp_request(json.dumps(request))
+    response = json.loads(response_str)
+
+    assert response["id"] == "2"
+    assert response["result"]["content"][0]["text"] == "Saved: important info"
+    assert response["result"]["isError"] is False
+
+@pytest.mark.asyncio
+async def test_call_async_tool_success(manager):
+    request = {
+        "jsonrpc": "2.0",
+        "method": "call_tool",
+        "params": {
+            "name": "async_action",
+            "arguments": {"val": 42}
+        },
+        "id": "3"
+    }
+    response_str = await manager.handle_mcp_request(json.dumps(request))
+    response = json.loads(response_str)
+
+    assert response["id"] == "3"
+    assert response["result"]["content"][0]["text"] == "Async: 42"
+
+@pytest.mark.asyncio
+async def test_policy_gating_denied(manager, registry):
+    # Register a tool that policy might deny
+    # PolicyLayer denies 'programmer' if it mentions .env
+    def programmer(code: str):
+        return "Executed"
+
+    registry.register_skill("programmer", programmer, "Executes code")
+    manager.register_action_tool("programmer", "Executes code", {})
+
+    request = {
+        "jsonrpc": "2.0",
+        "method": "call_tool",
+        "params": {
+            "name": "programmer",
+            "arguments": {"code": "read('.env')"}
+        },
+        "id": "4"
+    }
+    response_str = await manager.handle_mcp_request(json.dumps(request))
+    response = json.loads(response_str)
+
+    assert "error" in response
+    assert response["error"]["code"] == -32000
+    assert "Policy violation" in response["error"]["message"]
+
+@pytest.mark.asyncio
+async def test_invalid_json(manager):
+    response_str = await manager.handle_mcp_request("invalid json")
+    response = json.loads(response_str)
+    assert response["error"]["code"] == -32700
+
+@pytest.mark.asyncio
+async def test_missing_method(manager):
+    request = {"jsonrpc": "2.0", "id": "5"}
+    response_str = await manager.handle_mcp_request(json.dumps(request))
+    response = json.loads(response_str)
+    assert response["error"]["code"] == -32601
+
+@pytest.mark.asyncio
+async def test_tool_not_found(manager):
+    request = {
+        "jsonrpc": "2.0",
+        "method": "call_tool",
+        "params": {"name": "ghost_tool"},
+        "id": "6"
+    }
+    response_str = await manager.handle_mcp_request(json.dumps(request))
+    response = json.loads(response_str)
+    assert response["error"]["code"] == -32601
+    assert "not found" in response["error"]["message"]


### PR DESCRIPTION
This change implements a robust interface for Model Context Protocol (MCP) action tools, as part of the project's cognitive architecture. The new `MCPActionToolManagerV8` allows for the dynamic registration and invocation of state-mutating tools through a standardized JSON-RPC 2.0 interface. Crucially, all tool executions are gated by the agent's `PolicyLayer` to ensure safety and prevent unauthorized actions (e.g., accessing sensitive environment variables). 

Key additions:
- `magda_agent/mcp/action_tools_v8.py`: The core manager for action tools.
- `tests/test_mcp_action_tools_v8.py`: 8 tests verifying registration, successful calls, async execution, and policy blocking.
- Updated `agent_tasks.json` to mark the task as done.

---
*PR created automatically by Jules for task [15966977194030919875](https://jules.google.com/task/15966977194030919875) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPActionToolManagerV8` for JSON-RPC 2.0 action tool management
> - Adds [action_tools_v8.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/449/files#diff-061d2b4eefa754c7ec21c65d6cd2a82a9418228eddf74aabfca944ffacda32d3) with `MCPActionToolManagerV8`, which registers action tools, lists them via `list_tools`, and executes them via `call_tool` using JSON-RPC 2.0.
> - Execution is gated by a `PolicyLayer` before invoking `SkillRegistry.execute_skill`; policy denials and exceptions return error code `-32000`.
> - Supports both sync and async skill execution; wraps results in MCP content structure with `isError: true` for results starting with `'Error:'`.
> - Adds a test suite in [test_mcp_action_tools_v8.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/449/files#diff-30f3862a4b0a821f6ea7173d72ed3a5dd939b332768f90073dda712c8a6d8f7f) covering registration, listing, sync/async execution, policy denial, and malformed request handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c570b79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->