### PR TITLE
Implement MCP Realtime Guardrail Fallback mechanism

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8202,7 +8202,7 @@
     },
     {
       "id": "mcp-realtime-guardrail-fallback-87b26189",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Realtime Guardrail Fallback mechanism",
@@ -18256,6 +18256,54 @@
       "acceptance": [
         "OAuth2 client handles token expiration and dynamically fetches refreshed tokens.",
         "Tests mock token renewal and verify seamless continuation of sessions."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-rollout-v7",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Rollout with Exponential Discounting",
+      "description": "Inspired by OpenClaw-RL trends: implement backpropagation of delayed rewards across multi-turn conversation trajectories in OpenClawRLTrajectoryRolloutV6 using a configurable discount factor gamma to refine historical Q-values.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_rollout.py",
+        "tests/test_openclaw_rl_rollout.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory buffer correctly stores multiple turns. Delayed rewards are backpropagated correctly using exponential discounting. Tests verify Q-value convergence on mock reward signals."
+      ]
+    },
+    {
+      "id": "acs-persistence-granular-audit-v12",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Persistent Granular Audit Logger",
+      "description": "Inspired by ACS and Prempti trends: Implement a granular audit logger that extends ACSPersistence to store the detailed rule ID and evaluation logic details for each check in the SQLite database to facilitate longitudinal safety reviews.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_persistence.py",
+        "tests/test_acs_persistence.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Granular outcomes including rule ID and check context are logged. Tests verify querying and structure in SQLite."
+      ]
+    },
+    {
+      "id": "mcp-concurrency-active-task-monitoring-v4",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Concurrency Active Task Monitoring",
+      "description": "Inspired by OpenAI Agents SDK tool concurrency: Extend MCPConcurrentHandlerV3 to expose thread-safe active task counts and execution duration metrics to help the scheduler optimize parallel execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_concurrency_v3.py",
+        "tests/test_mcp_concurrency_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Active task count incremented and decremented thread-safely. Average execution duration calculated. Tests verify concurrency metrics under concurrent load."
       ]
     }
   ]

--- a/magda_agent/safety/realtime_guardrail.py
+++ b/magda_agent/safety/realtime_guardrail.py
@@ -1,0 +1,76 @@
+"""
+MCP Realtime Guardrail Fallback module.
+Implements a safety/execution fallback layer inspired by OpenAI Agents SDK realtime guardrails.
+Intercepts policy violations and tool execution failures, producing dynamic reprompt prompts
+to let the agent recover gracefully instead of hard-failing.
+"""
+
+import asyncio
+import logging
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+from magda_agent.safety.policy import PolicyLayer
+
+
+class MCPRealtimeGuardrailFallback:
+    """
+    Fallback layer for tool invocation that catches safety violations and execution
+    failures, generating dynamic reprompt prompts for recovery.
+    """
+
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None) -> None:
+        """
+        Initializes the MCPRealtimeGuardrailFallback.
+
+        Args:
+            policy_layer (Optional[PolicyLayer]): The policy evaluator to verify safety before execution.
+        """
+        self.policy_layer = policy_layer or PolicyLayer()
+
+    async def execute_with_reprompt_fallback(
+        self,
+        tool_func: Callable[..., Any],
+        tool_name: str,
+        kwargs: Dict[str, Any]
+    ) -> Tuple[bool, str]:
+        """
+        Executes the tool function with guardrails. If a violation is detected or an error occurs,
+        intercepts the issue and returns a structured tuple containing False and a dynamic reprompt prompt.
+
+        Args:
+            tool_func (Callable[..., Any]): The synchronous or asynchronous function representing the tool call.
+            tool_name (str): Name of the tool.
+            kwargs (Dict[str, Any]): Arguments passed to the tool.
+
+        Returns:
+            Tuple[bool, str]: (Success, Result or Reprompt prompt).
+        """
+        # 1. Policy check before tool execution
+        allow, explanation = self.policy_layer.evaluate(tool_name, **kwargs)
+        if not allow:
+            logging.warning(f"RealtimeGuardrail: Intercepted policy violation for '{tool_name}'.")
+            fallback_prompt = (
+                f"SAFETY ALERT: The execution of tool '{tool_name}' with arguments {kwargs} "
+                f"was blocked due to a policy violation: {explanation}. "
+                f"Please analyze the violation, dynamically revise your execution plan, and try a "
+                f"different, safe approach without violating safety policies."
+            )
+            return False, fallback_prompt
+
+        # 2. Execute the tool with try/except
+        try:
+            if asyncio.iscoroutinefunction(tool_func):
+                result = await tool_func(**kwargs)
+            else:
+                # Run synchronous tool in an executor to avoid blocking the asyncio event loop
+                result = await asyncio.to_thread(tool_func, **kwargs)
+            return True, str(result)
+        except Exception as e:
+            logging.error(f"RealtimeGuardrail: Intercepted tool execution failure for '{tool_name}'. Error: {e}")
+            fallback_prompt = (
+                f"EXECUTION FAILURE: Failed to execute tool '{tool_name}' with arguments {kwargs}. "
+                f"Error: {str(e)}. "
+                f"Please adjust your strategy, handle this error dynamically, and generate an "
+                f"alternative plan or fallback steps."
+            )
+            return False, fallback_prompt

--- a/tests/test_realtime_guardrail.py
+++ b/tests/test_realtime_guardrail.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, AsyncMock
 from magda_agent.agents.generator_agent import GeneratorAgent
 from magda_agent.safety.guardrails import RealtimeGuardrail, FallbackStrategy
 from magda_agent.safety.policy import PolicyLayer
+from magda_agent.safety.realtime_guardrail import MCPRealtimeGuardrailFallback
 
 @pytest.mark.asyncio
 async def test_guardrail_allows_legit_action():
@@ -132,3 +133,75 @@ async def test_guardrail_review_required():
     assert "Guardrail Fallback (REVIEW REQUIRED): Review needed" in result
     skills.execute_skill.assert_not_called()
     planner.clear_pending_plan.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_mcp_realtime_guardrail_success() -> None:
+    """
+    Tests that a successful tool execution goes through without violations
+    and returns (True, result).
+    """
+    policy = MagicMock(spec=PolicyLayer)
+    policy.evaluate.return_value = (True, "Allowed")
+
+    async def mock_tool(arg1: str) -> str:
+        return f"Executed with {arg1}"
+
+    fallback = MCPRealtimeGuardrailFallback(policy_layer=policy)
+    success, result = await fallback.execute_with_reprompt_fallback(
+        tool_func=mock_tool,
+        tool_name="test_tool",
+        kwargs={"arg1": "hello"}
+    )
+
+    assert success is True
+    assert result == "Executed with hello"
+    policy.evaluate.assert_called_once_with("test_tool", arg1="hello")
+
+
+@pytest.mark.asyncio
+async def test_mcp_realtime_guardrail_policy_violation() -> None:
+    """
+    Tests that a policy violation is intercepted and returns a safety fallback reprompt.
+    """
+    policy = MagicMock(spec=PolicyLayer)
+    policy.evaluate.return_value = (False, "Command injection pattern detected")
+
+    async def mock_tool(arg1: str) -> str:
+        return f"Executed with {arg1}"
+
+    fallback = MCPRealtimeGuardrailFallback(policy_layer=policy)
+    success, result = await fallback.execute_with_reprompt_fallback(
+        tool_func=mock_tool,
+        tool_name="restricted_tool",
+        kwargs={"arg1": "unsafe_input"}
+    )
+
+    assert success is False
+    assert "SAFETY ALERT:" in result
+    assert "blocked due to a policy violation: Command injection pattern detected" in result
+    policy.evaluate.assert_called_once_with("restricted_tool", arg1="unsafe_input")
+
+
+@pytest.mark.asyncio
+async def test_mcp_realtime_guardrail_execution_failure() -> None:
+    """
+    Tests that a tool execution failure is caught and returns an execution failure fallback reprompt.
+    """
+    policy = MagicMock(spec=PolicyLayer)
+    policy.evaluate.return_value = (True, "Allowed")
+
+    async def mock_tool_failing(arg1: str) -> str:
+        raise ConnectionError("Timeout connecting to server")
+
+    fallback = MCPRealtimeGuardrailFallback(policy_layer=policy)
+    success, result = await fallback.execute_with_reprompt_fallback(
+        tool_func=mock_tool_failing,
+        tool_name="unstable_tool",
+        kwargs={"arg1": "retry_this"}
+    )
+
+    assert success is False
+    assert "EXECUTION FAILURE:" in result
+    assert "Timeout connecting to server" in result
+    policy.evaluate.assert_called_once_with("unstable_tool", arg1="retry_this")


### PR DESCRIPTION
Implemented MCP Realtime Guardrail Fallback mechanism in magda_agent/safety/realtime_guardrail.py. Included 6 tests in tests/test_realtime_guardrail.py (both the original and new tests are fully preserved and pass). Updated agent_tasks.json, setting the status of the completed task to done and appending 3 new todo tasks. Verified everything with validation scripts and full test suites.

---
*PR created automatically by Jules for task [14341082838042849102](https://jules.google.com/task/14341082838042849102) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPRealtimeGuardrailFallback` class to wrap tool invocations with policy evaluation
> - Adds [`MCPRealtimeGuardrailFallback`](https://github.com/kazah4359-lgtm/Magda-agent/pull/508/files#diff-2b46aab1a71b1fa925f29e53c43a6cedb8ce06d0e7fff9f6d0bbfe113b14cc9d) in `magda_agent.safety.realtime_guardrail`, which evaluates a `PolicyLayer` before executing a tool and returns a `(bool, str)` tuple instead of propagating exceptions.
> - On policy denial, logs a warning and returns `(False, <safety reprompt>)`; on execution error, captures the exception and returns `(False, <failure reprompt>)`; on success, returns `(True, str(result))`.
> - Supports both async and sync tool functions via `asyncio.to_thread` for sync callables.
> - Adds three async tests covering the success, policy violation, and execution failure paths in [`tests/test_realtime_guardrail.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/508/files#diff-ba79cad15563149d3df786ca792a9a7bad6b1d536895fb20c8f32777b335b80a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1415b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->