### PR TITLE
Implement MCP Tool Concurrency Integration v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8015,7 +8015,7 @@
     },
     {
       "id": "mcp-tool-concurrency-integration-e80b41b0",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "high",
       "title": "MCP Tool Concurrency Integration v3",
@@ -17734,6 +17734,57 @@
       "acceptance": [
         "Context maps are completely cleared upon subagent cleanup.",
         "Tests verify that parent-child references do not cause cyclic reference leaks."
+      ]
+    },
+    {
+      "id": "mcp-multi-server-collision-resolver-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Multi-Server Tool Collisions Resolver",
+      "description": "Inspired by OpenAI Agents SDK namespacing trend: Implement a resolver module to automatically detect and handle name collisions between multiple registered MCP servers, using fallback heuristics.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_collision_resolver.py",
+        "tests/test_mcp_collision_resolver.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The resolver dynamically maps and resolves conflicting tools.",
+        "Tests mock multi-server setup and verify resolution logic."
+      ]
+    },
+    {
+      "id": "acs-policy-performance-benchmark-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "low",
+      "title": "ACS Policy Layer Performance Benchmark",
+      "description": "Inspired by ACS trend: Implement a benchmark tool to measure latency overhead introduced by the 5 validation checkpoints in safety workflows, saving execution metrics to a local SQLite table.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_performance_benchmark.py",
+        "tests/test_acs_performance_benchmark.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Benchmark tracks and records latency per checkpoint.",
+        "Tests verify metric insertion and retrieval."
+      ]
+    },
+    {
+      "id": "a2a-discoverer-capability-matcher-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "low",
+      "title": "A2A Discoverer Capability Matcher",
+      "description": "Inspired by A2A standard trend: Implement a matching algorithm that compares discovered Agent Card capabilities with local unresolved task requirements to optimize task delegation selection.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_capability_matcher.py",
+        "tests/test_a2a_capability_matcher.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Matcher scores and recommends optimal peer agents for delegation.",
+        "Tests verify recommendations with mock Agent Cards."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+- [x] mcp-tool-concurrency-integration-e80b41b0: MCP Tool Concurrency Integration v3
 - [x] claude-evaluator-multi-agent-teams-v2: Claude SDK Teams Orchestration Evaluator (2026-06-XX)
 * [x] FEATURE: Export Skills to MCP Tool Server (mcp-tool-export-skills) (2026-06-XX)
 * [x] FEATURE: Agent Guard ACS Checkpoints v6 (agent-guard-acs-checkpoints-v6)

--- a/magda_agent/integration/mcp_concurrency_v3.py
+++ b/magda_agent/integration/mcp_concurrency_v3.py
@@ -1,0 +1,277 @@
+import asyncio
+import inspect
+import json
+import threading
+import uuid
+from typing import List, Dict, Any, Optional
+
+from magda_agent.integration.mcp_server import MCPServer
+
+
+class MCPConcurrentHandlerV3:
+    """
+    Handles MCP server-prefixed tool names and runtime function tool concurrency.
+    Supports executing multiple MCP tools in parallel using asyncio and provides
+    thread-safe task tracking to ensure safe operations.
+    Supports dynamic mapping of multiple MCP servers with namespace prefixes and
+    supports separators like '__', '-', and '_'.
+    """
+
+    def __init__(
+        self,
+        server: Optional[MCPServer] = None,
+        server_prefix: str = "",
+        max_concurrency: int = 10,
+        separators: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Initializes the MCPConcurrentHandlerV3.
+
+        Args:
+            server: Optional initial MCPServer instance to register.
+            server_prefix: Optional prefix for the initial server.
+            max_concurrency: The maximum number of concurrent tool executions allowed.
+            separators: Optional list of separators to check for namespacing.
+        """
+        self.max_concurrency = max_concurrency
+        self.semaphore = asyncio.Semaphore(max_concurrency)
+        self.lock = threading.Lock()
+        self.active_tasks_count = 0
+        self.separators = separators or ["__", "-", "_"]
+        self.servers: Dict[str, MCPServer] = {}
+
+        if server is not None:
+            self.register_server(server_prefix, server)
+
+    def register_server(self, prefix: str, server: MCPServer) -> None:
+        """
+        Registers an MCPServer with a given prefix.
+
+        Args:
+            prefix: The server prefix/namespace.
+            server: The MCPServer instance.
+        """
+        self.servers[prefix] = server
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists available tools across all registered servers, optionally prepending prefixes.
+
+        Returns:
+            A list of dictionary definitions for MCP compatible tools.
+        """
+        all_tools = []
+        for prefix, server in self.servers.items():
+            tools = server.list_tools()
+            if not prefix:
+                all_tools.extend(tools)
+                continue
+
+            for tool in tools:
+                new_tool = dict(tool)
+                tool_name = tool["name"]
+
+                # Avoid double prefixing with server_id if applicable
+                server_id_prefix = f"{server.server_id}_" if getattr(server, "server_id", None) else ""
+                if server_id_prefix and tool_name.startswith(server_id_prefix):
+                    tool_name = tool_name[len(server_id_prefix):]
+
+                sep = self.separators[0] if self.separators else "__"
+                new_tool["name"] = f"{prefix}{sep}{tool_name}"
+                all_tools.append(new_tool)
+
+        return all_tools
+
+    async def handle_request(self, payload: str) -> str:
+        """
+        Handles a JSON-RPC payload string concurrently. Supports batch requests.
+        Respects max_concurrency limit.
+
+        Args:
+            payload: A raw JSON string containing a single object or an array of objects.
+
+        Returns:
+            A JSON string representing the JSON-RPC response or batch responses.
+        """
+        try:
+            request_data = json.loads(payload)
+        except json.JSONDecodeError:
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error"}
+            })
+
+        if isinstance(request_data, list):
+            if not request_data:
+                return json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32600, "message": "Invalid Request"}
+                })
+
+            tasks = []
+            for req in request_data:
+                if isinstance(req, dict):
+                    tasks.append(self._process_single_request_with_concurrency_safe(req.copy()))
+                else:
+                    # Handle invalid payload element in batch
+                    async def invalid_element() -> Dict[str, Any]:
+                        return {
+                            "jsonrpc": "2.0",
+                            "id": None,
+                            "error": {"code": -32600, "message": "Invalid Request"}
+                        }
+                    tasks.append(invalid_element())
+
+            results = await asyncio.gather(*tasks)
+            return json.dumps(results)
+        else:
+            result = await self._process_single_request_with_concurrency_safe(request_data.copy())
+            return json.dumps(result)
+
+    async def _process_single_request_with_concurrency_safe(self, req: dict) -> dict:
+        """
+        A safe wrapper around single request processing to catch unhandled exceptions.
+
+        Args:
+            req: A dictionary representing a single JSON-RPC request.
+
+        Returns:
+            A dictionary representing the JSON-RPC response.
+        """
+        try:
+            return await self._process_single_request_with_concurrency(req)
+        except Exception as e:
+            return {
+                "jsonrpc": "2.0",
+                "id": req.get("id") if isinstance(req, dict) else None,
+                "error": {"code": -32000, "message": f"Internal Error: {str(e)}"}
+            }
+
+    async def _process_single_request_with_concurrency(self, req: dict) -> dict:
+        """
+        Processes a single JSON-RPC request dictionary within the concurrency limits.
+
+        Args:
+            req: A dictionary representing a single JSON-RPC request.
+
+        Returns:
+            A dictionary representing the JSON-RPC response.
+        """
+        async with self.semaphore:
+            with self.lock:
+                self.active_tasks_count += 1
+
+            try:
+                return await self._process_single_request(req)
+            finally:
+                with self.lock:
+                    self.active_tasks_count -= 1
+
+    async def _process_single_request(self, req: dict) -> dict:
+        """
+        Processes a single JSON-RPC request dictionary, mapping and stripping the server prefix.
+
+        Args:
+            req: A dictionary representing a single JSON-RPC request.
+
+        Returns:
+            A dictionary representing the JSON-RPC response.
+        """
+        if not isinstance(req, dict):
+            return {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request"}
+            }
+
+        req_id = req.get("id", str(uuid.uuid4()))
+        method = req.get("method")
+        params = req.get("params", {})
+
+        if not method or not isinstance(method, str):
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": "Method not found"}
+            }
+
+        # Resolve server prefix
+        matched_prefix = None
+        matched_server = None
+        matched_sep = None
+
+        sorted_prefixes = sorted(self.servers.keys(), key=len, reverse=True)
+        for prefix in sorted_prefixes:
+            if not prefix:
+                continue
+            for sep in self.separators:
+                full_prefix = f"{prefix}{sep}"
+                if method.startswith(full_prefix):
+                    matched_prefix = prefix
+                    matched_server = self.servers[prefix]
+                    matched_sep = sep
+                    break
+            if matched_server:
+                break
+
+        if not matched_server and "" in self.servers:
+            matched_prefix = ""
+            matched_server = self.servers[""]
+
+        if not matched_server:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found or missing server prefix: {method}"}
+            }
+
+        # Strip prefix for inner execution
+        if matched_prefix:
+            stripped_method = method[len(matched_prefix) + len(matched_sep):]
+            req["method"] = stripped_method
+            method_to_check = stripped_method
+        else:
+            method_to_check = method
+
+        # Identify if the skill is async or sync
+        is_async = True
+        registry = getattr(getattr(matched_server, "exporter", None), "registry", None)
+        if registry and hasattr(registry, "skills") and method_to_check in registry.skills:
+            skill_func = registry.skills[method_to_check]
+            if not inspect.iscoroutinefunction(skill_func):
+                is_async = False
+
+        if not is_async:
+            # Run sync tool inside thread to avoid blocking the asyncio event loop
+            def run_sync() -> Any:
+                return registry.execute_skill(method_to_check, **params)
+
+            try:
+                result = await asyncio.to_thread(run_sync)
+                result_str = str(result)
+                if result_str.startswith("Error"):
+                    return {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "error": {"code": -32000, "message": result_str}
+                    }
+
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "content": [{"type": "text", "text": result_str}],
+                        "isError": False
+                    }
+                }
+            except Exception as e:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32000, "message": f"Error executing tool {method_to_check}: {e}"}
+                }
+        else:
+            # Async execution
+            return await matched_server.exporter.handle_rpc_request(req)

--- a/tests/test_mcp_concurrency_v3.py
+++ b/tests/test_mcp_concurrency_v3.py
@@ -1,0 +1,198 @@
+import asyncio
+import json
+import threading
+import time
+import pytest
+
+from magda_agent.integration.mcp_concurrency_v3 import MCPConcurrentHandlerV3
+from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.integration.mcp_exporter import MCPExporter
+from magda_agent.skills.registry import SkillRegistry
+
+
+@pytest.fixture
+def registry_1() -> SkillRegistry:
+    """Provides a SkillRegistry with sync and async skills."""
+    reg = SkillRegistry()
+
+    def sync_tool(arg: str) -> str:
+        time.sleep(0.1)
+        return f"sync_1_result_{arg}"
+
+    async def async_tool(arg: str) -> str:
+        await asyncio.sleep(0.1)
+        return f"async_1_result_{arg}"
+
+    reg.register_skill("sync_tool", sync_tool, "A sync skill")
+    reg.register_skill("async_tool", async_tool, "An async skill")
+    return reg
+
+
+@pytest.fixture
+def registry_2() -> SkillRegistry:
+    """Provides another SkillRegistry with different skills."""
+    reg = SkillRegistry()
+
+    def other_tool(arg: str) -> str:
+        return f"sync_2_result_{arg}"
+
+    reg.register_skill("other_tool", other_tool, "Other sync skill")
+    return reg
+
+
+@pytest.fixture
+def server_1(registry_1: SkillRegistry) -> MCPServer:
+    """Initializes MCPServer with registry_1."""
+    return MCPServer(MCPExporter(registry_1), server_id="")
+
+
+@pytest.fixture
+def server_2(registry_2: SkillRegistry) -> MCPServer:
+    """Initializes MCPServer with registry_2."""
+    return MCPServer(MCPExporter(registry_2), server_id="")
+
+
+@pytest.fixture
+def handler_v3(server_1: MCPServer, server_2: MCPServer) -> MCPConcurrentHandlerV3:
+    """Provides an MCPConcurrentHandlerV3 with two registered servers."""
+    handler = MCPConcurrentHandlerV3(server_1, "server_one", max_concurrency=5)
+    handler.register_server("server_two", server_2)
+    return handler
+
+
+def test_list_tools_v3(handler_v3: MCPConcurrentHandlerV3) -> None:
+    """Verifies that all tools across servers are listed with correct prefixes."""
+    tools = handler_v3.list_tools()
+    names = [t["name"] for t in tools]
+
+    assert "server_one__sync_tool" in names
+    assert "server_one__async_tool" in names
+    assert "server_two__other_tool" in names
+
+
+@pytest.mark.asyncio
+async def test_handle_request_single_v3(handler_v3: MCPConcurrentHandlerV3) -> None:
+    """Tests executing a single request via standard prefix."""
+    req = {"jsonrpc": "2.0", "id": "req-1", "method": "server_one__async_tool", "params": {"arg": "abc"}}
+    res_str = await handler_v3.handle_request(json.dumps(req))
+    res = json.loads(res_str)
+
+    assert res["jsonrpc"] == "2.0"
+    assert res["id"] == "req-1"
+    assert res["result"]["content"][0]["text"] == "async_1_result_abc"
+
+
+@pytest.mark.asyncio
+async def test_handle_request_custom_separator(handler_v3: MCPConcurrentHandlerV3) -> None:
+    """Tests executing requests with custom separators like dash or underscore."""
+    req_dash = {"jsonrpc": "2.0", "id": "req-dash", "method": "server_one-sync_tool", "params": {"arg": "dash"}}
+    res_str = await handler_v3.handle_request(json.dumps(req_dash))
+    res = json.loads(res_str)
+    assert res["result"]["content"][0]["text"] == "sync_1_result_dash"
+
+    req_underscore = {"jsonrpc": "2.0", "id": "req-under", "method": "server_two_other_tool", "params": {"arg": "under"}}
+    res_str_under = await handler_v3.handle_request(json.dumps(req_underscore))
+    res_under = json.loads(res_str_under)
+    assert res_under["result"]["content"][0]["text"] == "sync_2_result_under"
+
+
+@pytest.mark.asyncio
+async def test_handle_request_batch_concurrent_v3(handler_v3: MCPConcurrentHandlerV3) -> None:
+    """Tests parallel execution of sync and async tools to verify concurrency."""
+    req1 = {"jsonrpc": "2.0", "id": 1, "method": "server_one__sync_tool", "params": {"arg": "x"}}
+    req2 = {"jsonrpc": "2.0", "id": 2, "method": "server_one__async_tool", "params": {"arg": "y"}}
+    req3 = {"jsonrpc": "2.0", "id": 3, "method": "server_two__other_tool", "params": {"arg": "z"}}
+
+    start = asyncio.get_event_loop().time()
+    res_str = await handler_v3.handle_request(json.dumps([req1, req2, req3]))
+    end = asyncio.get_event_loop().time()
+
+    res = json.loads(res_str)
+    assert len(res) == 3
+
+    # Both req1 (sync sleep 0.1s) and req2 (async sleep 0.1s) run concurrently.
+    # Total execution should be around ~0.1s, much less than sequential 0.2s.
+    assert end - start < 0.18
+
+    # Verify all responses are correct
+    results = {r["id"]: r["result"]["content"][0]["text"] for r in res}
+    assert results[1] == "sync_1_result_x"
+    assert results[2] == "async_1_result_y"
+    assert results[3] == "sync_2_result_z"
+
+
+@pytest.mark.asyncio
+async def test_semaphore_limit_v3(handler_v3: MCPConcurrentHandlerV3) -> None:
+    """Verifies that the semaphore limits parallel concurrency as configured."""
+    handler_v3.semaphore = asyncio.Semaphore(1)  # Force sequential execution
+
+    req1 = {"jsonrpc": "2.0", "id": 1, "method": "server_one__async_tool", "params": {"arg": "a"}}
+    req2 = {"jsonrpc": "2.0", "id": 2, "method": "server_one__async_tool", "params": {"arg": "b"}}
+
+    start = asyncio.get_event_loop().time()
+    res_str = await handler_v3.handle_request(json.dumps([req1, req2]))
+    end = asyncio.get_event_loop().time()
+
+    res = json.loads(res_str)
+    assert len(res) == 2
+
+    # Since concurrency is limited to 1, both 0.1s tasks run sequentially, taking >= 0.2s
+    assert end - start >= 0.18
+
+
+@pytest.mark.asyncio
+async def test_active_tasks_count_v3(handler_v3: MCPConcurrentHandlerV3) -> None:
+    """Verifies thread-safe tracking of the active_tasks_count."""
+    req = {"jsonrpc": "2.0", "id": 1, "method": "server_one__async_tool", "params": {"arg": "active"}}
+
+    # Verify starting active count is 0
+    assert handler_v3.active_tasks_count == 0
+
+    # Start task in background
+    task = asyncio.create_task(handler_v3.handle_request(json.dumps(req)))
+
+    # Give the task a moment to start and grab the semaphore
+    await asyncio.sleep(0.01)
+
+    # Active count should now be 1
+    assert handler_v3.active_tasks_count == 1
+
+    await task
+
+    # Completed task should result in active count returning to 0
+    assert handler_v3.active_tasks_count == 0
+
+
+@pytest.mark.asyncio
+async def test_error_handling_v3(handler_v3: MCPConcurrentHandlerV3) -> None:
+    """Tests parsing errors, missing prefixes, invalid methods, and exceptions."""
+    # Invalid JSON
+    res_str = await handler_v3.handle_request("{invalid_json}")
+    res = json.loads(res_str)
+    assert res["error"]["code"] == -32700
+
+    # Empty batch
+    res_str = await handler_v3.handle_request("[]")
+    res = json.loads(res_str)
+    assert res["error"]["code"] == -32600
+
+    # Missing prefix (method name that doesn't map to any server prefix and no default server "")
+    req_no_prefix = {"jsonrpc": "2.0", "id": 1, "method": "unknown_tool", "params": {}}
+    res_str = await handler_v3.handle_request(json.dumps(req_no_prefix))
+    res = json.loads(res_str)
+    assert res["error"]["code"] == -32601
+    assert "Method not found" in res["error"]["message"]
+
+    # Exception inside tool execution gets caught gracefully
+    def failing_tool() -> str:
+        raise RuntimeError("Something went wrong")
+
+    handler_v3.servers["server_one"].exporter.registry.register_skill(
+        "fail_tool", failing_tool, "Failing skill"
+    )
+
+    req_fail = {"jsonrpc": "2.0", "id": 9, "method": "server_one__fail_tool", "params": {}}
+    res_str = await handler_v3.handle_request(json.dumps(req_fail))
+    res = json.loads(res_str)
+    assert res["error"]["code"] == -32000
+    assert "Something went wrong" in res["error"]["message"]


### PR DESCRIPTION
Implement MCPConcurrentHandlerV3 inside magda_agent/integration/mcp_concurrency_v3.py. The class manages namespaced/prefixed tool calls, thread-safe active task counts, concurrency limiting via semaphore, and async natively / sync inside thread pools. Added comprehensive test suite in tests/test_mcp_concurrency_v3.py, updated agent_tasks.json and backlog.md, and replenished tasks with three new trends.

---
*PR created automatically by Jules for task [11447424399126082644](https://jules.google.com/task/11447424399126082644) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add JSON-RPC 2.0 concurrent MCP tool handler with multi-server namespacing
> - Introduces [`MCPConcurrentHandlerV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/497/files#diff-4ab40ce8fff8a84724fc0994a2e7d9c3daecfba7389198d20c04363a4859a4a2), a JSON-RPC 2.0 handler that registers multiple `MCPServer` instances under string prefixes and routes tool calls by resolving the prefix from the method name.
> - Supports configurable separators for prefix parsing, semaphore-based concurrency limits, and thread-safe active task counting; sync tools run via `asyncio.to_thread`, async tools are awaited directly.
> - Handles both single and batch JSON-RPC requests, returning structured results or typed error codes (parse error, invalid request, unknown method, internal error).
> - Adds a comprehensive test suite in [`tests/test_mcp_concurrency_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/497/files#diff-ae7ce519dff9993057ac9b765f9400e1141bf76c29ec01118fbf0a8b669848f0) covering namespacing, batch concurrency timing, semaphore throttling, active task counting, and error propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c13146.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->