### PR TITLE
A2A Peer Delegation v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7452,7 +7452,7 @@
     },
     {
       "id": "a2a-peer-delegation-v4-5d34cc13",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Peer-to-Peer Delegation v4",
@@ -16048,6 +16048,57 @@
       "risk": "medium",
       "area": "skills",
       "status": "todo"
+    },
+    {
+      "id": "hermes-agent-scheduled-nightly-backups-v5",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Hermes Agent Scheduled Nightly Backups V5",
+      "description": "Inspired by Hermes trends: Implement a scheduled task for generating nightly backups using a cron scheduler.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_backups_v5.py",
+        "tests/test_cron_backups_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Nightly backup cron task executes successfully.",
+        "Tests mock time and backup execution."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-engine-plugin-v5",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Context Engine Plugin V5",
+      "description": "Inspired by OpenClaw trends: Implement a plugin interface for the Context Engine with lifecycle hooks.",
+      "allowed_paths": [
+        "magda_agent/memory/context_plugin_v5.py",
+        "tests/test_context_plugin_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin interface successfully registers hooks.",
+        "Tests verify hook execution."
+      ]
+    },
+    {
+      "id": "mcp-async-tool-delegation-manager-v5",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Async Tool Delegation Manager V5",
+      "description": "Inspired by MCP standard trend: Improve runtime tool concurrency utilizing asyncio.gather and error isolation boundaries for dynamic tools.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_v5.py",
+        "tests/test_mcp_concurrency_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Parallel dynamic tools execute smoothly.",
+        "Tests verify isolated exception handling."
+      ]
     }
   ]
 }

--- a/backlog.md
+++ b/backlog.md
@@ -236,3 +236,4 @@
 * [x] FEATURE: OpenClaw-RL Interactive Feedback Formatter (openclaw-rl-interactive-feedback-v1-uuid)
 * [x] FEATURE: OpenClaw-RL Interactive Feedback Formatter v2 (openclaw-rl-interactive-feedback-v2-uuid)
 * [x] FEATURE: OpenClaw RL Metrics System v2 (openclaw-rl-metrics-v2-unique)
+* [x] FEATURE: A2A Peer-to-Peer Delegation v4 (a2a-peer-delegation-v4-5d34cc13)

--- a/magda_agent/integration/a2a_delegation_v4.py
+++ b/magda_agent/integration/a2a_delegation_v4.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, List, Optional
+import httpx
+import logging
+
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_security import A2ASecurityContext
+from magda_agent.integration.a2a_tracing import A2ATracer
+
+logger = logging.getLogger(__name__)
+
+class A2ADelegatorV4:
+    """
+    Handles peer-to-peer task delegation using Agent Cards for asynchronous discovery.
+    """
+    def __init__(self, security_context: Optional[A2ASecurityContext] = None) -> None:
+        """
+        Initializes the delegator.
+        """
+        self.security_context = security_context or A2ASecurityContext()
+
+    async def delegate_task(self, peer_agent: AgentCardV3, task_payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Delegates a task to a peer agent asynchronously.
+
+        Args:
+            peer_agent (AgentCardV3): The agent card representing the peer.
+            task_payload (Dict[str, Any]): The payload containing the task context.
+
+        Returns:
+            Dict[str, Any]: The response from the peer agent.
+        """
+        endpoint = peer_agent.endpoints.get("rpc") or peer_agent.endpoints.get("mcp")
+        if not endpoint:
+            logger.error(f"Agent {peer_agent.agent_id} missing endpoint")
+            raise ValueError(f"Agent {peer_agent.agent_id} missing endpoint")
+
+        headers: Dict[str, str] = {}
+        A2ATracer.inject_headers(headers)
+
+        if self.security_context:
+            token = self.security_context.generate_token()
+            headers["Authorization"] = f"Bearer {token}"
+            self.security_context.trace_action("delegate_task", {"target_agent": peer_agent.name})
+
+        A2ATracer.record_event("peer_delegation", {"target_agent_id": peer_agent.agent_id})
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(endpoint, json=task_payload, headers=headers, timeout=10.0)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPError as e:
+            logger.error(f"Failed to delegate task to {peer_agent.agent_id} at {endpoint}: {e}")
+            raise

--- a/tests/test_a2a_delegation_v4.py
+++ b/tests/test_a2a_delegation_v4.py
@@ -1,0 +1,80 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+from typing import Any, Dict
+
+from magda_agent.integration.a2a_delegation_v4 import A2ADelegatorV4
+from magda_agent.integration.a2a_cards import AgentCardV3
+from magda_agent.integration.a2a_security import A2ASecurityContext
+
+
+@pytest.fixture
+def mock_agent_card() -> AgentCardV3:
+    return AgentCardV3(
+        agent_id="test-agent-id",
+        name="Test Agent",
+        description="A test agent",
+        capabilities=["code_execution"],
+        endpoints={"rpc": "http://test-agent/rpc", "mcp": "http://test-agent/mcp"},
+        protocol_version="v3"
+    )
+
+@pytest.fixture
+def mock_security_context() -> A2ASecurityContext:
+    context = MagicMock(spec=A2ASecurityContext)
+    context.generate_token.return_value = "fake-token"
+    return context
+
+@pytest.mark.asyncio
+async def test_delegate_task_success(mock_agent_card: AgentCardV3, mock_security_context: A2ASecurityContext) -> None:
+    """Test successful task delegation using mocked httpx.AsyncClient."""
+    delegator = A2ADelegatorV4(security_context=mock_security_context)
+    task_payload = {"task": "test_task"}
+    expected_response = {"status": "success", "result": "done"}
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = expected_response
+    mock_response.raise_for_status = MagicMock()
+
+    with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_response
+        result = await delegator.delegate_task(mock_agent_card, task_payload)
+
+        assert result == expected_response
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == "http://test-agent/rpc"
+        assert kwargs['json'] == task_payload
+        assert 'Authorization' in kwargs['headers']
+        assert kwargs['headers']['Authorization'] == "Bearer fake-token"
+        assert kwargs['timeout'] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_delegate_task_no_endpoint() -> None:
+    """Test task delegation fails when the agent has no endpoint."""
+    card = AgentCardV3(
+        agent_id="test-agent-id",
+        name="Test Agent",
+        description="A test agent",
+        capabilities=["code_execution"],
+        endpoints={},
+        protocol_version="v3"
+    )
+    delegator = A2ADelegatorV4()
+
+    with pytest.raises(ValueError, match="Agent test-agent-id missing endpoint"):
+        await delegator.delegate_task(card, {"task": "test_task"})
+
+
+@pytest.mark.asyncio
+async def test_delegate_task_http_error(mock_agent_card: AgentCardV3) -> None:
+    """Test task delegation handles HTTP errors properly."""
+    delegator = A2ADelegatorV4()
+    task_payload = {"task": "test_task"}
+
+    with patch('httpx.AsyncClient.post', new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = httpx.HTTPStatusError("Bad Request", request=MagicMock(), response=MagicMock())
+
+        with pytest.raises(httpx.HTTPError):
+            await delegator.delegate_task(mock_agent_card, task_payload)


### PR DESCRIPTION
Implemented peer-to-peer task delegation using Agent Cards for asynchronous discovery. Also added new trend-inspired tasks to agent_tasks.json and updated backlog.md.

---
*PR created automatically by Jules for task [6383729602847779566](https://jules.google.com/task/6383729602847779566) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A peer-to-peer task delegation via `A2ADelegatorV4`
> - Introduces [`A2ADelegatorV4`](https://github.com/kazah4359-lgtm/Magda-agent/pull/458/files#diff-6fb389073ec513b988138fe4414753ef025d88e8d17462b80b74186f64dc384d) to delegate tasks to peer agents over HTTP using `AgentCardV3`, `A2ASecurityContext`, and `A2ATracer`.
> - `delegate_task` selects a peer endpoint (preferring `rpc` over `mcp`), injects tracing headers, optionally adds a Bearer token, and POSTs the payload with a 10s timeout via `httpx.AsyncClient`.
> - Raises `ValueError` on missing endpoints and propagates `httpx.HTTPError` on HTTP failures.
> - Tests in [`tests/test_a2a_delegation_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/458/files#diff-7ef6164421bf33f5a1f20254aa906b0b3c805fecd49c1840f1998112b54a7f90) cover the success path, missing endpoint, and HTTP error propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65ae629.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->