### PR TITLE
feat: OpenClaw RL from tool outputs

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7656,7 +7656,7 @@
     },
     {
       "id": "openclaw-rl-tool-outputs-v2",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL from Tool Outputs",
@@ -16592,6 +16592,40 @@
       "acceptance": [
         "A2ADiscoveryServiceV3Unique can discover peers by matching capabilities.",
         "Tests mock httpx to verify async peer discovery."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-creation-from-experience-v5",
+      "title": "Hermes Agent Skills Creation v5",
+      "description": "Inspired by Hermes: Automate creating new persistent skills based on repetitive positive feedback experiences.",
+      "area": "skills",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/skills/skill_creator_v5.py",
+        "tests/test_skill_creator_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill creator identifies repeated positive actions and saves new tools.",
+        "Tests mock experience logs to verify skill generation."
+      ]
+    },
+    {
+      "id": "openclaw-rl-next-state-signals-v9",
+      "title": "OpenClaw RL Next-State Signals v9",
+      "description": "Inspired by OpenClaw: Extend RL capabilities to use latency and non-verbal usage as implicit feedback next-state signals.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/rl_next_state_signals_v9.py",
+        "tests/test_rl_next_state_signals_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Model weights adjust dynamically based on latency metrics.",
+        "Tests simulate usage timing."
       ]
     }
   ]

--- a/magda_agent/learning/rl_tool_outputs_v2.py
+++ b/magda_agent/learning/rl_tool_outputs_v2.py
@@ -1,0 +1,95 @@
+import logging
+from typing import Optional, List, Dict, Any
+
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.user_model.model import UserModel
+
+class OpenClawRLToolOutputsV2:
+    """
+    OpenClaw-RL Online Reinforcement Learning from Tool Outputs v2.
+    Implements online reinforcement learning by tracking direct feedback
+    signals from tool outputs, dynamically adjusting skill weights without
+    user feedback.
+    """
+
+    def __init__(
+        self,
+        habit_tracker: HabitTracker,
+        user_model: UserModel,
+    ) -> None:
+        """
+        Initializes the learner with its dependencies.
+
+        Args:
+            habit_tracker: The system for tracking habit/skill usage.
+            user_model: The user model to maintain user-specific preferences and skill weights.
+        """
+        self.habit_tracker = habit_tracker
+        self.user_model = user_model
+
+    async def process_tool_output_signal(
+        self,
+        tool_name: str,
+        tool_output: str,
+        action_context: str,
+        user_id: int,
+    ) -> None:
+        """
+        Analyzes the tool output to determine success or failure, and updates Q-values/weights dynamically.
+        This provides implicit reinforcement learning without requiring direct user feedback.
+
+        Args:
+            tool_name (str): The name of the tool/skill that was executed.
+            tool_output (str): The raw string output from the executed tool.
+            action_context (str): A description of the action taken (used for habit tracking).
+            user_id (int): The ID of the current user.
+        """
+        if not tool_output or not action_context:
+            return
+
+        # Simple heuristic for tool output success/failure
+        # If output contains error keywords, consider it a failure. Otherwise success.
+        output_lower = tool_output.lower()
+        error_keywords = ["error", "exception", "failed", "traceback", "not found", "unauthorized", "invalid"]
+        is_failure = any(kw in output_lower for kw in error_keywords)
+
+        reward = 2.0 if is_failure else 8.0
+
+        # Retrieve user model
+        model_data = self.user_model.get_model(user_id)
+
+        # Ensure skill_weights dictionary exists
+        if "skill_weights" not in model_data:
+            model_data["skill_weights"] = {}
+
+        current_weight = model_data["skill_weights"].get(tool_name, 1.0)
+
+        if reward > 5.0:
+            # Positive signal (tool succeeded)
+            # Increase weight by 0.2, max 2.0
+            new_weight = min(2.0, current_weight + 0.2)
+            model_data["skill_weights"][tool_name] = new_weight
+
+            # Record usage in habit tracker
+            self.habit_tracker.record_usage(
+                input_text=action_context,
+                skill_used=tool_name,
+                evaluation_score=reward,
+                user_id=user_id
+            )
+            logging.info(f"OpenClawRLToolOutputsV2: Positive tool output signal (reward={reward:.2f}). Reinforced skill: {tool_name} (weight: {current_weight:.2f} -> {new_weight:.2f})")
+        else:
+            # Negative signal (tool failed)
+            # Decrease weight by 0.2, min 0.1
+            new_weight = max(0.1, current_weight - 0.2)
+            model_data["skill_weights"][tool_name] = new_weight
+            logging.info(f"OpenClawRLToolOutputsV2: Negative tool output signal (reward={reward:.2f}). Penalized skill: {tool_name} (weight: {current_weight:.2f} -> {new_weight:.2f})")
+
+        # Save preferences state dynamically
+        if "rl_tool_preferences" not in model_data:
+            model_data["rl_tool_preferences"] = {}
+        model_data["rl_tool_preferences"]["last_tool_reward"] = reward
+
+        # Save the model
+        self.user_model.save_model(user_id, model_data)
+        logging.info(f"OpenClawRLToolOutputsV2: Updated user model for user {user_id} with tool output feedback.")

--- a/tests/test_rl_tool_outputs_v2.py
+++ b/tests/test_rl_tool_outputs_v2.py
@@ -1,0 +1,135 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.learning.rl_tool_outputs_v2 import OpenClawRLToolOutputsV2
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.user_model.model import UserModel
+
+@pytest.fixture
+def mock_habit_tracker():
+    return MagicMock(spec=HabitTracker)
+
+@pytest.fixture
+def mock_user_model():
+    model = MagicMock(spec=UserModel)
+    model.get_model.return_value = {
+        "preferences": {},
+        "communication_style": "default",
+        "expertise_level": "unknown",
+        "recurring_topics": [],
+        "skill_weights": {"weather_skill": 1.0}
+    }
+    return model
+
+@pytest.mark.asyncio
+async def test_successful_tool_output(mock_habit_tracker, mock_user_model):
+    learner = OpenClawRLToolOutputsV2(
+        habit_tracker=mock_habit_tracker,
+        user_model=mock_user_model
+    )
+
+    await learner.process_tool_output_signal(
+        tool_name="weather_skill",
+        tool_output="The weather in London is 20C and sunny.",
+        action_context="Get weather for London",
+        user_id=123
+    )
+
+    # Check that usage was recorded (reward 8.0)
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text="Get weather for London",
+        skill_used="weather_skill",
+        evaluation_score=8.0,
+        user_id=123
+    )
+
+    # Check that weight was increased from 1.0 to 1.2
+    mock_user_model.save_model.assert_called_once()
+    saved_model = mock_user_model.save_model.call_args[0][1]
+    assert saved_model["skill_weights"]["weather_skill"] == 1.2
+    assert saved_model["rl_tool_preferences"]["last_tool_reward"] == 8.0
+
+@pytest.mark.asyncio
+async def test_failed_tool_output(mock_habit_tracker, mock_user_model):
+    learner = OpenClawRLToolOutputsV2(
+        habit_tracker=mock_habit_tracker,
+        user_model=mock_user_model
+    )
+
+    await learner.process_tool_output_signal(
+        tool_name="weather_skill",
+        tool_output="Error: API key invalid.",
+        action_context="Get weather for London",
+        user_id=123
+    )
+
+    # Check that usage was NOT recorded because reward is 2.0 (<= 5.0)
+    mock_habit_tracker.record_usage.assert_not_called()
+
+    # Check that weight was decreased from 1.0 to 0.8
+    mock_user_model.save_model.assert_called_once()
+    saved_model = mock_user_model.save_model.call_args[0][1]
+    assert saved_model["skill_weights"]["weather_skill"] == 0.8
+    assert saved_model["rl_tool_preferences"]["last_tool_reward"] == 2.0
+
+@pytest.mark.asyncio
+async def test_max_weight_cap(mock_habit_tracker, mock_user_model):
+    # Set current weight to 1.9, it should cap at 2.0
+    mock_user_model.get_model.return_value = {
+        "skill_weights": {"weather_skill": 1.9}
+    }
+
+    learner = OpenClawRLToolOutputsV2(
+        habit_tracker=mock_habit_tracker,
+        user_model=mock_user_model
+    )
+
+    await learner.process_tool_output_signal(
+        tool_name="weather_skill",
+        tool_output="The weather in London is 20C and sunny.",
+        action_context="Get weather for London",
+        user_id=123
+    )
+
+    saved_model = mock_user_model.save_model.call_args[0][1]
+    assert saved_model["skill_weights"]["weather_skill"] == 2.0
+
+@pytest.mark.asyncio
+async def test_min_weight_floor(mock_habit_tracker, mock_user_model):
+    # Set current weight to 0.2, it should floor at 0.1
+    mock_user_model.get_model.return_value = {
+        "skill_weights": {"weather_skill": 0.2}
+    }
+
+    learner = OpenClawRLToolOutputsV2(
+        habit_tracker=mock_habit_tracker,
+        user_model=mock_user_model
+    )
+
+    await learner.process_tool_output_signal(
+        tool_name="weather_skill",
+        tool_output="Error: Timeout.",
+        action_context="Get weather for London",
+        user_id=123
+    )
+
+    saved_model = mock_user_model.save_model.call_args[0][1]
+    # 0.2 - 0.2 = 0.0, but should floor at 0.1
+    assert saved_model["skill_weights"]["weather_skill"] == 0.1
+
+@pytest.mark.asyncio
+async def test_empty_tool_output_returns_early(mock_habit_tracker, mock_user_model):
+    learner = OpenClawRLToolOutputsV2(
+        habit_tracker=mock_habit_tracker,
+        user_model=mock_user_model
+    )
+
+    await learner.process_tool_output_signal(
+        tool_name="weather_skill",
+        tool_output="",
+        action_context="Get weather for London",
+        user_id=123
+    )
+
+    mock_habit_tracker.record_usage.assert_not_called()
+    mock_user_model.save_model.assert_not_called()


### PR DESCRIPTION
Implements openclaw-rl-tool-outputs-v2

---
*PR created automatically by Jules for task [11444392552260571189](https://jules.google.com/task/11444392552260571189) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `OpenClawRLToolOutputsV2` for online reinforcement learning from tool outputs
> - Adds [`rl_tool_outputs_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/470/files#diff-76ef95d76d7c547925992b44be5c1b19088dfc06b8fe10e821d9f56c6c09e753) with `OpenClawRLToolOutputsV2`, which classifies tool outputs as success or failure using keyword heuristics and assigns rewards (8.0 / 2.0).
> - On success, skill weights in the user model increase by 0.2 (capped at 2.0); on failure they decrease by 0.2 (floored at 0.1). The last reward is persisted under `rl_tool_preferences.last_tool_reward`.
> - Habit usage is recorded via `HabitTracker` only on positive signals; empty `tool_output` or `action_context` cause an early return with no side effects.
> - Adds tests covering success/failure weight updates, weight clamping, and early-return behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29eae7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->