### PR TITLE
Implement OpenClaw Virtual Memory Plugin & Replenish Trends Tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -41,6 +41,23 @@
   },
   "tasks": [
     {
+      "id": "openclaw-virtual-memory-plugin-4b3bcc28",
+      "status": "done",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Memory Pattern Integration",
+      "description": "Inspired by trend: Virtual context management (MemGPT/Letta pattern). Implement an explicit swapping mechanism to seamlessly transition large context windows into structured memory layers, preventing token limit exhaustion.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_memory.py",
+        "tests/test_virtual_memory.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A modular swap mechanism is implemented for Context Engine",
+        "Tests cover token exhaustion mitigation limits"
+      ]
+    },
+    {
       "id": "mcp-concurrency-wrapper-v3",
       "status": "done",
       "area": "skills",
@@ -8164,23 +8181,6 @@
       "acceptance": [
         "Trajectory buffers persist across turns",
         "Delayed reward is properly backpropagated to previous steps"
-      ]
-    },
-    {
-      "id": "openclaw-virtual-memory-plugin-4b3bcc28",
-      "status": "todo",
-      "area": "memory",
-      "risk": "medium",
-      "title": "OpenClaw Virtual Memory Pattern Integration",
-      "description": "Inspired by trend: Virtual context management (MemGPT/Letta pattern). Implement an explicit swapping mechanism to seamlessly transition large context windows into structured memory layers, preventing token limit exhaustion.",
-      "allowed_paths": [
-        "magda_agent/memory/virtual_memory.py",
-        "tests/test_virtual_memory.py",
-        "agent_tasks.json"
-      ],
-      "acceptance": [
-        "A modular swap mechanism is implemented for Context Engine",
-        "Tests cover token exhaustion mitigation limits"
       ]
     },
     {
@@ -18205,6 +18205,57 @@
         "Monitors execution latency as feedback signal.",
         "Adjusts behavior weights (e.g., lower verbosity/higher directness) on high latency.",
         "Tests verify weight adjustments based on latency thresholds."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-alignment-v5",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Multimodal Alignments v5",
+      "description": "Inspired by OpenClaw trends: Implement real-time multimodal feedback processing in reinforcement learning loops by tracking user sentiment of image outputs to adapt verbosity weights.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_multimodal_v5.py",
+        "tests/test_openclaw_rl_multimodal_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL alignment loop adjusts weights upon image feedback.",
+        "Tests verify weight adjustments using mock multimodal sentiment signals."
+      ]
+    },
+    {
+      "id": "acs-security-checkpoints-persistence-v11",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Checkpoints Persistence and Auditing V11",
+      "description": "Inspired by Microsoft ACS (June 2026): Implement persistent SQL-based storage to record and audit historical outcomes across the 5 validation checkpoints for all agent workflows.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_persistence_v11.py",
+        "tests/test_acs_persistence_v11.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "SQL storage correctly serializes and saves checkpoint outcomes.",
+        "Tests verify querying historic checkpoint failures."
+      ]
+    },
+    {
+      "id": "mcp-oauth-client-refresher-v4",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Client OAuth2 Token Refresher V4",
+      "description": "Inspired by MCP Auth trend (June 2026): Implement automated token refresh for remote MCP tool servers to support long-lived tool execution sessions.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_client_auth_v4.py",
+        "tests/test_mcp_auth_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "OAuth2 client handles token expiration and dynamically fetches refreshed tokens.",
+        "Tests mock token renewal and verify seamless continuation of sessions."
       ]
     }
   ]

--- a/magda_agent/memory/virtual_memory.py
+++ b/magda_agent/memory/virtual_memory.py
@@ -1,0 +1,241 @@
+import logging
+import math
+from typing import List, Dict, Any, Optional
+from magda_agent.memory.context_engine import ContextPlugin
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.emotions.engine import PADState
+
+class VirtualMemoryPlugin(ContextPlugin):
+    """
+    OpenClaw Virtual Memory Pattern Integration.
+    An explicit swapping mechanism to transition large context windows (WorkingMemory)
+    into structured memory layers (EpisodicMemory) to prevent token limit/item count exhaustion.
+    """
+
+    def __init__(self, episodic_memory: Optional[EpisodicMemory] = None, token_limit: int = 2000) -> None:
+        """
+        Initializes the VirtualMemoryPlugin.
+
+        Args:
+            episodic_memory: Optional EpisodicMemory instance. If not provided, it will be initialized.
+            token_limit: Heuristic token limit before swapping.
+        """
+        self.episodic_memory = episodic_memory or EpisodicMemory(persist_directory=":memory:")
+        self.token_limit = token_limit
+        self.config: Dict[str, Any] = {}
+        logging.debug("Initialized VirtualMemoryPlugin")
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """
+        Bootstrap lifecycle hook. Initializes plugin state from config.
+
+        Args:
+            config: Configuration dictionary injected by ContextEngine.
+        """
+        self.config = config
+        self.token_limit = config.get("token_limit", self.token_limit)
+        logging.info(f"VirtualMemoryPlugin bootstrapped with token_limit={self.token_limit}")
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """
+        Ingest lifecycle hook. Process raw content before storing.
+
+        Args:
+            content: Raw string content.
+            metadata: Metadata associated with the content.
+
+        Returns:
+            Processed content.
+        """
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """
+        Assemble lifecycle hook. Constructs context prompt.
+
+        Args:
+            context_items: List of retrieved context items.
+            metadata: Metadata controlling assembly format.
+
+        Returns:
+            Assembled context string.
+        """
+        if not context_items:
+            return ""
+        items_str = "\n".join([f"- {getattr(item, 'content', str(item))}" for item in context_items])
+        return f"VIRTUAL CONTEXT:\n{items_str}"
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """
+        Compact lifecycle hook. Swaps out excess context items to EpisodicMemory to stay within token limits.
+
+        Args:
+            context_items: List of MemoryEntry items in working memory.
+            metadata: Metadata controlling compaction rules (like 'limit', 'user_id').
+
+        Returns:
+            The remaining working memory items after swapping.
+        """
+        user_id = metadata.get("user_id")
+        limit = metadata.get("limit", 10)
+
+        # First, check item count limit
+        if len(context_items) > limit:
+            excess_count = len(context_items) - limit
+            context_items = await self.swap_out(context_items, excess_count, user_id)
+
+        # Second, check token heuristic limit
+        while self._estimate_tokens(context_items) > self.token_limit and len(context_items) > 1:
+            context_items = await self.swap_out(context_items, 1, user_id)
+
+        return context_items
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """
+        Hook called before retrieval.
+
+        Args:
+            query: Searching query.
+            user_id: User ID.
+
+        Returns:
+            Query string.
+        """
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """
+        Hook called after retrieval.
+
+        Args:
+            context: Retrieved context elements.
+            query: Searching query.
+            user_id: User ID.
+
+        Returns:
+            Retrieved context elements.
+        """
+        return context
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """
+        Hook called before writing context.
+
+        Args:
+            context: Context item.
+            user_id: User ID.
+
+        Returns:
+            Context item.
+        """
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """
+        Hook called after writing context.
+
+        Args:
+            context: Context item.
+            user_id: User ID.
+        """
+        pass
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """
+        Hook called on context updates.
+
+        Args:
+            new_context: New context state.
+            user_id: User ID.
+        """
+        pass
+
+    # --- Custom Swap Methods ---
+
+    async def swap_out(self, context_items: List[Any], count: int, user_id: Optional[int] = None) -> List[Any]:
+        """
+        Transition/swap a given count of oldest context items to EpisodicMemory.
+
+        Args:
+            context_items: Working memory context items.
+            count: Number of oldest items to swap out.
+            user_id: Optional user ID filter.
+
+        Returns:
+            Remaining context items after swapping.
+        """
+        if not context_items or count <= 0:
+            return context_items
+
+        to_swap = context_items[:count]
+        remaining = context_items[count:]
+
+        for item in to_swap:
+            content = getattr(item, "content", str(item))
+            importance = getattr(item, "importance", 0.5)
+            emotional_state = getattr(item, "emotional_state", None)
+
+            metadata: Dict[str, Any] = {
+                "swapped_from_virtual": True,
+                "importance": importance,
+            }
+
+            if emotional_state and isinstance(emotional_state, PADState):
+                metadata.update({
+                    "pad_p": emotional_state.pleasure,
+                    "pad_a": emotional_state.arousal,
+                    "pad_d": emotional_state.dominance
+                })
+
+            self.episodic_memory.store_event(
+                text=content,
+                metadata=metadata,
+                user_id=user_id
+            )
+
+        logging.info(f"Swapped out {len(to_swap)} oldest items to episodic memory.")
+        return remaining
+
+    async def swap_in(self, context_items: List[Any], query: str, top_k: int = 3, user_id: Optional[int] = None) -> List[Any]:
+        """
+        Retrieve relevant past swapped memories from EpisodicMemory and load them back into WorkingMemory.
+
+        Args:
+            context_items: Current working memory context items.
+            query: Semantic search query for retrieval.
+            top_k: Number of items to retrieve.
+            user_id: Optional user ID filter.
+
+        Returns:
+            Updated context list containing swapped-in items.
+        """
+        events = self.episodic_memory.recall_events(query=query, top_k=top_k, user_id=user_id)
+        swapped_in_entries = []
+        for event in events:
+            # Avoid duplicating content already in context_items
+            if any(getattr(item, "content", "") == event for item in context_items):
+                continue
+            entry = MemoryEntry(
+                content=event,
+                importance=0.5,
+                emotional_state=PADState(0.0, 0.0, 0.0),
+                user_id=user_id
+            )
+            swapped_in_entries.append(entry)
+
+        logging.info(f"Swapped in {len(swapped_in_entries)} relevant items.")
+        return context_items + swapped_in_entries
+
+    def _estimate_tokens(self, entries: List[Any]) -> int:
+        """
+        Heuristic method to calculate token counts of entries.
+
+        Args:
+            entries: List of memory entries.
+
+        Returns:
+            Estimated token count.
+        """
+        total_words = sum(len(getattr(e, "content", str(e)).split()) for e in entries)
+        return int(total_words * 1.3)

--- a/tests/test_virtual_memory.py
+++ b/tests/test_virtual_memory.py
@@ -1,0 +1,89 @@
+import pytest
+from magda_agent.memory.virtual_memory import VirtualMemoryPlugin
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.emotions.engine import PADState
+
+@pytest.mark.asyncio
+async def test_virtual_memory_bootstrap() -> None:
+    """Test bootstrapping VirtualMemoryPlugin updates its configuration."""
+    plugin = VirtualMemoryPlugin(token_limit=1000)
+    config = {"token_limit": 500}
+    await plugin.bootstrap(config)
+    assert plugin.token_limit == 500
+
+@pytest.mark.asyncio
+async def test_virtual_memory_assemble() -> None:
+    """Test assemble constructs correct context prompt."""
+    plugin = VirtualMemoryPlugin()
+    entry1 = MemoryEntry("Hello world", 0.5, PADState(0.0, 0.0, 0.0))
+    entry2 = MemoryEntry("Context test", 0.8, PADState(0.0, 0.0, 0.0))
+    result = await plugin.assemble([entry1, entry2], {})
+    assert "VIRTUAL CONTEXT:" in result
+    assert "- Hello world" in result
+    assert "- Context test" in result
+
+@pytest.mark.asyncio
+async def test_virtual_memory_compact_by_count() -> None:
+    """Test compaction based on item limit."""
+    episodic_mem = EpisodicMemory(persist_directory=":memory:")
+    plugin = VirtualMemoryPlugin(episodic_memory=episodic_mem)
+
+    entries = [
+        MemoryEntry(f"Item {i}", 0.5, PADState(0.1, 0.2, 0.3)) for i in range(15)
+    ]
+
+    result = await plugin.compact(entries, {"limit": 10, "user_id": 42})
+    assert len(result) == 10
+    # First 5 items (0 to 4) should be swapped out to episodic memory
+    assert result[0].content == "Item 5"
+
+    events = episodic_mem.get_all_events(user_id=42)
+    assert len(events) == 5
+    assert events[0]["text"] == "Item 0"
+    assert events[0]["metadata"]["swapped_from_virtual"] is True
+    assert events[0]["metadata"]["pad_p"] == 0.1
+
+@pytest.mark.asyncio
+async def test_virtual_memory_compact_by_tokens() -> None:
+    """Test compaction based on token limits."""
+    episodic_mem = EpisodicMemory(persist_directory=":memory:")
+    # Small token limit (19) to trigger compaction and force dropping below 20 tokens
+    plugin = VirtualMemoryPlugin(episodic_memory=episodic_mem, token_limit=19)
+
+    # Each entry has 4 words -> ~5.2 tokens
+    entries = [
+        MemoryEntry("one two three four", 0.5, PADState(0.0, 0.0, 0.0)),
+        MemoryEntry("five six seven eight", 0.5, PADState(0.0, 0.0, 0.0)),
+        MemoryEntry("nine ten eleven twelve", 0.5, PADState(0.0, 0.0, 0.0)),
+        MemoryEntry("thirteen fourteen fifteen sixteen", 0.5, PADState(0.0, 0.0, 0.0)),
+        MemoryEntry("seventeen eighteen nineteen twenty", 0.5, PADState(0.0, 0.0, 0.0)),
+    ]
+
+    # Item limit is high (10), but token limit should force swap outs
+    result = await plugin.compact(entries, {"limit": 10, "user_id": 101})
+    # Total tokens is (5 * 4 * 1.3) = 26.
+    # To drop below 19 tokens, we must swap out at least 2 entries (each is ~5 tokens, leaving 3 entries with 15 tokens).
+    assert len(result) <= 3
+
+    events = episodic_mem.get_all_events(user_id=101)
+    assert len(events) >= 2
+    assert events[0]["metadata"]["swapped_from_virtual"] is True
+
+@pytest.mark.asyncio
+async def test_virtual_memory_swap_in() -> None:
+    """Test swapping in relevant memories."""
+    episodic_mem = EpisodicMemory(persist_directory=":memory:")
+    plugin = VirtualMemoryPlugin(episodic_memory=episodic_mem)
+
+    # Seed episodic memory
+    episodic_mem.store_event("Deep Learning is awesome", metadata={"swapped_from_virtual": True}, user_id=42)
+    episodic_mem.store_event("Context length matters", metadata={"swapped_from_virtual": True}, user_id=42)
+
+    current_context = [MemoryEntry("Regular dialogue", 0.5, PADState(0.0, 0.0, 0.0))]
+    updated_context = await plugin.swap_in(current_context, "Deep Learning", top_k=2, user_id=42)
+
+    # "Deep Learning is awesome" is more relevant and should be swapped in
+    contents = [e.content for e in updated_context]
+    assert len(updated_context) > 1
+    assert "Deep Learning is awesome" in contents

--- a/tests/test_virtual_memory.py
+++ b/tests/test_virtual_memory.py
@@ -29,16 +29,19 @@ async def test_virtual_memory_compact_by_count() -> None:
     episodic_mem = EpisodicMemory(persist_directory=":memory:")
     plugin = VirtualMemoryPlugin(episodic_memory=episodic_mem)
 
+    # Use a highly unique user_id to prevent cross-test contamination in in-memory ChromaDB
+    user_id = 998765432
+
     entries = [
-        MemoryEntry(f"Item {i}", 0.5, PADState(0.1, 0.2, 0.3)) for i in range(15)
+        MemoryEntry(f"Item {i}", 0.5, PADState(0.1, 0.2, 0.3), user_id=user_id) for i in range(15)
     ]
 
-    result = await plugin.compact(entries, {"limit": 10, "user_id": 42})
+    result = await plugin.compact(entries, {"limit": 10, "user_id": user_id})
     assert len(result) == 10
     # First 5 items (0 to 4) should be swapped out to episodic memory
     assert result[0].content == "Item 5"
 
-    events = episodic_mem.get_all_events(user_id=42)
+    events = episodic_mem.get_all_events(user_id=user_id)
     assert len(events) == 5
     assert events[0]["text"] == "Item 0"
     assert events[0]["metadata"]["swapped_from_virtual"] is True
@@ -51,22 +54,24 @@ async def test_virtual_memory_compact_by_tokens() -> None:
     # Small token limit (19) to trigger compaction and force dropping below 20 tokens
     plugin = VirtualMemoryPlugin(episodic_memory=episodic_mem, token_limit=19)
 
+    user_id = 998765433
+
     # Each entry has 4 words -> ~5.2 tokens
     entries = [
-        MemoryEntry("one two three four", 0.5, PADState(0.0, 0.0, 0.0)),
-        MemoryEntry("five six seven eight", 0.5, PADState(0.0, 0.0, 0.0)),
-        MemoryEntry("nine ten eleven twelve", 0.5, PADState(0.0, 0.0, 0.0)),
-        MemoryEntry("thirteen fourteen fifteen sixteen", 0.5, PADState(0.0, 0.0, 0.0)),
-        MemoryEntry("seventeen eighteen nineteen twenty", 0.5, PADState(0.0, 0.0, 0.0)),
+        MemoryEntry("one two three four", 0.5, PADState(0.0, 0.0, 0.0), user_id=user_id),
+        MemoryEntry("five six seven eight", 0.5, PADState(0.0, 0.0, 0.0), user_id=user_id),
+        MemoryEntry("nine ten eleven twelve", 0.5, PADState(0.0, 0.0, 0.0), user_id=user_id),
+        MemoryEntry("thirteen fourteen fifteen sixteen", 0.5, PADState(0.0, 0.0, 0.0), user_id=user_id),
+        MemoryEntry("seventeen eighteen nineteen twenty", 0.5, PADState(0.0, 0.0, 0.0), user_id=user_id),
     ]
 
     # Item limit is high (10), but token limit should force swap outs
-    result = await plugin.compact(entries, {"limit": 10, "user_id": 101})
+    result = await plugin.compact(entries, {"limit": 10, "user_id": user_id})
     # Total tokens is (5 * 4 * 1.3) = 26.
     # To drop below 19 tokens, we must swap out at least 2 entries (each is ~5 tokens, leaving 3 entries with 15 tokens).
     assert len(result) <= 3
 
-    events = episodic_mem.get_all_events(user_id=101)
+    events = episodic_mem.get_all_events(user_id=user_id)
     assert len(events) >= 2
     assert events[0]["metadata"]["swapped_from_virtual"] is True
 
@@ -76,12 +81,14 @@ async def test_virtual_memory_swap_in() -> None:
     episodic_mem = EpisodicMemory(persist_directory=":memory:")
     plugin = VirtualMemoryPlugin(episodic_memory=episodic_mem)
 
-    # Seed episodic memory
-    episodic_mem.store_event("Deep Learning is awesome", metadata={"swapped_from_virtual": True}, user_id=42)
-    episodic_mem.store_event("Context length matters", metadata={"swapped_from_virtual": True}, user_id=42)
+    user_id = 998765434
 
-    current_context = [MemoryEntry("Regular dialogue", 0.5, PADState(0.0, 0.0, 0.0))]
-    updated_context = await plugin.swap_in(current_context, "Deep Learning", top_k=2, user_id=42)
+    # Seed episodic memory
+    episodic_mem.store_event("Deep Learning is awesome", metadata={"swapped_from_virtual": True}, user_id=user_id)
+    episodic_mem.store_event("Context length matters", metadata={"swapped_from_virtual": True}, user_id=user_id)
+
+    current_context = [MemoryEntry("Regular dialogue", 0.5, PADState(0.0, 0.0, 0.0), user_id=user_id)]
+    updated_context = await plugin.swap_in(current_context, "Deep Learning", top_k=2, user_id=user_id)
 
     # "Deep Learning is awesome" is more relevant and should be swapped in
     contents = [e.content for e in updated_context]


### PR DESCRIPTION
This PR integrates the OpenClaw Virtual Memory Pattern into the Magda AI Agent's memory layers. By implementing the `VirtualMemoryPlugin` as a ContextPlugin, we establish an explicit, robust swapping mechanism that moves oldest working memory items to episodic memory when token limits or context constraints are breached, while allowing them to be semantically swapped back in on demand. In addition, `agent_tasks.json` has been updated and replenished with new, actionable tasks.

---
*PR created automatically by Jules for task [12209326119988380102](https://jules.google.com/task/12209326119988380102) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `VirtualMemoryPlugin` to swap working memory items into episodic memory
> - Adds [virtual_memory.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/506/files#diff-50184d7a67d6a4cf6e757620b188e580e0e555901108e8c28d327712f50320db), a `ContextPlugin` that maintains a token-limited working memory and persists oldest items to episodic memory when count or token thresholds are exceeded.
> - `compact` enforces both a max item count (default 10) and a token heuristic limit, swapping out oldest entries via `swap_out` which stores them with PAD state metadata.
> - `swap_in` performs a semantic query against episodic memory and appends relevant past events to the working context, skipping duplicates.
> - `assemble` renders the current working context as a `VIRTUAL CONTEXT:`-prefixed bullet list.
> - Adds a test suite in [tests/test_virtual_memory.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/506/files#diff-b8e7c98d6fc6fff988355c641e04c86835b58debab2e99402bbf105be6a299a3) covering bootstrap, assemble, compact (count and token limits), and swap_in.
> - Also updates `agent_tasks.json` to mark the plugin task as done and appends three new todo tasks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c7595b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->