### PR TITLE
Implement A2A Workflow Chaining

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7333,7 +7333,7 @@
     },
     {
       "id": "a2a-workflow-chaining-b3c1a29f",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Workflow Chaining",
@@ -15759,6 +15759,57 @@
         "Parallel tools execute successfully",
         "Tests pass"
       ]
+    },
+    {
+      "id": "mcp-dynamic-tool-concurrency-v12",
+      "title": "MCP Dynamic Tool Concurrency v12",
+      "description": "Inspired by OpenAI Agents SDK trends: Extend runtime tool concurrency to dynamically load tools over network and execute them in parallel.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_v12.py",
+        "tests/test_mcp_concurrency_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dynamically fetched tools can execute concurrently.",
+        "Tests verify dynamic parallel execution."
+      ],
+      "risk": "medium",
+      "area": "skills",
+      "status": "todo"
+    },
+    {
+      "id": "openclaw-memory-canvas-streaming-v2",
+      "title": "OpenClaw Memory Canvas Streaming v2",
+      "description": "Inspired by OpenClaw trends: Implement real-time WebSockets streaming for MemoryCanvas UI visualization.",
+      "allowed_paths": [
+        "magda_agent/visualization/memory_canvas_ws_v2.py",
+        "tests/test_memory_canvas_ws_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory canvas state is streamed via websockets.",
+        "Tests verify mock websocket endpoints."
+      ],
+      "risk": "medium",
+      "area": "visualization",
+      "status": "todo"
+    },
+    {
+      "id": "acs-guardrails-policy-v9",
+      "title": "ACS Compliance Policy Guardrails V9",
+      "description": "Inspired by ACS trends: Add rate limiting and temporal analysis to ACS compliance guardrails prior to tool execution.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guardrails_v9.py",
+        "tests/test_acs_guardrails_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Rate limiting added to ACS guardrails.",
+        "Tests verify rate limiting logic via AsyncMock."
+      ],
+      "risk": "medium",
+      "area": "safety",
+      "status": "todo"
     }
   ]
 }

--- a/magda_agent/integration/a2a_workflow.py
+++ b/magda_agent/integration/a2a_workflow.py
@@ -1,0 +1,69 @@
+import logging
+from typing import Dict, Any, List
+
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_security import A2ASecurityContext
+from magda_agent.integration.a2a_delegation import A2ADelegator
+
+
+class A2AWorkflowManager:
+    """
+    Manages peer-to-peer chaining of agent tasks natively without a central coordinator.
+    It orchestrates a workflow by passing context sequentially through a list of agents.
+    """
+    def __init__(self, delegator: A2ADelegator, security_context: A2ASecurityContext = None) -> None:
+        """
+        Initializes the A2AWorkflowManager.
+
+        Args:
+            delegator: An A2ADelegator instance to delegate tasks to peers.
+            security_context: Optional security context.
+        """
+        self.delegator = delegator
+        self.security_context = security_context or getattr(delegator, 'security_context', None) or A2ASecurityContext()
+
+    async def execute_chain(self, workflow_steps: List[Dict[str, Any]], target_agents: List[AgentCardV3], initial_context: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Executes a chain of tasks by delegating each step to a corresponding agent sequentially,
+        passing the output context of one step as the input context for the next.
+
+        Args:
+            workflow_steps: A list of step definitions, where each step corresponds to an agent in target_agents.
+            target_agents: A list of AgentCardV3 objects representing the peers to execute the steps.
+            initial_context: The initial context for the first step.
+
+        Returns:
+            The final context after all steps have been executed.
+        """
+        if len(workflow_steps) != len(target_agents):
+            raise ValueError("The number of workflow steps must match the number of target agents.")
+
+        current_context = initial_context.copy()
+
+        for step, agent in zip(workflow_steps, target_agents):
+            logging.info(f"Executing workflow step '{step.get('name', 'unnamed')}' on agent {agent.name}")
+
+            # Merge the step configuration into the current context
+            delegation_payload = {
+                "step_config": step,
+                "context": current_context
+            }
+
+            try:
+                # Delegate to peer
+                result_str = await self.delegator.delegate_to_peer(agent, delegation_payload)
+                logging.info(f"Step '{step.get('name', 'unnamed')}' completed with result: {result_str}")
+
+                # We expect the result_str to be handled or we update the context based on it.
+                # Since delegate_to_peer returns a status string in the current implementation,
+                # we'll record the result in the context. In a real scenario, delegate_to_peer
+                # might return structured data. For now, we embed the result string into the context.
+                current_context[f"result_{step.get('name', 'unnamed')}"] = result_str
+
+            except Exception as e:
+                logging.error(f"Workflow failed at step '{step.get('name', 'unnamed')}' on agent {agent.name}: {e}")
+                current_context["error"] = str(e)
+                current_context["failed_step"] = step.get('name', 'unnamed')
+                break
+
+        return current_context

--- a/tests/test_a2a_workflow.py
+++ b/tests/test_a2a_workflow.py
@@ -1,0 +1,92 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.integration.a2a_workflow import A2AWorkflowManager
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_security import A2ASecurityContext
+from magda_agent.integration.a2a_delegation import A2ADelegator
+
+@pytest.fixture
+def mock_delegator():
+    delegator = MagicMock(spec=A2ADelegator)
+    delegator.delegate_to_peer = AsyncMock()
+    return delegator
+
+@pytest.fixture
+def workflow_manager(mock_delegator):
+    return A2AWorkflowManager(delegator=mock_delegator)
+
+@pytest.fixture
+def target_agents():
+    agent1 = AgentCardV3(
+        agent_id="agent-1",
+        name="Step 1 Agent",
+        description="First agent",
+        capabilities=["data_gathering"],
+        endpoints={"mcp": "http://agent1:8000/mcp"},
+
+    )
+    agent2 = AgentCardV3(
+        agent_id="agent-2",
+        name="Step 2 Agent",
+        description="Second agent",
+        capabilities=["data_processing"],
+        endpoints={"mcp": "http://agent2:8000/mcp"},
+
+    )
+    return [agent1, agent2]
+
+@pytest.mark.asyncio
+async def test_execute_chain_successful(workflow_manager, mock_delegator, target_agents):
+    mock_delegator.delegate_to_peer.side_effect = ["Success Step 1", "Success Step 2"]
+
+    workflow_steps = [
+        {"name": "step_1", "action": "gather_data"},
+        {"name": "step_2", "action": "process_data"}
+    ]
+    initial_context = {"input": "start_data"}
+
+    final_context = await workflow_manager.execute_chain(workflow_steps, target_agents, initial_context)
+
+    # Verify delegation calls
+    assert mock_delegator.delegate_to_peer.call_count == 2
+
+    # Check the context was updated correctly
+    assert final_context["input"] == "start_data"
+    assert final_context["result_step_1"] == "Success Step 1"
+    assert final_context["result_step_2"] == "Success Step 2"
+
+@pytest.mark.asyncio
+async def test_execute_chain_length_mismatch(workflow_manager, target_agents):
+    workflow_steps = [
+        {"name": "step_1", "action": "gather_data"}
+    ]
+    initial_context = {"input": "start_data"}
+
+    with pytest.raises(ValueError, match="The number of workflow steps must match the number of target agents."):
+        await workflow_manager.execute_chain(workflow_steps, target_agents, initial_context)
+
+@pytest.mark.asyncio
+async def test_execute_chain_failure(workflow_manager, mock_delegator, target_agents):
+    mock_delegator.delegate_to_peer.side_effect = [
+        "Success Step 1",
+        Exception("Network error on step 2")
+    ]
+
+    workflow_steps = [
+        {"name": "step_1", "action": "gather_data"},
+        {"name": "step_2", "action": "process_data"}
+    ]
+    initial_context = {"input": "start_data"}
+
+    final_context = await workflow_manager.execute_chain(workflow_steps, target_agents, initial_context)
+
+    # It should have called both, but step 2 failed
+    assert mock_delegator.delegate_to_peer.call_count == 2
+
+    # Check context
+    assert final_context["input"] == "start_data"
+    assert final_context["result_step_1"] == "Success Step 1"
+    assert "result_step_2" not in final_context
+    assert final_context["error"] == "Network error on step 2"
+    assert final_context["failed_step"] == "step_2"


### PR DESCRIPTION
Implements A2A Workflow Manager for peer-to-peer chaining of agent tasks. Also adds new tasks based on June 2026 AI agent trends.

---
*PR created automatically by Jules for task [11611334664082687950](https://jules.google.com/task/11611334664082687950) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `A2AWorkflowManager` to chain agent tasks across peer agents
> - Adds [`A2AWorkflowManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/450/files#diff-d57f1c80eaa5b5e7549e4a7e621a76a02f872374da0878968cc05e4c39587052) with an `execute_chain` method that sequentially delegates workflow steps to corresponding target agents via `A2ADelegator.delegate_to_peer`.
> - Each step's result string is stored in the shared context under a `result_<step_name>` key, allowing later steps to reference earlier outputs.
> - On step count mismatch, raises `ValueError`; on delegation failure, records `error` and `failed_step` in context and halts further steps.
> - Adds [tests](https://github.com/kazah4359-lgtm/Magda-agent/pull/450/files#diff-cdd2ffbd16d1edd74141a528ccbdaaf77dd46fecd5febdda260f63949832ef92) covering successful chaining, length mismatch, and mid-chain failure scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6da155c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->