### PR TITLE
feat: Implement EvaluatorMultimodalV4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7690,7 +7690,7 @@
     },
     {
       "id": "claude-evaluator-multi-modal-v4",
-      "status": "todo",
+      "status": "done",
       "area": "evaluation",
       "risk": "medium",
       "title": "Claude Evaluator Multi-Modal Context v4",
@@ -16681,6 +16681,60 @@
         "Tool calls are intercepted and audited before execution.",
         "Policy rules can deny actions.",
         "Blocked actions return explanatory feedback."
+      ]
+    },
+    {
+      "id": "openclaw-rl-implicit-feedback-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Implicit Feedback Tracking v2",
+      "description": "Inspired by OpenClaw-RL: Implement online reinforcement learning from implicit feedback, tracking user engagement times and session lengths to adjust system behaviors and habit weights without direct prompting.",
+      "allowed_paths": [
+        "magda_agent/learning/implicit_rl_tracker.py",
+        "tests/test_implicit_rl_tracker.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A tracker exists that logs interaction time and frequency.",
+        "Weights are adjusted based on implicit signals.",
+        "Tests verify behavior changes."
+      ]
+    },
+    {
+      "id": "acs-validation-checkpoints-v2",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Guardrail Checkpoints Integration v2",
+      "description": "Based on Microsoft's Agent Control Specification (ACS): Introduce a robust guardrail system with explicit validation checkpoints before executing tools and emitting outputs.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guardrails.py",
+        "tests/test_acs_guardrails.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Guardrail system implements at least pre-tool and pre-output checkpoints.",
+        "Violations trigger an explicit block and feedback loop.",
+        "Tests confirm safety checks."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-v2",
+      "status": "todo",
+      "area": "orchestration",
+      "risk": "low",
+      "title": "Hermes-Style Cron Scheduler v2",
+      "description": "Implement a background task scheduler inspired by Hermes, capable of triggering daily summaries, nightly learning consolidations, and scheduled user reminders independently of direct interaction.",
+      "allowed_paths": [
+        "magda_agent/orchestration/cron_scheduler.py",
+        "tests/test_cron_scheduler.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A lightweight cron-like scheduler can register recurring tasks.",
+        "Scheduler executes tasks asynchronously.",
+        "Tests simulate time progression and task execution."
       ]
     }
   ]

--- a/magda_agent/agents/evaluator_multimodal_v4.py
+++ b/magda_agent/agents/evaluator_multimodal_v4.py
@@ -1,0 +1,98 @@
+from typing import Dict, Any, Optional
+import logging
+import json
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+
+class EvaluatorMultimodalV4(SubAgent):
+    """
+    Claude-inspired specialized sub-agent for evaluating output from Generator sub-agents.
+    Version 4: Supports multi-modal context (images + text) during evaluation.
+    """
+    def __init__(self, llm: LLMClient):
+        super().__init__(
+            llm=llm,
+            system_prompt=(
+                "You are an expert multi-modal Evaluator sub-agent (v4). "
+                "Critique the provided output against the user request, including any visual context. "
+                "Provide actionable feedback. You MUST output valid JSON only."
+            ),
+            use_isolation=False
+        )
+
+    async def evaluate_generator_output(self,
+                                        generator_output: str,
+                                        user_request: str,
+                                        images: Optional[list[str]] = None) -> Dict[str, Any]:
+        """
+        Evaluates the output produced by the Generator Agent and provides critique, handling images if provided.
+
+        Args:
+            generator_output (str): The text or code output generated.
+            user_request (str): The initial user request or context.
+            images (Optional[list[str]]): List of base64-encoded images.
+
+        Returns:
+            Dict[str, Any]: Parsed JSON representing the critique and feedback containing keys:
+                - score (int): 1-10 evaluation score.
+                - approved (bool): Whether the output is acceptable.
+                - feedback (str): Detailed, actionable critique.
+        """
+        logging.info("Starting EvaluatorMultimodalV4 evaluation...")
+
+        task = (
+            "Evaluate the generator's output against the user's original request.\n\n"
+            "Return a JSON object with the following schema:\n"
+            '{"score": <int 1-10>, "approved": <bool>, "feedback": "<detailed critique and actionable feedback>"}'
+        )
+
+        full_context = (
+            f"Parent Context:\n"
+            f"User Request:\n{user_request}\n"
+            "------------------------\n"
+            f"Generator Output:\n{generator_output}\n"
+            "------------------------\n"
+            f"\n\nAssigned Task:\n{task}"
+        )
+
+        content = [{"type": "text", "text": full_context}]
+
+        if images:
+            for img in images:
+                content.append({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{img}"
+                    }
+                })
+
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": content}
+        ]
+
+        try:
+            response_text = await self.llm.chat_completion(messages, temperature=0.2)
+
+            # Simple markdown cleaning if the LLM wraps it in markdown blocks
+            if "```" in response_text:
+                response_text = response_text.split("```")[1]
+                if response_text.lower().startswith("json"):
+                    response_text = response_text[4:]
+
+            result = json.loads(response_text.strip())
+
+            # Validate expected keys are present
+            if not all(k in result for k in ("score", "approved", "feedback")):
+                raise ValueError("Missing required keys in LLM JSON output")
+
+            return result
+
+        except Exception as e:
+            logging.error(f"EvaluatorMultimodalV4 review failed: {e}")
+            return {
+                "score": 0,
+                "approved": False,
+                "feedback": f"Evaluation error: {str(e)}"
+            }

--- a/tests/test_evaluator_multimodal_v4.py
+++ b/tests/test_evaluator_multimodal_v4.py
@@ -1,0 +1,84 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.evaluator_multimodal_v4 import EvaluatorMultimodalV4
+
+@pytest.mark.asyncio
+async def test_evaluator_v4_agent_approve_text_only():
+    """Tests the EvaluatorMultimodalV4 correctly parses a passing score from the LLM (text only)."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='{"score": 9, "approved": true, "feedback": "Great response!"}')
+
+    agent = EvaluatorMultimodalV4(llm=mock_llm)
+    result = await agent.evaluate_generator_output("The sky is blue.", "What color is the sky?")
+
+    assert result["score"] == 9
+    assert result["approved"] is True
+    assert result["feedback"] == "Great response!"
+
+    # Check messages
+    args, kwargs = mock_llm.chat_completion.call_args
+    messages = args[0]
+    assert len(messages) == 2
+    assert messages[1]["role"] == "user"
+    content = messages[1]["content"]
+    assert isinstance(content, list)
+    assert len(content) == 1
+    assert content[0]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_v4_agent_with_images():
+    """Tests the EvaluatorMultimodalV4 includes images in the LLM request."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='{"score": 8, "approved": true, "feedback": "Looks like a dog."}')
+
+    agent = EvaluatorMultimodalV4(llm=mock_llm)
+    images = ["base64_encoded_dog_image_1", "base64_encoded_dog_image_2"]
+    result = await agent.evaluate_generator_output("It is a dog.", "What is in the image?", images=images)
+
+    assert result["score"] == 8
+    assert result["approved"] is True
+    assert result["feedback"] == "Looks like a dog."
+
+    # Check messages
+    args, kwargs = mock_llm.chat_completion.call_args
+    messages = args[0]
+    assert len(messages) == 2
+    assert messages[1]["role"] == "user"
+    content = messages[1]["content"]
+    assert isinstance(content, list)
+    assert len(content) == 3
+    assert content[0]["type"] == "text"
+    assert content[1]["type"] == "image_url"
+    assert content[1]["image_url"]["url"] == "data:image/jpeg;base64,base64_encoded_dog_image_1"
+    assert content[2]["type"] == "image_url"
+    assert content[2]["image_url"]["url"] == "data:image/jpeg;base64,base64_encoded_dog_image_2"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_v4_agent_reject():
+    """Tests the EvaluatorMultimodalV4 correctly parses a failing score from the LLM with markdown."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='```json\n{"score": 4, "approved": false, "feedback": "Incorrect color."}\n```')
+
+    agent = EvaluatorMultimodalV4(llm=mock_llm)
+    result = await agent.evaluate_generator_output("The sky is green.", "What color is the sky?")
+
+    assert result["score"] == 4
+    assert result["approved"] is False
+    assert result["feedback"] == "Incorrect color."
+    mock_llm.chat_completion.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluator_v4_agent_error_handling_invalid_json():
+    """Tests the EvaluatorMultimodalV4 correctly handles JSON parsing errors."""
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = AsyncMock(return_value='This is not valid JSON')
+
+    agent = EvaluatorMultimodalV4(llm=mock_llm)
+    result = await agent.evaluate_generator_output("Some output", "Some request")
+
+    assert result["score"] == 0
+    assert result["approved"] is False
+    assert "Evaluation error" in result["feedback"] or "Expecting value" in result["feedback"]
+    mock_llm.chat_completion.assert_called_once()


### PR DESCRIPTION
Implements `EvaluatorMultimodalV4` in `magda_agent/agents/evaluator_multimodal_v4.py` to support multi-modal evaluations (images and text) by wrapping `SubAgent`. Tests were added in `tests/test_evaluator_multimodal_v4.py`. `agent_tasks.json` was updated to mark `claude-evaluator-multi-modal-v4` as done, and 3 new tasks based on AI trends were appended to the queue.

---
*PR created automatically by Jules for task [10150419021916421430](https://jules.google.com/task/10150419021916421430) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `EvaluatorMultimodalV4` sub-agent for text and image evaluation
> - Adds [`EvaluatorMultimodalV4`](https://github.com/kazah4359-lgtm/Magda-agent/pull/472/files#diff-ca8bc553290bc880d670e48f00d9fe163631f1e50bfc68cdb8ed20cb206bff6b), a new `SubAgent` subclass that sends mixed text-and-image payloads to the LLM and parses a structured JSON response with `score`, `approved`, and `feedback` keys.
> - Images are passed as base64 data URLs; the agent calls `llm.chat_completion` at temperature 0.2 and strips markdown code fences before JSON parsing.
> - On any exception (JSON parse failure, missing keys, etc.), the method returns a fallback dict with `score: 0`, `approved: False`, and an error message.
> - Adds four async pytest tests covering text-only evaluation, image inclusion, markdown-wrapped JSON handling, and invalid JSON error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9eb9801.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->