### PR TITLE
Implement Agent Guard Taint Tracking V2 and replenish tasks pool

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -7998,7 +7998,7 @@
     },
     {
       "id": "agent-guard-taint-tracking-v2",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "Agent Guard Taint Tracking v2",
@@ -17681,6 +17681,59 @@
       ],
       "acceptance": [
         "Scheduler initiates concurrent execution and monitors completion latency per tool. Tests verify correct scheduling and performance log output."
+      ]
+    },
+    {
+      "id": "a2a-peer-delegation-fallback-06a7",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Peer Delegation Error Handling and Fallback",
+      "description": "Inspired by A2A standard trend: Implement a robust retry-and-fallback mechanism when delegating tasks to external agents via the A2A network fails or times out.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_fallback_06a7.py",
+        "tests/test_a2a_fallback_06a7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A client correctly retries failed task delegations.",
+        "Falls back to a local planner or local tool execution on persistent peer failures.",
+        "Tests verify retry and fallback paths with mock peer endpoints."
+      ]
+    },
+    {
+      "id": "context-engine-plugin-instrumentation-06a8",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "Context Engine Plugin Lifecycle Instrumentation",
+      "description": "Inspired by Context Engine trend: Instrument the Context Engine plugin registry with latency and performance metrics tracking for each hook execution (bootstrap, ingest, assemble, compact).",
+      "allowed_paths": [
+        "magda_agent/memory/context_instrumentation_06a8.py",
+        "tests/test_context_instrumentation_06a8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Instrumented Context Engine measures and logs execution time for every plugin hook invocation.",
+        "Hook latency stats are stored in the longitudinal quality store.",
+        "Tests mock plugin executions and assert metrics generation."
+      ]
+    },
+    {
+      "id": "spawner-context-leak-fix-06a9",
+      "status": "todo",
+      "area": "stabilization",
+      "risk": "medium",
+      "title": "Fix Memory Leaks in Multi-Agent Context Spawner",
+      "description": "Improvement: Address memory leak in the Multi-Agent Context Spawner by ensuring parent-child references are cleanly disposed of and isolated context maps are explicitly cleared after subagent execution.",
+      "allowed_paths": [
+        "magda_agent/agents/spawner_leak_fix_06a9.py",
+        "tests/test_spawner_leak_fix_06a9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context maps are completely cleared upon subagent cleanup.",
+        "Tests verify that parent-child references do not cause cyclic reference leaks."
       ]
     }
   ]

--- a/magda_agent/safety/taint_tracking_v2.py
+++ b/magda_agent/safety/taint_tracking_v2.py
@@ -1,8 +1,13 @@
 """MCPKernel Taint Tracking Sandbox V2.
 
-Provides taint tracking with origin propagation and sandboxing for tool execution.
+Provides taint tracking with origin propagation and sandboxing for tool execution,
+and integrates with the Agent Guard runtime policy layer.
 """
+import inspect
+import logging
 from typing import Any, Callable, Dict, List, Set, Union
+
+from magda_agent.safety.agent_guard import AgentGuard, SecurityViolationError
 
 
 class PolicyViolationError(Exception):
@@ -12,23 +17,44 @@ class PolicyViolationError(Exception):
 
 class TaintedData:
     """Base class for tainted data wrappers that track origins."""
-    def __init__(self, value: Any, origins: Set[str] = None):
+    def __init__(self, value: Any, origins: Set[str] = None) -> None:
+        """Initialize the TaintedData.
+
+        Args:
+            value: The underlying untainted value.
+            origins: Optional set of origin sources.
+        """
         self.value = value
         self.origins = origins if origins is not None else set()
 
 
 class TaintedString(TaintedData, str):
     """A string subclass that marks data as tainted and tracks its origins."""
-    def __new__(cls, value: str, origins: Set[str] = None):
+    def __new__(cls, value: str, origins: Set[str] = None) -> "TaintedString":
+        """Create a new TaintedString instance."""
         obj = str.__new__(cls, value)
         return obj
 
-    def __init__(self, value: str, origins: Set[str] = None):
+    def __init__(self, value: str, origins: Set[str] = None) -> None:
+        """Initialize the TaintedString.
+
+        Args:
+            value: The string value.
+            origins: Optional set of origin sources.
+        """
         TaintedData.__init__(self, value, origins)
 
 
 def mark_tainted(s: Any, origin: str) -> Any:
-    """Marks a string, list, or dict as tainted recursively with the given origin."""
+    """Marks a string, list, or dict as tainted recursively with the given origin.
+
+    Args:
+        s: The object to taint.
+        origin: The source origin.
+
+    Returns:
+        The tainted object.
+    """
     if isinstance(s, str) and not isinstance(s, TaintedString):
         return TaintedString(s, {origin})
     elif isinstance(s, TaintedString):
@@ -42,7 +68,14 @@ def mark_tainted(s: Any, origin: str) -> Any:
 
 
 def is_tainted(s: Any) -> bool:
-    """Checks if an object or any of its nested structures is tainted."""
+    """Checks if an object or any of its nested structures is tainted.
+
+    Args:
+        s: The object to check.
+
+    Returns:
+        True if tainted, False otherwise.
+    """
     if isinstance(s, TaintedData):
         return True
     if isinstance(s, list):
@@ -53,7 +86,14 @@ def is_tainted(s: Any) -> bool:
 
 
 def get_origins(s: Any) -> Set[str]:
-    """Retrieves all origins from a tainted object recursively."""
+    """Retrieves all origins from a tainted object recursively.
+
+    Args:
+        s: The object to inspect.
+
+    Returns:
+        A set of all distinct origin strings.
+    """
     origins = set()
     if isinstance(s, TaintedData):
         origins.update(s.origins)
@@ -68,7 +108,14 @@ def get_origins(s: Any) -> Set[str]:
 
 
 def sanitize(s: Any) -> Any:
-    """Sanitizes tainted data, returning regular primitives recursively."""
+    """Sanitizes tainted data, returning regular primitives recursively.
+
+    Args:
+        s: The object to sanitize.
+
+    Returns:
+        The untainted, sanitized object.
+    """
     if isinstance(s, TaintedString):
         return str(s.value)
     elif isinstance(s, TaintedData):
@@ -87,38 +134,87 @@ class TaintTrackerV2:
         pass
 
     def taint(self, obj: Any, origin: str) -> Any:
-        """Mark an object as tainted recursively with an origin."""
+        """Mark an object as tainted recursively with an origin.
+
+        Args:
+            obj: The object to taint.
+            origin: The origin source.
+
+        Returns:
+            The tainted object.
+        """
         return mark_tainted(obj, origin)
 
     def taint_with_origins(self, obj: Any, origins: Set[str]) -> Any:
-        """Mark an object as tainted recursively with a set of origins."""
+        """Mark an object as tainted recursively with a set of origins.
+
+        Args:
+            obj: The object to taint.
+            origins: The set of origins.
+
+        Returns:
+            The tainted object.
+        """
         for origin in origins:
             obj = mark_tainted(obj, origin)
         return obj
 
     def is_tainted(self, obj: Any) -> bool:
-        """Check if an object or its contents are tainted."""
+        """Check if an object or its contents are tainted.
+
+        Args:
+            obj: The object to check.
+
+        Returns:
+            True if tainted, False otherwise.
+        """
         return is_tainted(obj)
 
     def get_origins(self, obj: Any) -> Set[str]:
-        """Get the origins of a tainted object."""
+        """Get the origins of a tainted object.
+
+        Args:
+            obj: The object to inspect.
+
+        Returns:
+            The set of origins.
+        """
         return get_origins(obj)
 
     def sanitize(self, obj: Any) -> Any:
-        """Sanitize an object recursively."""
+        """Sanitize an object recursively.
+
+        Args:
+            obj: The object to sanitize.
+
+        Returns:
+            The sanitized object.
+        """
         return sanitize(obj)
 
 
 class SandboxExecutionEnvironmentV2:
     """A sandbox for executing tools with taint origin propagation."""
     def __init__(self, tracker: TaintTrackerV2) -> None:
-        """Initialize the sandbox execution environment."""
+        """Initialize the sandbox execution environment.
+
+        Args:
+            tracker: The TaintTrackerV2 instance.
+        """
         self.tracker = tracker
 
     def execute(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        """
-        Execute a function in the sandbox.
+        """Execute a function in the sandbox.
+
         Automatically propagates taint from inputs to output, aggregating origins.
+
+        Args:
+            func: The function to execute.
+            *args: Positional arguments for the function.
+            **kwargs: Keyword arguments for the function.
+
+        Returns:
+            The result of execution, tainted if any inputs were tainted.
         """
         origins = set()
         for arg in args:
@@ -126,9 +222,40 @@ class SandboxExecutionEnvironmentV2:
         for val in kwargs.values():
             origins.update(self.tracker.get_origins(val))
 
-        # We pass sanitized arguments to the underlying function if needed,
-        # but the standard implementation passes the objects as-is.
         result = func(*args, **kwargs)
+
+        if inspect.isawaitable(result):
+            async def async_wrapper() -> Any:
+                res = await result
+                if origins:
+                    return self.tracker.taint_with_origins(res, origins)
+                return res
+            return async_wrapper()
+
+        if origins:
+            return self.tracker.taint_with_origins(result, origins)
+        return result
+
+    async def execute_async(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute an async function in the sandbox.
+
+        Automatically propagates taint from inputs to output, aggregating origins.
+
+        Args:
+            func: The async function to execute.
+            *args: Positional arguments for the function.
+            **kwargs: Keyword arguments for the function.
+
+        Returns:
+            The awaited result of execution, tainted if any inputs were tainted.
+        """
+        origins = set()
+        for arg in args:
+            origins.update(self.tracker.get_origins(arg))
+        for val in kwargs.values():
+            origins.update(self.tracker.get_origins(val))
+
+        result = await func(*args, **kwargs)
 
         if origins:
             return self.tracker.taint_with_origins(result, origins)
@@ -143,7 +270,16 @@ class MCPKernelV2:
         self.sandbox = SandboxExecutionEnvironmentV2(self.tracker)
 
     def execute_tool(self, tool_func: Callable[..., Any], inputs: Dict[str, Any], is_sensitive: bool = False) -> Any:
-        """Executes a tool within the kernel. If is_sensitive is True, tainted inputs will fail."""
+        """Executes a tool within the kernel. If is_sensitive is True, tainted inputs will fail.
+
+        Args:
+            tool_func: The tool function.
+            inputs: Dict of input arguments.
+            is_sensitive: Whether the tool is sensitive and should block tainted inputs.
+
+        Returns:
+            The result of tool execution.
+        """
         if is_sensitive:
             if self.tracker.is_tainted(inputs):
                 origins = self.tracker.get_origins(inputs)
@@ -156,3 +292,75 @@ class MCPKernelV2:
             if isinstance(e, PolicyViolationError):
                 raise
             raise RuntimeError(f"Tool execution failed: {str(e)}")
+
+
+class TaintTrackingAgentGuard(AgentGuard):
+    """An enhanced Agent Guard that implements taint tracking for external data traversing the policy layer."""
+    def __init__(self, policy_layer: Any, tracker: TaintTrackerV2 = None, sensitive_tools: Set[str] = None) -> None:
+        """Initializes the TaintTrackingAgentGuard.
+
+        Args:
+            policy_layer: The policy layer used to evaluate actions.
+            tracker: Optional TaintTrackerV2 instance.
+            sensitive_tools: Optional set of tool names considered sensitive.
+        """
+        super().__init__(policy_layer)
+        self.tracker = tracker or TaintTrackerV2()
+        self.sandbox = SandboxExecutionEnvironmentV2(self.tracker)
+        self.sensitive_tools = set(sensitive_tools) if sensitive_tools is not None else set()
+
+    def taint_input(self, data: Any, origin: str) -> Any:
+        """Marks an external input as tainted when it enters the agent's context.
+
+        Args:
+            data: The external input data to taint.
+            origin: The origin source of the taint.
+
+        Returns:
+            The recursively tainted data.
+        """
+        return self.tracker.taint(data, origin)
+
+    def execute_tool(self, tool_func: Callable, tool_name: str, **kwargs: Any) -> Any:
+        """Intercepts and evaluates a tool call before executing it, ensuring taint propagation.
+
+        Args:
+            tool_func: The actual tool function to execute if permitted.
+            tool_name: The name of the tool/action to evaluate.
+            **kwargs: The arguments to pass to the tool.
+
+        Returns:
+            The result of the tool execution with propagated taints.
+
+        Raises:
+            SecurityViolationError: If action is blocked by policy or is sensitive with tainted input.
+        """
+        # If the tool is sensitive and has tainted input, block it immediately
+        if tool_name in self.sensitive_tools:
+            if self.tracker.is_tainted(kwargs):
+                origins = self.tracker.get_origins(kwargs)
+                explanation = f"Tainted input to sensitive tool '{tool_name}' from origins: {origins}"
+                self.logger.warning(
+                    f"AgentGuard: Tool execution blocked for '{tool_name}'. Reason: {explanation}"
+                )
+                raise SecurityViolationError(f"Action '{tool_name}' blocked: {explanation}")
+
+        # Regular policy layer evaluation
+        allow, explanation = self.policy_layer.evaluate(tool_name, **kwargs)
+
+        if not allow:
+            self.logger.warning(
+                f"AgentGuard: Tool execution blocked for '{tool_name}'. Reason: {explanation}"
+            )
+            raise SecurityViolationError(f"Action '{tool_name}' blocked: {explanation}")
+
+        self.logger.info(f"AgentGuard: Tool execution permitted for '{tool_name}'.")
+
+        # Execute in sandbox environment
+        if inspect.iscoroutinefunction(tool_func):
+            async def async_wrapper() -> Any:
+                return await self.sandbox.execute_async(tool_func, **kwargs)
+            return async_wrapper()
+
+        result = self.sandbox.execute(tool_func, **kwargs)
+        return result

--- a/tests/test_taint_tracking_v2.py
+++ b/tests/test_taint_tracking_v2.py
@@ -1,5 +1,9 @@
-"""Tests for MCPKernel Taint Tracking V2."""
+"""Tests for MCPKernel Taint Tracking V2 and TaintTrackingAgentGuard."""
 import pytest
+from unittest.mock import MagicMock
+
+from magda_agent.safety.agent_guard import SecurityViolationError
+from magda_agent.safety.policy import PolicyLayer
 from magda_agent.safety.taint_tracking_v2 import (
     mark_tainted,
     is_tainted,
@@ -9,11 +13,12 @@ from magda_agent.safety.taint_tracking_v2 import (
     SandboxExecutionEnvironmentV2,
     MCPKernelV2,
     PolicyViolationError,
-    TaintedString
+    TaintedString,
+    TaintTrackingAgentGuard
 )
 
 
-def test_mark_tainted_and_is_tainted():
+def test_mark_tainted_and_is_tainted() -> None:
     """Test marking primitives and structures as tainted."""
     # Primitive string
     s = mark_tainted("hello", "user_input")
@@ -41,7 +46,7 @@ def test_mark_tainted_and_is_tainted():
     assert is_tainted(d["key"])
 
 
-def test_sanitize():
+def test_sanitize() -> None:
     """Test sanitizing tainted data."""
     s = mark_tainted("hello", "user_input")
     sanitized_s = sanitize(s)
@@ -56,7 +61,7 @@ def test_sanitize():
     assert not isinstance(sanitized_d["k"][0], TaintedString)
 
 
-def test_sandbox_execution_environment():
+def test_sandbox_execution_environment() -> None:
     """Test origin propagation through sandbox execution."""
     tracker = TaintTrackerV2()
     sandbox = SandboxExecutionEnvironmentV2(tracker)
@@ -84,11 +89,11 @@ def test_sandbox_execution_environment():
     assert "source_b" in origins
 
 
-def test_mcp_kernel_v2_policy_violation():
+def test_mcp_kernel_v2_policy_violation() -> None:
     """Test MCPKernelV2 policy violation on sensitive operations."""
     kernel = MCPKernelV2()
 
-    def mock_sensitive_tool(data: str):
+    def mock_sensitive_tool(data: str) -> str:
         """Mock sensitive tool."""
         return f"Executed: {data}"
 
@@ -107,12 +112,82 @@ def test_mcp_kernel_v2_policy_violation():
     assert "Tainted input to sensitive tool call from origins" in str(excinfo.value)
 
 
-def test_mcp_kernel_v2_execution_error():
+def test_mcp_kernel_v2_execution_error() -> None:
     """Test MCPKernelV2 handles regular exceptions properly."""
     kernel = MCPKernelV2()
 
-    def mock_failing_tool(data: str):
+    def mock_failing_tool(data: str) -> None:
         raise ValueError("Tool crashed")
 
     with pytest.raises(RuntimeError, match="Tool execution failed: Tool crashed"):
         kernel.execute_tool(mock_failing_tool, {"data": "test"})
+
+
+def test_taint_tracking_agent_guard_sync() -> None:
+    """Test TaintTrackingAgentGuard with synchronous tool and taint propagation."""
+    policy_mock = MagicMock(spec=PolicyLayer)
+    policy_mock.evaluate.return_value = (True, "Allowed")
+    guard = TaintTrackingAgentGuard(policy_layer=policy_mock)
+
+    # Taint an input entering context
+    external_input = guard.taint_input("unsafe_command", "external_api")
+    assert guard.tracker.is_tainted(external_input)
+    assert "external_api" in guard.tracker.get_origins(external_input)
+
+    def mock_sync_tool(cmd: str) -> str:
+        return f"run {cmd}"
+
+    # Execute tool
+    result = guard.execute_tool(mock_sync_tool, "test_tool", cmd=external_input)
+
+    # Assert taint propagates to output
+    assert guard.tracker.is_tainted(result)
+    assert "external_api" in guard.tracker.get_origins(result)
+    assert result == "run unsafe_command"
+
+
+@pytest.mark.asyncio
+async def test_taint_tracking_agent_guard_async() -> None:
+    """Test TaintTrackingAgentGuard with asynchronous tool and taint propagation."""
+    policy_mock = MagicMock(spec=PolicyLayer)
+    policy_mock.evaluate.return_value = (True, "Allowed")
+    guard = TaintTrackingAgentGuard(policy_layer=policy_mock)
+
+    # Taint an input entering context
+    external_input = guard.taint_input("unsafe_query", "webhook")
+    assert guard.tracker.is_tainted(external_input)
+    assert "webhook" in guard.tracker.get_origins(external_input)
+
+    async def mock_async_tool(query: str) -> str:
+        return f"query {query}"
+
+    # Execute async tool
+    coro = guard.execute_tool(mock_async_tool, "test_async_tool", query=external_input)
+    result = await coro
+
+    # Assert taint propagates to output
+    assert guard.tracker.is_tainted(result)
+    assert "webhook" in guard.tracker.get_origins(result)
+    assert result == "query unsafe_query"
+
+
+def test_taint_tracking_agent_guard_sensitive_block() -> None:
+    """Test TaintTrackingAgentGuard blocks sensitive tool calls with tainted inputs."""
+    policy_mock = MagicMock(spec=PolicyLayer)
+    policy_mock.evaluate.return_value = (True, "Allowed by policy")
+    guard = TaintTrackingAgentGuard(
+        policy_layer=policy_mock,
+        sensitive_tools={"dangerous_tool"}
+    )
+
+    external_input = guard.taint_input("dangerous_param", "untrusted_user")
+
+    def dangerous_tool(param: str) -> str:
+        return f"destroy {param}"
+
+    # Verify calling dangerous_tool with tainted input raises SecurityViolationError
+    with pytest.raises(SecurityViolationError) as excinfo:
+        guard.execute_tool(dangerous_tool, "dangerous_tool", param=external_input)
+
+    assert "untrusted_user" in str(excinfo.value)
+    assert "dangerous_tool" in str(excinfo.value)


### PR DESCRIPTION
This submission implements the core 'agent-guard-taint-tracking-v2' task by subclassing AgentGuard into TaintTrackingAgentGuard and enhancing SandboxExecutionEnvironmentV2 to support asynchronous and synchronous execution propagation. It also adds unit tests verifying the safety controls and taint propagation, updates 'agent_tasks.json' task status to 'done', and adds 3 new todo tasks following AI agent trends.

---
*PR created automatically by Jules for task [10556669606880805769](https://jules.google.com/task/10556669606880805769) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TaintTrackingAgentGuard` to block sensitive tool execution on tainted inputs
> - Introduces [`TaintTrackingAgentGuard`](https://github.com/kazah4359-lgtm/Magda-agent/pull/496/files#diff-b2b9c78832ad29117be5944651c9ee38c246786c002ca4ac88f07efc4aaf526c) extending `AgentGuard`, wiring a `TaintTrackerV2` and `SandboxExecutionEnvironmentV2` to enforce taint-based access control: if a tool is in the configured sensitive set and its inputs are tainted, a `SecurityViolationError` is raised before execution.
> - Rewrites `SandboxExecutionEnvironmentV2.execute` to aggregate taint origins from all positional and keyword arguments before tainting the result.
> - Adds tests for synchronous and asynchronous tool execution paths and sensitive-tool blocking in [`tests/test_taint_tracking_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/496/files#diff-62004a18af48ffba5eb557af89a6a2bfc6abf710d5352ff0cd0a2fa7c1b423c2).
> - Replenishes [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/496/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) with three new tasks covering peer delegation fallback, context engine instrumentation, and spawner context leak fix.
> - Risk: `SandboxExecutionEnvironmentV2.execute` uses `await` inside a non-`async` function (Python syntax error preventing module import), and `TaintTrackingAgentGuard.execute_tool` references `self.sandbox.execute_async` which is not defined, causing `AttributeError` on the async path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fa5dde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->