### PR TITLE
Implement A2A Task Delegation and Discovery mechanism

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7826,7 +7826,7 @@
     },
     {
       "id": "a2a-task-delegation-discovery-june-2026",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Task Delegation and Discovery",
@@ -17029,6 +17029,60 @@
         "Audit Trail V5 redacts sensitive keys recursively.",
         "Sanitization handles nested dicts and lists.",
         "Tests verify that sensitive data is masked in the database."
+      ]
+    },
+    {
+      "id": "acs-safety-checkpoints-v8-576638f5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Safety Checkpoints V8",
+      "description": "Inspired by Microsoft ACS standard (June 2026): Implement the 5 mandatory validation checkpoints within the PolicyLayer to standardize runtime guardrails for all agentic workflows.",
+      "allowed_paths": [
+        "magda_agent/safety/policy_layer_v8.py",
+        "tests/test_acs_checkpoints_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "PolicyLayer enforces 5 validation checkpoints before and after tool execution.",
+        "Tests verify that violations at any checkpoint block the workflow.",
+        "LLM-friendly error messages are returned for each checkpoint violation."
+      ]
+    },
+    {
+      "id": "magentic-one-blackboard-v3-34b5c415",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Magentic-One Blackboard Orchestration V3",
+      "description": "Inspired by Magentic-One orchestration trend: Implement a shared blackboard state module that allows specialized sub-agents to share context and observations safely during parallel task execution.",
+      "allowed_paths": [
+        "magda_agent/agents/blackboard_v3.py",
+        "tests/test_blackboard_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Blackboard module supports concurrent read/write from multiple sub-agents.",
+        "Observability events are triggered upon blackboard state changes.",
+        "Tests verify state consistency across multiple mock sub-agents."
+      ]
+    },
+    {
+      "id": "agentskills-marketplace-sync-v1-3ffe3335",
+      "status": "todo",
+      "area": "integration",
+      "risk": "low",
+      "title": "AgentSkills Marketplace Sync V1",
+      "description": "Inspired by agentskills.io standard: Implement a synchronization worker that periodically fetches and registers new skills from a standard skill marketplace to expand agent capabilities dynamically.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_sync_v1.py",
+        "tests/test_marketplace_sync_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worker fetches skill definitions in agentskills.io format.",
+        "Discovered skills are dynamically registered in the SkillRegistry.",
+        "Tests mock the marketplace API and verify successful skill registration."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -239,3 +239,4 @@
 * [x] FEATURE: A2A Peer-to-Peer Delegation v4 (a2a-peer-delegation-v4-5d34cc13)
 
 * [x] FEATURE: Online Learning from Dialog Interactions (online-learning-interaction-loop-june-2026) (2026-06-08)
+* [x] FEATURE: A2A Task Delegation and Discovery (a2a-task-delegation-discovery-june-2026) (2026-06-08)

--- a/magda_agent/agents/a2a_delegation.py
+++ b/magda_agent/agents/a2a_delegation.py
@@ -1,0 +1,66 @@
+from typing import Dict, Any, List, Optional
+import logging
+from magda_agent.integration.a2a_discovery import AgentCard
+from magda_agent.integration.a2a_discovery_v3_unique import A2ADiscoveryServiceV3Unique
+from magda_agent.integration.a2a_cards import AgentCardV3
+
+class A2ADelegationAgent:
+    """
+    A high-level agent responsible for A2A (Agent-to-Agent) operations.
+    It manages discovery of peers and delegation of subtasks.
+    Inspired by the A2A Protocol trend (June 2026).
+    """
+
+    def __init__(self, local_card: Optional[AgentCardV3] = None) -> None:
+        """
+        Initializes the A2ADelegationAgent.
+
+        Args:
+            local_card: The AgentCard representing this agent's identity and capabilities.
+        """
+        self.discovery_service = A2ADiscoveryServiceV3Unique()
+        self.local_card = local_card
+        if local_card:
+            logging.info(f"A2ADelegationAgent initialized for agent: {local_card.name}")
+
+    async def discover_peers(self, raw_cards: List[str]) -> List[AgentCardV3]:
+        """
+        Discovers other agents in the network by parsing their Agent Cards.
+
+        Args:
+            raw_cards: A list of JSON strings representing AgentCards.
+
+        Returns:
+            A list of successfully parsed AgentCardV3 objects.
+        """
+        peers = self.discovery_service.parse_and_register_cards(raw_cards)
+        logging.info(f"A2ADelegationAgent discovered {len(peers)} peers.")
+        return peers
+
+    async def delegate_task_by_capability(self, capability: str, task: Dict[str, Any]) -> str:
+        """
+        Delegates a task to a peer that has the required capability.
+
+        Args:
+            capability: The required capability for the task (e.g., 'data_analysis').
+            task: The task details or context to be delegated.
+
+        Returns:
+            A result string describing the delegation outcome and the target agent.
+        """
+        logging.info(f"A2ADelegationAgent attempting to delegate task requiring '{capability}'")
+        agents = self.discovery_service.find_agents_by_capability(capability)
+
+        if not agents:
+            logging.warning(f"No agents found for capability: {capability}")
+            return "No agent found"
+
+        # Select the first available agent
+        target_agent = agents[0]
+
+        try:
+            result = await self.discovery_service.delegate_task(target_agent.agent_id, task)
+            return f"Delegated to Agent {target_agent.name}: {result.get('status', 'Success')}"
+        except Exception as e:
+            logging.error(f"Delegation to {target_agent.name} failed: {e}")
+            return f"Delegation to {target_agent.name} failed: {e}"

--- a/tests/test_a2a_delegation.py
+++ b/tests/test_a2a_delegation.py
@@ -1,8 +1,75 @@
 import pytest
+import respx
+import json
+from httpx import Response
+from magda_agent.agents.a2a_delegation import A2ADelegationAgent
+from magda_agent.integration.a2a_cards import AgentCardV3
 from unittest.mock import MagicMock, AsyncMock, patch
 from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
 from magda_agent.integration.a2a_delegation import A2ADelegator
 from magda_agent.agents.planner_agent import PlannerAgent
+
+# --- New tests for A2ADelegationAgent ---
+
+@pytest.fixture
+def local_card_v3():
+    return AgentCardV3(
+        agent_id="magda-001",
+        name="Magda",
+        description="Core Agent",
+        capabilities=["orchestration"],
+        endpoints={"rpc": "http://magda/rpc"}
+    )
+
+@pytest.fixture
+def peer_card_v3_json():
+    return json.dumps({
+        "agent_id": "peer-002",
+        "name": "ExpertAgent",
+        "description": "Specialized in data analysis",
+        "capabilities": ["data_analysis"],
+        "endpoints": {"rpc": "http://expert-agent/rpc"},
+        "protocol_version": "v3"
+    })
+
+@pytest.mark.asyncio
+async def test_a2a_agent_discovery_v3(local_card_v3, peer_card_v3_json):
+    agent = A2ADelegationAgent(local_card=local_card_v3)
+
+    peers = await agent.discover_peers(raw_cards=[peer_card_v3_json])
+
+    assert len(peers) == 1
+    assert peers[0].agent_id == "peer-002"
+    assert peers[0].has_capability("data_analysis")
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_a2a_task_delegation_v3(local_card_v3, peer_card_v3_json):
+    agent = A2ADelegationAgent(local_card=local_card_v3)
+
+    await agent.discover_peers(raw_cards=[peer_card_v3_json])
+
+    respx.post("http://expert-agent/rpc/delegate").mock(return_value=Response(200, json={
+        "status": "Success",
+        "data": "Analysis complete"
+    }))
+
+    task_context = {"data": [1, 2, 3]}
+    result = await agent.delegate_task_by_capability("data_analysis", task_context)
+
+    assert "Delegated to Agent ExpertAgent" in result
+    assert "Success" in result
+
+@pytest.mark.asyncio
+async def test_a2a_delegation_no_agent_found_v3(local_card_v3):
+    agent = A2ADelegationAgent(local_card=local_card_v3)
+
+    result = await agent.delegate_task_by_capability("unknown_skill", {"test": "data"})
+
+    assert result == "No agent found"
+
+
+# --- Existing tests from tests/test_a2a_delegation.py ---
 
 @pytest.fixture
 def mock_agent_card():
@@ -16,10 +83,8 @@ def mock_agent_card():
 
 @pytest.fixture
 def a2a_discovery(mock_agent_card):
-    # local card doesn't matter for finding remote agents here
     local_card = AgentCard("local", "local", "local", [], {})
     discovery = A2ADiscovery(local_card)
-    # manually inject the mock agent
     discovery._discovered_agents[mock_agent_card.agent_id] = mock_agent_card
     discovery._capability_index["coding"] = [mock_agent_card.agent_id]
     discovery._capability_index["analysis"] = [mock_agent_card.agent_id]
@@ -30,15 +95,7 @@ def a2a_delegator(a2a_discovery):
     return A2ADelegator(a2a_discovery)
 
 def test_a2a_delegator_security_context_initialization(a2a_discovery: A2ADiscovery) -> None:
-    """
-    Tests that the A2ADelegator initializes its own A2ASecurityContext
-    if the provided discovery instance does not have one.
-
-    Args:
-        a2a_discovery: The A2ADiscovery fixture to use.
-    """
     from magda_agent.integration.a2a_security import A2ASecurityContext
-    # Ensure a2a_discovery has no security context
     a2a_discovery.security_context = None
     delegator = A2ADelegator(a2a_discovery)
     assert isinstance(delegator.security_context, A2ASecurityContext)
@@ -46,7 +103,6 @@ def test_a2a_delegator_security_context_initialization(a2a_discovery: A2ADiscove
 @pytest.mark.asyncio
 @patch('httpx.AsyncClient.post', new_callable=AsyncMock)
 async def test_a2a_delegator_finds_agent(mock_post, a2a_delegator):
-    from unittest.mock import MagicMock
     mock_response = MagicMock()
     mock_response.json.return_value = {"result": {"status": "Success"}}
     mock_response.raise_for_status.return_value = None
@@ -63,10 +119,8 @@ async def test_a2a_delegator_no_agent(a2a_delegator):
 @pytest.mark.asyncio
 @patch('httpx.AsyncClient.post', new_callable=AsyncMock)
 async def test_planner_agent_delegation(mock_post, a2a_delegator):
-    # Test PlannerAgent integrates with A2ADelegator
     planner_agent = PlannerAgent(planner=None, a2a_delegator=a2a_delegator)
 
-    from unittest.mock import MagicMock
     mock_response = MagicMock()
     mock_response.json.return_value = {"result": {"status": "Success"}}
     mock_response.raise_for_status.return_value = None
@@ -77,7 +131,6 @@ async def test_planner_agent_delegation(mock_post, a2a_delegator):
 
 @pytest.mark.asyncio
 async def test_planner_agent_no_delegator():
-    # Test PlannerAgent gracefully handles missing delegator
     planner_agent = PlannerAgent(planner=None, a2a_delegator=None)
 
     result = await planner_agent.delegate_subplan("coding", {"task": "Refactor module"})
@@ -86,14 +139,12 @@ async def test_planner_agent_no_delegator():
 @pytest.mark.asyncio
 @patch('httpx.AsyncClient.post', new_callable=AsyncMock)
 async def test_planner_agent_plan_delegation(mock_post, a2a_delegator):
-    from unittest.mock import MagicMock
     mock_planner = MagicMock()
     mock_planner.get_current_plan.return_value = [
         {"id": "step_1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "Delegate coding task"}
     ]
     planner_agent = PlannerAgent(planner=mock_planner, a2a_delegator=a2a_delegator)
 
-    from unittest.mock import MagicMock
     mock_response = MagicMock()
     mock_response.json.return_value = {"result": {"status": "Success"}}
     mock_response.raise_for_status.return_value = None
@@ -139,7 +190,6 @@ async def test_a2a_delegator_execute_plan(mock_post, a2a_delegator):
         {"id": "2", "skill": "some_other_skill", "description": "do something else"}
     ]
 
-    from unittest.mock import MagicMock
     mock_response = MagicMock()
     mock_response.json.return_value = {"result": {"status": "Success"}}
     mock_response.raise_for_status.return_value = None
@@ -154,13 +204,11 @@ async def test_a2a_delegator_execute_plan(mock_post, a2a_delegator):
 @pytest.mark.asyncio
 @patch('httpx.AsyncClient.post', new_callable=AsyncMock)
 async def test_a2a_delegator_delegate_to_peer(mock_post, a2a_delegator, mock_agent_card):
-    from unittest.mock import MagicMock
     mock_response = MagicMock()
     mock_response.json.return_value = {"result": {"status": "Success"}}
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
-    # Need to clear tracer registry to test recording
     from magda_agent.integration.a2a_tracing import A2ATracer
     A2ATracer.clear_registry()
     trace_id = "test_peer_delegation_trace"
@@ -174,11 +222,9 @@ async def test_a2a_delegator_delegate_to_peer(mock_post, a2a_delegator, mock_age
     assert "X-A2A-Trace-ID" in kwargs["headers"]
 
     history = A2ATracer.get_trace(trace_id)
-    # Events should be "delegation_sent" from inject_headers and "peer_delegation"
     events = [e["event"] for e in history]
     assert "peer_delegation" in events
 
-    # Check details of peer_delegation
     peer_event = next(e for e in history if e["event"] == "peer_delegation")
     assert peer_event["details"]["target_agent_id"] == mock_agent_card.agent_id
 


### PR DESCRIPTION
This PR implements the A2A (Agent-to-Agent) task delegation and discovery mechanism for the Magda AI Agent. It introduces a high-level `A2ADelegationAgent` that leverages the v3 discovery service to find capable peers and delegate tasks asynchronously. The PR also includes comprehensive unit tests and updates the project's task manifest and backlog with new items inspired by 2026 AI agent trends.

---
*PR created automatically by Jules for task [2117801889764967788](https://jules.google.com/task/2117801889764967788) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A task delegation and peer discovery via `A2ADelegationAgent`
> - Adds [`A2ADelegationAgent`](https://github.com/kazah4359-lgtm/Magda-agent/pull/480/files#diff-7cfac467738a99c406e5e3779e1bd60edaae5bd3526aac24b6575fcc42770c25) which wraps `A2ADiscoveryServiceV3Unique` to parse raw AgentCard v3 JSON strings and register peers.
> - Provides `delegate_task_by_capability` to route tasks to the first matching peer via its RPC endpoint, returning a human-readable success or failure string.
> - Adds tests in [`tests/test_a2a_delegation.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/480/files#diff-aaef19c58ed00f96582ff19c938d1502ef202197388b383adaa5e8664e4d131d) covering discovery, successful delegation, and the no-match fallback using `respx` to mock HTTP calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc2e0a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->