### PR TITLE
Implement MCP Dynamic Tool Discovery v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7724,7 +7724,7 @@
     },
     {
       "id": "mcp-dynamic-tool-discovery-v4",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Dynamic Tool Discovery v4",
@@ -16786,6 +16786,57 @@
       "acceptance": [
         "Abandoned worktrees are correctly pruned after timeout.",
         "Tests mock timeout and verify directory deletion."
+      ]
+    },
+    {
+      "id": "trend-mcp-dynamic-tool-discovery-v5-5a0095e9",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Discovery v5",
+      "description": "Inspired by MCP standard trend: Enhance the MCP Client to automatically poll known MCP server endpoints and dynamically discover new action tools without rebooting the agent.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_discovery_v5.py",
+        "tests/test_mcp_discovery_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Client polls servers and discovers tools dynamically.",
+        "Tests verify dynamic loading of new tools."
+      ]
+    },
+    {
+      "id": "trend-agent-teams-git-worktree-v12-906afdf3",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Agent Teams Git Worktree Isolation v12",
+      "description": "Inspired by Claude Agent SDK: Enhance the Subagent Spawner to aggressively prune abandoned git worktrees after subagent timeout to save disk space.",
+      "allowed_paths": [
+        "magda_agent/architecture/teams_worktree_v12.py",
+        "tests/test_teams_worktree_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Abandoned worktrees are correctly pruned after timeout.",
+        "Tests mock timeout and verify directory deletion."
+      ]
+    },
+    {
+      "id": "trend-openclaw-canvas-streaming-v3-5490d84e",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Streaming Enhancements v3",
+      "description": "Inspired by OpenClaw Live Visualization trend: Enhance the CanvasServerV2 to support binary patch updates (e.g., using bsdiff or jsonpatch) for even lower bandwidth consumption on large cognitive state objects.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_streaming_v3.py",
+        "tests/test_canvas_streaming_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "CanvasServerV3 supports patch diff updates.",
+        "Tests verify correct patch generation and client consumption."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_discovery_v4.py
+++ b/magda_agent/integration/mcp_discovery_v4.py
@@ -1,0 +1,91 @@
+import asyncio
+import os
+import importlib.util
+from typing import List, Dict, Any, Callable, Optional, Set
+from pydantic import BaseModel
+import logging
+
+logger = logging.getLogger(__name__)
+
+class MCPTool(BaseModel):
+    name: str
+    description: str
+    callable_func: Callable
+
+class MCPDynamicDiscoveryV4:
+    """
+    Auto-discovery mechanism that scans a configured tools directory and automatically registers new MCP tools without requiring restart.
+    """
+    def __init__(self, tools_dir: str) -> None:
+        """
+        Initializes the discovery mechanism with the tools directory.
+        """
+        self.tools_dir = tools_dir
+        self.tools: Dict[str, MCPTool] = {}
+        self._last_mtime: Dict[str, float] = {}
+        # Keep track of which tools came from which file to allow cleanup
+        self._file_to_tools: Dict[str, Set[str]] = {}
+
+    async def scan_and_register(self) -> None:
+        """Scans the tools directory and registers new or modified tools, and removes deleted ones."""
+        if not os.path.exists(self.tools_dir):
+            logger.warning(f"Tools directory {self.tools_dir} does not exist.")
+            return
+
+        current_files = set()
+
+        for filename in os.listdir(self.tools_dir):
+            if filename.endswith(".py") and not filename.startswith("__"):
+                filepath = os.path.join(self.tools_dir, filename)
+                current_files.add(filepath)
+                mtime = os.path.getmtime(filepath)
+
+                if filepath not in self._last_mtime or self._last_mtime[filepath] < mtime:
+                    try:
+                        module_name = filename[:-3]
+                        spec = importlib.util.spec_from_file_location(module_name, filepath)
+                        if spec and spec.loader:
+                            module = importlib.util.module_from_spec(spec)
+                            spec.loader.exec_module(module)
+
+                            # Cleanup old tools from this file if it was modified
+                            if filepath in self._file_to_tools:
+                                for old_tool_name in self._file_to_tools[filepath]:
+                                    if old_tool_name in self.tools:
+                                        del self.tools[old_tool_name]
+
+                            self._file_to_tools[filepath] = set()
+
+                            # Looking for register_tool function or TOOLS list
+                            if hasattr(module, 'register_tool'):
+                                tool = module.register_tool()
+                                if isinstance(tool, MCPTool):
+                                    self.tools[tool.name] = tool
+                                    self._file_to_tools[filepath].add(tool.name)
+                                    logger.info(f"Registered tool {tool.name} from {filename}")
+                            elif hasattr(module, 'TOOLS'):
+                                for tool in module.TOOLS:
+                                     if isinstance(tool, MCPTool):
+                                         self.tools[tool.name] = tool
+                                         self._file_to_tools[filepath].add(tool.name)
+                                logger.info(f"Registered tools from {filename}")
+                    except Exception as e:
+                        logger.error(f"Error loading tool from {filename}: {e}")
+                    finally:
+                         # Always update mtime even if it fails or has no tools, to prevent continuous reloading
+                         self._last_mtime[filepath] = mtime
+
+        # Cleanup deleted files
+        deleted_files = set(self._last_mtime.keys()) - current_files
+        for filepath in deleted_files:
+            if filepath in self._file_to_tools:
+                 for old_tool_name in self._file_to_tools[filepath]:
+                     if old_tool_name in self.tools:
+                         del self.tools[old_tool_name]
+                         logger.info(f"Removed tool {old_tool_name} from deleted file {filepath}")
+                 del self._file_to_tools[filepath]
+            del self._last_mtime[filepath]
+
+    def get_registered_tools(self) -> List[MCPTool]:
+        """Returns a list of all registered tools."""
+        return list(self.tools.values())

--- a/tests/test_mcp_discovery_v4.py
+++ b/tests/test_mcp_discovery_v4.py
@@ -1,0 +1,80 @@
+import pytest
+import os
+import tempfile
+import asyncio
+from typing import Any
+from magda_agent.integration.mcp_discovery_v4 import MCPDynamicDiscoveryV4, MCPTool
+
+@pytest.mark.asyncio
+async def test_mcp_discovery_v4_hot_reload() -> None:
+    """
+    Test the hot reloading mechanism of MCPDynamicDiscoveryV4.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        discovery = MCPDynamicDiscoveryV4(temp_dir)
+
+        # Initial scan, should be empty
+        await discovery.scan_and_register()
+        assert len(discovery.get_registered_tools()) == 0
+
+        # Create a mock tool file
+        tool_file_path = os.path.join(temp_dir, "mock_tool.py")
+        with open(tool_file_path, "w") as f:
+            f.write("""
+from typing import Any
+from magda_agent.integration.mcp_discovery_v4 import MCPTool
+
+def mock_callable() -> None:
+    pass
+
+def register_tool() -> MCPTool:
+    return MCPTool(name="mock_tool", description="A mock tool", callable_func=mock_callable)
+""")
+
+        # Scan again, should find the new tool
+        await discovery.scan_and_register()
+        tools = discovery.get_registered_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "mock_tool"
+
+        # Wait a bit to ensure mtime changes
+        await asyncio.sleep(0.1)
+
+        # Modify the tool file
+        with open(tool_file_path, "w") as f:
+             f.write("""
+from typing import Any
+from magda_agent.integration.mcp_discovery_v4 import MCPTool
+
+def mock_callable_v2() -> None:
+    pass
+
+def register_tool() -> MCPTool:
+    return MCPTool(name="mock_tool_v2", description="A modified mock tool", callable_func=mock_callable_v2)
+""")
+
+        # Scan again, should update the tool and remove the old one
+        await discovery.scan_and_register()
+        tools = discovery.get_registered_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "mock_tool_v2"
+
+        # Test file deletion
+        os.remove(tool_file_path)
+        await discovery.scan_and_register()
+        tools = discovery.get_registered_tools()
+        assert len(tools) == 0
+
+        # Test ignoring files with no tools
+        no_tool_file_path = os.path.join(temp_dir, "no_tool.py")
+        with open(no_tool_file_path, "w") as f:
+             f.write("""
+def some_func() -> None:
+    pass
+""")
+        await discovery.scan_and_register()
+        tools = discovery.get_registered_tools()
+        assert len(tools) == 0
+
+        # Ensure mtime is tracked for the no_tool file so we don't infinitely re-load it
+        assert no_tool_file_path in discovery._last_mtime


### PR DESCRIPTION
Implemented auto-discovery mechanism that scans a configured tools directory and automatically registers new MCP tools without requiring restart. Also updated agent_tasks.json.

---
*PR created automatically by Jules for task [15779264546363716086](https://jules.google.com/task/15779264546363716086) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add filesystem-based dynamic MCP tool discovery with hot-reload support
> - Introduces `MCPDynamicDiscoveryV4` in [`mcp_discovery_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/474/files#diff-817ac60a0388d0208048f1757c8bd677cd25e2733cb0ceb82e5a12166c8322c0), which scans a configured directory for Python modules and maintains an in-memory registry of `MCPTool` instances.
> - The `scan_and_register()` async method loads new or modified `.py` files, registers tools exposed via a `register_tool()` function or `TOOLS` list, and purges tools from deleted or modified files.
> - Tracks file modification times to avoid unnecessary reloads and cleans up stale tool entries when source files change or are removed.
> - An async test in [`test_mcp_discovery_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/474/files#diff-f1984f9244b5df8bba78d63d29e01506d3012737d769cc974d994978b17a718d) covers the full hot-reload lifecycle: initial empty scan, tool creation, name replacement on modification, deletion cleanup, and mtime tracking for empty files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d16b8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->