### PR TITLE
Implement MCP server-prefixed tools v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7571,7 +7571,7 @@
     },
     {
       "id": "mcp-server-prefixed-tools-v3-8d19abf1",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Server-Prefixed Tools v3",
@@ -16388,6 +16388,57 @@
       "acceptance": [
         "Aggregator successfully batches RL signals into trajectory updates.",
         "Tests verify metric batching logic and calculations."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-signals-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Multimodal Signals v1",
+      "description": "Enhance OpenClaw-RL to support multimodal next-state signals like image understanding and reaction latency.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_multimodal.py",
+        "tests/test_openclaw_rl_multimodal.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL can process multimodal signals.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-subagent-memory-compression-v2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "Claude Subagent Memory Compression v2",
+      "description": "Implement hierarchical memory compression for subagents dynamically scaling their virtual context window.",
+      "allowed_paths": [
+        "magda_agent/agents/compression_v2.py",
+        "tests/test_compression_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Memory is correctly compressed.",
+        "Tests verify context sizes."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-marketplace-v3",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Agent Skills Marketplace Integration v3",
+      "description": "Provide a standard interface to publish and install skills dynamically from an agentskills.io-compatible marketplace.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_v3.py",
+        "tests/test_marketplace_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Marketplace integrations support install and publish.",
+        "Tests mock HTTP interactions correctly."
       ]
     }
   ]

--- a/magda_agent/mcp/prefixed_tools_v3.py
+++ b/magda_agent/mcp/prefixed_tools_v3.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Dict, Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+class MCPServerPrefixedToolsV3:
+    """
+    Manages MCP action tools by automatically prefixing their names with a server ID.
+    Inspired by OpenAI Agents SDK tool namespacing.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the MCPServerPrefixedToolsV3.
+        """
+        self.tools: Dict[str, Dict[str, Any]] = {}
+
+    def format_tool_name(self, server_id: str, tool_name: str) -> str:
+        """
+        Formats a tool name with the given server ID prefix.
+
+        Args:
+            server_id: The ID of the MCP server.
+            tool_name: The original name of the tool.
+
+        Returns:
+            The prefixed tool name string.
+        """
+        return f"{server_id}_{tool_name}"
+
+    def register_tool(self, server_id: str, tool_name: str, description: str, input_schema: Dict[str, Any]) -> str:
+        """
+        Registers a tool with an automatic server prefix.
+
+        Args:
+            server_id: The ID of the MCP server providing the tool.
+            tool_name: The original name of the tool.
+            description: A description of the tool.
+            input_schema: JSON schema for tool inputs.
+
+        Returns:
+            The prefixed name under which the tool was registered.
+        """
+        prefixed_name = self.format_tool_name(server_id, tool_name)
+
+        self.tools[prefixed_name] = {
+            "name": prefixed_name,
+            "original_name": tool_name,
+            "server_id": server_id,
+            "description": description,
+            "inputSchema": input_schema,
+            "is_action": True
+        }
+
+        logger.info(f"Registered MCP prefixed tool: {prefixed_name}")
+        return prefixed_name
+
+    def get_tool(self, prefixed_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Retrieves a tool's metadata using its prefixed name.
+
+        Args:
+            prefixed_name: The namespaced tool name.
+
+        Returns:
+            The tool metadata dict if found, else None.
+        """
+        return self.tools.get(prefixed_name)
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists all registered prefixed tools.
+
+        Returns:
+            A list of tool metadata dictionaries.
+        """
+        return list(self.tools.values())

--- a/tests/test_prefixed_tools_v3.py
+++ b/tests/test_prefixed_tools_v3.py
@@ -1,0 +1,41 @@
+import pytest
+from magda_agent.mcp.prefixed_tools_v3 import MCPServerPrefixedToolsV3
+
+def test_format_tool_name():
+    manager = MCPServerPrefixedToolsV3()
+    assert manager.format_tool_name("server1", "my_tool") == "server1_my_tool"
+
+def test_register_and_get_tool():
+    manager = MCPServerPrefixedToolsV3()
+
+    prefixed_name = manager.register_tool(
+        server_id="test_server",
+        tool_name="search",
+        description="Search tool",
+        input_schema={"type": "object", "properties": {"q": {"type": "string"}}}
+    )
+
+    assert prefixed_name == "test_server_search"
+
+    tool = manager.get_tool("test_server_search")
+    assert tool is not None
+    assert tool["name"] == "test_server_search"
+    assert tool["original_name"] == "search"
+    assert tool["server_id"] == "test_server"
+    assert tool["description"] == "Search tool"
+    assert "q" in tool["inputSchema"]["properties"]
+
+def test_get_nonexistent_tool():
+    manager = MCPServerPrefixedToolsV3()
+    assert manager.get_tool("missing_tool") is None
+
+def test_list_tools():
+    manager = MCPServerPrefixedToolsV3()
+    manager.register_tool("srv1", "toolA", "descA", {})
+    manager.register_tool("srv2", "toolA", "descB", {})
+
+    tools = manager.list_tools()
+    assert len(tools) == 2
+    names = {t["name"] for t in tools}
+    assert "srv1_toolA" in names
+    assert "srv2_toolA" in names


### PR DESCRIPTION
Implementation of MCPServerPrefixedToolsV3.

---
*PR created automatically by Jules for task [6798667752711101456](https://jules.google.com/task/6798667752711101456) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **New MCP management:**
  - Implemented `MCPServerPrefixedToolsV3` to namespace tools with server ID prefixes.
  - Added support for registering, retrieving, and listing prefixed MCP tools.
- **Testing:**
  - Added `test_prefixed_tools_v3.py` to verify tool name formatting and registration logic.
- **Task tracking:**
  - Updated `agent_tasks.json` to mark the current task as done and added three new pending tasks for future development.


<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPServerPrefixedToolsV3` class to namespace MCP tools by server ID
> Introduces [`MCPServerPrefixedToolsV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/465/files#diff-2c0230ebff64ae710628aa60792a85eae02b9369747a1632dc278e853a5d39e1) to manage MCP action tools under server-prefixed names (e.g. `serverid_toolname`). The class supports registering tools with metadata, looking them up by prefixed name, and listing all registered tools. Tests covering all three operations are added in [`tests/test_prefixed_tools_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/465/files#diff-822fd668dbe88c9559d8b501fbd0eb5b791e52d417c7637c5b70f06e5ab5057e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f97e795.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->