### PR TITLE
feat(safety): Implement MCPKernel Sandboxed Execution v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7588,7 +7588,7 @@
     },
     {
       "id": "mcp-kernel-sandboxed-execution-v5-new-1234",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCPKernel Sandboxed Execution v5",
@@ -16439,6 +16439,57 @@
       "acceptance": [
         "Marketplace integrations support install and publish.",
         "Tests mock HTTP interactions correctly."
+      ]
+    },
+    {
+      "id": "mcp-action-tools-v9-new-101",
+      "status": "todo",
+      "area": "mcp",
+      "risk": "medium",
+      "title": "MCP Action Tools v9",
+      "description": "Support runtime function tool concurrency inspired by OpenAI Agents SDK.",
+      "allowed_paths": [
+        "magda_agent/mcp/action_tools_v9.py",
+        "tests/test_action_tools_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Concurrent tool executions are handled correctly.",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "a2a-enterprise-tracing-v9-new-102",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Enterprise Tracing v9",
+      "description": "Enterprise-ready distributed tracing for A2A delegation streams.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_tracing_v9.py",
+        "tests/test_a2a_tracing_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A streams are properly traced.",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "openclaw-rl-v6-new-103",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL v6",
+      "description": "Online reinforcement learning from user replies and tool outputs.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v6.py",
+        "tests/test_openclaw_rl_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Online RL handles next-state signals.",
+        "Tests pass"
       ]
     }
   ]

--- a/magda_agent/safety/sandbox_v5.py
+++ b/magda_agent/safety/sandbox_v5.py
@@ -1,0 +1,119 @@
+"""MCP Kernel Taint Tracking Sandbox v5.
+
+Inspired by MCPKernel taint tracking trend: Sandbox tool execution in containers to improve security.
+Provides a sandbox execution environment for MCP tools with taint tracking, supporting both
+synchronous and asynchronous executions, and timeout limits simulating container resource isolation.
+"""
+import asyncio
+import inspect
+from typing import Any, Callable, Dict, TypeVar
+
+from magda_agent.safety.taint_tracking_v2 import (
+    PolicyViolationError,
+    SandboxExecutionEnvironmentV2,
+    TaintTrackerV2,
+)
+
+T = TypeVar("T")
+
+class ContainerIsolationError(Exception):
+    """Raised when sandbox container limits (like timeouts) are exceeded."""
+    pass
+
+
+class MCPKernelSandboxV5:
+    """
+    Sandbox execution environment with taint tracking capabilities inspired by MCPKernel.
+    Version 5 introduces async support and simulated container-level timeouts.
+    """
+
+    def __init__(self, timeout_seconds: float = 10.0) -> None:
+        """
+        Initialize the MCPKernelSandboxV5.
+
+        Args:
+            timeout_seconds: The maximum time (in seconds) allowed for an async tool to execute
+                             before simulating a container isolation timeout.
+        """
+        self.tracker = TaintTrackerV2()
+        self.sandbox = SandboxExecutionEnvironmentV2(self.tracker)
+        self.timeout_seconds = timeout_seconds
+
+    def execute(self, tool_func: Callable[..., Any], inputs: Dict[str, Any], is_sensitive: bool = False) -> Any:
+        """
+        Executes a synchronous tool within the sandbox boundary.
+
+        Args:
+            tool_func: The synchronous function to execute.
+            inputs: A dictionary of inputs to pass to the function.
+            is_sensitive: If True, execution will fail if inputs contain tainted data.
+
+        Returns:
+            The result of the tool execution, appropriately tainted if inputs were tainted.
+
+        Raises:
+            PolicyViolationError: If is_sensitive is True and inputs contain tainted data.
+            RuntimeError: If the tool execution fails.
+            ValueError: If tool_func is an asynchronous coroutine function.
+        """
+        if inspect.iscoroutinefunction(tool_func):
+            raise ValueError("execute() does not support coroutine functions. Use execute_async() instead.")
+
+        self._check_taint(inputs, is_sensitive)
+
+        try:
+            return self.sandbox.execute(tool_func, **inputs)
+        except PolicyViolationError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Sandbox execution failed: {str(e)}") from e
+
+    async def execute_async(self, tool_func: Callable[..., Any], inputs: Dict[str, Any], is_sensitive: bool = False) -> Any:
+        """
+        Executes an asynchronous tool within the sandbox boundary with timeout limits.
+
+        Args:
+            tool_func: The asynchronous coroutine function to execute.
+            inputs: A dictionary of inputs to pass to the function.
+            is_sensitive: If True, execution will fail if inputs contain tainted data.
+
+        Returns:
+            The result of the async tool execution, appropriately tainted if inputs were tainted.
+
+        Raises:
+            PolicyViolationError: If is_sensitive is True and inputs contain tainted data.
+            ContainerIsolationError: If the execution exceeds the sandbox timeout limit.
+            RuntimeError: If the tool execution fails.
+            ValueError: If tool_func is a regular synchronous function.
+        """
+        if not inspect.iscoroutinefunction(tool_func):
+            raise ValueError("execute_async() requires a coroutine function. Use execute() instead.")
+
+        self._check_taint(inputs, is_sensitive)
+
+        # To propagate taint correctly, we need to gather origins manually here for async functions
+        # since SandboxExecutionEnvironmentV2.execute is synchronous and cannot await.
+        # So we replicate the tracking logic for async wrapper.
+
+        origins = set()
+        for val in inputs.values():
+            origins.update(self.tracker.get_origins(val))
+
+        try:
+            # Enforce container timeout isolation
+            result = await asyncio.wait_for(tool_func(**inputs), timeout=self.timeout_seconds)
+
+            if origins:
+                return self.tracker.taint_with_origins(result, origins)
+            return result
+
+        except asyncio.TimeoutError as e:
+            raise ContainerIsolationError(f"Execution timed out after {self.timeout_seconds} seconds") from e
+        except Exception as e:
+            raise RuntimeError(f"Sandbox async execution failed: {str(e)}") from e
+
+    def _check_taint(self, inputs: Dict[str, Any], is_sensitive: bool) -> None:
+        """Check for taint violation if the tool is sensitive."""
+        if is_sensitive and self.tracker.is_tainted(inputs):
+            origins = self.tracker.get_origins(inputs)
+            raise PolicyViolationError(f"Tainted input to sensitive tool call from origins: {origins}")

--- a/tests/test_sandbox_v5.py
+++ b/tests/test_sandbox_v5.py
@@ -1,0 +1,125 @@
+"""Tests for MCP Kernel Taint Tracking Sandbox v5."""
+
+import asyncio
+import pytest
+
+from magda_agent.safety.sandbox_v5 import MCPKernelSandboxV5, ContainerIsolationError
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError, is_tainted
+
+def sample_sync_tool(data: str) -> str:
+    """A sample synchronous tool."""
+    return f"Processed {data}"
+
+async def sample_async_tool(data: str) -> str:
+    """A sample asynchronous tool."""
+    return f"Processed Async {data}"
+
+async def slow_async_tool(data: str) -> str:
+    """A sample slow asynchronous tool that sleeps."""
+    await asyncio.sleep(0.5)
+    return f"Processed Slow {data}"
+
+def test_sync_safe_inputs_accepted() -> None:
+    """Test that a synchronous tool accepts safe data and returns untainted result."""
+    sandbox = MCPKernelSandboxV5()
+    result = sandbox.execute(sample_sync_tool, {"data": "alice"}, is_sensitive=False)
+    assert "Processed alice" in result
+    assert not is_tainted(result)
+
+def test_sync_taint_propagation_non_sensitive() -> None:
+    """Test that a synchronous tool propagates taint when not sensitive."""
+    sandbox = MCPKernelSandboxV5()
+    tainted_string = sandbox.tracker.taint("DROP TABLE users;", "user_input")
+
+    result = sandbox.execute(sample_sync_tool, {"data": tainted_string}, is_sensitive=False)
+
+    assert "Processed DROP TABLE users;" in result
+    assert is_tainted(result)
+    assert "user_input" in sandbox.tracker.get_origins(result)
+
+def test_sync_sensitive_tool_tainted_input() -> None:
+    """Test that a sensitive sync tool rejects tainted data."""
+    sandbox = MCPKernelSandboxV5()
+    tainted_string = sandbox.tracker.taint("DROP TABLE", "malicious")
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        sandbox.execute(sample_sync_tool, {"data": tainted_string}, is_sensitive=True)
+
+    assert "malicious" in str(exc_info.value)
+
+def test_sync_execution_error_handling() -> None:
+    """Test that sync execution errors are wrapped in RuntimeError."""
+    sandbox = MCPKernelSandboxV5()
+    def failing_tool(data: str) -> str:
+        raise ValueError("Tool failed")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        sandbox.execute(failing_tool, {"data": "alice"}, is_sensitive=False)
+
+    assert "Sandbox execution failed: Tool failed" in str(exc_info.value)
+
+def test_sync_rejects_async_tool() -> None:
+    """Test that execute() rejects async coroutine functions."""
+    sandbox = MCPKernelSandboxV5()
+    with pytest.raises(ValueError) as exc_info:
+        sandbox.execute(sample_async_tool, {"data": "alice"})
+    assert "use execute_async" in str(exc_info.value).lower()
+
+@pytest.mark.asyncio
+async def test_async_safe_inputs_accepted() -> None:
+    """Test that an async tool accepts safe data and returns untainted result."""
+    sandbox = MCPKernelSandboxV5()
+    result = await sandbox.execute_async(sample_async_tool, {"data": "bob"}, is_sensitive=False)
+    assert "Processed Async bob" in result
+    assert not is_tainted(result)
+
+@pytest.mark.asyncio
+async def test_async_taint_propagation() -> None:
+    """Test that an async tool propagates taint when not sensitive."""
+    sandbox = MCPKernelSandboxV5()
+    tainted_string = sandbox.tracker.taint("SELECT *", "db_input")
+
+    result = await sandbox.execute_async(sample_async_tool, {"data": tainted_string}, is_sensitive=False)
+
+    assert "Processed Async SELECT *" in result
+    assert is_tainted(result)
+    assert "db_input" in sandbox.tracker.get_origins(result)
+
+@pytest.mark.asyncio
+async def test_async_sensitive_tool_tainted_input() -> None:
+    """Test that a sensitive async tool rejects tainted data."""
+    sandbox = MCPKernelSandboxV5()
+    tainted_string = sandbox.tracker.taint("DELETE", "hacker")
+
+    with pytest.raises(PolicyViolationError):
+        await sandbox.execute_async(sample_async_tool, {"data": tainted_string}, is_sensitive=True)
+
+@pytest.mark.asyncio
+async def test_async_timeout_enforcement() -> None:
+    """Test that slow async tools timeout due to container isolation limits."""
+    sandbox = MCPKernelSandboxV5(timeout_seconds=0.1) # 100ms timeout
+
+    with pytest.raises(ContainerIsolationError) as exc_info:
+        await sandbox.execute_async(slow_async_tool, {"data": "slowpoke"}, is_sensitive=False)
+
+    assert "timed out" in str(exc_info.value).lower()
+
+@pytest.mark.asyncio
+async def test_async_execution_error_handling() -> None:
+    """Test that async execution errors are wrapped in RuntimeError."""
+    sandbox = MCPKernelSandboxV5()
+    async def failing_async_tool(data: str) -> str:
+        raise TypeError("Async crash")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await sandbox.execute_async(failing_async_tool, {"data": "alice"}, is_sensitive=False)
+
+    assert "Sandbox async execution failed: Async crash" in str(exc_info.value)
+
+@pytest.mark.asyncio
+async def test_async_rejects_sync_tool() -> None:
+    """Test that execute_async() rejects sync functions."""
+    sandbox = MCPKernelSandboxV5()
+    with pytest.raises(ValueError) as exc_info:
+        await sandbox.execute_async(sample_sync_tool, {"data": "alice"})
+    assert "requires a coroutine function" in str(exc_info.value).lower()


### PR DESCRIPTION
This PR completes the Magda Codex Agent task `mcp-kernel-sandboxed-execution-v5-new-1234`.

It introduces:
1. `MCPKernelSandboxV5` in `magda_agent/safety/sandbox_v5.py` to allow sandboxed tool execution.
2. Synchronous and asynchronous runtime evaluation via `execute()` and `execute_async()`.
3. Support for `TaintTrackerV2` integrations and `SandboxExecutionEnvironmentV2`.
4. Mocked container resource isolation limits by capping execution duration using timeouts (`ContainerIsolationError`).
5. A rigorous testing suite in `tests/test_sandbox_v5.py` that confirms correct behavior and proper blocking of tainted inputs.
6. Updates to `agent_tasks.json` tracking system, completing the current task and intelligently replenishing the pool with 3 new context-rich tasks based on June 2026 AI Agent Trends (`OpenClaw-RL`, `A2A Distributed Tracing`, `MCP Tool concurrency`).

Risk level of this module is high; code review is expected.

---
*PR created automatically by Jules for task [17338986015582772211](https://jules.google.com/task/17338986015582772211) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPKernelSandboxV5` with taint-tracking and sandboxed sync/async tool execution
> - Adds [sandbox_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/466/files#diff-ecda5d919771a606b9ff09b4a5a147b7d60e7f84bc63f7379087c5f7d7c2c0a4) implementing `MCPKernelSandboxV5`, which wraps tool execution with taint checking via `TaintTrackerV2` and isolation via `SandboxExecutionEnvironmentV2`.
> - Sync execution (`execute`) rejects coroutine functions, checks taint policy, and wraps non-policy errors in `RuntimeError`.
> - Async execution (`execute_async`) enforces a configurable timeout (default 10s) via `asyncio.wait_for`, propagates taint from inputs to results, and raises `ContainerIsolationError` on timeout.
> - Sensitive tools with tainted inputs raise `PolicyViolationError` in both sync and async paths.
> - Full test coverage added in [test_sandbox_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/466/files#diff-0b90006eb879099c8c10297cdcf0b7e398f5b43b14a4342ca54f6c356e4c903a) covering safe inputs, taint propagation, policy rejection, timeout enforcement, and function type validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb57ce4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->