### PR TITLE
MCP Action Tools Pre-flight Validation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8117,7 +8117,7 @@
     },
     {
       "id": "mcp-action-tools-preflight-v4",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Action Tools Pre-flight Validation",
@@ -18046,6 +18046,57 @@
       "acceptance": [
         "ACS Checkpoint executions are wrapped with timers, and stats are saved to a separate database table.",
         "Tests verify stats recording and querying."
+      ]
+    },
+    {
+      "id": "mcp-tool-failure-tracker-v13-a4b5c6d7",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "MCP Tool Telemetry and Failure Rate Tracker",
+      "description": "Inspired by the MCP standard trend (June 2026): Implement an asynchronous telemetry logger that tracks success/failure metrics and response latency for each remote and local MCP tool invocation, saving stats to SQLite.",
+      "allowed_paths": [
+        "magda_agent/telemetry/mcp_failure_tracker_v13.py",
+        "tests/test_mcp_failure_tracker_v13.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry records invocation success/failure and latency to SQLite.",
+        "Tests verify metric collection and query logic."
+      ]
+    },
+    {
+      "id": "a2a-discovery-rbac-v13-b5c6d7e8",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Peer Discovery with Role-Based Access Control",
+      "description": "Inspired by A2A Protocol and ACS safety standards: Implement role-based access control (RBAC) in the A2A Discovery manager to filter and restrict peer capability visibility based on requester roles.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_rbac_v13.py",
+        "tests/test_a2a_discovery_rbac_v13.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2ADiscoveryService filters peer capabilities based on verified role tokens.",
+        "Tests verify RBAC constraints on mock requests."
+      ]
+    },
+    {
+      "id": "openclaw-rl-prompt-compressor-v13-c6d7e8f9",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Adaptive Prompt Compressor",
+      "description": "Inspired by OpenClaw-RL and virtual context management trends: Implement an adaptive prompt compression hook that triggers aggressive LLM-driven context summarization when reinforcement feedback/rewards drop below a threshold.",
+      "allowed_paths": [
+        "magda_agent/learning/adaptive_compressor_v13.py",
+        "tests/test_adaptive_compressor_v13.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Adaptive compressor initiates prompt compression when low reward signals are encountered in RL.",
+        "Tests verify compression threshold trigger behavior."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_preflight.py
+++ b/magda_agent/integration/mcp_preflight.py
@@ -1,0 +1,237 @@
+"""MCP Action Tools Pre-flight Validation.
+
+Provides a pre-flight validation mechanism for all MCP action tools before invoking JSON-RPC.
+"""
+
+import json
+import re
+import logging
+from typing import Any, Dict, List, Tuple, Optional
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.safety.taint import is_tainted
+from magda_agent.integration.mcp_server import MCPServer
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+# Common hazardous injection and path traversal pattern compiled regexes
+_HAZARDOUS_SHELL_PATTERNS = [
+    re.compile(r"rm\s+-rf", re.IGNORECASE),
+    re.compile(r";\s*bash", re.IGNORECASE),
+    re.compile(r";\s*sh", re.IGNORECASE),
+    re.compile(r"\bcurl\b", re.IGNORECASE),
+    re.compile(r"\bwget\b", re.IGNORECASE),
+]
+
+_PATH_TRAVERSAL_PATTERNS = [
+    re.compile(r"\.\./\.\."),
+    re.compile(r"/etc/passwd"),
+    re.compile(r"/etc/hosts"),
+    re.compile(r"\.env\b", re.IGNORECASE),
+    re.compile(r"id_rsa", re.IGNORECASE),
+]
+
+_SQL_INJECTION_PATTERNS = [
+    re.compile(r"'\s*or\s*'\d+'\s*=\s*'\d+", re.IGNORECASE),
+    re.compile(r"'\s*or\s*\d+\s*=\s*\d+", re.IGNORECASE),
+    re.compile(r"union\s+select", re.IGNORECASE),
+]
+
+
+class MCPPreflightValidator:
+    """
+    Validator to perform pre-flight checks on MCP JSON-RPC requests
+    before executing the underlying tool or invoking the client.
+    """
+
+    def __init__(
+        self,
+        registry: Optional[SkillRegistry] = None,
+        forbidden_tools: Optional[List[str]] = None
+    ) -> None:
+        """
+        Initializes the MCPPreflightValidator.
+
+        Args:
+            registry (Optional[SkillRegistry]): The skill registry to validate against.
+            forbidden_tools (Optional[List[str]]): List of explicitly blacklisted tool names.
+        """
+        self.registry = registry
+        self.forbidden_tools = forbidden_tools or ["forbidden_tool", "unsafe_execute", "nuke_system"]
+
+    def _check_string_for_hazards(self, val: str) -> Tuple[bool, str]:
+        """
+        Inspects a single string for hazardous patterns (shell injection, path traversal, SQLi).
+
+        Args:
+            val (str): The string parameter to check.
+
+        Returns:
+            Tuple[bool, str]: (is_safe, error_reason)
+        """
+        for pattern in _HAZARDOUS_SHELL_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous shell pattern detected: {pattern.pattern}"
+
+        for pattern in _PATH_TRAVERSAL_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous path traversal pattern detected: {pattern.pattern}"
+
+        for pattern in _SQL_INJECTION_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous SQL injection pattern detected: {pattern.pattern}"
+
+        return True, ""
+
+    def _validate_value_recursively(self, val: Any) -> Tuple[bool, str]:
+        """
+        Recursively checks parameter values for hazardous strings or taint.
+
+        Args:
+            val (Any): Any value to check.
+
+        Returns:
+            Tuple[bool, str]: (is_safe, error_reason)
+        """
+        if is_tainted(val):
+            return False, "Tainted data detected in parameters."
+
+        if isinstance(val, str):
+            is_safe, reason = self._check_string_for_hazards(val)
+            if not is_safe:
+                return False, reason
+
+        elif isinstance(val, list):
+            for item in val:
+                is_safe, reason = self._validate_value_recursively(item)
+                if not is_safe:
+                    return False, reason
+
+        elif isinstance(val, dict):
+            for k, v in val.items():
+                # Check key
+                is_safe, reason = self._validate_value_recursively(k)
+                if not is_safe:
+                    return False, reason
+                # Check value
+                is_safe, reason = self._validate_value_recursively(v)
+                if not is_safe:
+                    return False, reason
+
+        return True, ""
+
+    def validate_request_dict(self, request: Dict[str, Any]) -> Tuple[bool, int, str]:
+        """
+        Validates a parsed JSON-RPC request dictionary.
+
+        Args:
+            request (Dict[str, Any]): The JSON-RPC request dictionary.
+
+        Returns:
+            Tuple[bool, int, str]: (is_valid, error_code, error_message)
+        """
+        if not isinstance(request, dict):
+            return False, -32600, "Invalid Request: request must be an object."
+
+        # Validate JSON-RPC version
+        if request.get("jsonrpc") != "2.0":
+            return False, -32600, "Invalid Request: jsonrpc version must be '2.0'."
+
+        method = request.get("method")
+        if not method or not isinstance(method, str):
+            return False, -32600, "Invalid Request: 'method' must be a non-empty string."
+
+        # Safety Check: Tainted tool names
+        if is_tainted(method):
+            return False, -32000, "Pre-flight Blocked: tool name is tainted."
+
+        # Safety Check: Explicitly forbidden tools
+        if method in self.forbidden_tools:
+            return False, -32000, f"Pre-flight Blocked: Tool '{method}' is blacklisted."
+
+        params = request.get("params", {})
+        if not isinstance(params, dict):
+            return False, -32602, "Invalid params: 'params' must be an object."
+
+        # Safety Check: Recursively inspect parameters for taint and hazardous patterns
+        is_safe, reason = self._validate_value_recursively(params)
+        if not is_safe:
+            return False, -32000, f"Pre-flight Blocked: {reason}"
+
+        # Skill Registry Schema and existence verification (if registry is available)
+        if self.registry:
+            # Strip server prefix if the registry itself uses local names
+            method_to_check = method
+            # If the registry doesn't have the prefixed name, try has_skill
+            if not self.registry.has_skill(method_to_check):
+                return False, -32601, f"Method not found: '{method}' is not registered."
+
+        return True, 0, ""
+
+    def validate_payload(self, payload: str) -> Tuple[bool, int, str]:
+        """
+        Validates a raw JSON-RPC payload string.
+
+        Args:
+            payload (str): The raw JSON-RPC payload string.
+
+        Returns:
+            Tuple[bool, int, str]: (is_valid, error_code, error_message)
+        """
+        try:
+            request = json.loads(payload)
+        except json.JSONDecodeError:
+            return False, -32700, "Parse error: payload is not valid JSON."
+
+        return self.validate_request_dict(request)
+
+
+class PreflightMCPServerWrapper:
+    """
+    Wrapper for MCPServer to intercept JSON-RPC payload executions
+    and perform pre-flight validation before passing the request to the underlying server.
+    """
+
+    def __init__(self, server: MCPServer, validator: Optional[MCPPreflightValidator] = None) -> None:
+        """
+        Initializes the PreflightMCPServerWrapper.
+
+        Args:
+            server (MCPServer): The MCPServer instance to wrap.
+            validator (Optional[MCPPreflightValidator]): The validator to use.
+        """
+        self.server = server
+        self.validator = validator or MCPPreflightValidator(registry=getattr(server.exporter, "registry", None))
+
+    async def handle_request(self, payload: str) -> str:
+        """
+        Intercepts and processes a JSON-RPC payload string with pre-flight checks.
+
+        Args:
+            payload (str): A JSON string representing the RPC request.
+
+        Returns:
+            str: A JSON string representing the RPC response.
+        """
+        is_valid, err_code, err_msg = self.validator.validate_payload(payload)
+
+        # If pre-flight validation fails, directly return the JSON-RPC error
+        if not is_valid:
+            logger.warning(f"MCP Pre-flight intercept: code={err_code}, message={err_msg}")
+            try:
+                request = json.loads(payload)
+                req_id = request.get("id")
+            except Exception:
+                req_id = None
+
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {
+                    "code": err_code,
+                    "message": err_msg
+                }
+            })
+
+        # Delegate to the wrapped server on successful pre-flight check
+        return await self.server.handle_request(payload)

--- a/tests/test_mcp_preflight.py
+++ b/tests/test_mcp_preflight.py
@@ -1,0 +1,219 @@
+import json
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.integration.mcp_preflight import MCPPreflightValidator, PreflightMCPServerWrapper
+from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.safety.taint import mark_tainted
+
+
+@pytest.fixture
+def mock_registry() -> SkillRegistry:
+    """Fixture for a mocked SkillRegistry."""
+    registry = MagicMock(spec=SkillRegistry)
+    registry.has_skill.side_effect = lambda name: name in ["get_weather", "add_numbers"]
+    return registry
+
+
+@pytest.fixture
+def mock_server() -> MCPServer:
+    """Fixture for a mocked MCPServer."""
+    server = MagicMock(spec=MCPServer)
+    server.handle_request = AsyncMock(return_value=json.dumps({
+        "jsonrpc": "2.0",
+        "id": "1",
+        "result": "success"
+    }))
+    # Mock server.exporter.registry
+    server.exporter = MagicMock()
+    server.exporter.registry = MagicMock(spec=SkillRegistry)
+    server.exporter.registry.has_skill.side_effect = lambda name: name in ["get_weather"]
+    return server
+
+
+def test_validator_valid_request(mock_registry: SkillRegistry) -> None:
+    """Tests that a standard, safe request dictionary passes validation."""
+    validator = MCPPreflightValidator(registry=mock_registry)
+    request = {
+        "jsonrpc": "2.0",
+        "method": "get_weather",
+        "params": {"location": "San Francisco"},
+        "id": "1"
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is True
+    assert err_code == 0
+    assert err_msg == ""
+
+
+def test_validator_invalid_jsonrpc() -> None:
+    """Tests that an invalid JSON-RPC version is rejected."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "1.0",
+        "method": "get_weather",
+        "params": {}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32600
+    assert "jsonrpc version must be '2.0'" in err_msg
+
+
+def test_validator_invalid_method() -> None:
+    """Tests that a missing or invalid method is rejected."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "2.0",
+        "params": {}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32600
+    assert "method" in err_msg
+
+
+def test_validator_tainted_method() -> None:
+    """Tests that a request with a tainted tool name (method) is blocked."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "2.0",
+        "method": mark_tainted("unsafe_tool"),
+        "params": {}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32000
+    assert "tool name is tainted" in err_msg
+
+
+def test_validator_forbidden_tool() -> None:
+    """Tests that blacklisted tools are blocked."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "2.0",
+        "method": "forbidden_tool",
+        "params": {}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32000
+    assert "blacklisted" in err_msg
+
+
+def test_validator_tainted_params() -> None:
+    """Tests that a request with tainted arguments in params is blocked."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "2.0",
+        "method": "get_weather",
+        "params": {"location": mark_tainted("New York")}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32000
+    assert "Tainted data detected" in err_msg
+
+
+def test_validator_hazardous_shell_injection() -> None:
+    """Tests that hazardous shell injection commands are blocked."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "2.0",
+        "method": "get_weather",
+        "params": {"location": "San Francisco; rm -rf /"}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32000
+    assert "Hazardous shell pattern detected" in err_msg
+
+
+def test_validator_path_traversal() -> None:
+    """Tests that path traversal attempts are blocked."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "2.0",
+        "method": "get_weather",
+        "params": {"location": "../../../etc/passwd"}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32000
+    assert "Hazardous path traversal pattern" in err_msg
+
+
+def test_validator_sql_injection() -> None:
+    """Tests that SQL injection strings are blocked."""
+    validator = MCPPreflightValidator()
+    request = {
+        "jsonrpc": "2.0",
+        "method": "get_weather",
+        "params": {"location": "' OR 1=1 --"}
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32000
+    assert "Hazardous SQL injection pattern" in err_msg
+
+
+def test_validator_unregistered_method(mock_registry: SkillRegistry) -> None:
+    """Tests that unregistered tools are rejected when SkillRegistry is active."""
+    validator = MCPPreflightValidator(registry=mock_registry)
+    request = {
+        "jsonrpc": "2.0",
+        "method": "non_existent_tool",
+        "params": {},
+        "id": "1"
+    }
+    is_valid, err_code, err_msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert err_code == -32601
+    assert "not registered" in err_msg
+
+
+@pytest.mark.asyncio
+async def test_wrapper_passes_safe_payload(mock_server: MCPServer) -> None:
+    """Tests that the wrapper forwards safe payloads to the underlying server."""
+    wrapper = PreflightMCPServerWrapper(server=mock_server)
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "get_weather",
+        "params": {"location": "Seattle"},
+        "id": "abc"
+    })
+    response_str = await wrapper.handle_request(payload)
+    response = json.loads(response_str)
+    assert response["result"] == "success"
+    mock_server.handle_request.assert_called_once_with(payload)
+
+
+@pytest.mark.asyncio
+async def test_wrapper_blocks_unsafe_payload(mock_server: MCPServer) -> None:
+    """Tests that the wrapper intercepts unsafe payloads and returns JSON-RPC error response."""
+    wrapper = PreflightMCPServerWrapper(server=mock_server)
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "forbidden_tool",
+        "params": {},
+        "id": "xyz"
+    })
+    response_str = await wrapper.handle_request(payload)
+    response = json.loads(response_str)
+    assert "error" in response
+    assert response["error"]["code"] == -32000
+    assert "blacklisted" in response["error"]["message"]
+    mock_server.handle_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wrapper_invalid_json_parsing(mock_server: MCPServer) -> None:
+    """Tests that invalid raw JSON payloads are intercepted at the parser layer."""
+    wrapper = PreflightMCPServerWrapper(server=mock_server)
+    payload = "{invalid_json}"
+    response_str = await wrapper.handle_request(payload)
+    response = json.loads(response_str)
+    assert "error" in response
+    assert response["error"]["code"] == -32700
+    assert "Parse error" in response["error"]["message"]
+    mock_server.handle_request.assert_not_called()


### PR DESCRIPTION
Introduces pre-flight validation for MCP action tools to intercept and block unsafe or malformed JSON-RPC requests before they can be executed by the underlying servers or tools.

Key changes:
1. `magda_agent/integration/mcp_preflight.py`:
   - `MCPPreflightValidator`: Handles structural JSON-RPC syntax checks, explicit blacklist checks, taint tracking via `is_tainted`, and deep inspection of parameters for SQL injection, shell command injection, and path traversal patterns.
   - `PreflightMCPServerWrapper`: Wraps `MCPServer` to intercept incoming `handle_request` calls, returning structured JSON-RPC error responses if validation fails, and delegating to the wrapped server if validation passes.
2. `tests/test_mcp_preflight.py`:
   - Comprehensive unit tests verifying successful routing of safe requests, structural parsing error handling, and strict blocking of blacklisted tools, tainted values, or malicious parameter payloads.
3. `agent_tasks.json`:
   - Marked the task `mcp-action-tools-preflight-v4` as completed (`done`).
   - Appended 3 new highly aligned, hex-suffixed tasks based on current June 2026 AI Agent trends.

---
*PR created automatically by Jules for task [8629583815381979598](https://jules.google.com/task/8629583815381979598) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pre-flight validation for MCP JSON-RPC action tool requests
> - Introduces [`MCPPreflightValidator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/503/files#diff-54d47faf47dafd75cfc66c837f5dbef9779e355b7ced2e89ce381fee89271870) that validates MCP JSON-RPC request dicts and raw payloads before dispatch, checking for taint, forbidden tools, hazardous shell commands, path traversal, and SQL injection via regex.
> - Adds [`PreflightMCPServerWrapper`](https://github.com/kazah4359-lgtm/Magda-agent/pull/503/files#diff-54d47faf47dafd75cfc66c837f5dbef9779e355b7ced2e89ce381fee89271870) that wraps an existing `MCPServer`, injecting validation on every `handle_request` call and returning structured JSON-RPC error responses (codes `-32700`, `-32600`, `-32602`, `-32601`, `-32000`) for blocked requests.
> - Covers valid and invalid cases in [`tests/test_mcp_preflight.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/503/files#diff-3a99831d59bb56d1e078d4dd379a1d6eba36af73239362916f3621ed3f360d13) including tainted params, hazardous strings, forbidden tools, and unregistered methods.
> - Risk: all MCP requests now pass through regex-based hazard scanning; malformed or borderline inputs that previously reached the server will be blocked at the wrapper layer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9deee60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->