### PR TITLE
ACS Guardrail Checkpoint Refactor to Stage-Based Pipeline

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8100,7 +8100,7 @@
     },
     {
       "id": "acs-guardrail-runtime-governance-621d3b4e",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "ACS Guardrail Checkpoint Refactor",
@@ -17995,6 +17995,57 @@
         "Documentation is successfully generated from skill definitions.",
         "Schema conforms to agentskills.io documentation format.",
         "Tests verify correct documentation outputs."
+      ]
+    },
+    {
+      "id": "hermes-online-skill-pruning-9c1b3a5d",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Online Skill Pruning based on Habit Strength",
+      "description": "Inspired by Hermes self-improving skills trend (June 2026): Implement an automated pruning routine that sweeps the ProceduralMemory and archives or de-registers skills whose habit weights or selection probabilities fall below a minimum threshold over time.",
+      "allowed_paths": [
+        "magda_agent/skills/pruning_v1.py",
+        "tests/test_skills_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill pruning removes low-probability skills from the registry.",
+        "Tests verify archived/pruned state changes correctly."
+      ]
+    },
+    {
+      "id": "openclaw-ws-session-heartbeat-a1b2c3d4",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw WebSockets Session Heartbeat and Auto-Reconnect",
+      "description": "Inspired by OpenClaw live state streaming: Implement a robust WebSocket heartbeat mechanism in the CanvasServer to verify active web clients, prune dead connections automatically, and support client auto-reconnection with session state playback.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_heartbeat_v1.py",
+        "tests/test_canvas_heartbeat_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "CanvasServer tracks heartbeats, cleans up disconnected websocket clients, and resumes state playback on re-connect.",
+        "Tests verify websocket heartbeat logic using mock connections."
+      ]
+    },
+    {
+      "id": "acs-policy-performance-logger-3c4d5e6f",
+      "status": "todo",
+      "area": "safety",
+      "risk": "low",
+      "title": "ACS Policy Performance and Checkpoint Overhead Logger",
+      "description": "Inspired by Microsoft ACS safety controls: Implement a structured performance monitoring and logging class that records the precise execution overhead (in milliseconds) for each of the 5 validation checkpoints, storing the stats in a local SQLite performance log.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_perf_logger_v1.py",
+        "tests/test_acs_perf_logger_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS Checkpoint executions are wrapped with timers, and stats are saved to a separate database table.",
+        "Tests verify stats recording and querying."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -156,6 +156,8 @@
 * [x] FEATURE: Healthcheck endpoint (2026-06-03)
 * [x] SECURITY: Изолировать system_execute_code — subprocess с таймаутом (2026-06-03)
 
+- [x] acs-guardrail-runtime-governance-621d3b4e: ACS Guardrail Checkpoint Refactor (2026-06-15)
+
 ---
 
 ## 🔍 Обнаружено (добавляется агентом автоматически)
@@ -200,6 +202,9 @@
 * [ ] MODULE: **Agent Skills Self-Documentation** — `magda_agent/skills/documentation.py`. Generates natural language documentation for all registered skills.
 * [ ] MODULE: **A2A Delegation Cost Estimation** — `magda_agent/integration/a2a_cost_estimator.py`. Predicts token usage and latency for P2P delegation.
 * [ ] MODULE: **RL Interaction Loop Entropy Tracking** — `magda_agent/learning/entropy_tracker.py`. Tracks behavior entropy to detect loops.
+* [ ] MODULE: **Hermes Online Skill Pruning** — `magda_agent/skills/pruning_v1.py`. Automatically prunes under-used skills from the registry.
+* [ ] MODULE: **OpenClaw WebSockets Session Heartbeat** — `magda_agent/visualization/canvas_heartbeat_v1.py`. Keeps WebSocket connections active.
+* [ ] MODULE: **ACS Policy Performance Logger** — `magda_agent/safety/acs_perf_logger_v1.py`. Tracks overhead of ACS Checkpoints.
 
 * [x] MODULE: **Curiosity Drive** — `magda_agent/exploration/curiosity.py`. (2026-06-05)
   Proactively suggests exploration tasks when boredom is high.

--- a/magda_agent/safety/acs_checkpoints.py
+++ b/magda_agent/safety/acs_checkpoints.py
@@ -1,6 +1,7 @@
 import logging
 import re
-from typing import Dict, Any, Tuple, Optional
+from enum import Enum
+from typing import Dict, Any, Tuple, Optional, List, Callable
 from magda_agent.safety.policy import PolicyLayer
 from magda_agent.safety.audit_trail import AuditTrail
 
@@ -15,15 +16,86 @@ class SecurityViolationError(Exception):
     """Exception raised when an action is blocked by ACS checkpoints."""
     pass
 
+class CheckpointStage(Enum):
+    """Stages of the Agent Control Specification validation pipeline."""
+    INPUT = "input"
+    EXECUTION = "execution"
+    OUTPUT = "output"
+
+class Checkpoint:
+    """Represents a discrete validation checkpoint within the ACS pipeline."""
+
+    def __init__(self, name: str, stage: CheckpointStage, validate_func: Callable[[Dict[str, Any]], Tuple[bool, str]]) -> None:
+        """
+        Initializes a Checkpoint instance.
+
+        Args:
+            name: Description/name of the checkpoint.
+            stage: CheckpointStage enum value.
+            validate_func: The validation function callable.
+        """
+        self.name = name
+        self.stage = stage
+        self.validate_func = validate_func
+
+    def run(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Runs the checkpoint validation function.
+
+        Args:
+            action_data: The dictionary containing action context and payload.
+
+        Returns:
+            A tuple of (is_passed, message).
+        """
+        return self.validate_func(action_data)
+
 class ACSCheckpoints:
     """
     Implements 5 ACS validation checkpoints for agentic workflows.
-    Ensures all actions pass through 5 checks before execution.
+    Refactored to execute checkpoints through a formal pipeline of discrete stages.
     """
+
     def __init__(self, policy_layer: Optional[PolicyLayer] = None, audit_trail: Optional[AuditTrail] = None) -> None:
+        """
+        Initializes the ACSCheckpoints pipeline.
+
+        Args:
+            policy_layer: Optional PolicyLayer for tool evaluation.
+            audit_trail: Optional AuditTrail for recording evaluation results.
+        """
         self.logger = logging.getLogger(__name__)
         self.policy_layer = policy_layer or PolicyLayer()
         self.audit_trail = audit_trail or AuditTrail()
+
+        # Build the pipeline of formal checkpoints
+        self.pipeline: List[Checkpoint] = [
+            Checkpoint(
+                name="Input Validation",
+                stage=CheckpointStage.INPUT,
+                validate_func=self.checkpoint_1_input_validation
+            ),
+            Checkpoint(
+                name="Intent Authorization",
+                stage=CheckpointStage.INPUT,
+                validate_func=self.checkpoint_2_intent_authorization
+            ),
+            Checkpoint(
+                name="Tool Policy",
+                stage=CheckpointStage.EXECUTION,
+                validate_func=self.checkpoint_3_tool_policy
+            ),
+            Checkpoint(
+                name="State Transition",
+                stage=CheckpointStage.EXECUTION,
+                validate_func=self.checkpoint_4_state_transition
+            ),
+            Checkpoint(
+                name="Output Sanitization",
+                stage=CheckpointStage.OUTPUT,
+                validate_func=self.checkpoint_5_output_sanitization
+            )
+        ]
 
     def checkpoint_1_input_validation(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
         """Checkpoint 1: Input Validation. Ensures action data is well-formed."""
@@ -106,15 +178,36 @@ class ACSCheckpoints:
 
         return True, "Checkpoint 5 Passed."
 
+    def _run_stage(self, stage: CheckpointStage, action_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Executes all checkpoints belonging to a specific CheckpointStage.
+
+        Args:
+            stage: The CheckpointStage to execute.
+            action_data: The dictionary containing action context and payload.
+
+        Returns:
+            A tuple of (is_passed, message).
+        """
+        for checkpoint in self.pipeline:
+            if checkpoint.stage == stage:
+                ok, reason = checkpoint.run(action_data)
+                if not ok:
+                    return False, reason
+        return True, f"{stage.name} validation stage passed."
+
     def validate_pre_execution(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """Runs checkpoints 1 to 4 and logs to audit trail on failure."""
-        for i, cp in enumerate([
-            self.checkpoint_1_input_validation,
-            self.checkpoint_2_intent_authorization,
-            self.checkpoint_3_tool_policy,
-            self.checkpoint_4_state_transition
-        ], 1):
-            ok, reason = cp(action_data)
+        """
+        Runs INPUT and EXECUTION checkpoint stages and logs to audit trail on failure.
+
+        Args:
+            action_data: The dictionary containing action context and payload.
+
+        Returns:
+            A tuple of (is_passed, message).
+        """
+        for stage in [CheckpointStage.INPUT, CheckpointStage.EXECUTION]:
+            ok, reason = self._run_stage(stage, action_data)
             if not ok:
                 self.logger.warning(reason)
                 self.audit_trail.log_call(
@@ -129,8 +222,16 @@ class ACSCheckpoints:
         return True, "Pre-execution ACS checkpoints passed."
 
     def validate_post_execution(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
-        """Runs checkpoint 5 and logs to audit trail on failure."""
-        ok, reason = self.checkpoint_5_output_sanitization(action_data)
+        """
+        Runs OUTPUT checkpoint stage and logs to audit trail on failure.
+
+        Args:
+            action_data: The dictionary containing action context and payload.
+
+        Returns:
+            A tuple of (is_passed, message).
+        """
+        ok, reason = self._run_stage(CheckpointStage.OUTPUT, action_data)
         if not ok:
             self.logger.warning(reason)
             self.audit_trail.log_call(
@@ -145,7 +246,15 @@ class ACSCheckpoints:
         return True, reason
 
     def validate_action(self, action_data: Dict[str, Any]) -> bool:
-        """Runs all 5 checkpoints and returns True if all pass."""
+        """
+        Runs all 5 checkpoints across all stages and returns True if all pass.
+
+        Args:
+            action_data: The dictionary containing action context and payload.
+
+        Returns:
+            True if all checkpoints pass, False otherwise.
+        """
         ok_pre, reason_pre = self.validate_pre_execution(action_data)
         if not ok_pre:
             return False
@@ -166,22 +275,19 @@ class ACSCheckpoints:
     def intercept_action(self, action_data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Intercepts an action, validates it, and raises SecurityViolationError on failure.
-        Useful for synchronous middleware-like validation.
+
+        Args:
+            action_data: The dictionary containing action context and payload.
+
+        Returns:
+            The input action_data if all checkpoints pass.
+
+        Raises:
+            SecurityViolationError: If any validation checkpoint fails.
         """
         if not self.validate_action(action_data):
-            # The reason is already logged in validate_action, but we need it for the exception.
-            # Re-running to get the exact failure if necessary, or just a generic error.
-            # For efficiency in a real system we'd return (bool, str) from validate_action.
-            # Let's just find the failing one.
-            checkpoints = [
-                self.checkpoint_1_input_validation,
-                self.checkpoint_2_intent_authorization,
-                self.checkpoint_3_tool_policy,
-                self.checkpoint_4_state_transition,
-                self.checkpoint_5_output_sanitization
-            ]
-            for checkpoint in checkpoints:
-                passed, reason = checkpoint(action_data)
+            for checkpoint in self.pipeline:
+                passed, reason = checkpoint.run(action_data)
                 if not passed:
                      raise SecurityViolationError(reason)
         return action_data

--- a/tests/test_acs_checkpoints.py
+++ b/tests/test_acs_checkpoints.py
@@ -1,5 +1,5 @@
 import pytest
-from magda_agent.safety.acs_checkpoints import ACSCheckpoints, SecurityViolationError
+from magda_agent.safety.acs_checkpoints import ACSCheckpoints, SecurityViolationError, CheckpointStage, Checkpoint
 from magda_agent.safety.policy import PolicyLayer
 from magda_agent.safety.audit_trail import AuditTrail
 
@@ -94,3 +94,33 @@ def test_audit_trail_logging():
 
     assert len(audit.get_all()) == 2
     assert audit.get_all()[1]["result"] == "allowed"
+
+def test_checkpoint_stage_enum():
+    assert CheckpointStage.INPUT.value == "input"
+    assert CheckpointStage.EXECUTION.value == "execution"
+    assert CheckpointStage.OUTPUT.value == "output"
+
+def test_checkpoint_class():
+    def dummy_validator(action_data):
+        return True, "Passed"
+
+    cp = Checkpoint(name="Dummy", stage=CheckpointStage.INPUT, validate_func=dummy_validator)
+    assert cp.name == "Dummy"
+    assert cp.stage == CheckpointStage.INPUT
+    assert cp.run({}) == (True, "Passed")
+
+def test_run_stage_explicitly():
+    checkpoints = ACSCheckpoints()
+    valid_data = {
+        "action_name": "test_action",
+        "tool_name": "allowed_tool"
+    }
+    # INPUT stage passes
+    passed, msg = checkpoints._run_stage(CheckpointStage.INPUT, valid_data)
+    assert passed is True
+
+    # Invalid input
+    invalid_data = {}
+    passed, msg = checkpoints._run_stage(CheckpointStage.INPUT, invalid_data)
+    assert passed is False
+    assert "Checkpoint 1 Failed" in msg


### PR DESCRIPTION
Refactored the ACS (Agent Control Specification) Guardrail Checkpoint system into a formal stage-based pipeline using explicit Checkpoint classes and CheckpointStage enums. Updated agent_tasks.json and backlog.md with status updates and added 3 new todo tasks reflecting modern June 2026 AI agent patterns. Added detailed unit tests to verify the behavior.

---
*PR created automatically by Jules for task [1835185964536057734](https://jules.google.com/task/1835185964536057734) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor ACS guardrail checkpoints to a stage-based pipeline
> - Introduces a `CheckpointStage` enum (`INPUT`, `EXECUTION`, `OUTPUT`) and a `Checkpoint` dataclass in [`acs_checkpoints.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/502/files#diff-d16056416f606d52a450ce4e5da0ff6d5b3979598c95b67700bce3d68a546576) to represent validations as discrete pipeline objects.
> - Replaces hard-coded function call sequences in `validate_pre_execution`, `validate_post_execution`, and `intercept_action` with a `_run_stage` helper that iterates the ordered pipeline and stops on first failure.
> - Success messages are now standardized to per-stage strings (e.g. `'INPUT validation stage passed.'`) rather than per-checkpoint strings.
> - Adds tests for the new enum, `Checkpoint` class, and `_run_stage` behavior in [`test_acs_checkpoints.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/502/files#diff-1a778e306552f445a02ae125fa7502cdaf9ae8693ea6714ff179dab479c82068).
> - Behavioral Change: observable success message strings from `validate_pre_execution` and `validate_post_execution` change to stage-level strings; overall validation logic and audit logging are otherwise equivalent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d412c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->