### PR TITLE
Implement Agent Guard Runtime Policy v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7520,7 +7520,7 @@
     },
     {
       "id": "agent-guard-runtime-policy-v5-new-suffix-789",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "Agent Guard Runtime Policy v5",
@@ -16235,6 +16235,57 @@
       "acceptance": [
         "A2A Discovery matches capabilities using Agent Cards v4.",
         "Tests verify mock discovery."
+      ]
+    },
+    {
+      "id": "mcp-context-engine-state-exporter-v5",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "title": "MCP Context Engine State Exporter v5",
+      "description": "Inspired by MCP standard trend: Expose Magda's Context Engine memory states dynamically over an MCP-compliant JSON-RPC server endpoint.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_context_exporter_v5.py",
+        "tests/test_mcp_context_exporter_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory state can be exported and accessed via MCP interface.",
+        "Tests verify format."
+      ]
+    },
+    {
+      "id": "openclaw-multi-agent-rl-telemetry-v5",
+      "area": "telemetry",
+      "risk": "low",
+      "status": "todo",
+      "title": "OpenClaw Multi-Agent RL Telemetry v5",
+      "description": "Inspired by OpenClaw trends: Implement real-time RL telemetry streaming for multi-agent workflows via WebSockets.",
+      "allowed_paths": [
+        "magda_agent/telemetry/openclaw_rl_telemetry_v5.py",
+        "tests/test_openclaw_rl_telemetry_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module formats telemetry events to JSON.",
+        "Tests verify WebSocket emission."
+      ]
+    },
+    {
+      "id": "claude-subagent-dependency-graph-exporter-v5",
+      "area": "planning",
+      "risk": "medium",
+      "status": "todo",
+      "title": "Claude Subagent Dependency Graph Exporter v5",
+      "description": "Inspired by Claude Agent SDK task system: Serialize internal dependency graphs into standard task format for external observability.",
+      "allowed_paths": [
+        "magda_agent/planning/dependency_graph_exporter_v5.py",
+        "tests/test_dependency_graph_exporter_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dependency graph exports to standard task format.",
+        "Tests verify JSON export schema."
       ]
     }
   ]

--- a/magda_agent/safety/guard_runtime_policy_v5.py
+++ b/magda_agent/safety/guard_runtime_policy_v5.py
@@ -1,0 +1,115 @@
+import logging
+import asyncio
+from typing import Any, Callable, Dict, Tuple, List, Optional
+from magda_agent.safety.policy import PolicyLayer
+from magda_agent.safety.guardrails import FallbackStrategy, SecurityViolationError
+
+class DynamicRule:
+    """
+    Interface for a dynamic context rule.
+    """
+    def evaluate(self, tool_name: str, **kwargs: Any) -> Tuple[bool, str]:
+        """
+        Evaluates the tool call.
+        Returns (True, "Allowed...") or (False, "Denied because...").
+        """
+        return True, "Default allow."
+
+class DynamicPolicyManager:
+    """
+    Manages and evaluates dynamic context rules.
+    """
+    def __init__(self) -> None:
+        self.rules: List[DynamicRule] = []
+
+    def add_rule(self, rule: DynamicRule) -> None:
+        """
+        Registers a dynamic rule.
+        """
+        self.rules.append(rule)
+
+    def evaluate(self, tool_name: str, **kwargs: Any) -> Tuple[bool, str]:
+        """
+        Evaluates all rules. If any rule denies, returns False and its explanation.
+        """
+        for rule in self.rules:
+            allow, explanation = rule.evaluate(tool_name, **kwargs)
+            if not allow:
+                return False, explanation
+        return True, "All dynamic rules allowed."
+
+class AgentGuardRuntimePolicyV5:
+    """
+    A robust runtime policy layer that intercepts tool executions based on
+    dynamic context rules, falling back to the static policy layer if allowed.
+    """
+    def __init__(self, policy_layer: PolicyLayer, default_strategy: FallbackStrategy = FallbackStrategy.STOP_EXECUTION):
+        self.policy_layer = policy_layer
+        self.dynamic_manager = DynamicPolicyManager()
+        self.default_strategy = default_strategy
+
+    def add_dynamic_rule(self, rule: DynamicRule) -> None:
+        """
+        Adds a dynamic rule to the policy manager.
+        """
+        self.dynamic_manager.add_rule(rule)
+
+    def check_action(self, tool_name: str, **kwargs: Any) -> Tuple[bool, str, FallbackStrategy]:
+        """
+        Checks dynamic rules first, then static policy.
+        """
+        dyn_allow, dyn_expl = self.dynamic_manager.evaluate(tool_name, **kwargs)
+        if not dyn_allow:
+            logging.warning(f"AgentGuardRuntimePolicyV5: Dynamic rule blocked '{tool_name}'. Reason: {dyn_expl}")
+            return False, dyn_expl, self.default_strategy
+
+        stat_allow, stat_expl = self.policy_layer.evaluate(tool_name, **kwargs)
+        if not stat_allow:
+            logging.warning(f"AgentGuardRuntimePolicyV5: Static rule blocked '{tool_name}'. Reason: {stat_expl}")
+            return False, stat_expl, self.default_strategy
+
+        return True, "Allowed", FallbackStrategy.NONE
+
+    def execute_with_guardrails(self, tool_func: Callable, tool_name: str, **kwargs: Any) -> Any:
+        """
+        Executes the given tool function if allowed by dynamic and static policies.
+        Supports both sync and async.
+        """
+        allow, explanation, strategy = self.check_action(tool_name, **kwargs)
+
+        def handle_fallback() -> Any:
+            if strategy == FallbackStrategy.STOP_EXECUTION:
+                raise SecurityViolationError(f"Action '{tool_name}' blocked: {explanation}")
+            elif strategy == FallbackStrategy.REQUEST_REVIEW:
+                return f"Review requested for action '{tool_name}': {explanation}"
+            elif strategy == FallbackStrategy.WARN_AND_CONTINUE:
+                return f"Warning: {explanation}. Action '{tool_name}' skipped."
+            return f"Action '{tool_name}' blocked: {explanation}"
+
+        if not allow:
+            if asyncio.iscoroutinefunction(tool_func):
+                async def async_fallback() -> Any:
+                    return handle_fallback()
+                return async_fallback()
+            return handle_fallback()
+
+        if asyncio.iscoroutinefunction(tool_func):
+            async def async_exec() -> Any:
+                try:
+                    return await tool_func(**kwargs)
+                except asyncio.CancelledError:
+                    logging.warning(f"Action '{tool_name}' interrupted (CancelledError).")
+                    raise
+                except Exception as e:
+                    logging.error(f"Error executing tool '{tool_name}': {e}")
+                    return f"Action '{tool_name}' failed during execution: {str(e)}"
+            return async_exec()
+        else:
+            try:
+                return tool_func(**kwargs)
+            except KeyboardInterrupt:
+                logging.warning(f"Action '{tool_name}' interrupted (KeyboardInterrupt).")
+                raise
+            except Exception as e:
+                logging.error(f"Error executing tool '{tool_name}': {e}")
+                return f"Action '{tool_name}' failed during execution: {str(e)}"

--- a/tests/test_guard_runtime_policy_v5.py
+++ b/tests/test_guard_runtime_policy_v5.py
@@ -1,0 +1,81 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock
+from magda_agent.safety.policy import PolicyLayer
+from magda_agent.safety.guardrails import FallbackStrategy, SecurityViolationError
+from magda_agent.safety.guard_runtime_policy_v5 import AgentGuardRuntimePolicyV5, DynamicRule
+
+class AlwaysDenyRule(DynamicRule):
+    def evaluate(self, tool_name: str, **kwargs) -> tuple:
+        return False, "Denied by dynamic rule"
+
+class AlwaysAllowRule(DynamicRule):
+    def evaluate(self, tool_name: str, **kwargs) -> tuple:
+        return True, "Allowed by dynamic rule"
+
+def test_dynamic_rule_blocks_action() -> None:
+    """Tests that a dynamic rule correctly blocks an action."""
+    mock_policy = MagicMock(spec=PolicyLayer)
+    # The static policy would allow it, but dynamic should block it first
+    mock_policy.evaluate.return_value = (True, "Allowed by static")
+
+    guard = AgentGuardRuntimePolicyV5(mock_policy)
+    guard.add_dynamic_rule(AlwaysDenyRule())
+
+    mock_tool = MagicMock()
+
+    with pytest.raises(SecurityViolationError, match="Action 'test_tool' blocked: Denied by dynamic rule"):
+        guard.execute_with_guardrails(mock_tool, "test_tool")
+
+    mock_tool.assert_not_called()
+    # Static policy shouldn't even be reached if dynamic blocks
+    mock_policy.evaluate.assert_not_called()
+
+def test_static_policy_blocks_action_after_dynamic_allows() -> None:
+    """Tests that the static policy can block an action even if dynamic rules allow it."""
+    mock_policy = MagicMock(spec=PolicyLayer)
+    mock_policy.evaluate.return_value = (False, "Blocked by static")
+
+    guard = AgentGuardRuntimePolicyV5(mock_policy)
+    guard.add_dynamic_rule(AlwaysAllowRule())
+
+    mock_tool = MagicMock()
+
+    with pytest.raises(SecurityViolationError, match="Action 'test_tool' blocked: Blocked by static"):
+        guard.execute_with_guardrails(mock_tool, "test_tool")
+
+    mock_tool.assert_not_called()
+    mock_policy.evaluate.assert_called_once_with("test_tool")
+
+def test_allowed_action_executes() -> None:
+    """Tests that an action is executed when both dynamic and static policies allow it."""
+    mock_policy = MagicMock(spec=PolicyLayer)
+    mock_policy.evaluate.return_value = (True, "Allowed by static")
+
+    guard = AgentGuardRuntimePolicyV5(mock_policy)
+    guard.add_dynamic_rule(AlwaysAllowRule())
+
+    mock_tool = MagicMock(return_value="Success")
+
+    result = guard.execute_with_guardrails(mock_tool, "safe_tool", arg="value")
+    assert result == "Success"
+    mock_tool.assert_called_once_with(arg="value")
+    mock_policy.evaluate.assert_called_once_with("safe_tool", arg="value")
+
+@pytest.mark.asyncio
+async def test_allowed_action_async_tool() -> None:
+    """Tests that an async tool executes when allowed."""
+    mock_policy = MagicMock(spec=PolicyLayer)
+    mock_policy.evaluate.return_value = (True, "Allowed by static")
+
+    guard = AgentGuardRuntimePolicyV5(mock_policy)
+    guard.add_dynamic_rule(AlwaysAllowRule())
+
+    async def async_mock_tool(arg: str) -> str:
+        return "Async Success"
+
+    result_coro = guard.execute_with_guardrails(async_mock_tool, "safe_async_tool", arg="value")
+    assert asyncio.iscoroutine(result_coro)
+    result = await result_coro
+    assert result == "Async Success"
+    mock_policy.evaluate.assert_called_once_with("safe_async_tool", arg="value")


### PR DESCRIPTION
Implemented Agent Guard Runtime Policy v5 as per docs/trends.md.
Also added new tasks into agent_tasks.json and updated the task status.

---
*PR created automatically by Jules for task [17914121450045744687](https://jules.google.com/task/17914121450045744687) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement Agent Guard Runtime Policy v5 with dynamic and static rule evaluation
> - Adds [`AgentGuardRuntimePolicyV5`](https://github.com/kazah4359-lgtm/Magda-agent/pull/462/files#diff-1669a48071a21efca7f8d923b43e8463c8a60f79590a84ce5c5d671e94143b9b) which composes a static `PolicyLayer` with a `DynamicPolicyManager` that evaluates an ordered list of `DynamicRule` instances, short-circuiting on first denial.
> - `check_action` evaluates dynamic rules before the static policy, returning an allow/deny decision plus a `FallbackStrategy` (default: `STOP_EXECUTION`).
> - `execute_with_guardrails` runs sync or async tool functions when allowed, and raises `SecurityViolationError`, returns a review message, or logs a warning based on the configured fallback strategy.
> - Adds tests covering dynamic denial precedence, static denial after dynamic allow, and sync/async execution paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecf9c55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->