### PR TITLE
Implement OpenClaw Online RL Next-State Signals v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7894,7 +7894,7 @@
     },
     {
       "id": "openclaw-online-rl-state-v5-1f0a1eb3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "OpenClaw Online RL Next-State Signals v5",
@@ -17238,6 +17238,57 @@
       "acceptance": [
         "Stability tracker identifies rapid oscillations in skill weights.",
         "Logs stability metrics to the longitudinal quality store."
+      ]
+    },
+    {
+      "id": "mcp-composition-engine-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Multi-Step Tool Composition",
+      "description": "Inspired by OpenAI Agents SDK: Implement an engine that allows composing multiple MCP tools into a single logical transaction with rollback capability.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_composition.py",
+        "tests/test_mcp_composition.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Engine correctly sequences multiple MCP calls.",
+        "Rollback works on failure."
+      ]
+    },
+    {
+      "id": "a2a-security-mesh-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A Security Mesh Enforcement",
+      "description": "Inspired by ACS and A2A trends: Implement a security mesh that enforces zero-trust principles for all peer-to-peer A2A task delegations.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_security_mesh.py",
+        "tests/test_a2a_security_mesh.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "All A2A calls require cryptographic proof of identity.",
+        "Policy layer blocks unauthorized peers."
+      ]
+    },
+    {
+      "id": "rl-emotion-matching-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL Emotion-Response Matching",
+      "description": "Inspired by OpenClaw-RL: Implement a module that uses RL to match response emotional tone to user PAD shifts in real-time, optimizing for long-term user satisfaction.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_emotion_matching.py",
+        "tests/test_rl_emotion_matching.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL agent optimizes tone based on user PAD feedback.",
+        "Tests verify weight updates on positive/negative shifts."
       ]
     }
   ]

--- a/magda_agent/learning/rl_next_state_v5.py
+++ b/magda_agent/learning/rl_next_state_v5.py
@@ -1,0 +1,126 @@
+import logging
+from typing import Optional, Dict, Any
+from magda_agent.learning.rl_metrics_v4 import RLMetricsTrackerV4
+
+class RLNextStateSignalsV5:
+    """
+    OpenClaw RL Next-State Signals v5.
+    Handles next-state signals dynamically and updates Q-values using RLMetricsTracker.
+    Inspired by OpenClaw-RL (June 2026).
+    """
+
+    def __init__(
+        self,
+        metrics_tracker: RLMetricsTrackerV4,
+        alpha: float = 0.1,
+        gamma: float = 0.9
+    ) -> None:
+        """
+        Initializes the RL Next-State Signals module.
+
+        Args:
+            metrics_tracker (RLMetricsTrackerV4): Tracker for logging rewards and Q-value updates.
+            alpha (float): Learning rate (0.0 to 1.0).
+            gamma (float): Discount factor for next-state Q-values (0.0 to 1.0).
+        """
+        self.metrics_tracker = metrics_tracker
+        self.alpha = alpha
+        self.gamma = gamma
+        self.q_table: Dict[str, float] = {}
+        logging.info("Initialized RLNextStateSignalsV5")
+
+    def parse_reward(self, text: str) -> float:
+        """
+        Parses a text signal to extract a reward score.
+
+        Args:
+            text (str): The text signal (e.g., user reply or tool output summary).
+
+        Returns:
+            float: A reward score between -1.0 and 1.0.
+        """
+        text_lower = text.lower()
+        # Basic normalization
+        words = text_lower.replace("'", "").replace(".", "").replace(",", "").replace("!", "").split()
+
+        positive_words = ["good", "great", "thanks", "awesome", "yes", "correct", "success", "resolved"]
+        negative_words = ["bad", "terrible", "wrong", "no", "incorrect", "fail", "error", "failed"]
+
+        if any(w in positive_words for w in words):
+            return 1.0
+        elif any(w in negative_words for w in words):
+            return -1.0
+        return 0.0
+
+    def process_signal(
+        self,
+        skill_id: str,
+        reward: float,
+        next_state_max_q: float = 0.0,
+        user_id: Optional[str] = None
+    ) -> float:
+        """
+        Processes a numerical reward signal and updates the Q-value for a skill.
+
+        Args:
+            skill_id (str): The identifier of the skill used.
+            reward (float): The immediate reward received.
+            next_state_max_q (float): The estimated maximum Q-value of the resulting next state.
+            user_id (Optional[str]): The optional ID of the user.
+
+        Returns:
+            float: The updated Q-value for the skill.
+        """
+        current_q = self.q_table.get(skill_id, 0.0)
+
+        # Q-learning temporal difference update rule:
+        # Q(s,a) = Q(s,a) + alpha * (reward + gamma * max(Q(s',a')) - Q(s,a))
+        td_target = reward + self.gamma * next_state_max_q
+        td_error = td_target - current_q
+        new_q = current_q + self.alpha * td_error
+
+        self.q_table[skill_id] = new_q
+
+        # Log metrics to the longitudinal tracker
+        self.metrics_tracker.log_reward(reward, skill_id, user_id=user_id)
+        self.metrics_tracker.log_weight_delta(new_q - current_q, skill_id, user_id=user_id)
+
+        logging.info(
+            f"RLNextStateSignalsV5: Updated Q-value for '{skill_id}' to {new_q:.4f} "
+            f"(Reward: {reward}, Next Q: {next_state_max_q}, TD Error: {td_error:.4f})"
+        )
+        return new_q
+
+    def handle_interaction(
+        self,
+        skill_id: str,
+        signal_text: str,
+        next_state_max_q: float = 0.0,
+        user_id: Optional[str] = None
+    ) -> float:
+        """
+        High-level method to handle an interaction by parsing a text signal and updating Q-values.
+
+        Args:
+            skill_id (str): The identifier of the skill.
+            signal_text (str): The text of the signal (e.g., user reply).
+            next_state_max_q (float): The estimated maximum Q-value of the next state.
+            user_id (Optional[str]): The optional ID of the user.
+
+        Returns:
+            float: The updated Q-value.
+        """
+        reward = self.parse_reward(signal_text)
+        return self.process_signal(skill_id, reward, next_state_max_q, user_id=user_id)
+
+    def get_q_value(self, skill_id: str) -> float:
+        """
+        Retrieves the current Q-value for a given skill.
+
+        Args:
+            skill_id (str): The identifier of the skill.
+
+        Returns:
+            float: The current Q-value.
+        """
+        return self.q_table.get(skill_id, 0.0)

--- a/tests/test_rl_next_state_v5.py
+++ b/tests/test_rl_next_state_v5.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.rl_next_state_v5 import RLNextStateSignalsV5
+from magda_agent.learning.rl_metrics_v4 import RLMetricsTrackerV4
+from magda_agent.metacognition.tracker import QualityTracker
+
+@pytest.fixture
+def mock_quality_tracker():
+    tracker = MagicMock(spec=QualityTracker)
+    return tracker
+
+@pytest.fixture
+def metrics_tracker(mock_quality_tracker):
+    return RLMetricsTrackerV4(quality_tracker=mock_quality_tracker)
+
+@pytest.fixture
+def rl_module(metrics_tracker):
+    return RLNextStateSignalsV5(metrics_tracker=metrics_tracker, alpha=0.1, gamma=0.9)
+
+def test_parse_reward(rl_module):
+    assert rl_module.parse_reward("This is great!") == 1.0
+    assert rl_module.parse_reward("That is bad.") == -1.0
+    assert rl_module.parse_reward("Just neutral.") == 0.0
+    assert rl_module.parse_reward("Yes, it works.") == 1.0
+    assert rl_module.parse_reward("No, it failed.") == -1.0
+
+def test_process_signal_update(rl_module, mock_quality_tracker):
+    skill_id = "test_skill"
+    reward = 1.0
+    next_state_max_q = 0.5
+
+    # Q(s,a) = 0 + 0.1 * (1.0 + 0.9 * 0.5 - 0) = 0.1 * 1.45 = 0.145
+    new_q = rl_module.process_signal(skill_id, reward, next_state_max_q)
+
+    assert new_q == pytest.approx(0.145)
+    assert rl_module.get_q_value(skill_id) == pytest.approx(0.145)
+
+    # Verify logging
+    assert mock_quality_tracker.log_metric.call_count == 2
+    # First call for reward
+    mock_quality_tracker.log_metric.assert_any_call("rl_reward_v4", 1.0, {"skill_name": skill_id, "user_id": None, "type": "reward"})
+    # Second call for weight delta
+    mock_quality_tracker.log_metric.assert_any_call("rl_weight_delta_v4", 0.145, {"skill_name": skill_id, "user_id": None, "type": "weight_delta"})
+
+def test_handle_interaction(rl_module):
+    skill_id = "chat_skill"
+    # Q(s,a) = 0 + 0.1 * (1.0 + 0.9 * 0.0 - 0) = 0.1
+    new_q = rl_module.handle_interaction(skill_id, "thanks a lot!")
+
+    assert new_q == pytest.approx(0.1)
+    assert rl_module.get_q_value(skill_id) == pytest.approx(0.1)
+
+def test_multiple_updates(rl_module):
+    skill_id = "multi_skill"
+
+    # First update: Q = 0.1
+    rl_module.handle_interaction(skill_id, "good")
+
+    # Second update: reward = 1.0, next_q = 0, Q = 0.1 + 0.1 * (1.0 - 0.1) = 0.19
+    new_q = rl_module.handle_interaction(skill_id, "great")
+
+    assert new_q == pytest.approx(0.19)


### PR DESCRIPTION
This PR implements the `RLNextStateSignalsV5` module, which handles reinforcement learning from next-state signals (user replies and tool outputs) using a Q-learning update rule. It integrates with the existing `RLMetricsTrackerV4` for longitudinal tracking. The PR also updates the `agent_tasks.json` manifest to reflect the completed task and introduces three new tasks inspired by June 2026 AI agent trends: `mcp-composition-engine-v1`, `a2a-security-mesh-v1`, and `rl-emotion-matching-v1`.

---
*PR created automatically by Jules for task [9451248347945220210](https://jules.google.com/task/9451248347945220210) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLNextStateSignalsV5` class with Q-learning updates and reward parsing
> - Adds [rl_next_state_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/484/files#diff-58291164a7ee9953f495bb283680ab3a1108a7d6bb70907d6cc627c33875cae2) implementing `RLNextStateSignalsV5`, which stores per-skill Q-values and updates them using a standard TD rule: `Q <- Q + alpha * (reward + gamma * max_next_Q - Q)`.
> - `parse_reward` maps positive/negative text tokens to `{1.0, 0.0, -1.0}`; `handle_interaction` parses reward from raw text and delegates to `process_signal`.
> - Reward and weight-delta metrics are logged after each update via the injected `RLMetricsTrackerV4`.
> - Tests in [test_rl_next_state_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/484/files#diff-f66250e53424c1c4e5f8a54346c4cb1bee7d83513e7b81dc3e4a2d554c6ea294) cover reward parsing, Q-value update correctness, metric logging, and sequential update accumulation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a45da2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->