### PR TITLE
feat: implement A2A Discovery Service v3 Unique and update tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7401,7 +7401,7 @@
     },
     {
       "id": "a2a-discovery-v3-unique",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery v3 (Agent Cards)",
@@ -15946,6 +15946,57 @@
       "risk": "medium",
       "area": "skills",
       "status": "todo"
+    },
+    {
+      "id": "hermes-cron-daily-backups-v10-unique",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Daily Backups V10",
+      "description": "Inspired by Hermes trends: Implement a scheduled task for generating nightly backups using a cron scheduler.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_backups_v10.py",
+        "tests/test_cron_backups_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Nightly backup cron task executes successfully.",
+        "Tests mock time and backup execution."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-isolation-v10-unique",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude Agent Teams Isolation V10",
+      "description": "Inspired by Claude Agent SDK trends: Implement Git worktree isolation enhancements for spawned subagents.",
+      "allowed_paths": [
+        "magda_agent/agents/worktree_manager_v10.py",
+        "tests/test_worktree_manager_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Git worktrees are correctly isolated.",
+        "Tests verify sandbox environments."
+      ]
+    },
+    {
+      "id": "openai-realtime-guardrail-fallback-v10-unique",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "OpenAI Realtime Guardrail Fallback V10",
+      "description": "Inspired by OpenAI Agents SDK trends: Implement realtime guardrails that catch and safely fallback during unsafe tool actions.",
+      "allowed_paths": [
+        "magda_agent/safety/fallback_v10.py",
+        "tests/test_fallback_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Realtime guardrails catch unsafe actions.",
+        "Tests verify fallback on mock failure."
+      ]
     }
   ]
 }

--- a/magda_agent/integration/a2a_discovery_v3_unique.py
+++ b/magda_agent/integration/a2a_discovery_v3_unique.py
@@ -1,0 +1,105 @@
+from typing import Dict, List, Optional, Any
+import json
+import logging
+import httpx
+from magda_agent.integration.a2a_cards import AgentCardV3
+
+
+class A2ADiscoveryServiceV3Unique:
+    """
+    Implements A2A Agent Discovery Service logic for v3.
+    This class handles parsing of AgentCards, registering them, finding peers by capabilities,
+    and delegating tasks to peers asynchronously.
+    """
+    def __init__(self) -> None:
+        """
+        Initializes the A2ADiscoveryServiceV3Unique registry.
+        """
+        self._discovered_agents: Dict[str, AgentCardV3] = {}
+
+    def parse_and_register_cards(self, raw_cards: List[str]) -> List[AgentCardV3]:
+        """
+        Parses a list of JSON string representations of Agent Cards
+        and registers them in the internal store.
+
+        Args:
+            raw_cards: A list of JSON strings representing AgentCards.
+
+        Returns:
+            A list of successfully parsed AgentCardV3 objects.
+        """
+        successfully_parsed: List[AgentCardV3] = []
+        for card_json in raw_cards:
+            try:
+                card = AgentCardV3.from_json(card_json)
+                self._discovered_agents[card.agent_id] = card
+                successfully_parsed.append(card)
+                logging.info(f"Successfully parsed and registered AgentCard for agent_id: {card.agent_id}")
+            except (json.JSONDecodeError, TypeError, ValueError, KeyError) as e:
+                logging.error(f"Failed to parse Agent Card. Error: {str(e)}, Raw Data: {card_json}")
+
+        return successfully_parsed
+
+    def get_agent_card(self, agent_id: str) -> Optional[AgentCardV3]:
+        """
+        Retrieves a registered AgentCardV3 by its agent_id.
+
+        Args:
+            agent_id: The ID of the agent to retrieve.
+
+        Returns:
+            The AgentCardV3 if found, else None.
+        """
+        return self._discovered_agents.get(agent_id)
+
+    def find_agents_by_capability(self, capability: str) -> List[AgentCardV3]:
+        """
+        Returns a list of Agent Cards that support the given capability.
+        Supports capability matching logic from AgentCardV3.
+
+        Args:
+            capability: The capability string to match.
+
+        Returns:
+            A list of matched AgentCardV3 objects.
+        """
+        matched_agents: List[AgentCardV3] = []
+        for agent in self._discovered_agents.values():
+            if agent.has_capability(capability):
+                matched_agents.append(agent)
+        return matched_agents
+
+    async def delegate_task(self, peer_agent_id: str, task_payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Delegates a task to a peer agent asynchronously using httpx.
+
+        Args:
+            peer_agent_id: The ID of the peer agent to delegate to.
+            task_payload: The dictionary payload describing the task.
+
+        Returns:
+            A dictionary containing the response or status of the delegation.
+
+        Raises:
+            ValueError: If the peer agent is not found or has no RPC endpoint.
+            httpx.HTTPError: If the HTTP request fails.
+        """
+        agent = self.get_agent_card(peer_agent_id)
+        if not agent:
+            logging.error(f"Cannot delegate to unknown agent: {peer_agent_id}")
+            raise ValueError(f"Agent not found: {peer_agent_id}")
+
+        rpc_endpoint = agent.endpoints.get("rpc")
+        if not rpc_endpoint:
+            logging.error(f"Agent {peer_agent_id} has no RPC endpoint")
+            raise ValueError(f"Agent {peer_agent_id} has no RPC endpoint")
+
+        logging.info(f"Delegating task to {peer_agent_id} at {rpc_endpoint}")
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{rpc_endpoint}/delegate",
+                json=task_payload
+            )
+            response.raise_for_status()
+            return response.json()

--- a/tests/test_a2a_discovery_v3_unique.py
+++ b/tests/test_a2a_discovery_v3_unique.py
@@ -1,0 +1,105 @@
+import pytest
+import json
+import respx
+import httpx
+from unittest.mock import AsyncMock
+
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_discovery_v3_unique import A2ADiscoveryServiceV3Unique
+
+@pytest.fixture
+def valid_card() -> AgentCardV3:
+    """Fixture providing a valid AgentCardV3."""
+    return AgentCardV3(
+        agent_id="agent-001",
+        name="TestAgent",
+        description="A test agent",
+        capabilities=["code_execution", "chat"],
+        endpoints={"rpc": "http://localhost:8080/rpc"},
+        protocol_version="v3"
+    )
+
+def test_parse_and_register_valid_cards(valid_card: AgentCardV3) -> None:
+    """Tests parsing and registering a valid AgentCard."""
+    service = A2ADiscoveryServiceV3Unique()
+    valid_json = valid_card.to_json()
+
+    parsed_cards = service.parse_and_register_cards([valid_json])
+
+    assert len(parsed_cards) == 1
+    assert parsed_cards[0].agent_id == "agent-001"
+
+    registered = service.get_agent_card("agent-001")
+    assert registered is not None
+    assert registered.name == "TestAgent"
+
+def test_parse_invalid_cards() -> None:
+    """Tests parsing invalid JSON cards."""
+    service = A2ADiscoveryServiceV3Unique()
+
+    invalid_json = '{"agent_id": "missing_quotes}'
+    missing_fields_json = '{"agent_id": "test-agent", "name": "Agent"}'
+
+    parsed_cards = service.parse_and_register_cards([invalid_json, missing_fields_json])
+
+    assert len(parsed_cards) == 0
+
+def test_find_agents_by_capability(valid_card: AgentCardV3) -> None:
+    """Tests finding an agent by an existing capability."""
+    service = A2ADiscoveryServiceV3Unique()
+    service.parse_and_register_cards([valid_card.to_json()])
+
+    agents = service.find_agents_by_capability("code_execution")
+    assert len(agents) == 1
+    assert agents[0].agent_id == "agent-001"
+
+    agents = service.find_agents_by_capability("unknown_cap")
+    assert len(agents) == 0
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_delegate_task_success(valid_card: AgentCardV3) -> None:
+    """Tests successfully delegating a task to a peer agent."""
+    service = A2ADiscoveryServiceV3Unique()
+    service.parse_and_register_cards([valid_card.to_json()])
+
+    task_payload = {"task": "do_something", "data": "test"}
+    rpc_endpoint = valid_card.endpoints["rpc"]
+
+    route = respx.post(f"{rpc_endpoint}/delegate").mock(return_value=httpx.Response(200, json={"status": "accepted"}))
+
+    response = await service.delegate_task("agent-001", task_payload)
+
+    assert response == {"status": "accepted"}
+    assert route.called
+
+@pytest.mark.asyncio
+async def test_delegate_task_agent_not_found() -> None:
+    """Tests delegating to a non-existent agent raises ValueError."""
+    service = A2ADiscoveryServiceV3Unique()
+
+    with pytest.raises(ValueError, match="Agent not found"):
+        await service.delegate_task("unknown-agent", {})
+
+@pytest.mark.asyncio
+async def test_delegate_task_no_endpoint(valid_card: AgentCardV3) -> None:
+    """Tests delegating to an agent without an RPC endpoint raises ValueError."""
+    service = A2ADiscoveryServiceV3Unique()
+    valid_card.endpoints = {}
+    service.parse_and_register_cards([valid_card.to_json()])
+
+    with pytest.raises(ValueError, match="has no RPC endpoint"):
+        await service.delegate_task("agent-001", {})
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_delegate_task_http_error(valid_card: AgentCardV3) -> None:
+    """Tests delegating raises httpx.HTTPStatusError on failure."""
+    service = A2ADiscoveryServiceV3Unique()
+    service.parse_and_register_cards([valid_card.to_json()])
+
+    rpc_endpoint = valid_card.endpoints["rpc"]
+    respx.post(f"{rpc_endpoint}/delegate").mock(return_value=httpx.Response(500))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await service.delegate_task("agent-001", {})


### PR DESCRIPTION
Implements the a2a-discovery-v3-unique task. Updates agent_tasks.json and appends three new unique tasks inspired by OpenClaw/Hermes/Claude/OpenAI.

---
*PR created automatically by Jules for task [10601185751149869900](https://jules.google.com/task/10601185751149869900) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A Discovery Service v3 with capability filtering and async task delegation
> - Adds [`A2ADiscoveryServiceV3Unique`](https://github.com/kazah4359-lgtm/Magda-agent/pull/454/files#diff-6362dd85b433748509dac102866dda18d8dd3f730e7348d3267b33756a238cdf) with an in-memory registry of `AgentCardV3` instances parsed from raw JSON strings.
> - Provides lookup by agent ID or capability string via `get_agent_card` and `find_agents_by_capability`.
> - Implements `delegate_task`, an async method that HTTP POSTs a task payload to a peer agent's `rpc` endpoint at `/delegate` using `httpx.AsyncClient`, raising `ValueError` for missing agents/endpoints and `httpx.HTTPStatusError` on non-2xx responses.
> - Adds full pytest coverage in [`tests/test_a2a_discovery_v3_unique.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/454/files#diff-9405f9fd056ff3bee06a48e6137ae0fb683c53ab703cb365a64b5aed92a37a60) including mocked HTTP scenarios via `respx`.
> - Updates [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/454/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) to mark one task done and add three new task entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33e8268.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->