### PR TITLE
Implement Context Engine Selective Retrieval v3 and replenish tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7981,7 +7981,7 @@
     },
     {
       "id": "context-engine-selective-retrieval-v3",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine Selective Retrieval v3",
@@ -17633,6 +17633,54 @@
       "acceptance": [
         "A2ADiscoveryCardsV3 successfully fetches remote Agent Cards and parses capability schemas.",
         "Tests verify parsing of standard capabilities with mock endpoints using respx."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-alignment-v3-f6a7b2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Multimodal Alignment V3",
+      "description": "Inspired by OpenClaw trends (June 2026): Implement an online reinforcement learning module that aligns tone and verbosity based on user reactions to multimodal image/text messages.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_multimodal_alignment_v3.py",
+        "tests/test_openclaw_rl_multimodal_alignment_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL agent dynamically tunes tone weights after processing multimodal user reactions. Tests mock reactions and verify weight updates."
+      ]
+    },
+    {
+      "id": "acs-safety-checkpoints-persistence-v10-def34",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Safety Checkpoints Persistence V10",
+      "description": "Inspired by Microsoft ACS (June 2026): Implement persistent storage using SQLite to save historical validation outcomes for the 5 safety checkpoints.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_persistence_v10.py",
+        "tests/test_acs_persistence_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS checkpoint results are serialized and saved to SQLite. Tests verify querying historic failure rates."
+      ]
+    },
+    {
+      "id": "mcp-concurrency-scheduler-v15-123ab",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Concurrency Scheduler V15",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a specialized scheduler for concurrent MCP tool execution with built-in execution latency tracking.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_scheduler_v15.py",
+        "tests/test_mcp_scheduler_v15.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler initiates concurrent execution and monitors completion latency per tool. Tests verify correct scheduling and performance log output."
       ]
     }
   ]

--- a/magda_agent/memory/context_selective_retrieval_v3.py
+++ b/magda_agent/memory/context_selective_retrieval_v3.py
@@ -1,0 +1,179 @@
+import logging
+import time
+from typing import Any, Dict, List, Optional
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+class ContextSelectiveRetrievalV3:
+    """
+    ContextSelectiveRetrievalV3 implements advanced context compression and selective
+    retrieval for Context Engine. It dynamically prunes context windows based on
+    token limits and prioritizes memories based on importance, query relevance, and temporal recency.
+    """
+    def __init__(self, llm: Optional[Any] = None, importance_threshold: float = 0.7) -> None:
+        """
+        Initializes the ContextSelectiveRetrievalV3.
+
+        Args:
+            llm: Optional language model integration for intelligent compaction.
+            importance_threshold: Importance threshold above which memory entries are considered critical.
+        """
+        self.llm = llm
+        self.importance_threshold = importance_threshold
+
+    def get_token_length(self, entries: List[MemoryEntry]) -> int:
+        """
+        Calculates estimated token length of given memory entries.
+
+        Args:
+            entries: A list of MemoryEntry objects.
+
+        Returns:
+            The estimated token count.
+        """
+        total_words = sum(len(e.content.split()) for e in entries)
+        return int(total_words * 1.3)
+
+    def calculate_relevance(self, content: str, query: Optional[str]) -> float:
+        """
+        Calculates a simple relevance score based on word overlap.
+
+        Args:
+            content: The text content of the memory entry.
+            query: The search query.
+
+        Returns:
+            A relevance score between 0.0 and 1.0.
+        """
+        if not query:
+            return 0.0
+        query_words = set(query.lower().split())
+        content_words = set(content.lower().split())
+        if not query_words:
+            return 0.0
+        overlap = query_words.intersection(content_words)
+        return len(overlap) / len(query_words)
+
+    async def prune_context(self, entries: List[MemoryEntry], max_tokens: int, query: Optional[str] = None) -> List[MemoryEntry]:
+        """
+        Intelligently prunes the list of memory entries to fit within max_tokens.
+        Prioritizes critical entries (importance >= threshold) and highly relevant entries.
+        Compresses less relevant entries if LLM is available, or drops them.
+
+        Args:
+            entries: The full list of MemoryEntry items.
+            max_tokens: The token limit for the context.
+            query: Optional semantic or keyword query.
+
+        Returns:
+            The pruned and prioritized list of MemoryEntry items.
+        """
+        if not entries:
+            return []
+
+        current_tokens = self.get_token_length(entries)
+        if current_tokens <= max_tokens:
+            return entries
+
+        logging.info(f"Context length ({current_tokens} tokens) exceeds limit ({max_tokens} tokens). Pruning dynamically...")
+
+        # Calculate composite score for each entry
+        scored_entries = []
+        n_entries = len(entries)
+        for idx, entry in enumerate(entries):
+            importance = entry.importance
+            relevance = self.calculate_relevance(entry.content, query)
+            recency = idx / max(1, n_entries - 1)  # Later items are more recent
+
+            # Composite prioritization score
+            score = (importance * 0.5) + (relevance * 0.3) + (recency * 0.2)
+            is_critical = importance >= self.importance_threshold or relevance >= 0.5
+            scored_entries.append((score, is_critical, entry))
+
+        # Separate critical and non-critical entries
+        critical = [item[2] for item in scored_entries if item[1]]
+        non_critical = [item[2] for item in scored_entries if not item[1]]
+
+        # If critical entries alone exceed the limit, truncate the lowest scoring critical entries
+        if self.get_token_length(critical) > max_tokens:
+            logging.warning("Critical entries alone exceed limit, truncating lowest scored critical entries.")
+            sorted_critical = sorted(
+                [(item[0], item[2]) for item in scored_entries if item[1]],
+                key=lambda x: x[0],
+                reverse=True
+            )
+            retained_critical = []
+            for _, entry in sorted_critical:
+                if self.get_token_length(retained_critical + [entry]) <= max_tokens:
+                    retained_critical.append(entry)
+                else:
+                    break
+            return sorted(retained_critical, key=lambda e: entries.index(e))
+
+        # We have some room left for non-critical entries
+        retained_entries = list(critical)
+        if not non_critical:
+            return retained_entries
+
+        # Try to compress non-critical entries if LLM is present
+        if self.llm:
+            try:
+                non_critical_text = "\n".join(e.content for e in non_critical)
+                prompt = (
+                    f"Summarize the following non-critical background information concisely "
+                    f"to fit within the remaining context limit:\n\n{non_critical_text}"
+                )
+                messages = [
+                    {"role": "system", "content": "You are a precise context compression engine. Output only the summarized text."},
+                    {"role": "user", "content": prompt}
+                ]
+                summary_content = await self.llm.chat_completion(messages, temperature=0.3)
+
+                avg_importance = sum(e.importance for e in non_critical) / len(non_critical)
+                first = non_critical[0]
+                tags = list(set(tag for e in non_critical for tag in e.tags))
+
+                summary_entry = MemoryEntry(
+                    content=summary_content.strip(),
+                    importance=avg_importance,
+                    emotional_state=getattr(first, 'emotional_state', PADState(0, 0, 0)),
+                    tags=tags,
+                    user_id=first.user_id
+                )
+
+                # Check if adding the summary entry fits in token limit
+                if self.get_token_length(retained_entries + [summary_entry]) <= max_tokens:
+                    retained_entries.append(summary_entry)
+                else:
+                    logging.warning("Compressed summary too large, dropping non-critical entries.")
+            except Exception as e:
+                logging.error(f"LLM compression failed: {e}. Falling back to dynamic truncation.")
+                self._truncate_non_critical(retained_entries, non_critical, max_tokens, scored_entries)
+        else:
+            self._truncate_non_critical(retained_entries, non_critical, max_tokens, scored_entries)
+
+        # Re-sort to maintain original order of entries (except for generated summaries placed at the end/correct spots)
+        return sorted(retained_entries, key=lambda e: entries.index(e) if e in entries else len(entries))
+
+    def _truncate_non_critical(self, retained: List[MemoryEntry], non_critical: List[MemoryEntry], max_tokens: int, scored_entries: List[Any]) -> None:
+        """Helper to append non-critical entries sorted by priority score until limit is reached."""
+        # Sort non-critical entries by composite score descending
+        sorted_non_critical = sorted(
+            [(item[0], item[2]) for item in scored_entries if not item[1]],
+            key=lambda x: x[0],
+            reverse=True
+        )
+        for _, entry in sorted_non_critical:
+            if self.get_token_length(retained + [entry]) <= max_tokens:
+                retained.append(entry)
+            else:
+                break
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        ContextPlugin compliant compact lifecycle hook.
+        Compacts the context items to fit within token bounds.
+        """
+        max_tokens = metadata.get("max_tokens", 1000)
+        query = metadata.get("query", None)
+        return await self.prune_context(context_items, max_tokens, query=query)

--- a/tests/test_context_selective_retrieval_v3.py
+++ b/tests/test_context_selective_retrieval_v3.py
@@ -1,0 +1,121 @@
+import pytest
+from unittest.mock import AsyncMock
+from typing import Any, List
+from magda_agent.memory.context_selective_retrieval_v3 import ContextSelectiveRetrievalV3
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+@pytest.mark.asyncio
+async def test_token_length_estimation() -> None:
+    """Tests the heuristic token length calculation based on word count."""
+    retriever = ContextSelectiveRetrievalV3()
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("word1 word2 word3", 0.5, state)
+    e2 = MemoryEntry("word4 word5", 0.6, state)
+
+    # 5 words * 1.3 = 6.5 -> 6 tokens
+    assert retriever.get_token_length([e1, e2]) == 6
+
+
+@pytest.mark.asyncio
+async def test_relevance_calculation() -> None:
+    """Tests basic keyword overlap-based relevance scoring."""
+    retriever = ContextSelectiveRetrievalV3()
+
+    score_full = retriever.calculate_relevance("test query overlap", "test query")
+    score_partial = retriever.calculate_relevance("test other", "test query")
+    score_none = retriever.calculate_relevance("other text", "test query")
+
+    assert score_full == 1.0
+    assert score_partial == 0.5
+    assert score_none == 0.0
+
+
+@pytest.mark.asyncio
+async def test_prune_context_under_limit() -> None:
+    """Verifies that no pruning occurs if context is under max_tokens."""
+    retriever = ContextSelectiveRetrievalV3()
+    state = PADState(0, 0, 0)
+
+    entries = [
+        MemoryEntry("apple banana cherry", 0.5, state),
+        MemoryEntry("date fig grape", 0.6, state)
+    ]
+
+    # Total words = 6 -> token length = 7. max_tokens = 10.
+    result = await retriever.prune_context(entries, max_tokens=10)
+    assert len(result) == 2
+    assert result == entries
+
+
+@pytest.mark.asyncio
+async def test_prune_context_with_truncation() -> None:
+    """Verifies that non-critical entries are truncated in priority order when LLM is absent."""
+    retriever = ContextSelectiveRetrievalV3(importance_threshold=0.8)
+    state = PADState(0, 0, 0)
+
+    # max_tokens = 5.
+    # Entries:
+    e1 = MemoryEntry("banana apple", 0.5, state) # Non-critical
+    e2 = MemoryEntry("grape cherry berry", 0.9, state) # Critical (importance >= 0.8)
+    e3 = MemoryEntry("kiwi lemon orange", 0.2, state) # Non-critical
+
+    entries = [e1, e2, e3]
+
+    # Total tokens: 8 * 1.3 = 10.
+    # Critical e2: tokens = 3 * 1.3 = 3.
+    # We want to prune with max_tokens = 6.
+    # Critical e2 must be retained.
+    result = await retriever.prune_context(entries, max_tokens=6)
+
+    assert len(result) < 3
+    assert e2 in result  # Critical entry must be preserved
+    assert retriever.get_token_length(result) <= 6
+
+
+@pytest.mark.asyncio
+async def test_prune_context_with_llm_compression() -> None:
+    """Tests context compression of non-critical memories using LLM client."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "Comp Summary"
+    retriever = ContextSelectiveRetrievalV3(llm=mock_llm, importance_threshold=0.8)
+    state = PADState(0.1, 0.2, 0.3)
+
+    e1 = MemoryEntry("very long non critical piece one", 0.4, state, tags=["tag1"])
+    e2 = MemoryEntry("very long critical piece two", 0.9, state, tags=["tag2"])
+    e3 = MemoryEntry("very long non critical piece three", 0.3, state, tags=["tag3"])
+
+    entries = [e1, e2, e3]
+
+    # Total tokens is high. We prune to max_tokens = 12.
+    result = await retriever.prune_context(entries, max_tokens=12, query="two")
+
+    # Critical e2 should be present because of its high importance
+    assert e2 in result
+    # Non-critical items (e1, e3) should be compressed into one MemoryEntry
+    assert len(result) == 2
+
+    summary_entry = [e for e in result if e != e2][0]
+    assert summary_entry.content == "Comp Summary"
+    assert "tag1" in summary_entry.tags
+    assert "tag3" in summary_entry.tags
+
+
+@pytest.mark.asyncio
+async def test_context_plugin_compact_lifecycle() -> None:
+    """Tests the compact method wrapper to ensure compatibility with ContextPlugin lifecycle."""
+    retriever = ContextSelectiveRetrievalV3()
+    state = PADState(0, 0, 0)
+
+    entries = [
+        MemoryEntry("one two", 0.5, state),
+        MemoryEntry("three four", 0.6, state)
+    ]
+
+    # Compact to max_tokens=3
+    metadata = {"max_tokens": 3}
+    result = await retriever.compact(entries, metadata)
+
+    assert len(result) < 2
+    assert retriever.get_token_length(result) <= 3


### PR DESCRIPTION
This PR implements the 'Context Engine Selective Retrieval v3' task, verifying token-based limit enforcement and prioritize memories based on importance, query relevance, and temporal recency. It also replenishes the task queue with 3 new high-quality, trend-aligned tasks.

---
*PR created automatically by Jules for task [11977299835500618414](https://jules.google.com/task/11977299835500618414) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ContextSelectiveRetrievalV3` for token-budget-aware context pruning and LLM summarization
> - Adds [context_selective_retrieval_v3.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/495/files#diff-2ce0be81577ec66f71a75a31c6ea6aeb909658343a2ca9f5d1f894865c01c686) implementing a new `ContextSelectiveRetrievalV3` class that scores memory entries by importance (0.5), relevance (0.3), and recency (0.2) to prune context within a max token budget.
> - Critical entries (importance >= threshold or relevance >= 0.5) are retained first; non-critical entries are either summarized via an optional LLM into a single merged `MemoryEntry` or truncated by score rank.
> - Exposes a `compact()` method compatible with the `ContextPlugin` interface, delegating to `prune_context` using `max_tokens` and `query` from metadata.
> - Adds a full test suite in [test_context_selective_retrieval_v3.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/495/files#diff-ba2cf4e8d173990abd6c7771609e6a593e9929fc9f0073afbc38a51ca830a779) covering token estimation, relevance scoring, truncation, LLM compression, and the compact lifecycle.
> - Updates [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/495/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) to mark one task done and append three new tasks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c152748.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->