### PR TITLE
Implement Hermes WhatsApp Channel Gateway v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8032,7 +8032,7 @@
     },
     {
       "id": "hermes-whatsapp-gateway-v2-e8512f68",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "Hermes WhatsApp Channel Gateway v2",
@@ -17785,6 +17785,57 @@
       "acceptance": [
         "Matcher scores and recommends optimal peer agents for delegation.",
         "Tests verify recommendations with mock Agent Cards."
+      ]
+    },
+    {
+      "id": "openai-agents-tool-routing-v3-f8a7e3d2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI Agents SDK Tool Routing and Concurrency Layer v3",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a robust tool routing and concurrency manager that wraps tools to execute them in parallel using asyncio.gather.",
+      "allowed_paths": [
+        "magda_agent/skills/tool_routing_v3.py",
+        "tests/test_tool_routing_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool routing manager correctly handles parallel execution via asyncio.gather.",
+        "Tests verify concurrency behavior and error boundary isolation."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-workspace-v3-e6b7d4a2",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Agent Teams Workspace Isolation v3",
+      "description": "Inspired by Claude Agent Teams: Implement directory workspace isolation for subagents executing parallel tasks to prevent context bleeding.",
+      "allowed_paths": [
+        "magda_agent/architecture/workspace_isolation_v3.py",
+        "tests/test_workspace_isolation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Workspace isolation layer successfully instantiates separate temporary directory paths.",
+        "Tests verify isolated operations and clean-up."
+      ]
+    },
+    {
+      "id": "context-engine-memory-improvement-v2-b50e6f7a",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "Context Engine Memory Consolidation Improvement v2",
+      "description": "Improvement: Optimize memory consolidation processes in the Context Engine by batching semantic fact extractions to reduce LLM overhead.",
+      "allowed_paths": [
+        "magda_agent/memory/consolidation_v2.py",
+        "tests/test_consolidation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Fact consolidation is batched efficiently during the overnight cleanup.",
+        "Tests verify that consolidation operates with minimal latency compared to single-item processing."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -95,6 +95,7 @@
 ---
 
 ## ✅ Выполнено
+- [x] hermes-whatsapp-gateway-v2-e8512f68: Hermes WhatsApp Channel Gateway v2
 - [x] mcp-tool-concurrency-integration-e80b41b0: MCP Tool Concurrency Integration v3
 - [x] claude-evaluator-multi-agent-teams-v2: Claude SDK Teams Orchestration Evaluator (2026-06-XX)
 * [x] FEATURE: Export Skills to MCP Tool Server (mcp-tool-export-skills) (2026-06-XX)

--- a/magda_agent/channels/whatsapp_v2.py
+++ b/magda_agent/channels/whatsapp_v2.py
@@ -1,0 +1,56 @@
+from typing import Any, Dict, Optional
+from magda_agent.channels.base import ChannelAdapter
+from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
+
+class WhatsAppAdapterV2(ChannelAdapter):
+    """Adapter for WhatsApp (v2) platform supporting unified gateway routing."""
+
+    def __init__(self, gateway: GatewayRouter) -> None:
+        """Initialize the WhatsApp v2 channel adapter.
+
+        Args:
+            gateway (GatewayRouter): The unified routing gateway.
+        """
+        super().__init__("whatsapp_v2", gateway)
+
+    async def receive(self, raw_data: Any) -> Any:
+        """Process an incoming raw WhatsApp message and route it.
+
+        Args:
+            raw_data (Any): The raw data representing the incoming message.
+                            Expected to be a dictionary or object with body/text/from/sender attributes.
+
+        Returns:
+            Any: The response from the routed gateway message handler.
+        """
+        text: str = ""
+        user_id: str = ""
+
+        if isinstance(raw_data, dict):
+            text = raw_data.get("body", raw_data.get("text", ""))
+            user_id = str(raw_data.get("from", raw_data.get("sender_id", "")))
+        else:
+            text = getattr(raw_data, "body", getattr(raw_data, "text", ""))
+            user_id = str(getattr(raw_data, "from", getattr(raw_data, "sender_id", "")))
+
+        msg = UnifiedMessage(
+            channel=self.channel_id,
+            text=text,
+            user_id=user_id,
+            metadata={"raw": raw_data}
+        )
+        return await self.gateway.route_message(msg)
+
+    async def send(self, recipient_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """Send an outgoing message via the WhatsApp platform.
+
+        Args:
+            recipient_id (str): The recipient's ID or phone number.
+            text (str): The text message to send.
+            metadata (Optional[Dict[str, Any]]): Additional metadata for sending.
+
+        Returns:
+            Any: A mock status or confirmation string.
+        """
+        # Simulated or mocked WhatsApp API response
+        return f"WhatsApp V2 sent to {recipient_id}: {text}"

--- a/tests/test_whatsapp_v2.py
+++ b/tests/test_whatsapp_v2.py
@@ -1,0 +1,86 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from typing import Any, Dict
+from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
+from magda_agent.channels.whatsapp_v2 import WhatsAppAdapterV2
+
+@pytest.fixture
+def gateway() -> GatewayRouter:
+    """Fixture to provide a GatewayRouter with mocked message routing behavior.
+
+    Returns:
+        GatewayRouter: A gateway router instance with AsyncMock routing.
+    """
+    router = GatewayRouter()
+    router.route_message = AsyncMock(return_value="whatsapp_routed")
+    return router
+
+@pytest.mark.asyncio
+async def test_whatsapp_v2_receive_dict(gateway: GatewayRouter) -> None:
+    """Test receiving a WhatsApp message with raw data as a dictionary.
+
+    Args:
+        gateway (GatewayRouter): The gateway router fixture.
+    """
+    adapter = WhatsAppAdapterV2(gateway)
+    assert adapter.channel_id == "whatsapp_v2"
+
+    raw_data: Dict[str, Any] = {
+        "body": "Hello WhatsApp V2",
+        "from": "whatsapp_user_1"
+    }
+
+    res: Any = await adapter.receive(raw_data)
+    assert res == "whatsapp_routed"
+
+    gateway.route_message.assert_called_once()
+    msg: UnifiedMessage = gateway.route_message.call_args[0][0]
+    assert msg.channel == "whatsapp_v2"
+    assert msg.text == "Hello WhatsApp V2"
+    assert msg.user_id == "whatsapp_user_1"
+    assert msg.metadata["raw"] == raw_data
+
+@pytest.mark.asyncio
+async def test_whatsapp_v2_receive_object(gateway: GatewayRouter) -> None:
+    """Test receiving a WhatsApp message with raw data as a generic object.
+
+    Args:
+        gateway (GatewayRouter): The gateway router fixture.
+    """
+    adapter = WhatsAppAdapterV2(gateway)
+
+    class RawObjectMessage:
+        """A simple helper mock object for WhatsApp message testing."""
+
+        def __init__(self, text: str, sender_id: str) -> None:
+            """Initialize raw object message properties.
+
+            Args:
+                text (str): Message content.
+                sender_id (str): Message sender ID.
+            """
+            self.text = text
+            self.sender_id = sender_id
+
+    raw_data = RawObjectMessage("Hi there", "wa_sender_99")
+
+    res: Any = await adapter.receive(raw_data)
+    assert res == "whatsapp_routed"
+
+    gateway.route_message.assert_called_once()
+    msg: UnifiedMessage = gateway.route_message.call_args[0][0]
+    assert msg.channel == "whatsapp_v2"
+    assert msg.text == "Hi there"
+    assert msg.user_id == "wa_sender_99"
+    assert msg.metadata["raw"] == raw_data
+
+@pytest.mark.asyncio
+async def test_whatsapp_v2_send(gateway: GatewayRouter) -> None:
+    """Test sending an outbound message using the WhatsApp V2 adapter.
+
+    Args:
+        gateway (GatewayRouter): The gateway router fixture.
+    """
+    adapter = WhatsAppAdapterV2(gateway)
+    res: Any = await adapter.send("wa_recipient", "Automated reply")
+    assert res == "WhatsApp V2 sent to wa_recipient: Automated reply"


### PR DESCRIPTION
This pull request implements the first todo task 'Hermes WhatsApp Channel Gateway v2' by adding `WhatsAppAdapterV2` in `magda_agent/channels/whatsapp_v2.py` and writing unit tests in `tests/test_whatsapp_v2.py`. It also updates `agent_tasks.json` with the task status set to 'done' and three new trend-inspired tasks, as well as keeping `backlog.md` in sync.

---
*PR created automatically by Jules for task [13657274860528652358](https://jules.google.com/task/13657274860528652358) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WhatsApp V2 channel adapter integrating with GatewayRouter
> - Adds [`WhatsAppAdapterV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/498/files#diff-5fe76edfcce0b0208cb8e1db3cef8e4e17df46051888cf8d150d25a5f369ba7b) implementing the `ChannelAdapter` interface with channel id `whatsapp_v2`, normalizing raw dict or object payloads into `UnifiedMessage` before routing via `GatewayRouter.route_message`.
> - The `send` method returns a mock confirmation string rather than making a real WhatsApp API call.
> - Adds pytest async tests in [`tests/test_whatsapp_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/498/files#diff-1ec880569410c032ef0d5f080c6c5d50138695c402feb941fa6115567f29bcda) covering dict input, object input, and send confirmation using `AsyncMock`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 223b66e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->