### PR TITLE
Agent Guard Audit Trail v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7758,7 +7758,7 @@
     },
     {
       "id": "agent-guard-audit-trail-v4-unique-5678",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Agent Guard Audit Trail v4",
@@ -16888,6 +16888,42 @@
       "acceptance": [
         "Guardrail intercepts tool calls",
         "Tests mock forbidden calls and assert blocks"
+      ]
+    },
+    {
+      "id": "hermes-persistent-skill-memory-v2-abc",
+      "title": "Hermes Persistent Skill Memory V2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "description": "Inspired by Hermes Agent (June 2026): Implement persistent skill memory where the agent records experience and improves skills over long-term usage.",
+      "allowed_paths": [
+        "magda_agent/memory/persistent_skill_v2.py",
+        "tests/test_persistent_skill_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Persistent skill memory is stored across sessions.",
+        "Agent can retrieve past usage of skills.",
+        "Tests verify skill storage and retrieval."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-hooks-v5-def",
+      "title": "OpenClaw Context Engine Hooks V5",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "description": "Inspired by OpenClaw trends (June 2026): Create a plugin-based Context Engine that exposes lifecycle hooks for modifying context prior to LLM submission.",
+      "allowed_paths": [
+        "magda_agent/architecture/context_engine_hooks_v5.py",
+        "tests/test_context_engine_hooks_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin architecture with pre/post context hooks.",
+        "Allows dynamic manipulation of context.",
+        "Tests verify hook execution order."
       ]
     }
   ]

--- a/magda_agent/safety/audit_trail_v4.py
+++ b/magda_agent/safety/audit_trail_v4.py
@@ -1,0 +1,234 @@
+import time
+import json
+import sqlite3
+import functools
+import inspect
+import copy
+from typing import Any, Callable, Dict, List, Optional
+
+
+class AuditTrailV4:
+    """
+    Agent Guard Audit Trail v4.
+    Inspired by Prempti (Falco) trend, this module provides an audit trail
+    that intercepts all tool calls, securely logs parameters and results
+    (scrubbing sensitive information), and stores them in an SQLite database
+    for offline review. Supports both synchronous and asynchronous tools.
+    """
+
+    def __init__(self, db_path: str = "audit_trail_v4.db") -> None:
+        """
+        Initializes the AuditTrailV4 with an SQLite database.
+
+        Args:
+            db_path: Path to the SQLite database file.
+        """
+        self.db_path = db_path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the SQLite database schema if not already initialized."""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    CREATE TABLE IF NOT EXISTS audit_logs_v4 (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp REAL NOT NULL,
+                        tool_name TEXT NOT NULL,
+                        args TEXT NOT NULL,
+                        kwargs TEXT NOT NULL,
+                        result TEXT NOT NULL,
+                        duration REAL NOT NULL
+                    )
+                    '''
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            import logging
+            logging.error(f"AuditTrailV4 DB Initialization failed at {self.db_path}: {e}")
+
+    def _sanitize(self, data: Any) -> Any:
+        """
+        Recursively scrubs sensitive information (passwords, keys, tokens, etc.)
+        from the data before logging.
+        """
+        if inspect.isawaitable(data):
+            return "<awaitable>"
+
+        # Prevent infinite recursion on self-referential structures
+        memo = {}
+
+        def _deep_sanitize(obj: Any) -> Any:
+            obj_id = id(obj)
+            if obj_id in memo:
+                return "<recursive reference>"
+
+            if isinstance(obj, dict):
+                memo[obj_id] = True
+                sanitized = {}
+                for k, v in obj.items():
+                    k_str = str(k).lower()
+                    # Check for sensitive keywords in the key
+                    is_sensitive = any(
+                        s in k_str for s in ["password", "api_key", "token", "secret", "auth", "credential", "private", "key"]
+                    )
+
+                    if is_sensitive:
+                        # Redact primitive types or full complex types completely to be safe
+                        if isinstance(v, (dict, list)):
+                            # Sanitize inside just in case or fully redact?
+                            # Safe approach: fully redact. But let's redact values of list/dict
+                            if isinstance(v, list):
+                                sanitized[k] = ["***" for _ in v]
+                            else:
+                                sanitized[k] = "***"
+                        else:
+                            sanitized[k] = "***"
+                    else:
+                        sanitized[k] = _deep_sanitize(v)
+                return sanitized
+
+            elif isinstance(obj, list):
+                memo[obj_id] = True
+                return [_deep_sanitize(item) for item in obj]
+
+            elif isinstance(obj, tuple):
+                memo[obj_id] = True
+                return tuple(_deep_sanitize(item) for item in obj)
+
+            try:
+                return copy.deepcopy(obj)
+            except Exception:
+                return f"<uncopiable: {type(obj).__name__}>"
+
+        return _deep_sanitize(data)
+
+    def _log_to_db(self, tool_name: str, args: tuple, kwargs: dict, result: Any, duration: float) -> None:
+        """
+        Serializes and saves the sanitized execution data to SQLite.
+        """
+        timestamp = time.time()
+
+        # Sanitize data
+        safe_args = self._sanitize(list(args))
+        safe_kwargs = self._sanitize(kwargs)
+        safe_result = self._sanitize(result)
+
+        # JSON serialize safely
+        def safe_dumps(obj):
+            try:
+                return json.dumps(obj)
+            except (TypeError, ValueError):
+                return str(obj)
+
+        args_json = safe_dumps(safe_args)
+        kwargs_json = safe_dumps(safe_kwargs)
+        result_json = safe_dumps(safe_result)
+
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    INSERT INTO audit_logs_v4 (timestamp, tool_name, args, kwargs, result, duration)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ''',
+                    (timestamp, tool_name, args_json, kwargs_json, result_json, duration)
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            import logging
+            logging.error(f"AuditTrailV4 DB logging failed: {e}")
+
+    def intercept(self, tool_name: Optional[str] = None) -> Callable:
+        """
+        A decorator to intercept tool calls.
+        It measures execution time, captures input/output, sanitizes them,
+        and stores the audit log securely offline.
+
+        Args:
+            tool_name: An optional explicit name for the tool. Defaults to the function's name.
+        """
+        def decorator(func: Callable) -> Callable:
+            name_to_use = tool_name or func.__name__
+
+            if inspect.iscoroutinefunction(func):
+                @functools.wraps(func)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    start_time = time.time()
+                    result = "<uninitialized_or_cancelled>"
+                    try:
+                        result = await func(*args, **kwargs)
+                        return result
+                    except BaseException as e:
+                        result = f"Error: {str(e)}"
+                        raise
+                    finally:
+                        duration = time.time() - start_time
+                        self._log_to_db(name_to_use, args, kwargs, result, duration)
+                return async_wrapper
+            else:
+                @functools.wraps(func)
+                def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    start_time = time.time()
+                    result = "<uninitialized_or_cancelled>"
+                    try:
+                        result = func(*args, **kwargs)
+                        return result
+                    except BaseException as e:
+                        result = f"Error: {str(e)}"
+                        raise
+                    finally:
+                        duration = time.time() - start_time
+                        self._log_to_db(name_to_use, args, kwargs, result, duration)
+                return sync_wrapper
+
+        return decorator
+
+    def get_logs(self) -> List[Dict[str, Any]]:
+        """
+        Retrieves all audit logs from the database.
+
+        Returns:
+            A list of dictionaries, where each dict represents an audit log entry.
+        """
+        logs = []
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT id, timestamp, tool_name, args, kwargs, result, duration FROM audit_logs_v4 ORDER BY timestamp ASC"
+                )
+                rows = cursor.fetchall()
+                for row in rows:
+                    try:
+                        args_obj = json.loads(row[3])
+                    except (ValueError, TypeError):
+                        args_obj = row[3]
+
+                    try:
+                        kwargs_obj = json.loads(row[4])
+                    except (ValueError, TypeError):
+                        kwargs_obj = row[4]
+
+                    try:
+                        result_obj = json.loads(row[5])
+                    except (ValueError, TypeError):
+                        result_obj = row[5]
+
+                    logs.append({
+                        "id": row[0],
+                        "timestamp": row[1],
+                        "tool_name": row[2],
+                        "args": args_obj,
+                        "kwargs": kwargs_obj,
+                        "result": result_obj,
+                        "duration": row[6]
+                    })
+        except sqlite3.Error as e:
+            import logging
+            logging.error(f"AuditTrailV4 DB query failed: {e}")
+
+        return logs

--- a/tests/test_audit_trail_v4.py
+++ b/tests/test_audit_trail_v4.py
@@ -1,0 +1,90 @@
+import pytest
+import asyncio
+import os
+from magda_agent.safety.audit_trail_v4 import AuditTrailV4
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_audit_trail_v4.db")
+
+@pytest.fixture
+def audit_trail(db_path):
+    return AuditTrailV4(db_path=db_path)
+
+def test_audit_trail_v4_sync_interception(audit_trail):
+    @audit_trail.intercept(tool_name="test_sync_tool")
+    def sync_tool(x, y):
+        return x + y
+
+    result = sync_tool(2, 3)
+    assert result == 5
+
+    logs = audit_trail.get_logs()
+    assert len(logs) == 1
+
+    log = logs[0]
+    assert log["tool_name"] == "test_sync_tool"
+    assert log["args"] == [2, 3]
+    assert log["result"] == 5
+    assert log["duration"] >= 0
+
+@pytest.mark.asyncio
+async def test_audit_trail_v4_async_interception(audit_trail):
+    @audit_trail.intercept(tool_name="test_async_tool")
+    async def async_tool(data, password="secret_password"):
+        await asyncio.sleep(0.01)
+        return {"status": "ok", "data": data}
+
+    result = await async_tool("some_data", password="super_secret")
+    assert result["status"] == "ok"
+
+    logs = audit_trail.get_logs()
+    assert len(logs) == 1
+
+    log = logs[0]
+    assert log["tool_name"] == "test_async_tool"
+    assert log["args"] == ["some_data"]
+    # Keyword args should be scrubbed
+    assert log["kwargs"]["password"] == "***"
+    assert log["result"] == {"status": "ok", "data": "some_data"}
+    assert log["duration"] >= 0.01
+
+def test_audit_trail_v4_sanitization(audit_trail):
+    @audit_trail.intercept(tool_name="sanitize_tool")
+    def sensitive_tool(api_key, nested_data, user_auth_token):
+        return {"private_key": "my_private_key", "public": "public_data"}
+
+    sensitive_tool(
+        api_key="12345",
+        nested_data={"secret_code": "42", "normal_info": "hello"},
+        user_auth_token="jwt123"
+    )
+
+    logs = audit_trail.get_logs()
+    assert len(logs) == 1
+    log = logs[0]
+
+    # Assert scrubbing of inputs
+    assert log["kwargs"]["api_key"] == "***"
+    assert log["kwargs"]["user_auth_token"] == "***"
+
+    # Assert nested dict scrubbing
+    assert log["kwargs"]["nested_data"]["secret_code"] == "***"
+    assert log["kwargs"]["nested_data"]["normal_info"] == "hello"
+
+    # Assert scrubbing of output results
+    assert log["result"]["private_key"] == "***"
+    assert log["result"]["public"] == "public_data"
+
+def test_audit_trail_v4_exception_logging(audit_trail):
+    @audit_trail.intercept()
+    def error_tool():
+        raise ValueError("Something went wrong")
+
+    with pytest.raises(ValueError):
+        error_tool()
+
+    logs = audit_trail.get_logs()
+    assert len(logs) == 1
+    assert logs[0]["tool_name"] == "error_tool"
+    assert "Error: Something went wrong" in str(logs[0]["result"])


### PR DESCRIPTION
Inspired by Prempti (Falco) trend, added an audit trail module (`AuditTrailV4`) that intercepts all tool calls, logs parameters and results securely by scrubbing sensitive information, and stores them for offline review in SQLite. Also added trend-inspired tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [6731871776710007753](https://jules.google.com/task/6731871776710007753) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AuditTrailV4` class to intercept and log agent tool calls to SQLite
> - Introduces [`audit_trail_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/476/files#diff-c5ca8994cb32fcffa139c7b04d9766f0317a3c37ba595fc1662e984508b48154) with an `AuditTrailV4` class that wraps sync and async tool functions via a decorator, recording args, kwargs, results, duration, and errors to a local SQLite database.
> - Sensitive fields (e.g. `password`, `api_key`, `token`, `secret`) are recursively redacted before any data is persisted.
> - Exceptions are captured and stored in the audit log but re-raised to preserve normal error propagation.
> - Adds four tests in [`tests/test_audit_trail_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/476/files#diff-8fa7aeb6ed66b2be7ad42e844a7c152682a538510d85076a46c114a32cc0eec6) covering sync interception, async interception, sanitization, and exception logging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e25f40a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->