### PR TITLE
Implement Context Engine Plugin v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7537,7 +7537,7 @@
     },
     {
       "id": "context-engine-plugin-v5-48fa1bc2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine Plugin v5",
@@ -16286,6 +16286,57 @@
       "acceptance": [
         "Dependency graph exports to standard task format.",
         "Tests verify JSON export schema."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-visualization-v6",
+      "title": "OpenClaw RL Canvas Metrics Visualization v6",
+      "description": "Inspired by OpenClaw trends: Stream RL performance metrics to the Canvas Live Visualization using a newer v6 format.",
+      "area": "visualization",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/visualization/rl_canvas_metrics_v6.py",
+        "tests/test_rl_canvas_metrics_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL metrics are streamed to Canvas in v6 format",
+        "Tests mock WebSocket and check payload"
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v11",
+      "title": "MCP Action Tool Exporter V11",
+      "description": "Inspired by MCP standards: Enhance the MCP exporter to handle advanced runtime concurrency and dynamic schema updates for v11.",
+      "area": "skills",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_exporter_v11.py",
+        "tests/test_mcp_exporter_v11.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Exporter V11 can handle dynamic schemas.",
+        "Tests verify concurrent updates."
+      ]
+    },
+    {
+      "id": "claude-subagent-teams-isolation-v11",
+      "title": "Claude Subagent Teams Isolation v11",
+      "description": "Inspired by Claude Agent SDK: Ensure git worktree isolation for hierarchical subagent spawns (v11 iteration).",
+      "area": "architecture",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/teams_isolation_v11.py",
+        "tests/test_teams_isolation_v11.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagents operate in isolated worktrees",
+        "Tests check path isolation logic"
       ]
     }
   ]

--- a/magda_agent/memory/context_engine_v5.py
+++ b/magda_agent/memory/context_engine_v5.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Callable, Any, Optional, List, Dict
+import inspect
+from magda_agent.architecture.context_hooks_v5 import HookRegistry
+from magda_agent.memory.context_engine import ContextEngine, ContextPlugin
+
+class DynamicHookRegistry(HookRegistry):
+    """
+    Extends HookRegistry with the ability to unregister hooks dynamically.
+    """
+    def unregister_hook(self, hook_type: str, callback: Callable) -> None:
+        """Removes a previously registered callback for a specific hook type."""
+        if hook_type in self._hooks:
+            # We want to remove the specific callback.
+            try:
+                self._hooks[hook_type].remove(callback)
+                callback_name = getattr(callback, '__name__', str(callback))
+                logging.debug(f"Unregistered hook '{hook_type}': {callback_name}")
+            except ValueError:
+                # Callback was not in the list for this hook_type
+                logging.warning(f"Attempted to unregister a hook '{hook_type}' that was not registered.")
+        else:
+            logging.warning(f"Attempted to unregister from an unknown hook type '{hook_type}'.")
+
+
+class ContextEngineV5(ContextEngine):
+    """
+    ContextEngineV5 manages context dynamically using a plugin architecture
+    with lifecycle hooks, supporting dynamic addition and removal of plugins.
+    """
+    def __init__(self, plugins: Optional[List[ContextPlugin]] = None, llm: Optional[Any] = None) -> None:
+        # Initialize base attributes
+        self._plugins: List[ContextPlugin] = []
+        self.llm = llm
+
+        # Override hook_registry with our dynamic version
+        self.hook_registry = DynamicHookRegistry()
+
+        if plugins:
+            for plugin in plugins:
+                self.register_plugin(plugin)
+
+    def unregister_plugin(self, plugin: ContextPlugin) -> None:
+        """Unregisters an existing plugin from the context engine."""
+        if plugin not in self._plugins:
+            logging.warning(f"Attempted to unregister plugin {plugin.__class__.__name__} which is not registered.")
+            return
+
+        # Remove from plugin list
+        self._plugins.remove(plugin)
+
+        # Unregister Sync hooks
+        if hasattr(plugin, 'before_retrieval'):
+            self.hook_registry.unregister_hook('before_retrieval', plugin.before_retrieval)
+        if hasattr(plugin, 'after_retrieval'):
+            self.hook_registry.unregister_hook('after_retrieval', plugin.after_retrieval)
+        if hasattr(plugin, 'on_context_update'):
+            self.hook_registry.unregister_hook('on_context_update', plugin.on_context_update)
+        if hasattr(plugin, 'before_write'):
+            self.hook_registry.unregister_hook('before_write', plugin.before_write)
+        if hasattr(plugin, 'after_write'):
+            self.hook_registry.unregister_hook('after_write', plugin.after_write)
+
+        # Unregister Async and common lifecycle hooks
+        if hasattr(plugin, 'bootstrap'):
+            self.hook_registry.unregister_hook('bootstrap', plugin.bootstrap)
+        if hasattr(plugin, 'ingest'):
+            self.hook_registry.unregister_hook('ingest', plugin.ingest)
+        if hasattr(plugin, 'assemble'):
+            self.hook_registry.unregister_hook('assemble', plugin.assemble)
+        if hasattr(plugin, 'compact'):
+            self.hook_registry.unregister_hook('compact', plugin.compact)
+
+        logging.debug(f"Unregistered plugin: {plugin.__class__.__name__}")

--- a/tests/test_context_engine_v5.py
+++ b/tests/test_context_engine_v5.py
@@ -1,0 +1,131 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from typing import Any
+from magda_agent.memory.context_engine_v5 import ContextEngineV5, DynamicHookRegistry
+from magda_agent.memory.context_engine import ContextPlugin
+
+class MockDynamicPlugin(ContextPlugin):
+    def __init__(self, prefix=""):
+        self.prefix = prefix
+        self.bootstrap_called = False
+        self.ingest_called = False
+        self.assemble_called = False
+        self.compact_called = False
+
+    async def bootstrap(self, config):
+        self.bootstrap_called = True
+
+    async def ingest(self, content, metadata):
+        self.ingest_called = True
+        return f"{self.prefix}ingested_{content}"
+
+    async def assemble(self, context_items, metadata):
+        self.assemble_called = True
+        return f"{self.prefix}assembled_context"
+
+    async def compact(self, context_items, metadata):
+        self.compact_called = True
+        return context_items[:-1] if context_items else []
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        return f"{self.prefix}{query}"
+
+    def after_retrieval(self, context: list, query: str, user_id: int) -> list:
+        return context
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        pass
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        pass
+
+
+def test_dynamic_hook_registry_unregister() -> None:
+    """Test that dynamic hook registry can unregister hooks."""
+    registry = DynamicHookRegistry()
+
+    mock_func = MagicMock(return_value="hooked")
+
+    # Test registration
+    registry.register_hook("custom_hook", mock_func)
+    assert len(registry._hooks["custom_hook"]) == 1
+
+    # Test execution
+    result = registry.trigger_hook("custom_hook", "arg")
+    assert result == "hooked"
+    mock_func.assert_called_once_with("arg")
+
+    # Test unregistration
+    registry.unregister_hook("custom_hook", mock_func)
+    assert len(registry._hooks["custom_hook"]) == 0
+
+    # Test execution after unregistration
+    result_after = registry.trigger_hook("custom_hook", "arg2")
+    assert result_after == "arg2" # Fallback behavior returns first arg
+    assert mock_func.call_count == 1 # Still 1, wasn't called again
+
+
+@pytest.mark.asyncio
+async def test_context_engine_v5_dynamic_plugin_registration() -> None:
+    """Test that ContextEngineV5 can dynamically register and unregister plugins."""
+    engine = ContextEngineV5()
+
+    plugin1 = MockDynamicPlugin(prefix="p1_")
+    plugin2 = MockDynamicPlugin(prefix="p2_")
+
+    # Register plugin1
+    engine.register_plugin(plugin1)
+
+    # Verify plugin1 hooks are active
+    assert engine.hook_registry.trigger_hook('before_retrieval', "query", 1) == "p1_query"
+    assert len(engine._plugins) == 1
+
+    # Register plugin2
+    engine.register_plugin(plugin2)
+    assert len(engine._plugins) == 2
+
+    # Verify chain of hooks.
+    # 'query' -> p1_before_retrieval -> 'p1_query' -> p2_before_retrieval -> 'p2_p1_query'
+    assert engine.hook_registry.trigger_hook('before_retrieval', "query", 1) == "p2_p1_query"
+
+    # Unregister plugin1
+    engine.unregister_plugin(plugin1)
+    assert len(engine._plugins) == 1
+    assert plugin1 not in engine._plugins
+
+    # Verify plugin1 hooks are gone, plugin2 hooks are active
+    # 'query' -> p2_before_retrieval -> 'p2_query'
+    assert engine.hook_registry.trigger_hook('before_retrieval', "query", 1) == "p2_query"
+
+    # Unregister plugin2
+    engine.unregister_plugin(plugin2)
+    assert len(engine._plugins) == 0
+
+    # Verify all hooks are gone
+    assert engine.hook_registry.trigger_hook('before_retrieval', "query", 1) == "query"
+
+def test_unregister_unregistered_plugin() -> None:
+    """Test unregistering a plugin that is not registered."""
+    engine = ContextEngineV5()
+    plugin1 = MockDynamicPlugin()
+
+    # Should not raise any errors, just log a warning
+    engine.unregister_plugin(plugin1)
+    assert len(engine._plugins) == 0
+
+def test_unregister_unregistered_hook() -> None:
+    """Test unregistering a hook that is not registered."""
+    registry = DynamicHookRegistry()
+    mock_func = MagicMock()
+
+    # Should not raise any errors, just log a warning
+    registry.unregister_hook("nonexistent_hook", mock_func)
+
+    registry.register_hook("existing_hook", mock_func)
+    mock_func2 = MagicMock()
+    # Unregistering a function that wasn't registered for this hook
+    registry.unregister_hook("existing_hook", mock_func2)
+    assert len(registry._hooks["existing_hook"]) == 1


### PR DESCRIPTION
Implement Context Engine Plugin v5

---
*PR created automatically by Jules for task [3316597893426978671](https://jules.google.com/task/3316597893426978671) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement Context Engine Plugin v5 with dynamic hook unregistration
> - Adds [`ContextEngineV5`](https://github.com/kazah4359-lgtm/Magda-agent/pull/463/files#diff-6ce3671b4156ac95329c1da95f952ed558662d90e25ca1621fa1628847c283ef) backed by a new `DynamicHookRegistry` that extends `HookRegistry` with an `unregister_hook` method, allowing previously registered callbacks to be removed.
> - Adds `unregister_plugin` to `ContextEngineV5`, which removes the plugin and cleans up all its sync and async hooks (e.g. `before_retrieval`, `after_retrieval`, `ingest`, `compact`).
> - Covers the new behavior with tests for chained hook effects, no-op unregistration of missing plugins, and graceful handling of unknown hook types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 74bb36a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

----
## Summary by Gitar

- **Core Architecture:**
  - Introduced `ContextEngineV5` to support dynamic plugin management and lifecycle hooks.
  - Added `DynamicHookRegistry` to enable runtime unregistration of specific callback hooks.
- **Plugin Management:**
  - Implemented `unregister_plugin` to automatically remove all associated lifecycle hooks from the engine.
- **Testing:**
  - Added `test_context_engine_v5.py` to verify dynamic registration, unregistration, and hook cleanup logic.
- **Task Tracking:**
  - Updated `agent_tasks.json` to mark the `context-engine-plugin-v5` task as done and added new task placeholders.

<sub>This will update automatically on new commits.</sub>