### PR TITLE
Implement OpenClaw-RL Multi-turn Trajectory Rollout

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8151,7 +8151,7 @@
     },
     {
       "id": "openclaw-rl-trajectory-rollout-v6",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "OpenClaw-RL Multi-turn Trajectory Rollout",
@@ -18151,6 +18151,60 @@
         "Compliance module logs checkpoint details.",
         "Generates structured Markdown compliance reports with success rates.",
         "Tests verify correct report generation and formatting."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-auto-discovery-v1-98a2f",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Auto-Discovery V1",
+      "description": "Inspired by June 2026 MCP trends: Implement a tool auto-discovery mechanism that scans a specified directory, dynamically registers Python modules as MCPTools using AST parsing, and updates the registry live without restarts.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_auto_discovery_v1.py",
+        "tests/test_mcp_auto_discovery_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Discovers and loads .py tool definitions from folder at runtime.",
+        "Schema generation maps type hints to JSON schema.",
+        "Tests verify registration and hot-reloading."
+      ]
+    },
+    {
+      "id": "a2a-decentralized-consensus-v1-671c2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Decentralized Task Consensus V1",
+      "description": "Inspired by the A2A (Agent-to-Agent) Protocol standard trend (June 2026): Implement a multi-agent consensus module for collaborative tasks where peer agents negotiate, sign, and validate plan execution results prior to finalization.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_consensus_v1.py",
+        "tests/test_a2a_consensus_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2AConsensusV1 allows multiple peers to vote on result validity.",
+        "Reaches consensus or raises negotiation exception on conflict.",
+        "Tests verify voting logic with mocked peer responses."
+      ]
+    },
+    {
+      "id": "openclaw-rl-latency-optimizer-v1-b12e3",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Latency Adaptive Behavior Optimizer V1",
+      "description": "Inspired by OpenClaw-RL trend (June 2026): Implement an online reinforcement learning optimizer that captures tool execution and API latency as implicit negative signals, adjusting behavior/directness weights to reduce latency.",
+      "allowed_paths": [
+        "magda_agent/learning/latency_optimizer_v1.py",
+        "tests/test_latency_optimizer_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Monitors execution latency as feedback signal.",
+        "Adjusts behavior weights (e.g., lower verbosity/higher directness) on high latency.",
+        "Tests verify weight adjustments based on latency thresholds."
       ]
     }
   ]

--- a/magda_agent/learning/openclaw_rl_rollout.py
+++ b/magda_agent/learning/openclaw_rl_rollout.py
@@ -1,0 +1,156 @@
+import logging
+from typing import Dict, List, Optional
+
+class ConversationStep:
+    """
+    Represents a single step in a conversational trajectory.
+    """
+    def __init__(self, skill_id: str, state_context: str, q_value: float = 0.0) -> None:
+        """
+        Initializes a ConversationStep.
+
+        Args:
+            skill_id (str): The ID of the skill used in this step.
+            state_context (str): The context of the state/action.
+            q_value (float): The current Q-value associated with this step/skill.
+        """
+        self.skill_id = skill_id
+        self.state_context = state_context
+        self.q_value = q_value
+
+class TrajectoryBuffer:
+    """
+    Buffers conversation steps for a user session.
+    """
+    def __init__(self, max_size: int = 20) -> None:
+        """
+        Initializes a TrajectoryBuffer.
+
+        Args:
+            max_size (int): The maximum number of steps to retain.
+        """
+        self.steps: List[ConversationStep] = []
+        self.max_size = max_size
+
+    def add_step(self, step: ConversationStep) -> None:
+        """
+        Adds a conversation step to the buffer, evicting the oldest if limit is reached.
+
+        Args:
+            step (ConversationStep): The step to add.
+        """
+        self.steps.append(step)
+        if len(self.steps) > self.max_size:
+            self.steps.pop(0)
+
+    def clear(self) -> None:
+        """
+        Clears the buffer.
+        """
+        self.steps.clear()
+
+class OpenClawRLTrajectoryRolloutV6:
+    """
+    Handles buffering of multi-turn trajectories and backpropagation of delayed rewards.
+    Inspired by OpenClaw-RL (June 2026).
+    """
+    def __init__(self, initial_q_values: Optional[Dict[str, float]] = None) -> None:
+        """
+        Initializes the OpenClawRLTrajectoryRolloutV6 learner.
+
+        Args:
+            initial_q_values (Optional[Dict[str, float]]): Optional initial Q-values for skills.
+        """
+        self.q_table: Dict[str, float] = initial_q_values or {}
+        self.buffers: Dict[str, TrajectoryBuffer] = {}
+        logging.info("Initialized OpenClawRLTrajectoryRolloutV6")
+
+    def get_buffer(self, user_id: str) -> TrajectoryBuffer:
+        """
+        Retrieves or creates a TrajectoryBuffer for a specific user.
+
+        Args:
+            user_id (str): The unique identifier of the user.
+
+        Returns:
+            TrajectoryBuffer: The user's trajectory buffer.
+        """
+        user_key = str(user_id)
+        if user_key not in self.buffers:
+            self.buffers[user_key] = TrajectoryBuffer()
+        return self.buffers[user_key]
+
+    def record_step(self, user_id: str, skill_id: str, state_context: str) -> None:
+        """
+        Records a conversation step for a specific user, persisting it across turns.
+
+        Args:
+            user_id (str): The unique identifier of the user.
+            skill_id (str): The ID of the skill used.
+            state_context (str): The context of the state/action.
+        """
+        buffer = self.get_buffer(user_id)
+        current_q = self.q_table.get(skill_id, 0.0)
+        step = ConversationStep(skill_id, state_context, current_q)
+        buffer.add_step(step)
+        logging.info(f"Recorded step for user '{user_id}': skill='{skill_id}', Q-value={current_q:.4f}")
+
+    def process_delayed_reward(
+        self,
+        user_id: str,
+        final_reward: float,
+        discount_factor: float = 0.9,
+        learning_rate: float = 0.1
+    ) -> Dict[str, float]:
+        """
+        Backpropagates a delayed reward to all previous steps in the buffer.
+        The reward decays exponentially based on the distance from the last step (index).
+
+        Args:
+            user_id (str): The unique identifier of the user.
+            final_reward (float): The delayed reward signal.
+            discount_factor (float): The discount factor (gamma) for delayed rewards.
+            learning_rate (float): The learning rate (alpha) for Q-value updates.
+
+        Returns:
+            Dict[str, float]: The updated Q-value dictionary for skills updated.
+        """
+        buffer = self.get_buffer(user_id)
+        steps = buffer.steps
+        if not steps:
+            logging.warning(f"No steps buffered for user '{user_id}'. Cannot backpropagate reward.")
+            return {}
+
+        updated_values: Dict[str, float] = {}
+        n = len(steps)
+        for idx in range(n):
+            step = steps[idx]
+            # Distance from the end (latest step)
+            distance_from_end = n - 1 - idx
+            discounted_reward = final_reward * (discount_factor ** distance_from_end)
+
+            # Update the Q-value: Q = Q + alpha * (discounted_reward - Q)
+            current_q = self.q_table.get(step.skill_id, 0.0)
+            td_error = discounted_reward - current_q
+            new_q = current_q + learning_rate * td_error
+
+            self.q_table[step.skill_id] = new_q
+            updated_values[step.skill_id] = new_q
+            step.q_value = new_q
+
+        logging.info(f"Backpropagated delayed reward {final_reward} to {n} steps for user '{user_id}'.")
+        # Clear the buffer after rollout to prevent double reward application
+        buffer.clear()
+        return updated_values
+
+    def get_q_value(self, skill_id: str) -> float:
+        """
+        Retrieves the Q-value for a given skill.
+
+        Args:
+            skill_id (str): The ID of the skill.
+
+        Returns:
+            float: The current Q-value.
+        """
+        return self.q_table.get(skill_id, 0.0)

--- a/tests/test_openclaw_rl_rollout.py
+++ b/tests/test_openclaw_rl_rollout.py
@@ -1,0 +1,96 @@
+import pytest
+from magda_agent.learning.openclaw_rl_rollout import OpenClawRLTrajectoryRolloutV6, ConversationStep
+
+def test_trajectory_buffer_turn_persistence() -> None:
+    """
+    Tests that trajectory steps are persisted correctly across turns in the user buffer,
+    including limit eviction and clear capabilities.
+    """
+    learner = OpenClawRLTrajectoryRolloutV6(initial_q_values={"search": 1.0})
+    user_id = "user_abc_123"
+
+    # Initially, buffer is empty
+    buffer = learner.get_buffer(user_id)
+    assert len(buffer.steps) == 0
+
+    # Record first step
+    learner.record_step(user_id, "search", "search state context")
+    assert len(buffer.steps) == 1
+    assert buffer.steps[0].skill_id == "search"
+    assert buffer.steps[0].state_context == "search state context"
+    assert buffer.steps[0].q_value == 1.0
+
+    # Record second step
+    learner.record_step(user_id, "math", "math state context")
+    assert len(buffer.steps) == 2
+    assert buffer.steps[1].skill_id == "math"
+    assert buffer.steps[1].state_context == "math state context"
+    assert buffer.steps[1].q_value == 0.0  # default Q-value is 0.0
+
+    # Check that another user has a separate buffer
+    other_user_id = "user_def_456"
+    other_buffer = learner.get_buffer(other_user_id)
+    assert len(other_buffer.steps) == 0
+
+    # Test buffer eviction with custom max_size
+    buffer.max_size = 2
+    learner.record_step(user_id, "code", "code state context")
+    # Buffer has max_size = 2, so "search" should be evicted
+    assert len(buffer.steps) == 2
+    assert buffer.steps[0].skill_id == "math"
+    assert buffer.steps[1].skill_id == "code"
+
+
+def test_trajectory_delayed_reward_backpropagation() -> None:
+    """
+    Tests that the delayed reward is properly discounted and backpropagated to previous steps
+    and updates the Q-table correctly.
+    """
+    learner = OpenClawRLTrajectoryRolloutV6(initial_q_values={"skill_a": 0.5, "skill_b": 0.3})
+    user_id = "user_xyz"
+
+    # Record 3 steps
+    learner.record_step(user_id, "skill_a", "state 1")
+    learner.record_step(user_id, "skill_b", "state 2")
+    learner.record_step(user_id, "skill_a", "state 3")
+
+    # Apply delayed reward
+    # final_reward = 1.0, discount_factor = 0.9, learning_rate = 0.1
+    # n = 3 steps
+    # Step 0 (idx 0, distance 2 from end): skill_a
+    #   discounted_reward = 1.0 * (0.9 ** 2) = 0.81
+    #   Q_new = 0.5 + 0.1 * (0.81 - 0.5) = 0.5 + 0.031 = 0.531
+    # Step 1 (idx 1, distance 1 from end): skill_b
+    #   discounted_reward = 1.0 * (0.9 ** 1) = 0.9
+    #   Q_new = 0.3 + 0.1 * (0.9 - 0.3) = 0.3 + 0.06 = 0.36
+    # Step 2 (idx 2, distance 0 from end): skill_a
+    #   discounted_reward = 1.0 * (0.9 ** 0) = 1.0
+    #   Q_new = 0.531 + 0.1 * (1.0 - 0.531) = 0.531 + 0.0469 = 0.5779
+
+    updated_values = learner.process_delayed_reward(
+        user_id,
+        final_reward=1.0,
+        discount_factor=0.9,
+        learning_rate=0.1
+    )
+
+    # Check returned updated values
+    assert pytest.approx(updated_values["skill_b"], abs=1e-5) == 0.36
+    assert pytest.approx(updated_values["skill_a"], abs=1e-5) == 0.5779
+
+    # Check Q-table
+    assert pytest.approx(learner.get_q_value("skill_a"), abs=1e-5) == 0.5779
+    assert pytest.approx(learner.get_q_value("skill_b"), abs=1e-5) == 0.36
+
+    # Verify buffer is cleared after processing
+    buffer = learner.get_buffer(user_id)
+    assert len(buffer.steps) == 0
+
+
+def test_trajectory_rollout_empty_buffer() -> None:
+    """
+    Tests delayed reward processing on an empty buffer does not crash and returns empty.
+    """
+    learner = OpenClawRLTrajectoryRolloutV6()
+    updated = learner.process_delayed_reward("empty_user", 1.0)
+    assert updated == {}


### PR DESCRIPTION
This PR implements the completed task ID `openclaw-rl-trajectory-rollout-v6` for OpenClaw-RL multi-turn trajectory rollout anddelayed reward backpropagation.
It also updates the `agent_tasks.json` file to mark the task as done and replenishes the queue with 3 new high-quality tasks inspired by June 2026 AI agent trends.
Full unit tests are provided, and all checks and schema validation have passed.

---
*PR created automatically by Jules for task [4887238286135130658](https://jules.google.com/task/4887238286135130658) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement multi-turn trajectory rollout with delayed reward backpropagation for OpenClaw-RL
> - Adds [`OpenClawRLTrajectoryRolloutV6`](https://github.com/kazah4359-lgtm/Magda-agent/pull/505/files#diff-0c1f3f903c95b7b9c07fe0a7efd3945c3e46b48d5b2d7a85a3d94eb0ec0fb533) which maintains a per-skill Q-value table and per-user `TrajectoryBuffer` to record multi-turn conversational steps.
> - `process_delayed_reward` backpropagates a final reward across buffered steps using exponential discounting and a TD(0)-style update (`Q <- Q + alpha * (discounted_reward - Q)`), then clears the buffer.
> - `TrajectoryBuffer` is a fixed-size FIFO buffer with size-based eviction, and `ConversationStep` encapsulates `skill_id`, `state_context`, and `q_value` per step.
> - Tests in [`tests/test_openclaw_rl_rollout.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/505/files#diff-941d2cd7586e6e94807b6f4e4df5b0ef3c5761ba68ce1a5d0afc6401f5415817) cover buffer persistence across users and turns, reward backpropagation correctness, and empty-buffer edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 927f56f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->