### PR TITLE
feat: Implement VirtualContextManagerV3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7605,7 +7605,7 @@
     },
     {
       "id": "memgpt-virtual-context-v3-new-5678",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT Virtual Context Management v3",
@@ -16489,6 +16489,57 @@
       ],
       "acceptance": [
         "Online RL handles next-state signals.",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "openclaw-rl-online-feedback-v7",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Online Feedback Loop V7",
+      "description": "Inspired by OpenClaw trend: Implement online reinforcement learning from user feedback for dynamic habit adjustment.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_user_behavior_v7.py",
+        "tests/test_rl_user_behavior_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Captures feedback correctly.",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "acs-runtime-security-controls-v7",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Runtime Security Controls Validator V7",
+      "description": "Inspired by Microsoft ACS standard trend: Implement runtime validation checkpoints for tool interception.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_validation_v7.py",
+        "tests/test_acs_validation_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Validates actions accurately.",
+        "Tests pass"
+      ]
+    },
+    {
+      "id": "agent-teams-context-spawner-v3",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Agent Teams Concurrent Context Spawner V3",
+      "description": "Inspired by Claude multi-agent worktrees trend: Implement subagent context spawner for parallel isolation.",
+      "allowed_paths": [
+        "magda_agent/agents/spawner_v3.py",
+        "tests/test_spawner_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Spawns concurrent subagents isolatedly.",
         "Tests pass"
       ]
     }

--- a/magda_agent/memory/virtual_context_v3.py
+++ b/magda_agent/memory/virtual_context_v3.py
@@ -1,0 +1,212 @@
+import logging
+from typing import TYPE_CHECKING, List, Optional
+from magda_agent.llm_client import LLMClient
+from magda_agent.emotions.engine import PADState
+from magda_agent.memory.working import MemoryEntry
+
+if TYPE_CHECKING:
+    from magda_agent.memory.working import WorkingMemory
+    from magda_agent.memory.episodic import EpisodicMemory
+
+class VirtualContextManagerV3:
+    """
+    VirtualContextManagerV3 implements advanced virtual context management for
+    explicitly paging out old short-term memory (WorkingMemory) into EpisodicMemory,
+    and paging it back in when requested, inspired by the MemGPT/Letta patterns.
+    """
+    def __init__(self, llm_client: Optional['LLMClient'] = None) -> None:
+        """
+        Initializes the VirtualContextManagerV3.
+
+        Args:
+            llm_client: An optional LLMClient for advanced summarization during compression.
+        """
+        self.llm_client = llm_client
+
+    async def compress_context(self, entries: List['MemoryEntry']) -> 'MemoryEntry':
+        """
+        Compresses multiple memory entries into a single summary entry using the LLM
+        or a fallback summarization technique.
+
+        Args:
+            entries: A list of MemoryEntry objects to compress.
+
+        Returns:
+            A new MemoryEntry containing the summarized context.
+
+        Raises:
+            ValueError: If the entries list is empty.
+        """
+        if not entries:
+            raise ValueError("No entries to compress")
+
+        combined_text = "\n".join(e.content for e in entries)
+
+        if self.llm_client:
+            prompt = [{"role": "system", "content": "Summarize these memory entries concisely."},
+                      {"role": "user", "content": combined_text}]
+            summary = await self.llm_client.chat_completion(prompt)
+        else:
+            summary = f"Summary of {len(entries)} items: {combined_text[:50]}..."
+
+        user_id = entries[0].user_id
+        avg_importance = sum(e.importance for e in entries) / len(entries)
+
+        # Calculate emotional state averages
+        avg_p = sum(e.emotional_state.pleasure for e in entries if e.emotional_state) / len(entries)
+        avg_a = sum(e.emotional_state.arousal for e in entries if e.emotional_state) / len(entries)
+        avg_d = sum(e.emotional_state.dominance for e in entries if e.emotional_state) / len(entries)
+        state = PADState(avg_p, avg_a, avg_d)
+
+        return MemoryEntry(content=summary, importance=avg_importance, emotional_state=state, user_id=user_id)
+
+    async def page_out_explicit(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, count: int = 1) -> None:
+        """
+        Explicitly moves the oldest `count` entries from WorkingMemory to EpisodicMemory.
+        Uses compression if more than one entry is specified.
+
+        Args:
+            working_memory: The WorkingMemory instance to page out from.
+            episodic_memory: The EpisodicMemory instance to page out into.
+            user_id: The ID of the user.
+            count: Number of oldest entries to page out.
+        """
+        entries = working_memory.get_entries(user_id=user_id)
+        if not entries:
+            return
+
+        to_remove = entries[:count]
+        original_to_remove = entries[:count]
+
+        if len(to_remove) > 1:
+            try:
+                compressed_entry = await self.compress_context(to_remove)
+                to_remove = [compressed_entry]
+            except Exception as e:
+                logging.error(f"Context compression failed during page_out_explicit: {e}")
+
+        for entry in to_remove:
+            metadata = {
+                "paged_out_explicitly": True,
+                "importance": entry.importance,
+            }
+            if entry.emotional_state:
+                metadata["pad_p"] = entry.emotional_state.pleasure
+                metadata["pad_a"] = entry.emotional_state.arousal
+                metadata["pad_d"] = entry.emotional_state.dominance
+            if entry.tags:
+                metadata["tags"] = ",".join(entry.tags)
+
+            episodic_memory.store_event(
+                text=entry.content,
+                metadata=metadata,
+                user_id=user_id
+            )
+            logging.debug(f"Paged out memory entry {entry.id} for user {user_id}")
+
+        for orig_entry in original_to_remove:
+            working_memory.remove(orig_entry.id, user_id=user_id)
+
+    async def page_in_explicit(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, query: str, top_k: int = 5) -> None:
+        """
+        Explicitly recalls relevant events from EpisodicMemory based on semantic similarity
+        and loads them into WorkingMemory.
+
+        Args:
+            working_memory: The WorkingMemory instance to page in to.
+            episodic_memory: The EpisodicMemory instance to page in from.
+            user_id: The ID of the user.
+            query: The semantic search query string.
+            top_k: The number of top results to fetch.
+        """
+        events = episodic_memory.recall_events(query=query, top_k=top_k, user_id=user_id)
+        for event_text in events:
+            entry = MemoryEntry(
+                content=event_text,
+                importance=0.5,
+                emotional_state=PADState(0, 0, 0),
+                user_id=user_id
+            )
+            await working_memory.add(entry)
+            logging.debug(f"Paged in explicit memory entry for user {user_id}: {event_text[:30]}...")
+
+    async def paginate_explicit_memory_blocks(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, block_size: int = 2) -> None:
+        """
+        Divides the working memory into discrete blocks of a given size and pages them out
+        to episodic memory explicitly. Avoids paging out incomplete blocks.
+
+        Args:
+            working_memory: The WorkingMemory instance to page out from.
+            episodic_memory: The EpisodicMemory instance to page out into.
+            user_id: The ID of the user.
+            block_size: The number of entries per block to paginate.
+        """
+        entries = working_memory.get_entries(user_id=user_id)
+        if not entries:
+            return
+
+        to_remove = entries[:- (len(entries) % block_size)] if len(entries) % block_size != 0 else entries
+        if not to_remove:
+            return
+
+        blocks = [to_remove[i:i + block_size] for i in range(0, len(to_remove), block_size)]
+
+        for block in blocks:
+            for entry in block:
+                metadata = {
+                    "paged_out_explicitly": True,
+                    "importance": entry.importance,
+                }
+                if entry.emotional_state:
+                    metadata["pad_p"] = entry.emotional_state.pleasure
+                    metadata["pad_a"] = entry.emotional_state.arousal
+                    metadata["pad_d"] = entry.emotional_state.dominance
+                if entry.tags:
+                    metadata["tags"] = ",".join(entry.tags)
+
+                episodic_memory.store_event(
+                    text=entry.content,
+                    metadata=metadata,
+                    user_id=user_id
+                )
+                logging.debug(f"Paged out memory entry {entry.id} in block explicitly for user {user_id}")
+
+            for entry in block:
+                working_memory.remove(entry.id, user_id=user_id)
+
+    def get_token_length(self, entries: List['MemoryEntry']) -> int:
+        """
+        Calculates a heuristic token length for the given memory entries.
+
+        Args:
+            entries: A list of MemoryEntry objects.
+
+        Returns:
+            The estimated token count.
+        """
+        total_words = sum(len(e.content.split()) for e in entries)
+        return int(total_words * 1.3)
+
+    async def maintain_working_memory_limits(self, working_memory: 'WorkingMemory', episodic_memory: 'EpisodicMemory', user_id: int, max_tokens: int = 4000) -> None:
+        """
+        Calculates token length of current working context and transparently pages out
+        older memories explicitly if the limit is exceeded.
+
+        Args:
+            working_memory: The WorkingMemory instance to manage.
+            episodic_memory: The EpisodicMemory instance to page into.
+            user_id: The ID of the user.
+            max_tokens: The maximum token length allowed before paging out.
+        """
+        entries = working_memory.get_entries(user_id=user_id)
+        if not entries:
+            return
+
+        current_tokens = self.get_token_length(entries)
+        if current_tokens <= max_tokens:
+            return
+
+        logging.info(f"Working memory context length ({current_tokens} tokens) exceeds limit ({max_tokens} tokens). Paging out...")
+
+        count_to_remove = max(1, len(entries) // 2)
+        await self.page_out_explicit(working_memory, episodic_memory, user_id, count=count_to_remove)

--- a/tests/test_virtual_context_v3.py
+++ b/tests/test_virtual_context_v3.py
@@ -1,0 +1,161 @@
+from unittest.mock import AsyncMock
+import pytest
+from magda_agent.memory.virtual_context_v3 import VirtualContextManagerV3
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.emotions.engine import PADState
+import asyncio
+
+@pytest.mark.asyncio
+async def test_virtual_context_v3_page_out_explicit() -> None:
+    wm = WorkingMemory(limit=5)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v3_out"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV3()
+
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("First Item", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second Item", 0.6, state, user_id=1)
+    e3 = MemoryEntry("Third Item", 0.7, state, user_id=1)
+
+    await wm.add(e1)
+    await wm.add(e2)
+    await wm.add(e3)
+
+    assert len(wm.get_entries(user_id=1)) == 3
+
+    # Explicitly page out the first 2 items
+    await vcm.page_out_explicit(wm, em, user_id=1, count=2)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 1
+    assert entries[0].content == "Third Item"
+
+    # Verify Episodic Memory has the paged out entry/entries
+    episodic_events = em.get_all_events(user_id=1)
+    assert len(episodic_events) > 0
+    # The paged out metadata should indicate explicit page out
+    assert episodic_events[0]["metadata"]["paged_out_explicitly"] == True
+
+@pytest.mark.asyncio
+async def test_virtual_context_v3_paginate_explicit_memory_blocks() -> None:
+    wm = WorkingMemory(limit=10)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v3_paginate_out"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV3()
+
+    state = PADState(0, 0, 0)
+
+    for i in range(5):
+        await wm.add(MemoryEntry(f"Item {i}", 0.5, state, user_id=1))
+
+    assert len(wm.get_entries(user_id=1)) == 5
+
+    await vcm.paginate_explicit_memory_blocks(wm, em, user_id=1, block_size=2)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 1
+    assert entries[0].content == "Item 4"
+
+    episodic_events = em.get_all_events(user_id=1)
+    assert len(episodic_events) == 4
+    assert episodic_events[0]["metadata"]["paged_out_explicitly"] == True
+
+@pytest.mark.asyncio
+async def test_virtual_context_v3_page_in_explicit() -> None:
+    wm = WorkingMemory(limit=5)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v3_in"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV3()
+
+    em.store_event("Historical facts about Python explicitly", metadata={"paged_out_explicitly": True}, user_id=2)
+
+    await vcm.page_in_explicit(wm, em, user_id=2, query="Python facts", top_k=1)
+
+    entries = wm.get_entries(user_id=2)
+    assert len(entries) == 1
+    assert "Historical facts about Python explicitly" in entries[0].content
+
+@pytest.mark.asyncio
+async def test_virtual_context_v3_compress_without_llm() -> None:
+    """Test that context compression works with fallback summary when LLM is absent."""
+    vcm = VirtualContextManagerV3()
+    state = PADState(0.1, 0.2, 0.3)
+    e1 = MemoryEntry("First", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second", 0.5, state, user_id=1)
+
+    summary = await vcm.compress_context([e1, e2])
+    assert "Summary of 2 items: First\nSecond" in summary.content
+    assert summary.importance == 0.5
+    assert summary.user_id == 1
+
+@pytest.mark.asyncio
+async def test_virtual_context_v3_compress_with_llm() -> None:
+    """Test that context compression leverages the LLM client to generate summaries."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "Mocked Summary V3"
+    vcm = VirtualContextManagerV3(llm_client=mock_llm)
+
+    state = PADState(0.1, 0.2, 0.3)
+    e1 = MemoryEntry("First", 0.5, state, user_id=1)
+    e2 = MemoryEntry("Second", 0.5, state, user_id=1)
+
+    summary = await vcm.compress_context([e1, e2])
+    assert summary.content == "Mocked Summary V3"
+    assert summary.importance == 0.5
+    assert summary.user_id == 1
+
+@pytest.mark.asyncio
+async def test_virtual_context_v3_maintain_limits_pages_out() -> None:
+    wm = WorkingMemory(limit=10)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v3_maintain_out"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV3()
+
+    state = PADState(0, 0, 0)
+
+    # 4 words -> ~5 tokens. 3 entries = ~15 tokens.
+    e1 = MemoryEntry("word1 word2 word3 word4", 0.5, state, user_id=1)
+    e2 = MemoryEntry("word5 word6 word7 word8", 0.6, state, user_id=1)
+    e3 = MemoryEntry("word9 word10 word11 word12", 0.7, state, user_id=1)
+
+    await wm.add(e1)
+    await wm.add(e2)
+    await wm.add(e3)
+
+    assert len(wm.get_entries(user_id=1)) == 3
+    assert vcm.get_token_length(wm.get_entries(user_id=1)) == int(12 * 1.3)
+
+    # Maintain with max_tokens = 10. Current is ~15.
+    await vcm.maintain_working_memory_limits(wm, em, user_id=1, max_tokens=10)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 2
+    assert entries[0].content == "word5 word6 word7 word8"
+    assert entries[1].content == "word9 word10 word11 word12"
+
+@pytest.mark.asyncio
+async def test_virtual_context_v3_maintain_limits_no_page_out() -> None:
+    wm = WorkingMemory(limit=10)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_v3_maintain_no_out"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+    vcm = VirtualContextManagerV3()
+
+    state = PADState(0, 0, 0)
+
+    # 4 words -> ~5 tokens
+    e1 = MemoryEntry("word1 word2 word3 word4", 0.5, state, user_id=1)
+    await wm.add(e1)
+
+    assert len(wm.get_entries(user_id=1)) == 1
+
+    await vcm.maintain_working_memory_limits(wm, em, user_id=1, max_tokens=10)
+
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 1


### PR DESCRIPTION
Implements virtual context management explicit memory paging (page in, page out, compress, and limits) in VirtualContextManagerV3, modeled after the MemGPT/Letta pattern. Added relevant tests with AsyncMock, updated the task manifest, and appended three new AI trend tasks.

---
*PR created automatically by Jules for task [11053149225605451913](https://jules.google.com/task/11053149225605451913) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `VirtualContextManagerV3` for working memory paging and compression
> - Adds [`VirtualContextManagerV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/467/files#diff-3b031074dc527fe365923a5610c1813de7fa10aa67d4b80a004407d45f4dab5e) with methods to page working memory entries in/out of episodic memory, compress multiple entries into a single summarized `MemoryEntry` via LLM or fallback, and paginate entries in fixed-size blocks.
> - `compress_context` averages importance and PADState across entries; when an `LLMClient` is provided it calls `chat_completion` with a summarization prompt, otherwise produces a plain-text fallback.
> - `maintain_working_memory_limits` enforces a max-token threshold by paging out the oldest half of entries when the heuristic estimate (word count × 1.3) exceeds the limit.
> - Full async test coverage is added in [`tests/test_virtual_context_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/467/files#diff-5e238876a6ad31d12f4b859f633075e4ab2c280eb35cd54d8d704a089c8dd2d7) covering page-out, page-in, block pagination, compression with and without LLM, and limit enforcement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56a32c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->