### PR TITLE
feat: implement openclaw rl metrics v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7384,7 +7384,7 @@
     },
     {
       "id": "openclaw-rl-metrics-v2-unique",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL Metrics System v2",
@@ -15895,6 +15895,57 @@
         "Telemetry data is logged upon tool execution.",
         "Tests verify telemetry generation on success and failure."
       ]
+    },
+    {
+      "id": "openclaw-canvas-ws-v3-unique",
+      "title": "OpenClaw Canvas WS Streaming V3",
+      "description": "Inspired by OpenClaw trends: Enhance Memory Canvas visualization to stream real-time JSON deltas to clients via WebSockets.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_ws_v3.py",
+        "tests/test_canvas_ws_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSockets stream state deltas.",
+        "Tests verify correct delta emission."
+      ],
+      "risk": "medium",
+      "area": "visualization",
+      "status": "todo"
+    },
+    {
+      "id": "a2a-telemetry-metrics-v4-unique",
+      "title": "A2A Mesh Telemetry V4",
+      "description": "Inspired by A2A Protocol trends: Implement a distributed telemetry broadcaster over the mesh network.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_telemetry_v4.py",
+        "tests/test_a2a_telemetry_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry payloads broadcast properly.",
+        "Tests pass with mock endpoints."
+      ],
+      "risk": "medium",
+      "area": "integration",
+      "status": "todo"
+    },
+    {
+      "id": "mcp-dynamic-tool-concurrency-v16-unique",
+      "title": "MCP Tool Concurrency V16",
+      "description": "Inspired by OpenAI Agents SDK: Improve runtime tool concurrency utilizing asyncio.gather and error isolation boundaries for dynamic tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_v16.py",
+        "tests/test_mcp_concurrency_v16.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Parallel dynamic tools execute smoothly.",
+        "Tests verify isolated exception handling."
+      ],
+      "risk": "medium",
+      "area": "skills",
+      "status": "todo"
     }
   ]
 }

--- a/backlog.md
+++ b/backlog.md
@@ -235,3 +235,4 @@
 * [x] FEATURE: MCP Kernel Taint Tracking Policy Engine (mcp-kernel-sandbox-taint-policy-v1-uuid)
 * [x] FEATURE: OpenClaw-RL Interactive Feedback Formatter (openclaw-rl-interactive-feedback-v1-uuid)
 * [x] FEATURE: OpenClaw-RL Interactive Feedback Formatter v2 (openclaw-rl-interactive-feedback-v2-uuid)
+* [x] FEATURE: OpenClaw RL Metrics System v2 (openclaw-rl-metrics-v2-unique)

--- a/magda_agent/learning/metrics_v2.py
+++ b/magda_agent/learning/metrics_v2.py
@@ -1,0 +1,101 @@
+import logging
+from typing import Optional, Dict, Any
+from magda_agent.metacognition.tracker import QualityTracker
+from magda_agent.learning.interactive_feedback import InteractiveFeedbackFormatterV2
+from magda_agent.llm_client import LLMClient
+
+class RLMetricsSystemV2:
+    """
+    OpenClaw RL Metrics System v2.
+    Captures longitudinal quality updates based on next-state signals (user replies).
+    Uses the V2 feedback formatter to extract more detailed intent.
+    Optionally, uses the LLM to understand deeper nuances if simple parsing yields a neutral intent.
+    """
+    def __init__(self, quality_tracker: QualityTracker, llm_client: Optional[LLMClient] = None) -> None:
+        """
+        Initializes the RL Metrics System v2.
+
+        Args:
+            quality_tracker (QualityTracker): Tracker to log metrics longitudinally.
+            llm_client (Optional[LLMClient]): The LLM client to use for complex feedback analysis.
+        """
+        self.quality_tracker = quality_tracker
+        self.formatter = InteractiveFeedbackFormatterV2()
+        self.llm_client = llm_client
+
+    async def capture_next_state_signal(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: Optional[str],
+        tool_output: Optional[str] = None
+    ) -> None:
+        """
+        Analyzes the user's reply as a next-state signal and logs RL metrics.
+        Uses LLM for deeper analysis if the simple parser is unsure.
+
+        Args:
+            user_reply (str): The user's reply text.
+            action_context (str): The context of the action that was taken.
+            user_id (Optional[str]): The user's ID.
+            tool_output (Optional[str], optional): The output of the tool, if any. Defaults to None.
+        """
+        if not user_reply:
+            return
+
+        signal_text = user_reply
+        if tool_output:
+            signal_text += f" [Tool Output: {tool_output}]"
+
+        feedback_signals = self.formatter.parse_detailed_feedback(signal_text)
+
+        intent = feedback_signals.get("intent", "neutral")
+        explicit_score = feedback_signals.get("explicit_score")
+        implicit_sentiment = feedback_signals.get("implicit_sentiment", 0.0)
+        is_correction = feedback_signals.get("is_correction", False)
+
+        # Fallback to LLM if the simple parser couldn't confidently classify intent
+        if intent == "neutral" and self.llm_client is not None:
+            prompt = f"Analyze the following user feedback in the context of action: {action_context}\nFeedback: '{user_reply}'\nIs this feedback a 'correction', 'praise', or 'neutral'?"
+            try:
+                llm_response = await self.llm_client.generate(prompt)
+                llm_text = llm_response.lower()
+                if "correction" in llm_text or "criticism" in llm_text:
+                    intent = "criticism"
+                    is_correction = True
+                    implicit_sentiment = min(implicit_sentiment, -0.5)
+                elif "praise" in llm_text:
+                    intent = "praise"
+                    implicit_sentiment = max(implicit_sentiment, 0.5)
+            except Exception as e:
+                logging.error(f"RLMetricsSystemV2: LLM fallback failed: {e}")
+
+        metadata: Dict[str, Any] = {
+            "user_id": user_id,
+            "action_context": action_context,
+            "is_correction": is_correction,
+            "intent": intent
+        }
+
+        # Log explicit score if available
+        if explicit_score is not None:
+            self.quality_tracker.log_metric("rl_explicit_score_v2", explicit_score, metadata)
+            logging.info(f"RLMetricsSystemV2: Logged rl_explicit_score_v2={explicit_score} for user {user_id}")
+
+        # Log implicit sentiment
+        self.quality_tracker.log_metric("rl_implicit_sentiment_v2", implicit_sentiment, metadata)
+        logging.info(f"RLMetricsSystemV2: Logged rl_implicit_sentiment_v2={implicit_sentiment} for user {user_id}")
+
+        # Calculate a combined quality score (0-100)
+        if explicit_score is not None:
+            quality_score = explicit_score * 10
+        else:
+            # Map sentiment [-1.0, 1.0] to [0, 100], base 50
+            quality_score = 50 + (implicit_sentiment * 50)
+            if is_correction or intent == "criticism":
+                quality_score = max(0.0, quality_score - 20)
+            elif intent == "praise":
+                quality_score = min(100.0, quality_score + 10)
+
+        self.quality_tracker.log_metric("rl_quality_score_v2", quality_score, metadata)
+        logging.info(f"RLMetricsSystemV2: Logged rl_quality_score_v2={quality_score} for user {user_id} with intent {intent}")

--- a/tests/test_rl_metrics_v2.py
+++ b/tests/test_rl_metrics_v2.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.learning.metrics_v2 import RLMetricsSystemV2
+from magda_agent.metacognition.tracker import QualityTracker
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_quality_tracker():
+    """Provides a mocked QualityTracker."""
+    return MagicMock(spec=QualityTracker)
+
+@pytest.fixture
+def mock_llm_client():
+    """Provides a mocked LLMClient."""
+    llm = MagicMock(spec=LLMClient)
+    llm.generate = AsyncMock()
+    return llm
+
+@pytest.fixture
+def rl_metrics_system_v2(mock_quality_tracker, mock_llm_client):
+    """Provides an RLMetricsSystemV2 instance with mocked dependencies."""
+    return RLMetricsSystemV2(quality_tracker=mock_quality_tracker, llm_client=mock_llm_client)
+
+@pytest.mark.asyncio
+async def test_capture_next_state_signal_empty(rl_metrics_system_v2, mock_quality_tracker):
+    """Test that empty replies are ignored."""
+    await rl_metrics_system_v2.capture_next_state_signal("", "context", "user_1")
+    mock_quality_tracker.log_metric.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_capture_next_state_signal_explicit_score(rl_metrics_system_v2, mock_quality_tracker):
+    """Test capturing an explicit score."""
+    reply = "I give this a 8.5/10, good job."
+    await rl_metrics_system_v2.capture_next_state_signal(reply, "test_action", "user_1")
+
+    # Check explicit score log
+    mock_quality_tracker.log_metric.assert_any_call(
+        "rl_explicit_score_v2",
+        8.5,
+        {"user_id": "user_1", "action_context": "test_action", "is_correction": False, "intent": "praise"}
+    )
+
+    # Check quality score log (8.5 * 10 = 85.0)
+    mock_quality_tracker.log_metric.assert_any_call(
+        "rl_quality_score_v2",
+        85.0,
+        {"user_id": "user_1", "action_context": "test_action", "is_correction": False, "intent": "praise"}
+    )
+
+@pytest.mark.asyncio
+async def test_capture_next_state_signal_with_llm_fallback(rl_metrics_system_v2, mock_quality_tracker, mock_llm_client):
+    """Test falling back to the LLM for neutral/ambiguous feedback."""
+    # A reply that doesn't trigger keywords in the formatter
+    reply = "hmm, let's look at this differently"
+    mock_llm_client.generate.return_value = "this is a correction"
+
+    await rl_metrics_system_v2.capture_next_state_signal(reply, "test_action", "user_2")
+
+    mock_llm_client.generate.assert_called_once()
+    calls = mock_quality_tracker.log_metric.call_args_list
+
+    # Should have logged rl_implicit_sentiment_v2 and rl_quality_score_v2
+    assert len(calls) == 2
+
+    # Intent should have been updated to criticism due to LLM
+    metadata = calls[0][0][2]
+    assert metadata["intent"] == "criticism"
+    assert metadata["is_correction"] == True
+
+@pytest.mark.asyncio
+async def test_capture_next_state_signal_positive_implicit(rl_metrics_system_v2, mock_quality_tracker):
+    """Test capturing positive implicit sentiment."""
+    reply = "That is perfect, thanks!"
+    await rl_metrics_system_v2.capture_next_state_signal(reply, "test_action", "user_3")
+
+    calls = mock_quality_tracker.log_metric.call_args_list
+    assert len(calls) == 2
+
+    sentiment_call = calls[0]
+    assert sentiment_call[0][0] == "rl_implicit_sentiment_v2"
+    assert sentiment_call[0][1] > 0.0
+
+    quality_call = calls[1]
+    assert quality_call[0][0] == "rl_quality_score_v2"
+    assert quality_call[0][1] > 50.0


### PR DESCRIPTION
Implements RL metrics v2 with interactive feedback v2 and LLM fallback. Also updates agent_tasks.json and backlog.md.

---
*PR created automatically by Jules for task [8928601603277040643](https://jules.google.com/task/8928601603277040643) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `RLMetricsSystemV2` to capture and log RL quality metrics
> - Adds [`magda_agent/learning/metrics_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/453/files#diff-8ca068a4f13161c4859668a227717cd1650fa36c643a49929ec97d1afb6711d5) with `RLMetricsSystemV2`, which parses user replies via `InteractiveFeedbackFormatterV2` to extract intent, explicit scores, and implicit sentiment.
> - Logs up to three metrics per interaction: `rl_explicit_score_v2`, `rl_implicit_sentiment_v2`, and `rl_quality_score_v2`, all via `QualityTracker`.
> - When parsed intent is neutral and an `LLMClient` is provided, queries the LLM to classify feedback, updating intent and sentiment before scoring.
> - Quality score maps explicit scores to a 0–100 range, or derives a score from implicit sentiment with bonuses/penalties for praise and criticism.
> - Adds [`tests/test_rl_metrics_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/453/files#diff-973ed8a6295399a13c7ba6a97b8700a2708839a0f9111b32c0b5a63d3c313c46) with four async tests covering empty replies, explicit scoring, LLM fallback, and positive sentiment handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29f5119.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->