### PR TITLE
Implement ACSGuardV6 input taint tracking and add new tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7843,7 +7843,7 @@
     },
     {
       "id": "agent-guard-acs-checkpoints-v6",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "Agent Guard ACS Checkpoints v6",
@@ -17083,6 +17083,57 @@
         "Worker fetches skill definitions in agentskills.io format.",
         "Discovered skills are dynamically registered in the SkillRegistry.",
         "Tests mock the marketplace API and verify successful skill registration."
+      ]
+    },
+    {
+      "id": "mcp-oauth-auth-v3",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Client OAuth2 Authentication",
+      "description": "Inspired by MCP Auth trend (June 2026): Implement OAuth2 support for connecting to remote MCP servers requiring token-based authorization.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_client_auth_v3.py",
+        "tests/test_mcp_auth_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP client successfully negotiates OAuth2 tokens.",
+        "Tests mock token exchange."
+      ]
+    },
+    {
+      "id": "a2a-recursive-validation-v4",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Recursive Agent Card Validation",
+      "description": "Inspired by A2A Protocol trend (June 2026): Implement a recursive validation mechanism for Agent Cards discovered via A2A to ensure deep delegation trees are safe.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v3_unique.py",
+        "tests/test_a2a_recursive_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Deeply nested Agent Cards are validated recursively.",
+        "Invalid cards in the tree trigger rejection."
+      ]
+    },
+    {
+      "id": "openclaw-rl-tone-adaptation-v5",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL Tone Adaptation",
+      "description": "Inspired by OpenClaw-RL trend (June 2026): Implement a behavior modifier that uses online reinforcement learning to adjust the agent's response tone based on user PAD shifts.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_user_behavior_v4.py",
+        "tests/test_tone_adaptation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent tone shifts in response to positive/negative user feedback.",
+        "Tests verify weight adjustments."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+* [x] FEATURE: Agent Guard ACS Checkpoints v6 (agent-guard-acs-checkpoints-v6)
 * [x] FEATURE: Online RL from User Feedback v6 (online-rl-user-feedback-v6)
 * [x] MODULE: **Virtual Context Manager** — magda_agent/memory/virtual_context.py.
 * [x] FEATURE: Hermes Skill Creation from Experience (hermes-skill-creation-8563188e)

--- a/magda_agent/safety/acs_guard_v6.py
+++ b/magda_agent/safety/acs_guard_v6.py
@@ -55,6 +55,9 @@ class ACSGuardV6:
             if not isinstance(workflow_data[field], str):
                 return False, f"Input validation failed: '{field}' must be a string."
 
+        if is_tainted(workflow_data.get("kwargs")):
+            return False, "Input validation failed: tainted data detected in tool inputs (kwargs)."
+
         return True, "Input validation passed."
 
     def checkpoint_2_intent_authorization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
@@ -63,6 +66,9 @@ class ACSGuardV6:
         Verifies if the agent's intent is authorized.
         """
         action = workflow_data.get("action")
+        if is_tainted(action):
+            return False, "Intent authorization failed: action is tainted."
+
         # Standard allowed intents in ACS-like architectures
         allowed_intents = {
             "read", "write", "execute", "plan", "reflect", "delegate", "analyze", "chat"
@@ -82,10 +88,18 @@ class ACSGuardV6:
         Checks if the tool complies with defined policies using the PolicyLayer.
         """
         tool = workflow_data.get("tool")
+        if is_tainted(tool):
+            return False, "Tool policy failed: tool name is tainted."
+
         if tool == "forbidden_tool":
             return False, f"Tool policy failed: tool '{tool}' is forbidden."
 
         kwargs = workflow_data.get("kwargs", {})
+        # Note: checkpoint_1 already checks for tainted kwargs,
+        # but we re-check here for completeness if called in isolation.
+        if is_tainted(kwargs):
+            return False, "Tool policy failed: tainted data detected in tool inputs (kwargs)."
+
         allow, explanation = self.policy_layer.evaluate(tool, **kwargs)
         if not allow:
             return False, f"Tool policy failed: {explanation}"

--- a/tests/test_acs_guard_v6.py
+++ b/tests/test_acs_guard_v6.py
@@ -43,6 +43,16 @@ def test_checkpoint_1_input_validation(acs_guard: ACSGuardV6) -> None:
     assert not passed
     assert "missing 'action' field" in reason
 
+    # Fail - tainted kwargs
+    tainted_kwargs = mark_tainted({"path": "/etc/passwd"})
+    passed, reason = acs_guard.checkpoint_1_input_validation({
+        "action": "read",
+        "tool": "cat",
+        "kwargs": tainted_kwargs
+    })
+    assert not passed
+    assert "tainted data detected in tool inputs" in reason
+
 
 def test_checkpoint_2_intent_authorization(acs_guard: ACSGuardV6) -> None:
     """Tests the intent authorization checkpoint."""
@@ -61,11 +71,21 @@ def test_checkpoint_2_intent_authorization(acs_guard: ACSGuardV6) -> None:
     assert not passed
     assert "not in allowed intents list" in reason
 
+    # Fail - tainted action
+    passed, reason = acs_guard.checkpoint_2_intent_authorization({"action": mark_tainted("read")})
+    assert not passed
+    assert "action is tainted" in reason
+
 
 def test_checkpoint_3_tool_policy(acs_guard: ACSGuardV6, mock_policy_layer: MagicMock) -> None:
     """Tests the tool policy checkpoint with mocking."""
     # Pass
     assert acs_guard.checkpoint_3_tool_policy({"tool": "ls"})[0]
+
+    # Fail - tainted tool name
+    passed, reason = acs_guard.checkpoint_3_tool_policy({"tool": mark_tainted("ls")})
+    assert not passed
+    assert "tool name is tainted" in reason
 
     # Fail - forbidden_tool
     passed, reason = acs_guard.checkpoint_3_tool_policy({"tool": "forbidden_tool"})


### PR DESCRIPTION
Implemented explicit taint tracking for tool inputs in ACSGuardV6. This enhancement ensures that any tainted data (e.g., from untrusted user input) is detected and blocked at the earliest possible stage in the safety guardrail.

Changes:
1.  **magda_agent/safety/acs_guard_v6.py**:
    *   Updated `checkpoint_1_input_validation` to detect tainted `kwargs`.
    *   Updated `checkpoint_2_intent_authorization` to detect tainted actions.
    *   Updated `checkpoint_3_tool_policy` to detect tainted tool names and re-verify `kwargs`.
2.  **tests/test_acs_guard_v6.py**:
    *   Added test cases for tainted `kwargs`, `action`, and `tool` name.
3.  **agent_tasks.json**:
    *   Marked `agent-guard-acs-checkpoints-v6` as `done`.
    *   Added 3 new `todo` tasks: `mcp-oauth-auth-v3`, `a2a-recursive-validation-v4`, and `openclaw-rl-tone-adaptation-v5`.
4.  **backlog.md**:
    *   Added the completed task to the "Выполнено" section.

All tests passed (1447/1447).

---
*PR created automatically by Jules for task [3081706507118238606](https://jules.google.com/task/3081706507118238606) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add input taint tracking to `ACSGuardV6` checkpoints
> Adds `is_tainted` checks to the three `ACSGuardV6` checkpoint methods in [`acs_guard_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/481/files#diff-71e9c69ddc5fa3cdd6978a914b1f02cda615a18100456aaaba4cf3bfd3c13094) so that tainted `kwargs`, `action`, or `tool` values cause early rejection before any policy evaluation. Tests in [`test_acs_guard_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/481/files#diff-eab8fea168130eeb3cec4349228cf8c0ec387b1d370b616026a394efcdb2b425) cover each new failure path. Also adds three new agent tasks and marks the ACS checkpoints feature as completed in the backlog.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 984d8fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->