### PR TITLE
feat: implement OpenClaw Canvas streaming v2 with partial state diffs

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7707,7 +7707,7 @@
     },
     {
       "id": "openclaw-canvas-streaming-v2",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw Canvas Streaming Enhancements v2",
@@ -16735,6 +16735,57 @@
         "A lightweight cron-like scheduler can register recurring tasks.",
         "Scheduler executes tasks asynchronously.",
         "Tests simulate time progression and task execution."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-streaming-v3-5490d84e",
+      "title": "OpenClaw Canvas Streaming Enhancements v3",
+      "area": "visualization",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by OpenClaw Live Visualization trend: Enhance the CanvasServerV2 to support binary patch updates (e.g., using bsdiff or jsonpatch) for even lower bandwidth consumption on large cognitive state objects.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_streaming_v3.py",
+        "tests/test_canvas_streaming_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "CanvasServerV3 supports patch diff updates.",
+        "Tests verify correct patch generation and client consumption."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-discovery-v5-5a0095e9",
+      "title": "MCP Dynamic Tool Discovery v5",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "description": "Inspired by MCP standard trend: Enhance the MCP Client to automatically poll known MCP server endpoints and dynamically discover new action tools without rebooting the agent.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_discovery_v5.py",
+        "tests/test_mcp_discovery_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Client polls servers and discovers tools dynamically.",
+        "Tests verify dynamic loading of new tools."
+      ]
+    },
+    {
+      "id": "agent-teams-git-worktree-v12-906afdf3",
+      "title": "Agent Teams Git Worktree Isolation v12",
+      "area": "architecture",
+      "risk": "high",
+      "status": "todo",
+      "description": "Inspired by Claude Agent SDK: Enhance the Subagent Spawner to aggressively prune abandoned git worktrees after subagent timeout to save disk space.",
+      "allowed_paths": [
+        "magda_agent/architecture/teams_worktree_v12.py",
+        "tests/test_teams_worktree_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Abandoned worktrees are correctly pruned after timeout.",
+        "Tests mock timeout and verify directory deletion."
       ]
     }
   ]

--- a/magda_agent/visualization/canvas_streaming_v2.py
+++ b/magda_agent/visualization/canvas_streaming_v2.py
@@ -1,0 +1,121 @@
+import asyncio
+import json
+import logging
+from typing import List, Dict, Any, Optional
+from fastapi import WebSocket
+
+from magda_agent.consciousness.core import Consciousness
+
+logger = logging.getLogger(__name__)
+
+def compute_diff(old_state: str, new_state: str) -> Optional[Dict[str, Any]]:
+    """
+    Computes a simple dictionary diff between old_state and new_state (JSON strings).
+    Returns a dict with the changed keys or None if no changes.
+    """
+    if old_state == new_state:
+        return None
+
+    try:
+        old_dict = json.loads(old_state) if old_state else {}
+        new_dict = json.loads(new_state) if new_state else {}
+    except json.JSONDecodeError:
+        return {"_raw": new_state}
+
+    diff = {}
+    for key, value in new_dict.items():
+        if key not in old_dict or old_dict[key] != value:
+            diff[key] = value
+
+    # Note: For simplicity, we just send keys that are updated or new.
+    # Deleted keys might require a more complex representation (e.g. {"key": None}).
+    # We will assume dict updates are additive or overwrite.
+    for key in old_dict:
+        if key not in new_dict:
+            diff[key] = None # Marker for deleted keys
+
+    if not diff:
+        return None
+
+    return diff
+
+class CanvasServerV2:
+    """
+    WebSocket server for streaming live visualization of Magda's internal cognitive state.
+    Enhances V1 by supporting partial state diff updates.
+    """
+    def __init__(self, consciousness: Consciousness, interval: float = 1.0):
+        # Dynamically import to avoid circular dependencies if necessary
+        from magda_agent.visualization.canvas_v3 import CanvasVisualizerV3
+        self.visualizer = CanvasVisualizerV3(consciousness)
+        self.active_connections: List[WebSocket] = []
+        self.consciousness = consciousness
+        self.interval = interval
+        self._streaming_task: Optional[asyncio.Task] = None
+        self._running = False
+        self._last_broadcasted_state: str = ""
+
+    async def connect(self, websocket: WebSocket):
+        """Accept a websocket connection, add it, and send full current state."""
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info(f"Canvas client connected. Total clients: {len(self.active_connections)}")
+
+        # On fresh connection, we should ideally send the full state.
+        # But to keep logic simple across all clients, the broadcast loop sends diffs globally.
+        # Here we just send the current full state to this specific client.
+        try:
+            current_state = self.visualizer.get_state_json()
+            full_update = {"type": "full", "data": json.loads(current_state)}
+            await websocket.send_text(json.dumps(full_update))
+        except Exception as e:
+            logger.error(f"Failed to send initial full state: {e}")
+
+    def disconnect(self, websocket: WebSocket):
+        """Remove a websocket connection from the pool."""
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+            logger.info(f"Canvas client disconnected. Total clients: {len(self.active_connections)}")
+
+    async def broadcast(self, message: str):
+        """Broadcast a message to all active websocket connections."""
+        disconnected = []
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(message)
+            except Exception as e:
+                logger.error(f"Failed to send message to canvas client: {e}")
+                disconnected.append(connection)
+
+        for conn in disconnected:
+            self.disconnect(conn)
+
+    async def start_streaming(self):
+        """Start the background task that periodically broadcasts the cognitive state."""
+        self._running = True
+        logger.info("Canvas visualization streaming (V2) started.")
+        self._last_broadcasted_state = ""
+
+        while self._running:
+            try:
+                if self.active_connections:
+                    current_state = self.visualizer.get_state_json()
+                    diff = compute_diff(self._last_broadcasted_state, current_state)
+
+                    if diff:
+                        update_payload = {"type": "diff", "data": diff}
+                        # If there was no previous state, we might as well just send full or diff (diff is full here)
+                        if not self._last_broadcasted_state:
+                           update_payload["type"] = "full"
+
+                        await self.broadcast(json.dumps(update_payload))
+                        self._last_broadcasted_state = current_state
+
+            except Exception as e:
+                logger.error(f"Error while streaming canvas state V2: {e}")
+            await asyncio.sleep(self.interval)
+
+    async def stop_streaming(self):
+        """Stop the background streaming task."""
+        self._running = False
+        logger.info("Canvas visualization streaming (V2) stopped.")

--- a/tests/test_canvas_streaming_v2.py
+++ b/tests/test_canvas_streaming_v2.py
@@ -1,0 +1,130 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from magda_agent.visualization.canvas_streaming_v2 import compute_diff, CanvasServerV2
+
+def test_compute_diff_no_changes():
+    old_state = json.dumps({"a": 1, "b": 2})
+    new_state = json.dumps({"a": 1, "b": 2})
+    assert compute_diff(old_state, new_state) is None
+
+def test_compute_diff_changes():
+    old_state = json.dumps({"a": 1, "b": 2})
+    new_state = json.dumps({"a": 1, "b": 3, "c": 4})
+    diff = compute_diff(old_state, new_state)
+    assert diff == {"b": 3, "c": 4}
+
+def test_compute_diff_deleted_keys():
+    old_state = json.dumps({"a": 1, "b": 2})
+    new_state = json.dumps({"a": 1})
+    diff = compute_diff(old_state, new_state)
+    assert diff == {"b": None}
+
+def test_compute_diff_empty_old_state():
+    old_state = ""
+    new_state = json.dumps({"a": 1})
+    diff = compute_diff(old_state, new_state)
+    assert diff == {"a": 1}
+
+@pytest.mark.asyncio
+async def test_canvas_server_v2_connect():
+    consciousness_mock = MagicMock()
+    with patch('magda_agent.visualization.canvas_v3.CanvasVisualizerV3') as MockVisualizer:
+        mock_vis_instance = MockVisualizer.return_value
+        mock_vis_instance.get_state_json.return_value = json.dumps({"test": "initial"})
+
+        server = CanvasServerV2(consciousness_mock)
+        websocket_mock = AsyncMock()
+
+        await server.connect(websocket_mock)
+
+        websocket_mock.accept.assert_awaited_once()
+        assert websocket_mock in server.active_connections
+
+        # Check that it sent the initial full state
+        expected_msg = json.dumps({"type": "full", "data": {"test": "initial"}})
+        websocket_mock.send_text.assert_awaited_once_with(expected_msg)
+
+@pytest.mark.asyncio
+async def test_canvas_server_v2_disconnect():
+    consciousness_mock = MagicMock()
+    server = CanvasServerV2(consciousness_mock)
+    websocket_mock = AsyncMock()
+
+    # Fake connect
+    server.active_connections.append(websocket_mock)
+    assert len(server.active_connections) == 1
+
+    server.disconnect(websocket_mock)
+    assert len(server.active_connections) == 0
+
+@pytest.mark.asyncio
+async def test_canvas_server_v2_broadcast():
+    consciousness_mock = MagicMock()
+    server = CanvasServerV2(consciousness_mock)
+    websocket_mock1 = AsyncMock()
+    websocket_mock2 = AsyncMock()
+
+    server.active_connections = [websocket_mock1, websocket_mock2]
+
+    await server.broadcast("hello")
+
+    websocket_mock1.send_text.assert_awaited_once_with("hello")
+    websocket_mock2.send_text.assert_awaited_once_with("hello")
+
+@pytest.mark.asyncio
+async def test_canvas_server_v2_streaming_loop():
+    consciousness_mock = MagicMock()
+
+    with patch('magda_agent.visualization.canvas_v3.CanvasVisualizerV3') as MockVisualizer:
+        mock_vis_instance = MockVisualizer.return_value
+
+        # State transitions
+        # 1. First iteration: "" -> {"a": 1} (Full)
+        # 2. Second iteration: {"a": 1} -> {"a": 1, "b": 2} (Diff)
+        # 3. Third iteration: {"a": 1, "b": 2} -> {"a": 1, "b": 2} (No change)
+
+        states = [
+            json.dumps({"a": 1}),
+            json.dumps({"a": 1, "b": 2}),
+            json.dumps({"a": 1, "b": 2}),
+            json.dumps({"a": 1, "b": 2}),
+        ]
+
+        state_iter = iter(states)
+        mock_vis_instance.get_state_json.side_effect = lambda: next(state_iter)
+
+        server = CanvasServerV2(consciousness_mock, interval=0.01)
+        websocket_mock = AsyncMock()
+        server.active_connections.append(websocket_mock)
+
+        # We need to run start_streaming in a task and let it run a few iterations, then stop it.
+        # Alternatively, we mock asyncio.sleep to break the loop or advance state.
+
+        loop_counter = 0
+        original_sleep = asyncio.sleep
+
+        async def mock_sleep(delay):
+            nonlocal loop_counter
+            loop_counter += 1
+            if loop_counter >= 3:
+                server._running = False
+            await original_sleep(0) # yield control
+
+        with patch('asyncio.sleep', side_effect=mock_sleep):
+            await server.start_streaming()
+
+        # Verify broadcasts
+        assert websocket_mock.send_text.call_count == 2
+
+        # First call should be type: full (because last_state was empty)
+        call1 = websocket_mock.send_text.call_args_list[0][0][0]
+        assert json.loads(call1) == {"type": "full", "data": {"a": 1}}
+
+        # Second call should be type: diff
+        call2 = websocket_mock.send_text.call_args_list[1][0][0]
+        assert json.loads(call2) == {"type": "diff", "data": {"b": 2}}
+
+        # Third iteration had no change, so no 3rd call


### PR DESCRIPTION
Implements openclaw-canvas-streaming-v2 task. Includes CanvasServerV2 for WebSocket partial state updates and corresponding tests. Added 3 new tasks to agent_tasks.json.

---
*PR created automatically by Jules for task [4902078584033717712](https://jules.google.com/task/4902078584033717712) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WebSocket canvas streaming server with partial state diffs
> - Adds [`CanvasServerV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/473/files#diff-b840ffafadc04bd98e3b032f6dff3b2bb2cb57793e7b38e69fef0acf591c1541) — a WebSocket server that periodically broadcasts the visualized cognitive state to all connected clients, sending a full snapshot on connect and shallow key-level diffs on subsequent updates.
> - Adds [`compute_diff`](https://github.com/kazah4359-lgtm/Magda-agent/pull/473/files#diff-b840ffafadc04bd98e3b032f6dff3b2bb2cb57793e7b38e69fef0acf591c1541) to compare consecutive JSON state strings, returning only changed/added keys with deleted keys marked `None`, or falling back to a raw payload when JSON is invalid.
> - Skips broadcasts when state is unchanged between polling intervals.
> - Test coverage in [`tests/test_canvas_streaming_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/473/files#diff-c4050087ac5a585b5329b11001537801aebccc997dcd49fe50b015b47bf2a61b) covers diff edge cases, connect/disconnect lifecycle, broadcast fanout, and the full→diff streaming loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ae936f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->