### PR TITLE
Implement Subagent Heartbeat Monitor

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7367,7 +7367,7 @@
     },
     {
       "id": "subagent-heartbeat-monitor-74d1a2f1",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Subagent Heartbeat Monitor",
@@ -15843,6 +15843,57 @@
       "acceptance": [
         "Feedback processor correctly captures signals and logs them.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugin-interface-v1-e5c63734",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Plugin Interface V1",
+      "description": "Inspired by OpenClaw trends: Implement a plugin interface for the Context Engine with lifecycle hooks.",
+      "allowed_paths": [
+        "magda_agent/memory/context_plugin_v1.py",
+        "tests/test_context_plugin_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin interface successfully registers hooks.",
+        "Tests verify hook execution."
+      ]
+    },
+    {
+      "id": "hermes-daily-report-scheduler-v1-304d0b6d",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Daily Report Scheduler V1",
+      "description": "Inspired by Hermes cron scheduler trends: Implement a scheduled task for generating daily reports based on episodic memory.",
+      "allowed_paths": [
+        "magda_agent/operations/daily_report_v1.py",
+        "tests/test_daily_report_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Daily report task executes successfully.",
+        "Tests mock time and memory retrieval."
+      ]
+    },
+    {
+      "id": "mcp-tool-registry-telemetry-v1-d6ef4f7c",
+      "status": "todo",
+      "area": "observability",
+      "risk": "medium",
+      "title": "MCP Tool Registry Telemetry V1",
+      "description": "Inspired by MCP standard trend: Add usage telemetry to the MCP tool registry to track tool popularity and failure rates.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_telemetry_v1.py",
+        "tests/test_mcp_telemetry_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry data is logged upon tool execution.",
+        "Tests verify telemetry generation on success and failure."
       ]
     }
   ]

--- a/magda_agent/agents/heartbeat.py
+++ b/magda_agent/agents/heartbeat.py
@@ -1,0 +1,113 @@
+import asyncio
+import logging
+import time
+from typing import Dict, List, Optional
+
+class SubagentHeartbeatMonitor:
+    """
+    SubagentHeartbeatMonitor tracks heartbeat signals from Subagents (e.g. those spawned
+    by SubagentSpawnerV2 in isolated git worktrees) to detect deadlocks or crashes.
+    """
+    def __init__(self) -> None:
+        """
+        Initializes the SubagentHeartbeatMonitor.
+        """
+        self._heartbeats: Dict[str, float] = {}
+        self._monitor_task: Optional[asyncio.Task] = None
+        self._is_running = False
+
+    def register_agent(self, agent_id: str) -> None:
+        """
+        Registers an agent to be monitored.
+
+        Args:
+            agent_id: The unique identifier of the subagent.
+        """
+        self._heartbeats[agent_id] = time.time()
+        logging.info(f"Registered agent {agent_id} for heartbeat monitoring.")
+
+    def record_heartbeat(self, agent_id: str) -> None:
+        """
+        Records a heartbeat signal from a registered agent.
+
+        Args:
+            agent_id: The unique identifier of the subagent.
+        """
+        if agent_id in self._heartbeats:
+            self._heartbeats[agent_id] = time.time()
+            logging.debug(f"Recorded heartbeat for agent {agent_id}.")
+        else:
+            logging.warning(f"Received heartbeat for unregistered agent {agent_id}.")
+
+    def check_deadlocks(self, timeout_seconds: float) -> List[str]:
+        """
+        Checks for agents that have not sent a heartbeat within the timeout window.
+
+        Args:
+            timeout_seconds: The maximum allowed time (in seconds) between heartbeats.
+
+        Returns:
+            A list of agent IDs that have exceeded the timeout.
+        """
+        deadlocked_agents = []
+        current_time = time.time()
+        for agent_id, last_heartbeat in list(self._heartbeats.items()):
+            if current_time - last_heartbeat > timeout_seconds:
+                deadlocked_agents.append(agent_id)
+
+        if deadlocked_agents:
+            logging.warning(f"Detected deadlocked agents: {deadlocked_agents}")
+
+        return deadlocked_agents
+
+    async def _monitor_loop(self, timeout_seconds: float, check_interval: float) -> None:
+        """
+        The background loop that periodically checks for deadlocks.
+        """
+        self._is_running = True
+        try:
+            while self._is_running:
+                await asyncio.sleep(check_interval)
+                deadlocked = self.check_deadlocks(timeout_seconds)
+                if deadlocked:
+                    self._handle_deadlocked_agents(deadlocked)
+        except asyncio.CancelledError:
+            self._is_running = False
+            logging.info("Heartbeat monitor loop cancelled.")
+
+    def _handle_deadlocked_agents(self, deadlocked_agents: List[str]) -> None:
+        """
+        Handles alerting for deadlocked agents.
+
+        Args:
+            deadlocked_agents: A list of agent IDs that are deadlocked.
+        """
+        # In a real system, this could trigger recovery, cleanup, or alerts.
+        # For this requirement, triggering an alert via logging is sufficient.
+        for agent_id in deadlocked_agents:
+            logging.error(f"ALERT: Subagent {agent_id} failed to send a heartbeat within the timeout window.")
+
+    def start_monitor(self, timeout_seconds: float = 30.0, check_interval: float = 5.0) -> None:
+        """
+        Starts the background monitoring task.
+
+        Args:
+            timeout_seconds: Maximum time without a heartbeat before alerting.
+            check_interval: How often to check the heartbeats.
+        """
+        if self._monitor_task is None or self._monitor_task.done():
+            self._monitor_task = asyncio.create_task(self._monitor_loop(timeout_seconds, check_interval))
+            logging.info(f"Started subagent heartbeat monitor (timeout={timeout_seconds}s, interval={check_interval}s).")
+
+    async def stop_monitor(self) -> None:
+        """
+        Stops the background monitoring task.
+        """
+        self._is_running = False
+        if self._monitor_task and not self._monitor_task.done():
+            self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
+        logging.info("Stopped subagent heartbeat monitor.")

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,107 @@
+import asyncio
+import time
+from unittest.mock import patch, MagicMock, AsyncMock
+import pytest
+
+from magda_agent.agents.heartbeat import SubagentHeartbeatMonitor
+
+def test_monitor_registration() -> None:
+    """Tests that a subagent can be registered and its heartbeat is tracked."""
+    monitor = SubagentHeartbeatMonitor()
+    agent_id = "agent_1"
+
+    with patch("magda_agent.agents.heartbeat.time.time", return_value=100.0):
+        monitor.register_agent(agent_id)
+
+    assert agent_id in monitor._heartbeats
+    assert monitor._heartbeats[agent_id] == 100.0
+
+def test_monitor_record_heartbeat() -> None:
+    """Tests that a heartbeat updates the timestamp."""
+    monitor = SubagentHeartbeatMonitor()
+    agent_id = "agent_1"
+
+    with patch("magda_agent.agents.heartbeat.time.time", return_value=100.0):
+        monitor.register_agent(agent_id)
+
+    with patch("magda_agent.agents.heartbeat.time.time", return_value=110.0):
+        monitor.record_heartbeat(agent_id)
+
+    assert monitor._heartbeats[agent_id] == 110.0
+
+def test_monitor_record_heartbeat_unregistered() -> None:
+    """Tests recording heartbeat for an unregistered agent."""
+    monitor = SubagentHeartbeatMonitor()
+    agent_id = "agent_1"
+
+    with patch("magda_agent.agents.heartbeat.logging.warning") as mock_warning:
+        monitor.record_heartbeat(agent_id)
+        mock_warning.assert_called_once_with(f"Received heartbeat for unregistered agent {agent_id}.")
+    assert agent_id not in monitor._heartbeats
+
+def test_monitor_check_deadlocks() -> None:
+    """Tests deadlock detection logic."""
+    monitor = SubagentHeartbeatMonitor()
+    monitor._heartbeats = {
+        "agent_active": 100.0,
+        "agent_dead": 50.0
+    }
+
+    # Current time is 120.0
+    # Timeout is 30.0
+    # agent_active last heartbeat was 20.0 seconds ago (alive)
+    # agent_dead last heartbeat was 70.0 seconds ago (deadlocked)
+    with patch("magda_agent.agents.heartbeat.time.time", return_value=120.0):
+        deadlocked = monitor.check_deadlocks(timeout_seconds=30.0)
+
+    assert "agent_dead" in deadlocked
+    assert "agent_active" not in deadlocked
+
+@pytest.mark.asyncio
+async def test_monitor_background_loop() -> None:
+    """Tests the background monitoring loop with mocking."""
+    monitor = SubagentHeartbeatMonitor()
+
+    # We will patch check_deadlocks to return a deadlocked agent
+    with patch.object(monitor, "check_deadlocks", return_value=["agent_dead"]) as mock_check:
+        with patch.object(monitor, "_handle_deadlocked_agents") as mock_handle:
+            # We want the loop to run once and then exit.
+            def side_effect(*args, **kwargs):
+                monitor._is_running = False
+                return ["agent_dead"]
+            mock_check.side_effect = side_effect
+
+            # Since check_interval is passed to sleep, let's patch sleep to avoid waiting
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                # Run the loop directly for testing
+                monitor._is_running = True
+                await monitor._monitor_loop(timeout_seconds=30.0, check_interval=0.1)
+
+            mock_check.assert_called_with(30.0)
+            mock_handle.assert_called_with(["agent_dead"])
+
+@pytest.mark.asyncio
+async def test_monitor_start_stop() -> None:
+    """Tests starting and stopping the monitor task without patching asyncio.create_task globally."""
+    monitor = SubagentHeartbeatMonitor()
+
+    # Create a quick loop that finishes itself fast to not hang
+    # Note: _monitor_loop is called as self._monitor_loop(timeout, interval), so it takes timeout and interval.
+    # When patching an object method with a function, we must not include 'self' as the first param if we replace the bound method,
+    # but patch.object on an instance handles this trickily. Let's patch it properly.
+
+    async def fast_dummy_loop(*args, **kwargs):
+        monitor._is_running = True
+        await asyncio.sleep(0.01)
+        monitor._is_running = False
+
+    with patch.object(monitor, '_monitor_loop', side_effect=fast_dummy_loop):
+        monitor.start_monitor()
+        assert monitor._monitor_task is not None
+        assert not monitor._monitor_task.done()
+
+        await monitor.stop_monitor()
+        assert not monitor._is_running
+        # Let asyncio scheduler clean up the cancelled task
+        await asyncio.sleep(0.01)
+        assert monitor._monitor_task.cancelled() or monitor._monitor_task.done()


### PR DESCRIPTION
Implements a heartbeat monitor for subagents. Tracks signals, identifies deadlocks against a timeout window. Fully unit tested. Task marked as done in agent_tasks.json and 3 new tasks added as per recent AI trends.

---
*PR created automatically by Jules for task [1000632055418244144](https://jules.google.com/task/1000632055418244144) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `SubagentHeartbeatMonitor` to detect deadlocked subagents
> - Adds [heartbeat.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/452/files#diff-38314e410b240742a3d43dab5d1ba71e1fe167fc01de33abd27944482db460c3) with `SubagentHeartbeatMonitor`, a class that tracks per-agent last-seen timestamps and periodically checks for agents that have exceeded a configurable timeout.
> - The monitor runs a background `asyncio` task via `start_monitor`/`stop_monitor`, logs warnings on missed heartbeats, and logs errors for each deadlocked agent via `_handle_deadlocked_agents`.
> - Unregistered agents that emit a heartbeat produce a warning log without modifying state.
> - Adds [tests/test_heartbeat.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/452/files#diff-eebfc3ac618f9c2df4d1dbb362253b9310a52bbf62a2f3effcbc63dd883ef17a) with five test cases covering registration, heartbeat recording, deadlock detection, the background loop, and start/stop lifecycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 165554d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->