### PR TITLE
Implement Git Worktree Multi-Agent Isolation v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7964,7 +7964,7 @@
     },
     {
       "id": "claude-git-worktree-team-isolation-v4",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Git Worktree Team Isolation v4",
@@ -17582,6 +17582,57 @@
       "acceptance": [
         "Entropy tracker identifies repetitive behavior patterns",
         "High entropy score triggers curiosity drive update"
+      ]
+    },
+    {
+      "id": "openclaw-rl-metrics-tracker-v4-8f92a11b",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Metrics Tracker v4",
+      "description": "Inspired by OpenClaw-RL trend: Implement a metrics tracker that logs online reinforcement learning trajectory updates, tracking longitudinal reward trends and habit stability metrics.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_metrics_v4.py",
+        "tests/test_rl_metrics_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RLMetricsTrackerV4 successfully tracks reward trajectory updates and habit weight stability.",
+        "Unit tests verify metric logging and query operations."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-discovery-v4-cc21a4f5",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Discovery v4",
+      "description": "Inspired by Model Context Protocol trends: Enhance MCP dynamic discovery mechanism to scan a directory and dynamically load .py files as MCPTool instances using importlib without requiring a server restart.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_discovery_v4.py",
+        "tests/test_mcp_discovery_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCPDynamicDiscoveryV4 dynamically loads valid Python tool definitions from a folder at runtime.",
+        "Tests verify that hot-loading tool files registers them in the active MCP registry."
+      ]
+    },
+    {
+      "id": "a2a-discovery-cards-v3-e8a1d123",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Discovery Cards v3",
+      "description": "Inspired by Agent-to-Agent standard: Implement a discovery card manager to fetch and parse AgentCardV3 capabilities from A2A endpoints asynchronously using httpx.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_cards_v3.py",
+        "tests/test_a2a_discovery_cards_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2ADiscoveryCardsV3 successfully fetches remote Agent Cards and parses capability schemas.",
+        "Tests verify parsing of standard capabilities with mock endpoints using respx."
       ]
     }
   ]

--- a/magda_agent/isolation/git_worktree_multi.py
+++ b/magda_agent/isolation/git_worktree_multi.py
@@ -1,0 +1,65 @@
+import asyncio
+import logging
+from typing import List, Callable, Coroutine, Any, Optional
+from magda_agent.isolation.git_worktree import GitWorktreeManager
+
+class GitWorktreeMultiManager:
+    """
+    Manages concurrent multi-agent Git worktree execution.
+    Ensures parallel tasks run with total context isolation in separate git worktrees,
+    preventing state bleeding.
+    """
+    def __init__(self, base_dir: str = "/tmp/magda_worktrees_multi") -> None:
+        """
+        Initializes the GitWorktreeMultiManager.
+
+        Args:
+            base_dir: Base directory under which individual worktrees will be created.
+        """
+        self.base_dir = base_dir
+        self.worktree_manager = GitWorktreeManager(base_dir=base_dir)
+
+    async def execute_concurrently(
+        self,
+        tasks: List[Callable[[str], Coroutine[Any, Any, Any]]],
+        branch_names: Optional[List[Optional[str]]] = None
+    ) -> List[Any]:
+        """
+        Executes a list of asynchronous task callables concurrently, each inside an isolated git worktree.
+
+        Args:
+            tasks: A list of callables, where each callable takes the worktree path (str) as an argument
+                   and returns a Coroutine.
+            branch_names: Optional list of branch names corresponding to each task. If not provided or
+                          less than the number of tasks, detached HEAD worktrees are created.
+
+        Returns:
+            A list of results from the tasks in the same order.
+        """
+        if not tasks:
+            return []
+
+        if branch_names is None:
+            branch_names = [None] * len(tasks)
+        elif len(branch_names) < len(tasks):
+            branch_names = list(branch_names) + [None] * (len(tasks) - len(branch_names))
+
+        async def run_single_task(
+            task: Callable[[str], Coroutine[Any, Any, Any]],
+            branch_name: Optional[str]
+        ) -> Any:
+            """
+            Runs a single task within an isolated git worktree managed context.
+            """
+            async with self.worktree_manager.isolated_environment(branch_name=branch_name) as worktree_path:
+                logging.info(f"Running concurrent task in worktree path: {worktree_path}")
+                return await task(worktree_path)
+
+        results = await asyncio.gather(*(run_single_task(t, b) for t, b in zip(tasks, branch_names)), return_exceptions=True)
+
+        for r in results:
+            if isinstance(r, Exception):
+                logging.error(f"Concurrent task execution encountered an exception: {r}")
+                raise r
+
+        return results

--- a/tests/test_git_worktree_multi.py
+++ b/tests/test_git_worktree_multi.py
@@ -1,0 +1,59 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch
+from typing import List
+from magda_agent.isolation.git_worktree_multi import GitWorktreeMultiManager
+
+@pytest.mark.asyncio
+async def test_execute_concurrently_success() -> None:
+    """Test that GitWorktreeMultiManager executes tasks concurrently inside unique paths."""
+    manager = GitWorktreeMultiManager(base_dir="/tmp/test_worktrees_multi")
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    paths_seen: List[str] = []
+
+    async def sample_task(worktree_path: str) -> str:
+        paths_seen.append(worktree_path)
+        await asyncio.sleep(0.01)
+        return f"Result from {worktree_path}"
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        results = await manager.execute_concurrently(
+            tasks=[sample_task, sample_task, sample_task],
+            branch_names=["b1", "b2", "b3"]
+        )
+
+        assert len(results) == 3
+        assert len(set(paths_seen)) == 3
+        for path in paths_seen:
+            assert "test_worktrees_multi/worktree_" in path
+
+        assert mock_exec.call_count == 6
+
+@pytest.mark.asyncio
+async def test_execute_concurrently_exception_handling() -> None:
+    """Test that GitWorktreeMultiManager cleans up all worktrees even if one task raises an exception."""
+    manager = GitWorktreeMultiManager(base_dir="/tmp/test_worktrees_multi")
+
+    mock_process = AsyncMock()
+    mock_process.communicate.return_value = (b"", b"")
+    mock_process.returncode = 0
+
+    async def failing_task(worktree_path: str) -> str:
+        await asyncio.sleep(0.01)
+        raise ValueError("Task failed")
+
+    async def succeeding_task(worktree_path: str) -> str:
+        await asyncio.sleep(0.01)
+        return "OK"
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_process) as mock_exec:
+        with pytest.raises(ValueError, match="Task failed"):
+            await manager.execute_concurrently(
+                tasks=[succeeding_task, failing_task]
+            )
+
+        assert mock_exec.call_count == 4


### PR DESCRIPTION
Implement GitWorktreeMultiManager to support executing parallel multi-agent tasks concurrently in their own isolated git worktrees. Update agent_tasks.json and add unit tests.

---
*PR created automatically by Jules for task [8214701415040738195](https://jules.google.com/task/8214701415040738195) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **New implementation:**
  - Added `GitWorktreeMultiManager` to enable isolated concurrent task execution using git worktrees.
- **Task backlog updates:**
  - Marked `claude-git-worktree-team-isolation-v4` as `done`.
  - Added new task definitions for `OpenClaw-RL Metrics Tracker`, `MCP Dynamic Discovery`, and `A2A Discovery Cards`.
- **Testing:**
  - Introduced `test_git_worktree_multi.py` to verify concurrent execution paths and exception handling.

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `GitWorktreeMultiManager` to run async tasks concurrently in isolated git worktrees
> - Adds [`GitWorktreeMultiManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/494/files#diff-d6608eb388d30064b24f995550b9176babc27feb71170ede89dbbd07fa0a7292) which wraps `GitWorktreeManager` to coordinate concurrent execution of multiple async tasks, each in its own isolated worktree.
> - `execute_concurrently` accepts a list of async task callables and optional per-task branch names, runs them via `asyncio.gather`, and returns results in order or re-raises the first exception encountered.
> - Adds tests in [`tests/test_git_worktree_multi.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/494/files#diff-a75f227912a4ed958c7ba917f4e3835fb36ca722b7141084015eb49d3bde235e) covering success and exception-propagation paths by patching `asyncio.create_subprocess_exec`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 360ed7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->