### PR TITLE
Implement OpenClaw RL Canvas Visualization Module and metrics exporter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8083,7 +8083,7 @@
     },
     {
       "id": "openclaw-rl-canvas-metrics-d42db27e",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL Canvas Visualization Module",
@@ -17941,6 +17941,60 @@
         "Transaction manager sequences and executes tool calls.",
         "Successfully rolls back registered actions on execution failure of subsequent steps.",
         "Tests verify sequential execution and rollback functionality using mock stateful tools."
+      ]
+    },
+    {
+      "id": "openai-agents-tool-parallel-optimizer-f38b1234",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "OpenAI Agents SDK Tool Parallel Execution Optimizer",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a wrapper helper to identify which tool executions in the plan are safe to run concurrently, executing them in parallel with bounded asyncio.gather limits.",
+      "allowed_paths": [
+        "magda_agent/skills/parallel_optimizer.py",
+        "tests/test_parallel_optimizer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Wrapper successfully identifies and runs safe parallel tool execution.",
+        "Limit bounds are respected.",
+        "Tests verify concurrent execution and error containment."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-logger-ab76cd34",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "title": "OpenClaw-RL Real-time Trajectory Logger",
+      "description": "Inspired by OpenClaw-RL trend: Create a trajectory logger that saves sequence of transitions (state, action, reward, next_state) of user replies and skill selections to a structured local store for future policy tuning.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_logger.py",
+        "tests/test_trajectory_logger.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Transitions are successfully logged.",
+        "Trajectories are persistent across runs.",
+        "Tests verify correct logging formats."
+      ]
+    },
+    {
+      "id": "hermes-skill-doc-generator-89abef78",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Skill Auto-Documentation Generator",
+      "description": "Inspired by Hermes skills standard: Implement an automatic generator that parses the parameters and docstrings of newly created skills to generate agentskills.io-compatible documentation pages dynamically.",
+      "allowed_paths": [
+        "magda_agent/skills/doc_generator.py",
+        "tests/test_doc_generator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Documentation is successfully generated from skill definitions.",
+        "Schema conforms to agentskills.io documentation format.",
+        "Tests verify correct documentation outputs."
       ]
     }
   ]

--- a/magda_agent/learning/canvas_metrics.py
+++ b/magda_agent/learning/canvas_metrics.py
@@ -1,0 +1,160 @@
+import logging
+from typing import Dict, List, Any, Optional
+from magda_agent.learning.openclaw_rl_metrics import OpenClawRLMetrics
+
+logger = logging.getLogger(__name__)
+
+class RLCanvasMetricsExporter:
+    """
+    RLCanvasMetricsExporter handles the transformation and formatting of
+    reinforcement learning metrics for direct ingestion by live Canvas UIs.
+
+    It converts tracked Q-values and raw rewards history into normalized metrics,
+    calculates moving averages, detects trends, and aggregates behavioral metrics.
+    """
+
+    def __init__(self, metrics: OpenClawRLMetrics) -> None:
+        """
+        Initializes the exporter with a reference to the active OpenClawRLMetrics tracker.
+
+        Args:
+            metrics (OpenClawRLMetrics): The underlying RL metrics instance to export from.
+        """
+        self.metrics = metrics
+
+    def get_normalized_q_values(self) -> Dict[str, float]:
+        """
+        Normalizes Q-values to a standard scale of [0.0, 1.0] across all tracked skills.
+        If all Q-values are identical, they are mapped to 0.5.
+
+        Returns:
+            Dict[str, float]: Normalized Q-values mapped by skill identifier.
+        """
+        q_vals = self.metrics.q_values
+        if not q_vals:
+            return {}
+
+        min_val = min(q_vals.values())
+        max_val = max(q_vals.values())
+        diff = max_val - min_val
+
+        if diff == 0.0:
+            return {skill: 0.5 for skill in q_vals}
+
+        return {skill: (val - min_val) / diff for skill, val in q_vals.items()}
+
+    def get_moving_average_reward(self, window_size: int = 5) -> float:
+        """
+        Calculates the moving average reward over the specified window size.
+
+        Args:
+            window_size (int): The number of recent rewards to consider. Defaults to 5.
+
+        Returns:
+            float: The moving average reward, or 0.0 if no rewards are present.
+        """
+        rewards = self.metrics.recent_rewards
+        if not rewards:
+            return 0.0
+
+        window = rewards[-window_size:]
+        total_reward = sum(entry["reward"] for entry in window if "reward" in entry)
+        return total_reward / len(window)
+
+    def detect_reward_trend(self, split_ratio: float = 0.5) -> str:
+        """
+        Detects whether the reward signal trend is "improving", "declining", or "stable"
+        by comparing the average of the older half to the newer half of recent rewards.
+
+        Args:
+            split_ratio (float): The ratio at which to split the history. Defaults to 0.5.
+
+        Returns:
+            str: One of "improving", "declining", "stable", or "insufficient_data".
+        """
+        rewards = self.metrics.recent_rewards
+        if len(rewards) < 4:
+            return "insufficient_data"
+
+        split_idx = int(len(rewards) * split_ratio)
+        older_half = rewards[:split_idx]
+        newer_half = rewards[split_idx:]
+
+        avg_older = sum(entry["reward"] for entry in older_half) / len(older_half)
+        avg_newer = sum(entry["reward"] for entry in newer_half) / len(newer_half)
+
+        difference = avg_newer - avg_older
+        if difference > 0.05:
+            return "improving"
+        elif difference < -0.05:
+            return "declining"
+        else:
+            return "stable"
+
+    def get_skill_activity_metrics(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Aggregates activity metrics per skill, tracking occurrence counts and
+        average reward achieved per skill.
+
+        Returns:
+            Dict[str, Dict[str, Any]]: Aggregated skills stats including count and avg_reward.
+        """
+        stats: Dict[str, Dict[str, Any]] = {}
+        for entry in self.metrics.recent_rewards:
+            skill = entry.get("skill_id", "unknown")
+            reward = entry.get("reward", 0.0)
+
+            if skill not in stats:
+                stats[skill] = {"count": 0, "total_reward": 0.0}
+
+            stats[skill]["count"] += 1
+            stats[skill]["total_reward"] += reward
+
+        formatted_stats: Dict[str, Dict[str, Any]] = {}
+        for skill, data in stats.items():
+            count = data["count"]
+            formatted_stats[skill] = {
+                "count": count,
+                "average_reward": data["total_reward"] / count if count > 0 else 0.0
+            }
+
+        return formatted_stats
+
+    def export_canvas_payload(self) -> Dict[str, Any]:
+        """
+        Transforms and packages the metrics into a highly-structured payload
+        ready for live Canvas UI ingestion.
+
+        Returns:
+            Dict[str, Any]: The structured UI visualization state.
+        """
+        try:
+            raw_data = self.metrics.get_visualization_data()
+            normalized_q = self.get_normalized_q_values()
+            moving_avg_5 = self.get_moving_average_reward(window_size=5)
+            trend = self.detect_reward_trend()
+            skill_stats = self.get_skill_activity_metrics()
+
+            return {
+                "status": raw_data.get("status", "active"),
+                "total_rewards_received": raw_data.get("reward_count", 0),
+                "global_average_q": raw_data.get("average_q", 0.0),
+                "moving_average_reward_5": moving_avg_5,
+                "trajectory_trend": trend,
+                "skills_coverage": {
+                    skill: {
+                        "q_value": raw_val,
+                        "normalized_q_value": normalized_q.get(skill, 0.5),
+                        "activity": skill_stats.get(skill, {}).get("count", 0),
+                        "avg_reward": skill_stats.get(skill, {}).get("average_reward", 0.0)
+                    }
+                    for skill, raw_val in raw_data.get("q_values", {}).items()
+                },
+                "raw_rewards_trajectory": raw_data.get("recent_rewards", [])
+            }
+        except Exception as e:
+            logger.error(f"Error exporting canvas metrics: {e}")
+            return {
+                "status": "error",
+                "error_message": str(e)
+            }

--- a/tests/test_canvas_metrics.py
+++ b/tests/test_canvas_metrics.py
@@ -1,0 +1,126 @@
+import pytest
+from magda_agent.learning.openclaw_rl_metrics import OpenClawRLMetrics
+from magda_agent.learning.canvas_metrics import RLCanvasMetricsExporter
+
+def test_exporter_empty_metrics() -> None:
+    """Test that the exporter handles empty metrics structures gracefully."""
+    metrics = OpenClawRLMetrics()
+    exporter = RLCanvasMetricsExporter(metrics)
+
+    assert exporter.get_normalized_q_values() == {}
+    assert exporter.get_moving_average_reward() == 0.0
+    assert exporter.detect_reward_trend() == "insufficient_data"
+    assert exporter.get_skill_activity_metrics() == {}
+
+    payload = exporter.export_canvas_payload()
+    assert payload["status"] == "active"
+    assert payload["total_rewards_received"] == 0
+    assert payload["trajectory_trend"] == "insufficient_data"
+    assert payload["skills_coverage"] == {}
+    assert payload["raw_rewards_trajectory"] == []
+
+def test_exporter_normalized_q_values() -> None:
+    """Test standard and edge cases of Q-values normalization."""
+    metrics = OpenClawRLMetrics()
+    exporter = RLCanvasMetricsExporter(metrics)
+
+    # All identical values should map to 0.5
+    metrics.update_q_value("skill_1", 1.5)
+    metrics.update_q_value("skill_2", 1.5)
+    normalized = exporter.get_normalized_q_values()
+    assert normalized == {"skill_1": 0.5, "skill_2": 0.5}
+
+    # Distinct values should scale properly [0.0, 1.0]
+    metrics.update_q_value("skill_3", 0.0)
+    metrics.update_q_value("skill_4", 3.0)
+    distinct_normalized = exporter.get_normalized_q_values()
+    assert distinct_normalized["skill_3"] == 0.0
+    assert distinct_normalized["skill_4"] == 1.0
+    assert distinct_normalized["skill_1"] == 0.5
+    assert distinct_normalized["skill_2"] == 0.5
+
+def test_exporter_moving_averages() -> None:
+    """Test that the moving average considers only the defined window size."""
+    metrics = OpenClawRLMetrics()
+    exporter = RLCanvasMetricsExporter(metrics)
+
+    metrics.add_reward("skill_a", 1.0)
+    metrics.add_reward("skill_a", 2.0)
+    metrics.add_reward("skill_a", 3.0)
+
+    # Average of last 5 (which is 3 items actually present): (1+2+3)/3 = 2.0
+    assert exporter.get_moving_average_reward(window_size=5) == 2.0
+
+    # Average of last 2: (2+3)/2 = 2.5
+    assert exporter.get_moving_average_reward(window_size=2) == 2.5
+
+def test_exporter_reward_trends() -> None:
+    """Test the detection of improving, declining, or stable trends."""
+    metrics = OpenClawRLMetrics()
+    exporter = RLCanvasMetricsExporter(metrics)
+
+    # Not enough data initially
+    assert exporter.detect_reward_trend() == "insufficient_data"
+
+    # Improving: older is lower, newer is higher
+    metrics.add_reward("skill_a", 0.1)
+    metrics.add_reward("skill_a", 0.2)
+    metrics.add_reward("skill_a", 0.8)
+    metrics.add_reward("skill_a", 0.9)
+    assert exporter.detect_reward_trend() == "improving"
+
+    # Declining: older is higher, newer is lower
+    metrics_declining = OpenClawRLMetrics()
+    exporter_declining = RLCanvasMetricsExporter(metrics_declining)
+    metrics_declining.add_reward("skill_a", 1.0)
+    metrics_declining.add_reward("skill_a", 0.9)
+    metrics_declining.add_reward("skill_a", 0.2)
+    metrics_declining.add_reward("skill_a", 0.1)
+    assert exporter_declining.detect_reward_trend() == "declining"
+
+    # Stable: difference is very small
+    metrics_stable = OpenClawRLMetrics()
+    exporter_stable = RLCanvasMetricsExporter(metrics_stable)
+    metrics_stable.add_reward("skill_a", 0.5)
+    metrics_stable.add_reward("skill_a", 0.5)
+    metrics_stable.add_reward("skill_a", 0.52)
+    metrics_stable.add_reward("skill_a", 0.48)
+    assert exporter_stable.detect_reward_trend() == "stable"
+
+def test_exporter_skill_activity_metrics() -> None:
+    """Test the aggregation of metrics per skill identifier."""
+    metrics = OpenClawRLMetrics()
+    exporter = RLCanvasMetricsExporter(metrics)
+
+    metrics.add_reward("skill_alpha", 1.0)
+    metrics.add_reward("skill_alpha", 2.0)
+    metrics.add_reward("skill_beta", 4.0)
+
+    stats = exporter.get_skill_activity_metrics()
+    assert stats["skill_alpha"] == {"count": 2, "average_reward": 1.5}
+    assert stats["skill_beta"] == {"count": 1, "average_reward": 4.0}
+
+def test_exporter_canvas_payload_schema() -> None:
+    """Test the structure and values of the complete Canvas payload."""
+    metrics = OpenClawRLMetrics()
+    exporter = RLCanvasMetricsExporter(metrics)
+
+    metrics.update_q_value("skill_a", 1.0)
+    metrics.update_q_value("skill_b", 2.0)
+    metrics.add_reward("skill_a", 1.5)
+    metrics.add_reward("skill_b", 2.5)
+
+    payload = exporter.export_canvas_payload()
+    assert payload["status"] == "active"
+    assert payload["total_rewards_received"] == 2
+    assert payload["global_average_q"] == 1.5
+    assert payload["moving_average_reward_5"] == 2.0
+    assert payload["trajectory_trend"] == "insufficient_data"
+    assert "skill_a" in payload["skills_coverage"]
+    assert "skill_b" in payload["skills_coverage"]
+
+    skill_a_data = payload["skills_coverage"]["skill_a"]
+    assert skill_a_data["q_value"] == 1.0
+    assert skill_a_data["normalized_q_value"] == 0.0
+    assert skill_a_data["activity"] == 1
+    assert skill_a_data["avg_reward"] == 1.5


### PR DESCRIPTION
Created the RLCanvasMetricsExporter module under magda_agent/learning/canvas_metrics.py to format and transform Q-values and reward updates for live Canvas UI ingestion. Added unit tests in tests/test_canvas_metrics.py, updated agent_tasks.json, and replenished task list with new modern AI agent tasks.

---
*PR created automatically by Jules for task [9456412384686948287](https://jules.google.com/task/9456412384686948287) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLCanvasMetricsExporter` class to export OpenClaw RL metrics as Canvas UI payloads
> - Adds [`canvas_metrics.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/501/files#diff-8889fce922d154a9f82d24482ec23be1914735ef9695f19094ab89758913297f) with `RLCanvasMetricsExporter`, which wraps an `OpenClawRLMetrics` instance and exposes normalized Q-values, moving average rewards (default window=5), qualitative trend detection, and per-skill activity aggregation.
> - The `export_canvas_payload` method assembles these into a structured dict with keys `status`, `total_rewards_received`, `global_average_q`, `moving_average_reward_5`, `trajectory_trend`, `skills_coverage`, and `raw_rewards_trajectory`; errors are caught and returned as `{'status': 'error', ...}`.
> - Adds [`tests/test_canvas_metrics.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/501/files#diff-6a1ca46b941d457d75270c2a42c51de26f5966ba5a630d2e6092cd9e3863aca0) with six tests covering empty state, normalization edge cases, moving averages, trend detection, skill aggregation, and full payload schema.
> - Updates [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/501/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) with three new `todo` tasks for parallel tool optimization, RL trajectory logging, and skill doc generation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bdb949.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->