### PR TITLE
feat: Add MCP Kernel Runtime v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7418,7 +7418,7 @@
     },
     {
       "id": "mcp-kernel-runtime-v4-unique",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Kernel Runtime v4",
@@ -15997,6 +15997,57 @@
         "Realtime guardrails catch unsafe actions.",
         "Tests verify fallback on mock failure."
       ]
+    },
+    {
+      "id": "openclaw-rl-dynamic-behavior-v3-unique",
+      "title": "OpenClaw RL Dynamic Behavior Adjustment V3",
+      "description": "Inspired by OpenClaw trends: Implement continuous online learning logic to dynamically adjust response length and tone based on user feedback.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_dynamic_rl_v3.py",
+        "tests/test_openclaw_dynamic_rl_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Continuous RL loop correctly adjusts behavioral parameters.",
+        "Tests verify parameter update based on reward signals."
+      ],
+      "risk": "medium",
+      "area": "learning",
+      "status": "todo"
+    },
+    {
+      "id": "claude-subagent-spawning-v4-unique",
+      "title": "Claude Subagent Spawning V4",
+      "description": "Inspired by Claude Agent SDK trends: Develop a manager that spawns isolated Git worktree subagents for parallel execution of multi-step plans.",
+      "allowed_paths": [
+        "magda_agent/agents/claude_spawner_v4.py",
+        "tests/test_claude_spawner_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents are correctly spawned and tracked.",
+        "Tests verify parallel spawning using AsyncMock."
+      ],
+      "risk": "medium",
+      "area": "multi-agent",
+      "status": "todo"
+    },
+    {
+      "id": "hermes-skill-creation-v5-unique",
+      "title": "Hermes Skill Creation V5",
+      "description": "Inspired by Hermes Agent trends: Add the ability to capture successfully executed tool workflows as reusable procedural skills.",
+      "allowed_paths": [
+        "magda_agent/skills/hermes_skill_creator_v5.py",
+        "tests/test_hermes_skill_creator_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Workflows are successfully parsed and saved as skills.",
+        "Tests verify skill registration."
+      ],
+      "risk": "medium",
+      "area": "skills",
+      "status": "todo"
     }
   ]
 }

--- a/magda_agent/safety/mcp_kernel_runtime_v4.py
+++ b/magda_agent/safety/mcp_kernel_runtime_v4.py
@@ -1,0 +1,144 @@
+"""
+MCP Kernel Runtime V4.
+
+Inspired by MCPKernel taint tracking trend: this module provides a runtime proxy
+that enforces taint policies for tool calls.
+"""
+
+import inspect
+from functools import wraps
+from typing import Any, Callable, Dict, Optional, Coroutine
+
+from magda_agent.safety.mcp_taint_policy import MCPTaintPolicyEngine
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError
+
+
+class MCPKernelRuntimeV4:
+    """
+    Acts as a runtime proxy enforcing taint policy for tool calls.
+    """
+
+    def __init__(self, policy_engine: Optional[MCPTaintPolicyEngine] = None) -> None:
+        """
+        Initializes the MCPKernelRuntimeV4.
+
+        Args:
+            policy_engine: The policy engine used for evaluating data streams.
+                If not provided, a new one is created.
+        """
+        self.policy_engine = policy_engine or MCPTaintPolicyEngine()
+
+    def execute_tool(
+        self,
+        tool_func: Callable[..., Any],
+        inputs: Dict[str, Any],
+        is_sensitive: bool = False,
+        is_trusted: bool = False,
+    ) -> Any:
+        """
+        Evaluates the input stream, executes the tool, and evaluates the output stream.
+
+        Args:
+            tool_func: The actual tool function to execute if permitted.
+            inputs: A dictionary of inputs to pass to the tool.
+            is_sensitive: If True, the tool is considered sensitive and execution will
+                fail if inputs contain any tainted data.
+            is_trusted: If True, the output is considered trusted and execution will
+                succeed even if it contains tainted data.
+
+        Returns:
+            The result of the tool execution if permitted.
+
+        Raises:
+            PolicyViolationError: If input/output policies are violated.
+        """
+        # 1. Evaluate Input Stream
+        self.policy_engine.evaluate_stream(inputs, is_sensitive=is_sensitive)
+
+        # 2. Execute Tool
+        # We handle coroutine vs sync inside runtime_proxy, but we also support direct calls
+        if inspect.iscoroutinefunction(tool_func):
+            async def async_wrapper() -> Any:
+                result = await tool_func(**inputs)
+                self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+                return result
+            return async_wrapper()
+
+        result = tool_func(**inputs)
+
+        # Handle synchronous execution returning an awaitable (e.g. from wrapper)
+        if inspect.isawaitable(result):
+            async def async_result_wrapper() -> Any:
+                awaited_result = await result
+                self.policy_engine.evaluate_output_stream(awaited_result, is_trusted=is_trusted)
+                return awaited_result
+            return async_result_wrapper()
+
+        # 3. Evaluate Output Stream
+        self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+
+        return result
+
+    def runtime_proxy(self, is_sensitive: bool = False, is_trusted: bool = False) -> Callable:
+        """
+        A decorator to wrap a tool function with the MCPKernelRuntimeV4.
+
+        Args:
+            is_sensitive: If True, the tool is considered sensitive.
+            is_trusted: If True, the output is considered trusted.
+
+        Returns:
+            The decorated tool function.
+        """
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            @wraps(func)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                # To be generic, combine args and kwargs into an inputs dictionary
+                # For simplicity, we just package everything into a dict.
+                # Real MCP tools often take named parameters (kwargs).
+                # We'll map args to positional indices if necessary.
+
+                sig = inspect.signature(func)
+                bound_args = sig.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+                inputs = dict(bound_args.arguments)
+
+                # Check inputs
+                self.policy_engine.evaluate_stream(inputs, is_sensitive=is_sensitive)
+
+                result = func(*args, **kwargs)
+
+                # Check if the synchronous wrapper returned a coroutine
+                if inspect.isawaitable(result):
+                     async def async_eval() -> Any:
+                         awaited_result = await result
+                         self.policy_engine.evaluate_output_stream(awaited_result, is_trusted=is_trusted)
+                         return awaited_result
+                     return async_eval()
+
+                # Check output
+                self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+
+                return result
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                sig = inspect.signature(func)
+                bound_args = sig.bind(*args, **kwargs)
+                bound_args.apply_defaults()
+                inputs = dict(bound_args.arguments)
+
+                # Check inputs
+                self.policy_engine.evaluate_stream(inputs, is_sensitive=is_sensitive)
+
+                result = await func(*args, **kwargs)
+
+                # Check output
+                self.policy_engine.evaluate_output_stream(result, is_trusted=is_trusted)
+
+                return result
+
+            return async_wrapper if inspect.iscoroutinefunction(func) else sync_wrapper
+
+        return decorator

--- a/tests/test_mcp_kernel_runtime_v4.py
+++ b/tests/test_mcp_kernel_runtime_v4.py
@@ -1,0 +1,125 @@
+"""Tests for the MCPKernelRuntimeV4 module."""
+
+import pytest
+
+from magda_agent.safety.mcp_kernel_runtime_v4 import MCPKernelRuntimeV4
+from magda_agent.safety.mcp_taint_policy import MCPTaintPolicyEngine
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError, TaintTrackerV2
+
+
+@pytest.fixture
+def runtime() -> MCPKernelRuntimeV4:
+    """Fixture providing an MCPKernelRuntimeV4 instance."""
+    return MCPKernelRuntimeV4()
+
+
+def test_execute_tool_sensitive_rejects_tainted_input(runtime: MCPKernelRuntimeV4) -> None:
+    """Test that a sensitive tool rejects tainted input."""
+    def sample_tool(data: str) -> str:
+        return f"Processed {data}"
+
+    tracker = runtime.policy_engine.tracker
+    tainted_input = tracker.taint({"data": "untrusted"}, "malicious_source")
+
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call"):
+        runtime.execute_tool(sample_tool, inputs=tainted_input, is_sensitive=True)
+
+
+def test_execute_tool_non_sensitive_accepts_tainted_input(runtime: MCPKernelRuntimeV4) -> None:
+    """Test that a non-sensitive tool accepts tainted input."""
+    def sample_tool(data: str) -> str:
+        return f"Processed {data}"
+
+    tracker = runtime.policy_engine.tracker
+    # Input is tainted but not the string itself to bypass simple tests, let's taint a string.
+    tainted_str = tracker.taint("untrusted", "malicious_source")
+
+    # We execute and return the tainted string
+    def sample_tool_2(data: str) -> str:
+        return data
+
+    inputs = {"data": tainted_str}
+
+    # Tool is not sensitive and output is untrusted. We should fail output validation
+    # since output is tainted and tool is untrusted.
+    with pytest.raises(PolicyViolationError, match="Tainted output from untrusted tool call"):
+         runtime.execute_tool(sample_tool_2, inputs=inputs, is_sensitive=False, is_trusted=False)
+
+
+def test_execute_tool_untrusted_rejects_tainted_output(runtime: MCPKernelRuntimeV4) -> None:
+    """Test that an untrusted tool rejects tainted output."""
+    def sample_tool() -> str:
+        return runtime.policy_engine.tracker.taint("secret", "db")
+
+    with pytest.raises(PolicyViolationError, match="Tainted output from untrusted tool call"):
+        runtime.execute_tool(sample_tool, inputs={}, is_sensitive=False, is_trusted=False)
+
+
+def test_execute_tool_trusted_accepts_tainted_output(runtime: MCPKernelRuntimeV4) -> None:
+    """Test that a trusted tool accepts tainted output."""
+    def sample_tool() -> str:
+        return runtime.policy_engine.tracker.taint("secret", "db")
+
+    result = runtime.execute_tool(sample_tool, inputs={}, is_sensitive=False, is_trusted=True)
+    assert runtime.policy_engine.tracker.is_tainted(result)
+
+
+def test_runtime_proxy_sync(runtime: MCPKernelRuntimeV4) -> None:
+    """Test the runtime_proxy decorator with a synchronous function."""
+
+    @runtime.runtime_proxy(is_sensitive=True, is_trusted=False)
+    def my_sync_tool(a: str, b: str = "default") -> str:
+        return f"{a} {b}"
+
+    # Clean inputs -> clean output
+    res = my_sync_tool("hello")
+    assert res == "hello default"
+
+    # Tainted input -> rejected because sensitive
+    tainted_input = runtime.policy_engine.tracker.taint("bad", "source")
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call"):
+        my_sync_tool(tainted_input)
+
+    @runtime.runtime_proxy(is_sensitive=False, is_trusted=False)
+    def my_tainted_tool() -> str:
+         return runtime.policy_engine.tracker.taint("secret", "db")
+
+    # Tainted output -> rejected because untrusted
+    with pytest.raises(PolicyViolationError, match="Tainted output from untrusted tool call"):
+        my_tainted_tool()
+
+
+@pytest.mark.asyncio
+async def test_runtime_proxy_async(runtime: MCPKernelRuntimeV4) -> None:
+    """Test the runtime_proxy decorator with an asynchronous function."""
+
+    @runtime.runtime_proxy(is_sensitive=True, is_trusted=False)
+    async def my_async_tool(a: str, b: str = "default") -> str:
+        return f"{a} {b}"
+
+    # Clean inputs -> clean output
+    res = await my_async_tool("hello")
+    assert res == "hello default"
+
+    # Tainted input -> rejected because sensitive
+    tainted_input = runtime.policy_engine.tracker.taint("bad", "source")
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call"):
+        await my_async_tool(tainted_input)
+
+    @runtime.runtime_proxy(is_sensitive=False, is_trusted=True)
+    async def my_trusted_async_tool() -> str:
+         return runtime.policy_engine.tracker.taint("secret", "db")
+
+    # Tainted output -> accepted because trusted
+    res2 = await my_trusted_async_tool()
+    assert runtime.policy_engine.tracker.is_tainted(res2)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_async(runtime: MCPKernelRuntimeV4) -> None:
+    """Test execute_tool directly with an asynchronous function."""
+    async def sample_tool() -> str:
+        return "async clean"
+
+    res = await runtime.execute_tool(sample_tool, inputs={}, is_sensitive=False, is_trusted=False)
+    assert res == "async clean"


### PR DESCRIPTION
Implement the MCP Kernel Runtime module that acts as a runtime proxy enforcing taint policy for tool calls.

---
*PR created automatically by Jules for task [16244116840021326362](https://jules.google.com/task/16244116840021326362) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP Kernel Runtime v4 with taint policy enforcement for tool calls
> - Adds [`MCPKernelRuntimeV4`](https://github.com/kazah4359-lgtm/Magda-agent/pull/455/files#diff-699169f31600e73f5f6a960d37d266551ea68337896da021c2341c945dea31d2), a runtime proxy that enforces taint policies on tool inputs and outputs using `MCPTaintPolicyEngine`, raising `PolicyViolationError` on violations.
> - `execute_tool` supports both sync and async tools, including sync functions that return awaitables, by wrapping output evaluation post-await.
> - `runtime_proxy` is a decorator factory that binds arguments and enforces the same taint checks transparently around any tool function.
> - Tests in [`tests/test_mcp_kernel_runtime_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/455/files#diff-3924b8514a98946a227149ba973a41a42c1fd95d1bab678f81a77a46e50880ad) cover sensitive input rejection, tainted output handling, trusted flag behavior, and async/sync decorator correctness.
> - Risk: any tool wrapped with `runtime_proxy` or called via `execute_tool` may now raise `PolicyViolationError` where previously it would not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 633b930.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->