### PR TITLE
Implement MCP Client Authentication V3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7741,7 +7741,7 @@
     },
     {
       "id": "mcp-client-auth-v3-unique-1234",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Client Authentication Support v3",
@@ -16837,6 +16837,57 @@
       "acceptance": [
         "CanvasServerV3 supports patch diff updates.",
         "Tests verify correct patch generation and client consumption."
+      ]
+    },
+    {
+      "id": "memory-context-compression-v1",
+      "title": "Memory Context Compression v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "description": "Implement a context compression module to optimize memory storage for episodic and semantic memory.",
+      "allowed_paths": [
+        "magda_agent/memory/context_compression_v1.py",
+        "tests/test_context_compression_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context compression module exists",
+        "Tests verify memory is compressed"
+      ]
+    },
+    {
+      "id": "integration-cross-channel-sync-v1",
+      "title": "Cross-Channel Conversation Sync v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "description": "Implement cross-channel sync for user conversations to keep consistent context across platforms.",
+      "allowed_paths": [
+        "magda_agent/integration/cross_channel_sync_v1.py",
+        "tests/test_cross_channel_sync_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Conversations are synchronized",
+        "Tests mock different channels and verify state"
+      ]
+    },
+    {
+      "id": "safety-policy-guardrail-v1",
+      "title": "Safety Policy Guardrail v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "description": "Implement a safety policy guardrail interceptor for tool calls.",
+      "allowed_paths": [
+        "magda_agent/safety/policy_guardrail_v1.py",
+        "tests/test_policy_guardrail_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Guardrail intercepts tool calls",
+        "Tests mock forbidden calls and assert blocks"
       ]
     }
   ]

--- a/magda_agent/integration/mcp_client_auth_v3.py
+++ b/magda_agent/integration/mcp_client_auth_v3.py
@@ -1,0 +1,52 @@
+from typing import Dict, Optional
+import os
+
+class MCPClientAuthV3:
+    """
+    Manages authentication configuration for the MCP Client.
+    Supports API keys and OAuth tokens for connecting to remote MCP servers.
+    Inspired by MCP standards trend.
+    """
+    def __init__(self, api_key: Optional[str] = None, oauth_token: Optional[str] = None) -> None:
+        """
+        Initializes the MCPClientAuthV3 with optional authentication credentials.
+
+        Args:
+            api_key: An optional API key string.
+            oauth_token: An optional OAuth bearer token string.
+        """
+        self.api_key = api_key
+        self.oauth_token = oauth_token
+
+    def set_api_key(self, api_key: str) -> None:
+        """
+        Sets the API key for authentication.
+
+        Args:
+            api_key: The API key to use.
+        """
+        self.api_key = api_key
+
+    def set_oauth_token(self, token: str) -> None:
+        """
+        Sets the OAuth token for authentication.
+
+        Args:
+            token: The OAuth bearer token to use.
+        """
+        self.oauth_token = token
+
+    def get_auth_headers(self) -> Dict[str, str]:
+        """
+        Generates the required HTTP headers for authentication based on configured credentials.
+        Prioritizes OAuth token over API key if both are set.
+
+        Returns:
+            Dict[str, str]: A dictionary of HTTP headers.
+        """
+        headers: Dict[str, str] = {}
+        if self.oauth_token:
+            headers["Authorization"] = f"Bearer {self.oauth_token}"
+        elif self.api_key:
+            headers["x-api-key"] = self.api_key
+        return headers

--- a/tests/test_mcp_client_auth_v3.py
+++ b/tests/test_mcp_client_auth_v3.py
@@ -1,0 +1,32 @@
+import pytest
+from magda_agent.integration.mcp_client_auth_v3 import MCPClientAuthV3
+
+def test_mcp_client_auth_no_credentials():
+    auth = MCPClientAuthV3()
+    headers = auth.get_auth_headers()
+    assert headers == {}
+
+def test_mcp_client_auth_with_api_key():
+    auth = MCPClientAuthV3(api_key="test_api_key")
+    headers = auth.get_auth_headers()
+    assert headers == {"x-api-key": "test_api_key"}
+
+def test_mcp_client_auth_with_oauth_token():
+    auth = MCPClientAuthV3(oauth_token="test_oauth_token")
+    headers = auth.get_auth_headers()
+    assert headers == {"Authorization": "Bearer test_oauth_token"}
+
+def test_mcp_client_auth_priority():
+    auth = MCPClientAuthV3(api_key="test_api_key", oauth_token="test_oauth_token")
+    headers = auth.get_auth_headers()
+    assert headers == {"Authorization": "Bearer test_oauth_token"}
+
+def test_mcp_client_auth_setters():
+    auth = MCPClientAuthV3()
+    auth.set_api_key("new_api_key")
+    headers = auth.get_auth_headers()
+    assert headers == {"x-api-key": "new_api_key"}
+
+    auth.set_oauth_token("new_oauth_token")
+    headers = auth.get_auth_headers()
+    assert headers == {"Authorization": "Bearer new_oauth_token"}


### PR DESCRIPTION
Implements robust auth support for MCP Client using API keys and OAuth tokens, updating agent_tasks.json and including tests.

---
*PR created automatically by Jules for task [3037581872376689357](https://jules.google.com/task/3037581872376689357) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPClientAuthV3` class for MCP client authentication with OAuth and API key support
> Adds [mcp_client_auth_v3.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/475/files#diff-de75e1629673293828eb2995a89c3ed4f6dd9ae76892a84dc7093000fb5fa1a6) with an `MCPClientAuthV3` class that builds HTTP auth headers from stored credentials. `get_auth_headers` returns an `Authorization: Bearer` header when an OAuth token is set, an `x-api-key` header when only an API key is set, or an empty dict when neither is present. Unit tests covering all credential combinations are included in [test_mcp_client_auth_v3.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/475/files#diff-e01efe9eea9fbb23416462306ec421003cca8810be6b5d4cf99dbf65c035df9a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abacda2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->