### PR TITLE
Implement RLMetricsTrackerV4 and Update Agent Tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7860,7 +7860,7 @@
     },
     {
       "id": "openclaw-rl-metrics-tracker-v4",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL Metrics Tracker v4",
@@ -17134,6 +17134,59 @@
       "acceptance": [
         "Agent tone shifts in response to positive/negative user feedback.",
         "Tests verify weight adjustments."
+      ]
+    },
+    {
+      "id": "mcp-client-auth-v3-oauth-refresh",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Client OAuth2 Token Refresh",
+      "description": "Inspired by MCP Auth trend (June 2026): Implement automated OAuth2 token refresh for remote MCP tool servers to ensure long-lived tool sessions.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_client_auth_v3.py",
+        "tests/test_mcp_auth_refresh_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP client successfully refreshes expired OAuth2 tokens.",
+        "Tests mock token expiration and verify refresh logic."
+      ]
+    },
+    {
+      "id": "a2a-semantic-discovery-v3-embeddings",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Semantic Discovery via Embeddings",
+      "description": "Inspired by A2A Protocol trend (June 2026): Enhance the A2A discovery service with semantic embedding search to find approximate capability matches when exact string matching fails.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v3_unique.py",
+        "magda_agent/memory/semantic.py",
+        "tests/test_a2a_semantic_discovery_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A Discovery can find peers with semantically similar capabilities.",
+        "Tests verify that \"web search\" matches \"internet search\" via embeddings."
+      ]
+    },
+    {
+      "id": "context-engine-v5-dynamic-hook-unregistration",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Dynamic Context Hook Unregistration",
+      "description": "Inspired by Context Engine trend (June 2026): Implement a mechanism in ContextEngineV5 to dynamically unregister hooks and plugins at runtime to optimize resource usage and prevent context pollution.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_v5.py",
+        "tests/test_context_engine_unreg_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ContextEngineV5 allows unregistering active hooks.",
+        "Unregistered hooks are no longer executed during context cycles.",
+        "Tests verify unregistration logic."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -241,3 +241,4 @@
 
 * [x] FEATURE: Online Learning from Dialog Interactions (online-learning-interaction-loop-june-2026) (2026-06-08)
 * [x] FEATURE: A2A Task Delegation and Discovery (a2a-task-delegation-discovery-june-2026) (2026-06-08)
+* [x] FEATURE: OpenClaw RL Metrics Tracker v4 (openclaw-rl-metrics-tracker-v4) (2026-06-10)

--- a/magda_agent/learning/rl_metrics_v4.py
+++ b/magda_agent/learning/rl_metrics_v4.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Optional, List, Dict, Any
+from magda_agent.metacognition.tracker import QualityTracker
+
+class RLMetricsTrackerV4:
+    """
+    OpenClaw RL Metrics Tracker v4.
+    Tracks longitudinal reinforcement learning metrics such as reward trends
+    and skill weight stability over time.
+    """
+
+    def __init__(self, quality_tracker: QualityTracker) -> None:
+        """
+        Initializes the RL Metrics Tracker.
+
+        Args:
+            quality_tracker (QualityTracker): The persistent tracker for logging metrics.
+        """
+        self.quality_tracker = quality_tracker
+        logging.info("Initialized RLMetricsTrackerV4")
+
+    def log_reward(self, reward: float, skill_name: str, user_id: Optional[str] = None) -> None:
+        """
+        Logs a reward signal for a specific skill.
+
+        Args:
+            reward (float): The reward value received.
+            skill_name (str): The name of the skill the reward is for.
+            user_id (Optional[str]): The ID of the user providing the feedback.
+        """
+        metadata = {
+            "skill_name": skill_name,
+            "user_id": user_id,
+            "type": "reward"
+        }
+        self.quality_tracker.log_metric("rl_reward_v4", reward, metadata)
+        logging.debug(f"RLMetricsTrackerV4: Logged reward {reward} for skill {skill_name}")
+
+    def log_weight_delta(self, delta: float, skill_name: str, user_id: Optional[str] = None) -> None:
+        """
+        Logs a change in a skill's weight.
+
+        Args:
+            delta (float): The change in the skill's weight.
+            skill_name (str): The name of the skill.
+            user_id (Optional[str]): The ID of the user providing the feedback.
+        """
+        metadata = {
+            "skill_name": skill_name,
+            "user_id": user_id,
+            "type": "weight_delta"
+        }
+        self.quality_tracker.log_metric("rl_weight_delta_v4", delta, metadata)
+        logging.debug(f"RLMetricsTrackerV4: Logged weight delta {delta} for skill {skill_name}")
+
+    def get_reward_trend(self, skill_name: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """
+        Retrieves the reward trend for a specific skill.
+
+        Args:
+            skill_name (str): The name of the skill.
+            limit (int): The number of recent entries to retrieve.
+
+        Returns:
+            List[Dict[str, Any]]: A list of recent reward entries for the skill.
+        """
+        all_rewards = self.quality_tracker.get_metrics("rl_reward_v4", limit=limit * 5)
+        # Filter by skill_name manually as QualityTracker's get_metrics doesn't filter metadata
+        filtered = [r for r in all_rewards if r.get("skill_name") == skill_name][:limit]
+        return filtered
+
+    def calculate_average_reward(self, skill_name: str, limit: int = 10) -> Optional[float]:
+        """
+        Calculates the average reward for a skill over recent interactions.
+
+        Args:
+            skill_name (str): The name of the skill.
+            limit (int): The number of recent entries to consider.
+
+        Returns:
+            Optional[float]: The average reward, or None if no entries exist.
+        """
+        recent_rewards = self.get_reward_trend(skill_name, limit=limit)
+        if not recent_rewards:
+            return None
+
+        total = sum(float(r.get("value", 0.0)) for r in recent_rewards)
+        return total / len(recent_rewards)

--- a/tests/test_rl_metrics_v4.py
+++ b/tests/test_rl_metrics_v4.py
@@ -1,0 +1,71 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.rl_metrics_v4 import RLMetricsTrackerV4
+from magda_agent.metacognition.tracker import QualityTracker
+
+def test_log_reward() -> None:
+    """Tests that logging a reward correctly calls the underlying quality tracker."""
+    mock_tracker = MagicMock(spec=QualityTracker)
+    rl_tracker = RLMetricsTrackerV4(mock_tracker)
+
+    rl_tracker.log_reward(1.0, "search_skill", user_id="user123")
+
+    mock_tracker.log_metric.assert_called_once_with(
+        "rl_reward_v4", 1.0,
+        {"skill_name": "search_skill", "user_id": "user123", "type": "reward"}
+    )
+
+def test_log_weight_delta() -> None:
+    """Tests that logging a weight delta correctly calls the underlying quality tracker."""
+    mock_tracker = MagicMock(spec=QualityTracker)
+    rl_tracker = RLMetricsTrackerV4(mock_tracker)
+
+    rl_tracker.log_weight_delta(0.1, "search_skill", user_id="user123")
+
+    mock_tracker.log_metric.assert_called_once_with(
+        "rl_weight_delta_v4", 0.1,
+        {"skill_name": "search_skill", "user_id": "user123", "type": "weight_delta"}
+    )
+
+def test_get_reward_trend() -> None:
+    """Tests that getting the reward trend correctly filters metrics by skill name."""
+    mock_tracker = MagicMock(spec=QualityTracker)
+    rl_tracker = RLMetricsTrackerV4(mock_tracker)
+
+    mock_tracker.get_metrics.return_value = [
+        {"value": 1.0, "skill_name": "search_skill"},
+        {"value": 0.5, "skill_name": "other_skill"},
+        {"value": 0.8, "skill_name": "search_skill"},
+    ]
+
+    trend = rl_tracker.get_reward_trend("search_skill", limit=2)
+
+    assert len(trend) == 2
+    assert trend[0]["value"] == 1.0
+    assert trend[1]["value"] == 0.8
+    mock_tracker.get_metrics.assert_called_with("rl_reward_v4", limit=10)
+
+def test_calculate_average_reward() -> None:
+    """Tests that average reward calculation is correct for a given skill."""
+    mock_tracker = MagicMock(spec=QualityTracker)
+    rl_tracker = RLMetricsTrackerV4(mock_tracker)
+
+    mock_tracker.get_metrics.return_value = [
+        {"value": 1.0, "skill_name": "search_skill"},
+        {"value": 0.8, "skill_name": "search_skill"},
+    ]
+
+    avg = rl_tracker.calculate_average_reward("search_skill", limit=10)
+
+    assert avg == 0.9
+
+def test_calculate_average_reward_none() -> None:
+    """Tests that average reward returns None when no metrics are found."""
+    mock_tracker = MagicMock(spec=QualityTracker)
+    rl_tracker = RLMetricsTrackerV4(mock_tracker)
+
+    mock_tracker.get_metrics.return_value = []
+
+    avg = rl_tracker.calculate_average_reward("non_existent_skill")
+
+    assert avg is None


### PR DESCRIPTION
This PR implements the `RLMetricsTrackerV4` class, which provides longitudinal tracking of reinforcement learning metrics, such as reward trends and skill weight stability. The implementation utilizes the existing `QualityTracker` for persistent storage.

Key changes:
- `magda_agent/learning/rl_metrics_v4.py`: New class with methods to log rewards and weight deltas, and retrieve trends.
- `tests/test_rl_metrics_v4.py`: Comprehensive unit tests with mocks.
- `agent_tasks.json`: Updated task statuses and added new tasks (`mcp-client-auth-v3-oauth-refresh`, `a2a-semantic-discovery-v3-embeddings`, `context-engine-v5-dynamic-hook-unregistration`).
- `backlog.md`: Synchronized with the completed task.

All tests pass, and the task manifest is validated.

---
*PR created automatically by Jules for task [11574043823667733570](https://jules.google.com/task/11574043823667733570) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLMetricsTrackerV4` class to log and query RL rewards and weight deltas
> - Adds [`rl_metrics_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/482/files#diff-e05cd2da2f4e6b9d3ad378ae066b4cb967a4bafacec3e5e1db78bce10ba310be) with `RLMetricsTrackerV4`, which wraps an injected `QualityTracker` to record per-skill reward and weight delta signals under the metric keys `rl_reward_v4` and `rl_weight_delta_v4`.
> - Provides `get_reward_trend` and `calculate_average_reward` methods that fetch and filter stored metrics by skill name, returning `None` when no data exists.
> - Adds four unit tests in [`tests/test_rl_metrics_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/482/files#diff-82c72172d614659db15f5156d6bbcfa4f6bdb295d729741150f0afe9a482a750) covering reward logging, weight delta logging, trend filtering, and average calculation using a `MagicMock` `QualityTracker`.
> - Updates `agent_tasks.json` with three new task entries and marks one existing task as done; appends the feature to `backlog.md`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 706d045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->