### PR TITLE
Implement ACS guardrail persistence and update agent tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7860,7 +7860,7 @@
     },
     {
       "id": "acs-guardrail-persistence",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "ACS Control Specification Persistence",
@@ -17309,6 +17309,70 @@
       "acceptance": [
         "CanvasServer sends JSON-Patch deltas",
         "WebSocket bandwidth usage is significantly reduced"
+      ]
+    },
+    {
+      "id": "mcp-discovery-v7-86f1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Discovery V7",
+      "description": "Inspired by MCP standard trend: Implement a mechanism to scan a local directory for .py files, extract MCP tools using AST, and register them dynamically at runtime.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_discovery_v7.py",
+        "tests/test_mcp_discovery_v7.py"
+      ],
+      "acceptance": [
+        "Tools are discovered from files",
+        "Dynamic registration works without restart"
+      ]
+    },
+    {
+      "id": "a2a-retry-v5-92a1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Delegation V5 with Retry Policy",
+      "description": "Inspired by A2A task delegation trend: Implement an exponential backoff retry policy for A2A task delegation to handle transient network failures.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_retry_v5.py",
+        "tests/test_a2a_retry_v5.py"
+      ],
+      "acceptance": [
+        "Retry logic triggers on timeout/connection error",
+        "Exponential backoff works"
+      ]
+    },
+    {
+      "id": "rl-directness-v8-44b2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Directness Habit V8",
+      "description": "Inspired by OpenClaw-RL trend: Extract implicit feedback from user interaction frequency to adjust the directness habit weight in Procedural Memory.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_directness_v8.py",
+        "tests/test_rl_directness_v8.py"
+      ],
+      "acceptance": [
+        "Implicit feedback affects habit weights",
+        "Directness adjusts over multiple interactions"
+      ]
+    },
+    {
+      "id": "sqlite-concurrency-fix-77b3",
+      "status": "todo",
+      "area": "stabilization",
+      "risk": "medium",
+      "title": "SQLite Concurrent Access Improvement",
+      "description": "Improvement: Implement a connection pool or retry wrapper for SQLite to prevent database is locked errors during parallel execution.",
+      "allowed_paths": [
+        "magda_agent/utils/sqlite_pool.py",
+        "magda_agent/safety/audit_trail.py"
+      ],
+      "acceptance": [
+        "Concurrent writes do not fail",
+        "Tests verify multi-threaded access"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -244,3 +244,4 @@
 * [x] FEATURE: A2A Task Delegation and Discovery (a2a-task-delegation-discovery-june-2026) (2026-06-08)
 * [x] FEATURE: A2A Protocol Discovery and Delegation (agent-to-agent-delegation) (2026-06-11)
 * [x] FEATURE: OpenClaw RL Metrics Tracker v4 (openclaw-rl-metrics-tracker-v4) (2026-06-10)
+* [x] FEATURE: ACS Control Specification Persistence (acs-guardrail-persistence) (2026-06-12)

--- a/magda_agent/safety/acs_guard_v6.py
+++ b/magda_agent/safety/acs_guard_v6.py
@@ -5,7 +5,7 @@ from magda_agent.safety.policy import PolicyLayer
 from magda_agent.safety.audit_trail import AuditTrail
 from magda_agent.safety.taint import is_tainted
 from magda_agent.safety.acs_sandboxing import ACSToolSandbox
-from magda_agent.safety.acs_sandboxing import ACSToolSandbox
+from magda_agent.safety.acs_persistence import ACSPersistence
 
 _SENSITIVE_PATTERNS = (
     re.compile(r"api[_-]?key|token|password|private[_-]?key|secret[_-]?key", re.IGNORECASE),
@@ -25,17 +25,24 @@ class ACSGuardV6:
     across all skills using 5 validation checkpoints.
     """
 
-    def __init__(self, policy_layer: Optional[PolicyLayer] = None, audit_trail: Optional[AuditTrail] = None) -> None:
+    def __init__(
+        self,
+        policy_layer: Optional[PolicyLayer] = None,
+        audit_trail: Optional[AuditTrail] = None,
+        persistence: Optional[ACSPersistence] = None
+    ) -> None:
         """
         Initializes the ACS Guard V6.
 
         Args:
             policy_layer: An optional policy layer for evaluating tool policies.
             audit_trail: An optional audit trail for logging checkpoint results.
+            persistence: An optional persistence layer for recording checkpoint states.
         """
         self.logger = logging.getLogger(__name__)
         self.policy_layer = policy_layer or PolicyLayer()
         self.audit_trail = audit_trail or AuditTrail()
+        self.persistence = persistence or ACSPersistence()
         self.tool_sandbox = ACSToolSandbox()
 
     def checkpoint_1_input_validation(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
@@ -206,6 +213,14 @@ class ACSGuardV6:
 
         for i, checkpoint in enumerate(checkpoints, 1):
             passed, reason = checkpoint(workflow_data)
+            status = "passed" if passed else "failed"
+            self.persistence.log_checkpoint(
+                checkpoint_id=i,
+                status=status,
+                reason=reason,
+                workflow_context=workflow_data
+            )
+
             if not passed:
                 self.logger.warning(f"ACS Checkpoint {i} Failed: {reason}")
                 self.audit_trail.log_call(

--- a/magda_agent/safety/acs_persistence.py
+++ b/magda_agent/safety/acs_persistence.py
@@ -1,0 +1,99 @@
+import sqlite3
+import json
+import time
+import logging
+from typing import Dict, Any, Optional
+
+class ACSPersistence:
+    """
+    Persists ACS (Agent Control Specification) validation checkpoint states to SQLite.
+    Allows for audit trails and runtime policy adjustments by recording the outcome
+    of each of the 5 validation checkpoints.
+    """
+
+    def __init__(self, db_path: str = "acs_persistence.db") -> None:
+        """
+        Initializes the ACSPersistence layer.
+
+        Args:
+            db_path: Path to the SQLite database file.
+        """
+        self.db_path = db_path
+        self.logger = logging.getLogger(__name__)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the SQLite database schema."""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    CREATE TABLE IF NOT EXISTS acs_checkpoints_log (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp REAL NOT NULL,
+                        checkpoint_id INTEGER NOT NULL,
+                        status TEXT NOT NULL,
+                        reason TEXT,
+                        workflow_context TEXT
+                    )
+                    '''
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to initialize ACS persistence database at {self.db_path}: {e}")
+
+    def log_checkpoint(
+        self,
+        checkpoint_id: int,
+        status: str,
+        reason: Optional[str] = None,
+        workflow_context: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """
+        Logs the result of an ACS checkpoint.
+
+        Args:
+            checkpoint_id: The ID of the checkpoint (1-5).
+            status: The status of the checkpoint ("passed" or "failed").
+            reason: Optional reason for the status.
+            workflow_context: Optional context data related to the workflow.
+        """
+        timestamp = time.time()
+        context_json = json.dumps(workflow_context) if workflow_context else None
+
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    INSERT INTO acs_checkpoints_log (timestamp, checkpoint_id, status, reason, workflow_context)
+                    VALUES (?, ?, ?, ?, ?)
+                    ''',
+                    (timestamp, checkpoint_id, status, reason, context_json)
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to log ACS checkpoint {checkpoint_id} to database: {e}")
+
+    def get_logs(self, checkpoint_id: Optional[int] = None) -> list:
+        """
+        Retrieves logs from the database.
+
+        Args:
+            checkpoint_id: Optional filter by checkpoint ID.
+
+        Returns:
+            A list of log entries.
+        """
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                if checkpoint_id:
+                    cursor.execute("SELECT * FROM acs_checkpoints_log WHERE checkpoint_id = ?", (checkpoint_id,))
+                else:
+                    cursor.execute("SELECT * FROM acs_checkpoints_log")
+                return cursor.fetchall()
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to retrieve ACS logs: {e}")
+            return []

--- a/tests/test_acs_persistence.py
+++ b/tests/test_acs_persistence.py
@@ -1,0 +1,75 @@
+import pytest
+import os
+import sqlite3
+from magda_agent.safety.acs_persistence import ACSPersistence
+from magda_agent.safety.acs_guard_v6 import ACSGuardV6, SecurityViolationError
+
+@pytest.fixture
+def temp_db(tmp_path):
+    db_path = tmp_path / "test_acs.db"
+    return str(db_path)
+
+def test_acs_persistence_logging(temp_db):
+    persistence = ACSPersistence(db_path=temp_db)
+    context = {"tool": "test_tool", "action": "read", "kwargs": {"path": "test.txt"}}
+
+    persistence.log_checkpoint(1, "passed", "Input validation passed", context)
+    persistence.log_checkpoint(2, "failed", "Unauthorized intent", context)
+
+    logs = persistence.get_logs()
+    assert len(logs) == 2
+
+    # log 1: id, timestamp, checkpoint_id, status, reason, workflow_context
+    assert logs[0][2] == 1
+    assert logs[0][3] == "passed"
+    assert "Input validation passed" in logs[0][4]
+    assert "test_tool" in logs[0][5]
+
+    assert logs[1][2] == 2
+    assert logs[1][3] == "failed"
+    assert "Unauthorized intent" in logs[1][4]
+
+def test_acs_guard_integration(temp_db):
+    persistence = ACSPersistence(db_path=temp_db)
+    guard = ACSGuardV6(persistence=persistence)
+
+    workflow_data = {
+        "action": "read",
+        "tool": "safe_tool",
+        "kwargs": {"param": "value"},
+        "current_state": "idle",
+        "next_state": "executing"
+    }
+
+    # Mocking policy_layer to always allow
+    guard.policy_layer.evaluate = lambda tool, **kwargs: (True, "Allowed by mock")
+
+    guard.intercept_action(workflow_data)
+
+    logs = persistence.get_logs()
+    # Should have 5 logs, one for each checkpoint
+    assert len(logs) == 5
+    for i in range(5):
+        assert logs[i][2] == i + 1
+        assert logs[i][3] == "passed"
+
+def test_acs_guard_failure_persistence(temp_db):
+    persistence = ACSPersistence(db_path=temp_db)
+    guard = ACSGuardV6(persistence=persistence)
+
+    workflow_data = {
+        "action": "unauthorized_action",
+        "tool": "safe_tool",
+        "kwargs": {"param": "value"}
+    }
+
+    with pytest.raises(SecurityViolationError):
+        guard.intercept_action(workflow_data)
+
+    logs = persistence.get_logs()
+    # Checkpoint 1 should pass, Checkpoint 2 should fail
+    assert len(logs) == 2
+    assert logs[0][2] == 1
+    assert logs[0][3] == "passed"
+    assert logs[1][2] == 2
+    assert logs[1][3] == "failed"


### PR DESCRIPTION
This PR implements the ACS validation checkpoint persistence layer using SQLite, integrates it into the ACS Guard V6, and updates the agent task manifest with new future-facing tasks based on June 2026 trends.

Key changes:
- **ACS Persistence**: Added a new module `magda_agent/safety/acs_persistence.py` that manages a SQLite table `acs_checkpoints_log` to store granular outcomes for the five Agent Control Specification validation checkpoints.
- **Guard Integration**: Modified `ACSGuardV6` to use the persistence layer, ensuring every tool action's validation history is recorded for audit trails.
- **Testing**: Added `tests/test_acs_persistence.py` which verifies successful and failed checkpoint logging.
- **Task Replenishment**: Marked `acs-guardrail-persistence` as `done` and added 3 new `todo` tasks (MCP Dynamic Discovery V7, A2A Delegation V5 with Retry, OpenClaw-RL Directness Habit V8) and 1 improvement task (SQLite Concurrency Fix) to `agent_tasks.json`.
- **Validation**: Confirmed all 1472 existing and new tests pass. Removed any generated binary database files from the submission.

---
*PR created automatically by Jules for task [9092329429847409781](https://jules.google.com/task/9092329429847409781) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SQLite-backed persistence for ACS guardrail checkpoint logging
> - Adds [`ACSPersistence`](https://github.com/kazah4359-lgtm/Magda-agent/pull/488/files#diff-21d7cff68f894f842900b79d1d611b961cbe20630bd344ce3ed4fe9444193576), a new class that manages a SQLite database (`acs_persistence.db`) to store a log of each ACS checkpoint evaluation, including status, reason, and workflow context.
> - Extends [`ACSGuardV6`](https://github.com/kazah4359-lgtm/Magda-agent/pull/488/files#diff-71e9c69ddc5fa3cdd6978a914b1f02cda615a18100456aaaba4cf3bfd3c13094) to accept an optional `ACSPersistence` instance (defaulting to a new one) and write a pass/fail row to the database for each checkpoint evaluated in `intercept_action`.
> - Adds tests in [`tests/test_acs_persistence.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/488/files#diff-35c6abf696615bb250c28040c551af1670dbad9256d53b8828cb4dc7b30dd8ec) covering direct persistence logging, full guard integration, and failure-path persistence.
> - Risk: the default behavior now writes to `acs_persistence.db` on disk for every `intercept_action` call; callers that do not provide a custom persistence instance will incur SQLite I/O without any opt-out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f952a85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->