### PR TITLE
feat(safety): implement mcp-kernel-taint-tracking-v3-fe34585d

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8066,7 +8066,7 @@
     },
     {
       "id": "mcp-kernel-taint-tracking-v3-fe34585d",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCPKernel Taint Tracking Extension V3",
@@ -17887,6 +17887,60 @@
       "acceptance": [
         "Patch manager correctly generates and applies JSON state patches.",
         "Tests verify that bandwidth is significantly reduced compared to full-state streaming."
+      ]
+    },
+    {
+      "id": "a2a-agent-card-crypto-verify-40ab7f1d",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Secure Agent Card Cryptographic Verification",
+      "description": "Inspired by A2A Protocol standard trend (enterprise-ready security): Implement a validation layer that checks cryptographic signatures of remote Agent Cards before registering them or delegating tasks, preventing spoofing in peer-to-peer networks.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_crypto_verify.py",
+        "tests/test_a2a_crypto_verify.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Verification layer successfully validates signed Agent Card JSON payloads.",
+        "Rejects unsigned or corrupted signatures with a SecurityError.",
+        "Tests verify verification and rejection behavior using mock keys."
+      ]
+    },
+    {
+      "id": "context-engine-plugin-perf-monitor-87cb5d2c",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "Context Engine Plugin Performance Monitor",
+      "description": "Inspired by OpenClaw plugin architecture trend: Develop a telemetry monitoring component within the Context Engine to track execution times and latency overhead of each active plugin hook (bootstrap, ingest, assemble, compact).",
+      "allowed_paths": [
+        "magda_agent/memory/plugin_perf_monitor.py",
+        "tests/test_plugin_perf_monitor.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Performance monitor records and logs latency per hook execution.",
+        "Allows querying of metrics for downstream longitudinal quality tracking.",
+        "Tests verify latency recording under simulated hook executions."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-rollback-manager-2b7e1f9a",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Action Tool Rollback Transaction Manager",
+      "description": "Inspired by OpenAI Agents SDK trend where action tools grew to 65%: Implement a transaction manager that sequences multiple state-mutating MCP tool calls and triggers a rollback of previous actions if a subsequent step in the sequence fails.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_transaction_manager.py",
+        "tests/test_mcp_transaction_manager.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Transaction manager sequences and executes tool calls.",
+        "Successfully rolls back registered actions on execution failure of subsequent steps.",
+        "Tests verify sequential execution and rollback functionality using mock stateful tools."
       ]
     }
   ]

--- a/magda_agent/safety/taint_tracking_v3.py
+++ b/magda_agent/safety/taint_tracking_v3.py
@@ -1,0 +1,141 @@
+"""MCPKernel Taint Tracking Sandbox V3.
+
+Provides an enhanced taint tracking system (TaintTrackerV3) and an integrated
+memory block (TaintedEpisodicMemory) to preserve and trace data provenance
+across memory boundaries (episodic memory).
+"""
+import logging
+import math
+from typing import Any, Dict, List, Optional, Set
+
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.safety.taint_tracking_v2 import TaintTrackerV2
+
+
+class TaintTrackerV3(TaintTrackerV2):
+    """Enhanced TaintTracker that adds support for tracing data provenance across episodic and other memory blocks explicitly."""
+
+    def __init__(self) -> None:
+        """Initialize the TaintTrackerV3."""
+        super().__init__()
+
+
+class TaintedEpisodicMemory(EpisodicMemory):
+    """An enhanced EpisodicMemory that integrates with TaintTrackerV3 to maintain taint tracks
+
+    and trace data provenance when data is stored and retrieved.
+    """
+
+    def __init__(self, persist_directory: str = "./episodic_memory_db", tracker: Optional[TaintTrackerV3] = None) -> None:
+        """Initialize the TaintedEpisodicMemory.
+
+        Args:
+            persist_directory: The directory path for ChromaDB storage.
+            tracker: An optional TaintTrackerV3 instance.
+        """
+        super().__init__(persist_directory=persist_directory)
+        self.tracker = tracker or TaintTrackerV3()
+
+    def store_event(self, text: str, metadata: Optional[dict] = None, user_id: Optional[int] = None) -> None:
+        """Store an event in episodic memory, preserving its taint tracks in the metadata.
+
+        Args:
+            text: The text event content, potentially containing tainted data.
+            metadata: Optional dictionary of metadata associated with the event.
+            user_id: Optional user identifier.
+        """
+        if metadata is None:
+            metadata = {}
+        else:
+            metadata = metadata.copy()
+
+        # If text is tainted, capture its origins
+        if self.tracker.is_tainted(text):
+            origins = list(self.tracker.get_origins(text))
+            # ChromaDB supports string, int, float, bool. It does NOT support lists in metadata values.
+            # So we serialize the origins list into a comma-separated string.
+            metadata["_taint_origins"] = ",".join(origins)
+            metadata["_is_tainted"] = True
+
+        # Sanitize everything to standard python types before storing
+        clean_text = self.tracker.sanitize(text)
+        clean_metadata = self.tracker.sanitize(metadata)
+
+        super().store_event(clean_text, clean_metadata, user_id)
+
+    def get_all_events(self, user_id: Optional[int] = None, include_decayed: bool = False, limit: int = 100) -> List[Dict[str, Any]]:
+        """Retrieve all events, reconstructing any tainted text from stored origins.
+
+        Args:
+            user_id: Optional user identifier to filter by.
+            include_decayed: Whether to include decayed events.
+            limit: Maximum number of events to retrieve.
+
+        Returns:
+            A list of event dictionaries with reconstructed tainted text.
+        """
+        events = super().get_all_events(user_id=user_id, include_decayed=include_decayed, limit=limit)
+        for event in events:
+            meta = event.get("metadata", {})
+            if meta and meta.get("_is_tainted") and "_taint_origins" in meta:
+                origins_str = meta["_taint_origins"]
+                origins = set(origins_str.split(",")) if origins_str else set()
+                event["text"] = self.tracker.taint_with_origins(event["text"], origins)
+        return events
+
+    def recall_events(self, query: str, top_k: int = 5, user_id: Optional[int] = None) -> List[str]:
+        """Recall relevant events, reconstructing taint tracks on returned strings.
+
+        Args:
+            query: Semantic search query string.
+            top_k: Number of retrieved results to return.
+            user_id: Optional user identifier to filter by.
+
+        Returns:
+            A list of recalled strings, with reconstructed taint tracking where applicable.
+        """
+        try:
+            query_kwargs = {
+                "query_texts": [query],
+                "n_results": top_k * 2
+            }
+            where_clause = {"decayed": False}
+            if user_id is not None:
+                where_clause["user_id"] = user_id
+
+            if len(where_clause) > 1:
+                query_kwargs["where"] = {"$and": [{"user_id": user_id}, {"decayed": False}]}
+            else:
+                query_kwargs["where"] = where_clause
+
+            results = self.collection.query(**query_kwargs)
+            if results and results.get("documents") and len(results["documents"]) > 0:
+                docs = results["documents"][0]
+                dists = results["distances"][0] if "distances" in results and results["distances"] else [0.0] * len(docs)
+                metas = results["metadatas"][0] if "metadatas" in results and results["metadatas"] else [{}] * len(docs)
+
+                scored_docs = []
+                for doc, dist, meta in zip(docs, dists, metas):
+                    meta = meta or {}
+                    pad_p = float(meta.get("pad_p", 0.0))
+                    pad_a = float(meta.get("pad_a", 0.0))
+                    pad_d = float(meta.get("pad_d", 0.0))
+
+                    intensity = math.sqrt(pad_p**2 + pad_a**2 + pad_d**2)
+                    adjusted_score = dist - (intensity * 1.0)
+                    scored_docs.append((adjusted_score, doc, meta))
+
+                scored_docs.sort(key=lambda x: x[0])
+
+                recalled = []
+                for _, doc, meta in scored_docs[:top_k]:
+                    if meta and meta.get("_is_tainted") and "_taint_origins" in meta:
+                        origins_str = meta["_taint_origins"]
+                        origins = set(origins_str.split(",")) if origins_str else set()
+                        doc = self.tracker.taint_with_origins(doc, origins)
+                    recalled.append(doc)
+                return recalled
+            return []
+        except Exception as e:
+            logging.error(f"Failed to recall episodic events in TaintedEpisodicMemory: {e}")
+            return []

--- a/tests/test_taint_tracking_v3.py
+++ b/tests/test_taint_tracking_v3.py
@@ -1,0 +1,54 @@
+"""Tests for MCPKernel Taint Tracking V3 and TaintedEpisodicMemory."""
+import pytest
+
+from magda_agent.safety.taint_tracking_v3 import TaintTrackerV3, TaintedEpisodicMemory
+
+
+def test_taint_tracker_v3_initialization() -> None:
+    """Test that TaintTrackerV3 can be successfully initialized and behaves like TaintTrackerV2."""
+    tracker = TaintTrackerV3()
+    assert tracker is not None
+
+    # Verify basic inheritance functionality
+    tainted = tracker.taint("test", "user_prompt")
+    assert tracker.is_tainted(tainted)
+    assert tracker.get_origins(tainted) == {"user_prompt"}
+
+
+def test_tainted_episodic_memory_store_and_recall() -> None:
+    """Test storing and recalling tainted events in TaintedEpisodicMemory preserves taint tracks."""
+    tracker = TaintTrackerV3()
+    # Initialize with ephemeral ChromaDB client (via ":memory:") for speed and isolation
+    memory = TaintedEpisodicMemory(persist_directory=":memory:", tracker=tracker)
+
+    # 1. Store clean event
+    memory.store_event("Clean event content", metadata={"importance": 0.9}, user_id=42)
+
+    # 2. Store tainted event
+    tainted_text = tracker.taint("Tainted event command", "untrusted_user")
+    memory.store_event(tainted_text, metadata={"importance": 1.0}, user_id=42)
+
+    # 3. Retrieve all events and verify taint propagation
+    events = memory.get_all_events(user_id=42)
+    assert len(events) == 2
+
+    # Map by content
+    clean_retrieved = next(e for e in events if "Clean" in e["text"])
+    tainted_retrieved = next(e for e in events if "Tainted" in e["text"])
+
+    # Verify clean event has no taint
+    assert not tracker.is_tainted(clean_retrieved["text"])
+
+    # Verify tainted event has reconstructed taint tracks
+    assert tracker.is_tainted(tainted_retrieved["text"])
+    assert tracker.get_origins(tainted_retrieved["text"]) == {"untrusted_user"}
+
+    # 4. Recall events based on query and verify reconstructed taints
+    recalled_clean = memory.recall_events(query="Clean", top_k=1, user_id=42)
+    assert len(recalled_clean) == 1
+    assert not tracker.is_tainted(recalled_clean[0])
+
+    recalled_tainted = memory.recall_events(query="Tainted", top_k=1, user_id=42)
+    assert len(recalled_tainted) == 1
+    assert tracker.is_tainted(recalled_tainted[0])
+    assert tracker.get_origins(recalled_tainted[0]) == {"untrusted_user"}


### PR DESCRIPTION
This PR implements the task `mcp-kernel-taint-tracking-v3-fe34585d` (MCPKernel Taint Tracking Extension V3).

Changes:
1. Created `TaintTrackerV3` inheriting from `TaintTrackerV2`.
2. Created `TaintedEpisodicMemory` inheriting from `EpisodicMemory` that integrates with `TaintTrackerV3` to automatically trace, serialize, and reconstruct taint tracks across episodic memory blocks using ChromaDB metadata.
3. Wrote comprehensive unit tests in `tests/test_taint_tracking_v3.py` utilizing memory-only/ephemeral ChromaDB instances.
4. Updated `agent_tasks.json` status of the task to done.
5. Added 3 new todo tasks to `agent_tasks.json` representing current June 2026 AI agent trends.
6. Verified task schema and ran pytest suite successfully.

---
*PR created automatically by Jules for task [8864290905177728673](https://jules.google.com/task/8864290905177728673) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add taint-tracking episodic memory with provenance persistence in `TaintedEpisodicMemory`
> - Introduces [`taint_tracking_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/500/files#diff-0b668966435c9af6d97772381ff27dc7d4258b665502c9dda6443a33a6a091a8) with `TaintTrackerV3` (a thin subclass of `TaintTrackerV2`) and `TaintedEpisodicMemory`, which extends `EpisodicMemory` to persist and reconstruct taint provenance across memory boundaries.
> - On `store_event`, tainted text has its origins serialized into metadata fields (`_taint_origins`, `_is_tainted`) and both text and metadata are sanitized before storage.
> - On `get_all_events` and `recall_events`, taint is reconstructed for flagged entries using stored origins; `recall_events` also re-ranks results by adjusting retrieval distance with PAD intensity scores from metadata.
> - Adds end-to-end tests in [`test_taint_tracking_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/500/files#diff-71af59ff9ce38ffe1758499c88ebd1c2c0fec890f3fb59c2b77d737bc49e2176) covering initialization, store/recall, and taint reconstruction.
> - Behavioral Change: `recall_events` returns an empty list (with a logged error) on query failure rather than propagating an exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3b47ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->