### PR TITLE
A2A Delegation Circuit Breaker Implementation and Task Replenishment

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8134,7 +8134,7 @@
     },
     {
       "id": "a2a-delegation-circuit-breaker-v5",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Delegation Circuit Breaker",
@@ -18097,6 +18097,60 @@
       "acceptance": [
         "Adaptive compressor initiates prompt compression when low reward signals are encountered in RL.",
         "Tests verify compression threshold trigger behavior."
+      ]
+    },
+    {
+      "id": "mcp-oauth-consent-v3-e8a2b5c6",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP OAuth2 Dynamic Consent",
+      "description": "Inspired by MCP Auth and consent flow trend (June 2026): Implement a dynamic user consent prompt manager for remote MCP servers that require OAuth2 authentication, allowing user confirmation before sharing sensitive context keys.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_consent_v3.py",
+        "tests/test_mcp_consent_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "User is prompted for consent when an MCP tool requires authentication.",
+        "Consent decisions are cached and respected in future calls.",
+        "Tests mock user prompt input and verify behavior."
+      ]
+    },
+    {
+      "id": "openclaw-rl-reward-heuristic-v1-a7d9f8c3",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Interactive Reward Heuristic",
+      "description": "Inspired by OpenClaw-RL trend (June 2026): Implement an interactive reward heuristic module that parses explicit user rating commands (e.g. '/rate 5', '/rate 1') inside the message content and maps them thread-safely to update procedural habit weights.",
+      "allowed_paths": [
+        "magda_agent/learning/reward_heuristic_v1.py",
+        "tests/test_reward_heuristic_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Reward heuristic parses '/rate X' command from user replies.",
+        "Maps ratings to numerical rewards (normalized from -1.0 to 1.0) and adjusts skill/habit weights.",
+        "Tests verify weight adjustments based on positive and negative rating commands."
+      ]
+    },
+    {
+      "id": "acs-compliance-report-v2-b9d8e5f4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Compliance Real-time Report",
+      "description": "Inspired by Microsoft ACS safety standard trend (June 2026): Implement a real-time compliance reporting module that tracks check outcomes across the 5 validation checkpoints and generates a formatted Markdown report for continuous auditing.",
+      "allowed_paths": [
+        "magda_agent/safety/compliance_report_v2.py",
+        "tests/test_compliance_report_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Compliance module logs checkpoint details.",
+        "Generates structured Markdown compliance reports with success rates.",
+        "Tests verify correct report generation and formatting."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_circuit_breaker.py
+++ b/magda_agent/integration/a2a_circuit_breaker.py
@@ -1,0 +1,192 @@
+from enum import Enum
+import time
+import logging
+from typing import Any, Dict, Callable, Optional, Coroutine
+
+logger = logging.getLogger(__name__)
+
+class CircuitState(Enum):
+    """
+    Represents the states of the circuit breaker.
+    """
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+class CircuitBreakerOpenException(Exception):
+    """
+    Exception raised when a request is blocked because the circuit breaker is OPEN.
+    """
+    pass
+
+class PeerState:
+    """
+    Represents the state of a single peer agent.
+    """
+    def __init__(self) -> None:
+        """
+        Initializes the state for a single peer agent.
+        """
+        self.state: CircuitState = CircuitState.CLOSED
+        self.consecutive_failures: int = 0
+        self.consecutive_successes: int = 0
+        self.last_state_change: float = time.time()
+
+class A2ADelegationCircuitBreaker:
+    """
+    A circuit breaker implementation for A2A (Agent-to-Agent) task delegation.
+    Prevents continuous task delegation failures to unresponsive peer agents
+    by tripping the circuit and gracefully degrading.
+    """
+    def __init__(
+        self,
+        failure_threshold: int = 3,
+        recovery_timeout: float = 5.0,
+        success_threshold: int = 2
+    ) -> None:
+        """
+        Initializes the circuit breaker with custom thresholds.
+
+        Args:
+            failure_threshold (int): Number of consecutive failures to trip the circuit.
+            recovery_timeout (float): Time in seconds to wait before checking if peer recovered.
+            success_threshold (int): Number of consecutive successes in HALF_OPEN to close the circuit.
+        """
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.success_threshold = success_threshold
+        self.peer_states: Dict[str, PeerState] = {}
+
+    def _get_or_create_peer_state(self, peer_id: str) -> PeerState:
+        """
+        Retrieves or initializes the state tracker for a given peer agent ID.
+        """
+        if peer_id not in self.peer_states:
+            self.peer_states[peer_id] = PeerState()
+        return self.peer_states[peer_id]
+
+    def get_peer_state(self, peer_id: str) -> CircuitState:
+        """
+        Gets the current state of the circuit breaker for a peer agent.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+
+        Returns:
+            CircuitState: The current circuit state (CLOSED, OPEN, HALF_OPEN).
+        """
+        peer_state = self._get_or_create_peer_state(peer_id)
+        if peer_state.state == CircuitState.OPEN:
+            now = time.time()
+            if now - peer_state.last_state_change >= self.recovery_timeout:
+                # Transition to HALF_OPEN
+                logger.info(f"Circuit breaker for peer {peer_id} transitioning from OPEN to HALF_OPEN due to timeout.")
+                peer_state.state = CircuitState.HALF_OPEN
+                peer_state.consecutive_successes = 0
+                peer_state.last_state_change = now
+        return peer_state.state
+
+    def is_execution_allowed(self, peer_id: str) -> bool:
+        """
+        Determines whether execution is allowed for a peer agent.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+
+        Returns:
+            bool: True if execution is allowed, False otherwise.
+        """
+        state = self.get_peer_state(peer_id)
+        return state in (CircuitState.CLOSED, CircuitState.HALF_OPEN)
+
+    def record_success(self, peer_id: str) -> None:
+        """
+        Records a successful execution, updating the peer's state.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+        """
+        peer_state = self._get_or_create_peer_state(peer_id)
+        if peer_state.state == CircuitState.HALF_OPEN:
+            peer_state.consecutive_successes += 1
+            if peer_state.consecutive_successes >= self.success_threshold:
+                logger.info(f"Circuit breaker for peer {peer_id} reset to CLOSED after {peer_state.consecutive_successes} successes.")
+                peer_state.state = CircuitState.CLOSED
+                peer_state.consecutive_failures = 0
+                peer_state.consecutive_successes = 0
+                peer_state.last_state_change = time.time()
+        elif peer_state.state == CircuitState.CLOSED:
+            peer_state.consecutive_failures = 0
+
+    def record_failure(self, peer_id: str) -> None:
+        """
+        Records a failed execution, possibly tripping the circuit.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+        """
+        peer_state = self._get_or_create_peer_state(peer_id)
+        now = time.time()
+        if peer_state.state == CircuitState.CLOSED:
+            peer_state.consecutive_failures += 1
+            if peer_state.consecutive_failures >= self.failure_threshold:
+                logger.warning(f"Circuit breaker for peer {peer_id} tripped to OPEN after {peer_state.consecutive_failures} failures.")
+                peer_state.state = CircuitState.OPEN
+                peer_state.last_state_change = now
+        elif peer_state.state == CircuitState.HALF_OPEN:
+            logger.warning(f"Circuit breaker for peer {peer_id} tripped back to OPEN after failure in HALF_OPEN.")
+            peer_state.state = CircuitState.OPEN
+            peer_state.consecutive_failures = self.failure_threshold
+            peer_state.consecutive_successes = 0
+            peer_state.last_state_change = now
+
+    async def execute(
+        self,
+        peer_id: str,
+        func: Callable[..., Coroutine[Any, Any, Any]],
+        *args: Any,
+        fallback_func: Optional[Callable[..., Any]] = None,
+        **kwargs: Any
+    ) -> Any:
+        """
+        Executes an asynchronous function with circuit breaker protection.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+            func (Callable): The asynchronous function/coroutine to execute.
+            args (Any): Variable positional arguments to pass to the function.
+            fallback_func (Optional[Callable]): Optional sync or async function to call on failure/block.
+            kwargs (Any): Variable keyword arguments to pass to the function.
+
+        Returns:
+            Any: The result of the function execution, or fallback.
+
+        Raises:
+            CircuitBreakerOpenException: If the circuit is OPEN and no fallback_func is provided.
+        """
+        if not self.is_execution_allowed(peer_id):
+            logger.warning(f"Execution blocked by circuit breaker for peer {peer_id}.")
+            if fallback_func is not None:
+                return await self._execute_fallback(fallback_func, *args, **kwargs)
+            raise CircuitBreakerOpenException(f"Circuit breaker for peer {peer_id} is OPEN.")
+
+        try:
+            result = await func(*args, **kwargs)
+            self.record_success(peer_id)
+            return result
+        except Exception as e:
+            logger.exception(f"Exception during execution under circuit breaker for peer {peer_id}: {e}")
+            self.record_failure(peer_id)
+            if fallback_func is not None:
+                return await self._execute_fallback(fallback_func, *args, **kwargs)
+            raise
+
+    async def _execute_fallback(self, fallback_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """
+        Helper to execute sync or async fallbacks.
+        """
+        import inspect
+        if inspect.iscoroutinefunction(fallback_func):
+            return await fallback_func(*args, **kwargs)
+        else:
+            return fallback_func(*args, **kwargs)

--- a/tests/test_a2a_circuit_breaker.py
+++ b/tests/test_a2a_circuit_breaker.py
@@ -1,0 +1,182 @@
+import pytest
+import asyncio
+import time
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.integration.a2a_circuit_breaker import (
+    A2ADelegationCircuitBreaker,
+    CircuitState,
+    CircuitBreakerOpenException,
+)
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_normal_execution() -> None:
+    """
+    Verifies that the circuit breaker allows execution when CLOSED and tracks state.
+    """
+    breaker = A2ADelegationCircuitBreaker(failure_threshold=2, recovery_timeout=0.1, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def mock_delegate() -> Dict[str, Any]:
+        return {"status": "success"}
+
+    result = await breaker.execute(peer_id, mock_delegate)
+    assert result == {"status": "success"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_trips_on_failures() -> None:
+    """
+    Verifies that the circuit breaker trips to OPEN after consecutive failures exceed threshold.
+    """
+    breaker = A2ADelegationCircuitBreaker(failure_threshold=2, recovery_timeout=1.0, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Peer unresponsive")
+
+    # First failure
+    with pytest.raises(ValueError, match="Peer unresponsive"):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.CLOSED
+
+    # Second failure - should trip to OPEN
+    with pytest.raises(ValueError, match="Peer unresponsive"):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Execution is now blocked and raises CircuitBreakerOpenException
+    with pytest.raises(CircuitBreakerOpenException):
+        await breaker.execute(peer_id, failing_delegate)
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_recovery_to_half_open_and_close() -> None:
+    """
+    Verifies that the circuit breaker recovers to HALF_OPEN after timeout and closes on successes.
+    """
+    breaker = A2ADelegationCircuitBreaker(failure_threshold=1, recovery_timeout=0.1, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Peer unresponsive")
+
+    # Trip the circuit
+    with pytest.raises(ValueError):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Wait for recovery timeout
+    await asyncio.sleep(0.12)
+
+    # Check state should become HALF_OPEN
+    assert breaker.get_peer_state(peer_id) == CircuitState.HALF_OPEN
+
+    # Successful execution trial 1
+    async def successful_delegate() -> Dict[str, Any]:
+        return {"result": "ok"}
+
+    res = await breaker.execute(peer_id, successful_delegate)
+    assert res == {"result": "ok"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.HALF_OPEN
+
+    # Successful execution trial 2 - should close the circuit
+    res2 = await breaker.execute(peer_id, successful_delegate)
+    assert res2 == {"result": "ok"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_half_open_fails_fast() -> None:
+    """
+    Verifies that if an execution fails in HALF_OPEN, the circuit trips back to OPEN immediately.
+    """
+    breaker = A2ADelegationCircuitBreaker(failure_threshold=1, recovery_timeout=0.1, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Peer unresponsive")
+
+    # Trip the circuit
+    with pytest.raises(ValueError):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Wait for recovery timeout
+    await asyncio.sleep(0.12)
+    assert breaker.get_peer_state(peer_id) == CircuitState.HALF_OPEN
+
+    # Failure in HALF_OPEN should trip back to OPEN immediately
+    with pytest.raises(ValueError, match="Peer unresponsive"):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_peer_isolation() -> None:
+    """
+    Verifies that circuit breaker state is isolated per peer.
+    """
+    breaker = A2ADelegationCircuitBreaker(failure_threshold=1, recovery_timeout=1.0)
+    peer_a = "peer-A"
+    peer_b = "peer-B"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Failed")
+
+    async def successful_delegate() -> str:
+        return "success"
+
+    # Trip Peer A
+    with pytest.raises(ValueError):
+        await breaker.execute(peer_a, failing_delegate)
+    assert breaker.get_peer_state(peer_a) == CircuitState.OPEN
+
+    # Peer B should still be CLOSED and functional
+    assert breaker.get_peer_state(peer_b) == CircuitState.CLOSED
+    res = await breaker.execute(peer_b, successful_delegate)
+    assert res == "success"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_synchronous_fallback() -> None:
+    """
+    Verifies that synchronous fallback functions degrade execution gracefully.
+    """
+    breaker = A2ADelegationCircuitBreaker(failure_threshold=1, recovery_timeout=1.0)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Failed")
+
+    def sync_fallback() -> Dict[str, Any]:
+        return {"status": "fallback_local", "reason": "service_unavailable"}
+
+    # Fails and triggers fallback
+    res = await breaker.execute(peer_id, failing_delegate, fallback_func=sync_fallback)
+    assert res == {"status": "fallback_local", "reason": "service_unavailable"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Blocked execution calls fallback directly
+    res2 = await breaker.execute(peer_id, failing_delegate, fallback_func=sync_fallback)
+    assert res2 == {"status": "fallback_local", "reason": "service_unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_asynchronous_fallback() -> None:
+    """
+    Verifies that asynchronous fallback functions degrade execution gracefully.
+    """
+    breaker = A2ADelegationCircuitBreaker(failure_threshold=1, recovery_timeout=1.0)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Failed")
+
+    async def async_fallback() -> Dict[str, Any]:
+        return {"status": "fallback_async_local"}
+
+    res = await breaker.execute(peer_id, failing_delegate, fallback_func=async_fallback)
+    assert res == {"status": "fallback_async_local"}


### PR DESCRIPTION
This submission implements the A2A task delegation circuit breaker module, marks the task done in the task queue, and replenishes the queue with three new, highly-relevant June 2026 AI agent trend tasks (MCP OAuth2 Dynamic Consent, OpenClaw-RL Interactive Reward Heuristic, and ACS Compliance Real-time Report). Fully typed, documented, and tested.

---
*PR created automatically by Jules for task [12190968190951569871](https://jules.google.com/task/12190968190951569871) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A delegation circuit breaker with per-peer state tracking and fallback support
> - Adds [`A2ADelegationCircuitBreaker`](https://github.com/kazah4359-lgtm/Magda-agent/pull/504/files#diff-fd82e17386698a7babe9cd4bffa7018f08f0041c211dc923d35917afc2b4f151) implementing the circuit breaker pattern for async peer-to-peer delegation calls, with configurable failure/success thresholds and recovery timeout.
> - Tracks circuit state (`CLOSED`, `OPEN`, `HALF_OPEN`) independently per peer, so a failing peer does not affect others.
> - The `execute` method blocks calls when the circuit is `OPEN`, allows trial calls in `HALF_OPEN`, and routes to sync or async fallbacks when provided; raises `CircuitBreakerOpenException` when blocked with no fallback.
> - Adds [tests](https://github.com/kazah4359-lgtm/Magda-agent/pull/504/files#diff-9e738472a65d8ebac002a4e50c5cd18ab3a680a3673006b7030b5a0ef2a398e7) covering normal execution, tripping, recovery, half-open failure, peer isolation, and both fallback types.
> - Also appends three new task entries to `agent_tasks.json` and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbfeeb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->