### PR TITLE
Implement Claude Multi Agent Teams v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7554,7 +7554,7 @@
     },
     {
       "id": "claude-multi-agent-v2-38d01b1a",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "Claude Multi Agent Teams v2",
@@ -16337,6 +16337,57 @@
       "acceptance": [
         "Subagents operate in isolated worktrees",
         "Tests check path isolation logic"
+      ]
+    },
+    {
+      "id": "claude-subagent-dependency-graph-visualizer-v2",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude Subagent Dependency Graph Visualizer v2",
+      "description": "Inspired by Claude Agent Teams trend: Create a visualizer module that converts internal subagent dependency graphs into a visual format (like Mermaid JS) for debugging and observability.",
+      "allowed_paths": [
+        "magda_agent/agents/multi_agent_visualizer.py",
+        "tests/test_multi_agent_visualizer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Visualizer correctly converts DAG to Mermaid representation.",
+        "Tests verify visualizer output."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-prefixed-registry-v4",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Action Tool Prefixed Registry v4",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a robust dynamic tool registry that allows automatic runtime prefixing of tool names based on their MCP server to prevent name collisions in multi-server setups.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_prefixed_registry.py",
+        "tests/test_mcp_prefixed_registry.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tools are registered with their respective MCP server prefixes.",
+        "Tests verify tool retrieval by prefixed name."
+      ]
+    },
+    {
+      "id": "openclaw-rl-metrics-aggregator-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "title": "OpenClaw RL Metrics Aggregator v2",
+      "description": "Inspired by OpenClaw trends: Implement a metrics aggregator that batches fine-grained online reinforcement learning signals into larger trajectory updates to reduce noise during model tuning.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_aggregator_v2.py",
+        "tests/test_rl_aggregator_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Aggregator successfully batches RL signals into trajectory updates.",
+        "Tests verify metric batching logic and calculations."
       ]
     }
   ]

--- a/magda_agent/agents/multi_agent_v2.py
+++ b/magda_agent/agents/multi_agent_v2.py
@@ -1,0 +1,90 @@
+import asyncio
+from typing import List, Dict, Any, Optional, Callable
+import logging
+
+class DAGMultiAgentPlanner:
+    """
+    A multi-agent task execution planner that handles dependency graphs (DAGs) internally
+    to process sub-agent tasks in parallel when they don't have dependencies.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the DAG planner.
+        """
+        self.tasks: Dict[str, Dict[str, Any]] = {}
+
+    def add_task(self, task_id: str, payload: Any, dependencies: Optional[List[str]] = None) -> None:
+        """
+        Adds a task to the DAG.
+
+        Args:
+            task_id (str): Unique identifier for the task.
+            payload (Any): The payload or context for the task.
+            dependencies (Optional[List[str]]): List of task IDs that this task depends on.
+        """
+        self.tasks[task_id] = {
+            "id": task_id,
+            "payload": payload,
+            "dependencies": dependencies or [],
+            "completed": False,
+            "result": None
+        }
+
+    async def execute_dag(self, mock_executor: Optional[Callable[[Any], Any]] = None) -> Dict[str, Any]:
+        """
+        Executes the entire DAG, running independent tasks in parallel.
+
+        Args:
+            mock_executor (Optional[Callable[[Any], Any]]): An optional async function to execute tasks.
+                                                            If None, a default mock is used.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping task_id to its result.
+        """
+        task_futures: Dict[str, asyncio.Future] = {}
+        for task_id in self.tasks:
+            task_futures[task_id] = asyncio.Future()
+
+        async def run_task(task_id: str) -> None:
+            task = self.tasks[task_id]
+
+            try:
+                # Wait for all dependencies
+                for dep_id in task["dependencies"]:
+                    if dep_id not in task_futures:
+                        raise ValueError(f"Dependency {dep_id} for task {task_id} not found in DAG.")
+                    await task_futures[dep_id]
+
+                # Execute the task
+                if mock_executor:
+                    result = await mock_executor(task["payload"])
+                else:
+                    # Default mock behavior if no executor provided
+                    result = f"Result of {task_id}"
+
+                task["completed"] = True
+                task["result"] = result
+                if not task_futures[task_id].done():
+                    task_futures[task_id].set_result(result)
+            except Exception as e:
+                if not task_futures[task_id].done():
+                    task_futures[task_id].set_exception(e)
+                raise
+
+        # Create all tasks
+        execution_tasks = [asyncio.create_task(run_task(task_id)) for task_id in self.tasks]
+
+        # Wait for all to complete
+        if execution_tasks:
+            results = await asyncio.gather(*execution_tasks, return_exceptions=True)
+            for res in results:
+                if isinstance(res, Exception):
+                    # To prevent "Future exception was never retrieved", we need to ensure all futures that have an exception are read.
+                    # A simple way to do this is to just call exception() on all of them here since we're going to raise anyway.
+                    for future in task_futures.values():
+                        if future.done() and not future.cancelled():
+                            future.exception()
+                    raise res
+
+        return {task_id: self.tasks[task_id]["result"] for task_id in self.tasks}

--- a/tests/test_multi_agent_v2.py
+++ b/tests/test_multi_agent_v2.py
@@ -1,0 +1,91 @@
+import pytest
+import asyncio
+from magda_agent.agents.multi_agent_v2 import DAGMultiAgentPlanner
+
+@pytest.mark.asyncio
+async def test_dag_multi_agent_planner_execution():
+    """
+    Test that the DAGMultiAgentPlanner executes tasks in the correct order based on dependencies.
+    """
+    planner = DAGMultiAgentPlanner()
+
+    planner.add_task("task1", "payload1")
+    planner.add_task("task2", "payload2", dependencies=["task1"])
+    planner.add_task("task3", "payload3", dependencies=["task1"])
+    planner.add_task("task4", "payload4", dependencies=["task2", "task3"])
+
+    execution_order = []
+
+    async def mock_executor(payload):
+        # Record execution order based on payload
+        execution_order.append(payload)
+        await asyncio.sleep(0.01) # Simulate some work to allow event loop to switch context
+        return f"processed_{payload}"
+
+    results = await planner.execute_dag(mock_executor=mock_executor)
+
+    # task1 must be first
+    assert execution_order[0] == "payload1"
+
+    # task2 and task3 can be in any order, but must be in positions 1 and 2
+    assert set(execution_order[1:3]) == {"payload2", "payload3"}
+
+    # task4 must be last
+    assert execution_order[3] == "payload4"
+
+    assert results["task1"] == "processed_payload1"
+    assert results["task2"] == "processed_payload2"
+    assert results["task3"] == "processed_payload3"
+    assert results["task4"] == "processed_payload4"
+
+@pytest.mark.asyncio
+async def test_dag_multi_agent_planner_missing_dependency():
+    """
+    Test that the DAGMultiAgentPlanner raises an error when a dependency is missing.
+    """
+    planner = DAGMultiAgentPlanner()
+    planner.add_task("task1", "payload1", dependencies=["missing_task"])
+
+    with pytest.raises(ValueError, match="Dependency missing_task for task task1 not found in DAG."):
+        try:
+            await planner.execute_dag()
+        finally:
+            # Clean up pending tasks to avoid "Task was destroyed but it is pending"
+            for task in asyncio.all_tasks():
+                if task is not asyncio.current_task():
+                    task.cancel()
+
+@pytest.mark.asyncio
+async def test_dag_multi_agent_planner_default_executor():
+    """
+    Test that the DAGMultiAgentPlanner uses a default executor when none is provided.
+    """
+    planner = DAGMultiAgentPlanner()
+    planner.add_task("task1", "payload1")
+
+    results = await planner.execute_dag()
+    assert results["task1"] == "Result of task1"
+
+
+@pytest.mark.asyncio
+async def test_dag_multi_agent_planner_exception_handling():
+    """
+    Test that the DAGMultiAgentPlanner correctly handles exceptions in tasks and prevents deadlocks.
+    """
+    planner = DAGMultiAgentPlanner()
+
+    planner.add_task("task1", "payload1")
+    planner.add_task("task2", "payload2", dependencies=["task1"])
+
+    async def mock_executor_with_error(payload):
+        if payload == "payload1":
+            raise RuntimeError("Task failed")
+        return f"processed_{payload}"
+
+    with pytest.raises(RuntimeError, match="Task failed"):
+        try:
+            await planner.execute_dag(mock_executor=mock_executor_with_error)
+        finally:
+            for task in asyncio.all_tasks():
+                if task is not asyncio.current_task():
+                    task.cancel()


### PR DESCRIPTION
Implement Claude Multi Agent Teams v2

---
*PR created automatically by Jules for task [15471297033020583233](https://jules.google.com/task/15471297033020583233) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **New DAG Planner:**
  - Added `DAGMultiAgentPlanner` in `multi_agent_v2.py` to handle asynchronous task dependency execution.
  - Implemented parallel execution for independent tasks using `asyncio.Future` and `asyncio.gather`.
- **Task Management:**
  - Updated `agent_tasks.json` to mark the current task as done and added several new upcoming tasks.
- **Testing:**
  - Added `test_multi_agent_v2.py` covering successful dependency resolution, missing dependency errors, and exception handling.

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DAG-based async multi-agent task planner with parallel execution
> - Introduces `DAGMultiAgentPlanner` in [multi_agent_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/464/files#diff-30f7cce3611774e302f5074da33bfdf9a3f88ecab1050af50f4e98835b3f90df), which registers tasks with dependencies and executes them concurrently when their dependencies are satisfied.
> - Tasks are executed as asyncio futures; independent tasks run in parallel while dependent tasks await their predecessors' futures before starting.
> - Raises `ValueError` when a declared dependency is not registered, and propagates the first task exception while draining remaining futures to avoid unhandled warnings.
> - Adds four test cases covering dependency ordering, missing dependencies, default executor output, and exception propagation.
> - Risk: no timeout or cancellation policy on long-running tasks; a stalled task will block all downstream dependents indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed579e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->