### PR TITLE
Implement WorktreeDispatcherV6 and update task manifest

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7877,7 +7877,7 @@
     },
     {
       "id": "claude-team-git-worktrees-v6",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Team Git Worktrees v6",
@@ -17187,6 +17187,57 @@
         "ContextEngineV5 allows unregistering active hooks.",
         "Unregistered hooks are no longer executed during context cycles.",
         "Tests verify unregistration logic."
+      ]
+    },
+    {
+      "id": "mcp-streaming-tool-outputs-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Streaming Tool Outputs",
+      "description": "Inspired by OpenAI and Anthropic streaming trends (June 2026): Implement streaming support for MCP tool outputs to allow the agent to process partial results and reduce perceived latency.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_streaming_v1.py",
+        "tests/test_mcp_streaming_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCPStreamingHandler correctly processes partial tool outputs.",
+        "Tests verify streaming chunks are aggregated or handled incrementally."
+      ]
+    },
+    {
+      "id": "a2a-p2p-capability-negotiation-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A P2P Capability Negotiation",
+      "description": "Inspired by the A2A standard trend: Implement a P2P capability negotiation protocol that allows agents to negotiate task parameters and resource requirements.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_negotiation_v1.py",
+        "tests/test_a2a_negotiation_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agents can exchange and negotiate capability constraints.",
+        "Negotiation protocol handles multi-turn refinement."
+      ]
+    },
+    {
+      "id": "rl-skill-weight-stability-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "title": "Online RL Skill Weight Stability Tracker",
+      "description": "Inspired by OpenClaw-RL online learning: Implement a monitoring module that tracks the stability of skill weights in Procedural Memory.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_stability_v1.py",
+        "tests/test_rl_stability_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Stability tracker identifies rapid oscillations in skill weights.",
+        "Logs stability metrics to the longitudinal quality store."
       ]
     }
   ]

--- a/magda_agent/agents/worktree_dispatcher_v6.py
+++ b/magda_agent/agents/worktree_dispatcher_v6.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+from typing import List, Dict, Any
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.isolation.git_worktree import GitWorktreeManager
+
+class WorktreeDispatcherV6:
+    """
+    WorktreeDispatcherV6 coordinates a team of SubAgents, ensuring each
+    operates within an isolated Git worktree for parallel task execution.
+    Inspired by Claude Agent Teams trend (June 2026).
+    """
+    def __init__(self, llm: LLMClient, base_dir: str = "/tmp/magda_worktrees_v6"):
+        """
+        Initializes the WorktreeDispatcherV6.
+
+        Args:
+            llm: The LLM client for subagents.
+            base_dir: Base directory for Git worktrees.
+        """
+        self.llm = llm
+        self.worktree_manager = GitWorktreeManager(base_dir=base_dir)
+
+    async def dispatch_tasks(self, tasks: List[Dict[str, Any]], base_context: str) -> List[str]:
+        """
+        Dispatches multiple tasks to parallel subagents with worktree isolation.
+
+        Args:
+            tasks: List of task specifications (description, system_prompt).
+            base_context: Shared context for all subagents.
+
+        Returns:
+            List of execution results.
+        """
+        logging.info(f"WorktreeDispatcherV6 dispatching {len(tasks)} tasks with isolation.")
+
+        async def run_task(task_spec: Dict[str, Any]) -> str:
+            """
+            Executes a single subagent task within an isolated worktree.
+
+            Args:
+                task_spec: The specification for the individual task.
+
+            Returns:
+                The result of the task execution.
+            """
+            task_desc = task_spec.get("description", "No description provided.")
+            system_prompt = task_spec.get("system_prompt", "You are an isolated Sub-Agent.")
+
+            try:
+                # Use the isolated_environment context manager from GitWorktreeManager for robust cleanup
+                async with self.worktree_manager.isolated_environment() as worktree_path:
+                    logging.info(f"Subagent operating in isolated worktree: {worktree_path}")
+
+                    # Create subagent without its own internal isolation since we manage it here
+                    sub_agent = SubAgent(llm=self.llm, system_prompt=system_prompt, use_isolation=False)
+
+                    # Augment context with worktree info
+                    augmented_context = f"{base_context}\n\nIsolated Worktree Path: {worktree_path}"
+
+                    result = await sub_agent.execute(task=task_desc, context=augmented_context)
+                    return result
+            except Exception as e:
+                logging.error(f"Failed to dispatch subagent task: {e}")
+                return f"Error: Dispatch failed - {e}"
+
+        results = await asyncio.gather(*(run_task(task) for task in tasks))
+        return list(results)

--- a/tests/test_worktree_dispatcher_v6.py
+++ b/tests/test_worktree_dispatcher_v6.py
@@ -1,0 +1,51 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+from magda_agent.agents.worktree_dispatcher_v6 import WorktreeDispatcherV6
+from magda_agent.llm_client import LLMClient
+
+@pytest.mark.asyncio
+async def test_dispatch_tasks_success():
+    # Mock LLMClient
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat_completion = AsyncMock(return_value="Task completed successfully")
+
+    # Mock GitWorktreeManager to avoid actual git commands
+    with patch("magda_agent.agents.worktree_dispatcher_v6.GitWorktreeManager") as MockManager:
+        mock_instance = MockManager.return_value
+        # isolated_environment is an async context manager
+        mock_instance.isolated_environment.return_value.__aenter__ = AsyncMock(return_value="/tmp/mock_worktree")
+        mock_instance.isolated_environment.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        dispatcher = WorktreeDispatcherV6(llm=mock_llm)
+
+        tasks = [
+            {"description": "Task 1", "system_prompt": "Prompt 1"},
+            {"description": "Task 2", "system_prompt": "Prompt 2"}
+        ]
+        base_context = "Some base context"
+
+        results = await dispatcher.dispatch_tasks(tasks, base_context)
+
+        assert len(results) == 2
+        assert all(r == "Task completed successfully" for r in results)
+        assert mock_llm.chat_completion.call_count == 2
+        assert mock_instance.isolated_environment.call_count == 2
+
+@pytest.mark.asyncio
+async def test_dispatch_tasks_isolation_failure():
+    # Mock LLMClient
+    mock_llm = MagicMock(spec=LLMClient)
+
+    # Mock GitWorktreeManager to raise an exception
+    with patch("magda_agent.agents.worktree_dispatcher_v6.GitWorktreeManager") as MockManager:
+        mock_instance = MockManager.return_value
+        mock_instance.isolated_environment.return_value.__aenter__ = AsyncMock(side_effect=Exception("Git failure"))
+
+        dispatcher = WorktreeDispatcherV6(llm=mock_llm)
+
+        tasks = [{"description": "Task 1"}]
+        results = await dispatcher.dispatch_tasks(tasks, "context")
+
+        assert len(results) == 1
+        assert "Error: Dispatch failed - Git failure" in results[0]


### PR DESCRIPTION
This PR implements the `WorktreeDispatcherV6` component, which enables the Magda AI Agent to spawn multiple parallel subagents, each operating in its own isolated Git worktree. This ensures process isolation and prevents cross-contamination of files during concurrent task execution. 

Key changes:
- `magda_agent/agents/worktree_dispatcher_v6.py`: New dispatcher class.
- `tests/test_worktree_dispatcher_v6.py`: Comprehensive tests for the new dispatcher.
- `agent_tasks.json`: Updated task status and added new trend-based tasks.

The implementation follows the cognitive architecture principles and uses existing `GitWorktreeManager` and `SubAgent` components. All tests passed.

---
*PR created automatically by Jules for task [4248884944543915958](https://jules.google.com/task/4248884944543915958) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WorktreeDispatcherV6` to run sub-agent tasks concurrently in isolated Git worktrees
> - Adds [`WorktreeDispatcherV6`](https://github.com/kazah4359-lgtm/Magda-agent/pull/483/files#diff-aa9a4cbf6916e74d0804a4ac91a50f0ba11dbc0091ea2160c3bd0ce3e921f83a) which accepts a list of task specs and dispatches them concurrently using `asyncio.gather`, each in its own Git worktree via `GitWorktreeManager.isolated_environment`.
> - Each task gets a `SubAgent` with a task-specific `system_prompt`; the base context is augmented with the worktree path before execution.
> - Failures during worktree acquisition or task execution are caught and returned as error strings rather than raising.
> - Adds two async pytest tests in [`tests/test_worktree_dispatcher_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/483/files#diff-1aac3cbc92c7150cd2d47151a1639596fab1fde92544f86efcffb976d822e280) covering the success path and isolation failure path.
> - Updates [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/483/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) with three new `todo` tasks and marks one existing task as `done`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41f636b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->