### PR TITLE
Implement Online Learning from Dialogue Sentiment

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7809,7 +7809,7 @@
     },
     {
       "id": "online-learning-interaction-loop-june-2026",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "Online Learning from Dialog Interactions",
@@ -16976,6 +16976,60 @@
       "area": "safety",
       "risk": "high",
       "status": "todo"
+    },
+    {
+      "id": "a2a-discovery-agent-cards-v5-enterprise",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Agent Cards V5 with Enterprise Auth",
+      "description": "Inspired by A2A Protocol trend (June 2026): Implement Agent Cards V5 with built-in enterprise authentication tokens and capability-based access control for peer-to-peer delegation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_cards_v5.py",
+        "tests/test_a2a_cards_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent Cards V5 correctly include auth tokens.",
+        "Discovery service filters peers based on capability matching and valid tokens.",
+        "Tests verify secure exchange of Agent Cards."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-discovery-v6-runtime",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Discovery V6 Runtime Poller",
+      "description": "Inspired by MCP trend (June 2026): Implement a runtime poller for the MCP client that dynamically discovers and hot-swaps action tools from registered MCP servers without requiring a restart.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_discovery_v6.py",
+        "tests/test_mcp_discovery_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP client polling loop correctly identifies new tools.",
+        "Tools are injected into the SkillRegistry at runtime.",
+        "Tests mock MCP server tool addition and verify dynamic execution."
+      ]
+    },
+    {
+      "id": "audit-trail-sanitization-v5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "low",
+      "title": "Audit Trail V5: Recursive PII Sanitization",
+      "description": "Inspired by Prempti and ACS trends (June 2026): Enhance the Audit Trail with recursive sanitization of tool arguments and results to ensure no PII or sensitive keys (API keys, passwords) are logged to the SQLite database.",
+      "allowed_paths": [
+        "magda_agent/safety/audit_trail_v5.py",
+        "tests/test_audit_trail_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audit Trail V5 redacts sensitive keys recursively.",
+        "Sanitization handles nested dicts and lists.",
+        "Tests verify that sensitive data is masked in the database."
+      ]
     }
   ]
 }

--- a/backlog.md
+++ b/backlog.md
@@ -237,3 +237,5 @@
 * [x] FEATURE: OpenClaw-RL Interactive Feedback Formatter v2 (openclaw-rl-interactive-feedback-v2-uuid)
 * [x] FEATURE: OpenClaw RL Metrics System v2 (openclaw-rl-metrics-v2-unique)
 * [x] FEATURE: A2A Peer-to-Peer Delegation v4 (a2a-peer-delegation-v4-5d34cc13)
+
+* [x] FEATURE: Online Learning from Dialog Interactions (online-learning-interaction-loop-june-2026) (2026-06-08)

--- a/magda_agent/learning/dialogue_v3.py
+++ b/magda_agent/learning/dialogue_v3.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Dict, List, Optional
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
 
 logger = logging.getLogger(__name__)
 
@@ -7,17 +8,25 @@ class DialogueOnlineLearnerV3:
     """
     Online learning from dialogue v3.
     Extracts immediate context from conversation and dynamically adjusts agent behavior.
+    Inspired by OpenClaw-RL trend (June 2026).
     """
-    def __init__(self) -> None:
+    def __init__(self, mirror_neurons: Optional[MirrorNeurons] = None) -> None:
+        self.mirror_neurons = mirror_neurons or MirrorNeurons()
         self.active_modifiers: List[Dict[str, Any]] = []
+        # Initial behavior weights
+        self.weights = {
+            "verbosity": 1.0,
+            "directness": 1.0,
+            "empathy": 1.0
+        }
 
     def process_turn(self, user_message: str, agent_response: Optional[str] = None) -> None:
         """
-        Analyzes user message to extract immediate learning insights (preferences/constraints).
+        Analyzes user message to extract immediate learning insights and adjust behavior weights.
         """
         msg_lower = user_message.lower()
 
-        # Very basic keyword heuristics to immediately adjust context
+        # 1. Direct instructions/preferences extraction
         if "always" in msg_lower or "must" in msg_lower:
             insight = {
                 "type": "preference",
@@ -36,21 +45,50 @@ class DialogueOnlineLearnerV3:
             self.active_modifiers.append(insight)
             logger.info(f"Learned constraint from dialogue: {insight['effect']}")
 
+        # 2. Online RL from sentiment signals (MirrorNeurons)
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_message)
+
+        # Adjust weights based on pleasure shift (P-shift) as a reward signal
+        if p_shift > 0:
+            # Positive reinforcement
+            self.weights["verbosity"] = min(2.0, self.weights["verbosity"] + 0.1)
+            self.weights["empathy"] = min(2.0, self.weights["empathy"] + 0.1)
+            logger.info(f"Positive dialogue signal (P={p_shift:.2f}). Reinforced verbosity and empathy.")
+        elif p_shift < 0:
+            # Negative reinforcement
+            self.weights["verbosity"] = max(0.5, self.weights["verbosity"] - 0.1)
+            self.weights["directness"] = min(2.0, self.weights["directness"] + 0.1)
+            logger.info(f"Negative dialogue signal (P={p_shift:.2f}). Reduced verbosity, increased directness.")
+
     def get_context_modifiers(self) -> str:
         """
-        Returns a formatted string of active behavioral modifiers to be injected into prompts.
+        Returns a formatted string of active behavioral modifiers and weights to be injected into prompts.
         """
-        if not self.active_modifiers:
-            return ""
+        sections = []
 
-        lines = ["--- Immediate Context Modifications ---"]
-        for mod in self.active_modifiers:
-            lines.append(f"- {mod['effect']}")
-        return "\n".join(lines)
+        if self.active_modifiers:
+            lines = ["--- Immediate Context Modifications ---"]
+            for mod in self.active_modifiers:
+                lines.append(f"- {mod['effect']}")
+            sections.append("\n".join(lines))
+
+        # Behavior weights section
+        weight_lines = ["--- Dynamic Behavior Adjustments ---"]
+        for key, value in self.weights.items():
+            if value > 1.2:
+                weight_lines.append(f"- Increase {key} (Strength: {value:.1f})")
+            elif value < 0.8:
+                weight_lines.append(f"- Decrease {key} (Strength: {value:.1f})")
+
+        if len(weight_lines) > 1:
+            sections.append("\n".join(weight_lines))
+
+        return "\n\n".join(sections) if sections else ""
 
     def clear_session(self) -> None:
         """
-        Clears the current dialogue modifiers for a new session.
+        Clears the current dialogue modifiers and resets weights for a new session.
         """
         self.active_modifiers.clear()
+        self.weights = {"verbosity": 1.0, "directness": 1.0, "empathy": 1.0}
         logger.info("DialogueOnlineLearnerV3 session cleared.")

--- a/tests/test_dialogue_v3.py
+++ b/tests/test_dialogue_v3.py
@@ -21,6 +21,36 @@ def test_process_turn_constraint() -> None:
     assert "Constraint established" in modifiers
     assert "never use emojis" in modifiers
 
+def test_process_turn_positive_reinforcement() -> None:
+    """Test positive reinforcement from user message."""
+    learner = DialogueOnlineLearnerV3()
+    # Trigger positive sentiment
+    for _ in range(5):
+        learner.process_turn("This is great! I am so happy with your work!")
+
+    assert learner.weights["verbosity"] > 1.0
+    assert learner.weights["empathy"] > 1.0
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Dynamic Behavior Adjustments ---" in modifiers
+    assert "Increase verbosity" in modifiers
+    assert "Increase empathy" in modifiers
+
+def test_process_turn_negative_reinforcement() -> None:
+    """Test negative reinforcement from user message."""
+    learner = DialogueOnlineLearnerV3()
+    # Trigger negative sentiment
+    for _ in range(5):
+        learner.process_turn("This is terrible and bad. I am very angry.")
+
+    assert learner.weights["verbosity"] < 1.0
+    assert learner.weights["directness"] > 1.0
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Dynamic Behavior Adjustments ---" in modifiers
+    assert "Decrease verbosity" in modifiers
+    assert "Increase directness" in modifiers
+
 def test_process_turn_no_insight() -> None:
     """Test when no learning insight is extracted."""
     learner = DialogueOnlineLearnerV3()
@@ -34,8 +64,11 @@ def test_clear_session() -> None:
     """Test clearing the active modifiers session."""
     learner = DialogueOnlineLearnerV3()
     learner.process_turn("You must always reply in JSON format.")
+    learner.process_turn("Great job!")
     assert len(learner.active_modifiers) == 1
+    assert learner.weights["verbosity"] > 1.0
 
     learner.clear_session()
     assert len(learner.active_modifiers) == 0
+    assert learner.weights["verbosity"] == 1.0
     assert learner.get_context_modifiers() == ""


### PR DESCRIPTION
This PR implements the "Online Learning from Dialog Interactions" task.
Key changes:
- Updated \`magda_agent/learning/dialogue_v3.py\` to use \`MirrorNeurons\` for sentiment analysis and adjust behavioral weights (verbosity, empathy, directness) as a form of online RL.
- Enhanced \`tests/test_dialogue_v3.py\` with new test cases for positive/negative reinforcement.
- Marked the task as \`done\` in \`agent_tasks.json\` and updated \`backlog.md\`.
- Added 3 new \`todo\` tasks to \`agent_tasks.json\`:
    1. A2A Agent Cards V5 with Enterprise Auth
    2. MCP Dynamic Discovery V6 Runtime Poller
    3. Audit Trail V5: Recursive PII Sanitization
- All tests passed and manifest validation succeeded.

---
*PR created automatically by Jules for task [12596389611478602673](https://jules.google.com/task/12596389611478602673) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add online learning from dialogue sentiment to `DialogueOnlineLearnerV3`
> - Adds dynamic behavior weights (`verbosity`, `directness`, `empathy`) to [`DialogueOnlineLearnerV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/479/files#diff-62138c8e2b87787375791bc2292604a90b1bcd17c289e0758f4774549bb22345), initialized to 1.0 and adjusted each turn based on sentiment via a `MirrorNeurons` dependency.
> - On positive sentiment, `verbosity` and `empathy` increase; on negative sentiment, `verbosity` decreases and `directness` increases.
> - `get_context_modifiers` now returns an additional section with increase/decrease directives when any weight crosses the 1.2 or 0.8 threshold.
> - `clear_session` resets all weights to 1.0 alongside clearing `active_modifiers`.
> - Callers can inject a custom `MirrorNeurons` instance; one is instantiated by default if not provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 013850d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->