### PR TITLE
Implement A2A local network mDNS discovery

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8219,7 +8219,7 @@
     },
     {
       "id": "a2a-mdns-discovery",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A local network mDNS discovery",
@@ -18304,6 +18304,60 @@
       ],
       "acceptance": [
         "Active task count incremented and decremented thread-safely. Average execution duration calculated. Tests verify concurrency metrics under concurrent load."
+      ]
+    },
+    {
+      "id": "a2a-mdns-security-token-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A mDNS Discovery Secure Token Authentication",
+      "description": "Inspired by A2A Protocol security standards (June 2026): Implement secure token exchange and cryptographic validation for mDNS-discovered agents to prevent rogue agents from spoofing capabilities in local networks.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mdns_secure.py",
+        "tests/test_a2a_mdns_secure.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2AMDNSSecureDiscovery enforces token-based handshake with discovered peers.",
+        "Invalid tokens automatically disconnect/blacklist the peer.",
+        "Tests mock mDNS handshakes and verify authorization blocking."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-evaluation-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Quality Evaluation",
+      "description": "Inspired by OpenClaw-RL trend: Implement a trajectory quality evaluator that analyzes conversational rollouts to detect repetitiveness, loops, or frustration signals, mapping them to negative RL feedback.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_evaluator.py",
+        "tests/test_trajectory_evaluator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "TrajectoryEvaluator detects conversation loops and frustration patterns.",
+        "Fitted weights are updated online using reinforcement learning signals.",
+        "Tests verify feedback loop updates with mock conversation inputs."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v1",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Worktree Pruning and Resource Optimizer",
+      "description": "Inspired by Claude Agent SDK Agent Teams trend: Implement a daemon/worker class within GitWorktreeManager to monitor parallel subagent worktree allocations and aggressively prune abandoned or orphaned worktrees to optimize disk space.",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_pruner.py",
+        "tests/test_worktree_pruner.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pruner daemon identifies inactive, timed-out, or orphaned subagent worktrees.",
+        "Safely prunes workspaces and deletes associated directories.",
+        "Tests mock subagent timelines and verify automatic cleanup."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -257,3 +257,10 @@
 * [x] FEATURE: OpenClaw RL Metrics Tracker v4 (openclaw-rl-metrics-tracker-v4) (2026-06-10)
 * [x] FEATURE: OpenClaw RL Metrics and Visualization v3 (openclaw-rl-metrics-v3-unique) (2026-06-14)
 * [x] FEATURE: ACS Control Specification Persistence (acs-guardrail-persistence) (2026-06-12)
+
+
+## 📡 A2A mDNS & Self-Improvement Loops (June 2026 Trends)
+* [x] FEATURE: A2A local network mDNS discovery (a2a-mdns-discovery)
+* [ ] FEATURE: A2A mDNS Discovery Secure Token Authentication (a2a-mdns-security-token-v1)
+* [ ] FEATURE: OpenClaw RL Trajectory Quality Evaluation (openclaw-rl-trajectory-evaluation-v2)
+* [ ] FEATURE: Claude Worktree Pruning and Resource Optimizer (claude-worktree-pruning-optimizer-v1)

--- a/magda_agent/integration/a2a_mdns.py
+++ b/magda_agent/integration/a2a_mdns.py
@@ -1,0 +1,288 @@
+import socket
+import logging
+from typing import Dict, List, Optional, Any
+from zeroconf.asyncio import AsyncZeroconf, AsyncServiceBrowser, AsyncServiceInfo
+from magda_agent.integration.a2a_discovery import AgentCard
+
+logger = logging.getLogger(__name__)
+
+
+class A2AMDNSListener:
+    """
+    Listener to receive mDNS service events and delegate them to A2AMDNSDiscovery.
+    """
+
+    def __init__(self, discovery_parent: "A2AMDNSDiscovery") -> None:
+        """
+        Initializes the listener with a reference to the parent discovery instance.
+
+        Args:
+            discovery_parent: The parent A2AMDNSDiscovery instance.
+        """
+        self.discovery_parent = discovery_parent
+
+    def add_service(self, zc: Any, type_: str, name: str) -> None:
+        """
+        Callback when a new service is added. Schedules asynchronous resolution.
+
+        Args:
+            zc: The Zeroconf instance.
+            type_: The service type.
+            name: The service name.
+        """
+        import asyncio
+        asyncio.create_task(self.async_add_service(zc, type_, name))
+
+    def remove_service(self, zc: Any, type_: str, name: str) -> None:
+        """
+        Callback when a service is removed. Schedules asynchronous removal.
+
+        Args:
+            zc: The Zeroconf instance.
+            type_: The service type.
+            name: The service name.
+        """
+        import asyncio
+        asyncio.create_task(self.async_remove_service(zc, type_, name))
+
+    def update_service(self, zc: Any, type_: str, name: str) -> None:
+        """
+        Callback when a service is updated. Schedules asynchronous update/resolution.
+
+        Args:
+            zc: The Zeroconf instance.
+            type_: The service type.
+            name: The service name.
+        """
+        import asyncio
+        asyncio.create_task(self.async_add_service(zc, type_, name))
+
+    async def async_add_service(self, zc: Any, type_: str, name: str) -> None:
+        """
+        Asynchronously fetches details of the added/updated service and processes it.
+
+        Args:
+            zc: The Zeroconf instance.
+            type_: The service type.
+            name: The service name.
+        """
+        try:
+            aio_zc = self.discovery_parent.aio_zc
+            if aio_zc is None:
+                return
+            info = await aio_zc.get_service_info(type_, name)
+            if info:
+                await self.discovery_parent.process_discovered_service(info)
+        except Exception as e:
+            logger.error(f"Error fetching service info for {name}: {e}")
+
+    async def async_remove_service(self, zc: Any, type_: str, name: str) -> None:
+        """
+        Asynchronously removes the service from discovered peers list.
+
+        Args:
+            zc: The Zeroconf instance.
+            type_: The service type.
+            name: The service name.
+        """
+        await self.discovery_parent.process_removed_service(name)
+
+
+class A2AMDNSDiscovery:
+    """
+    Handles mDNS-based discovery of other agents in the local network and
+    broadcasting the local agent's card without requiring a central registry.
+    """
+
+    def __init__(self, local_card: AgentCard, service_type: str = "_a2a._tcp.local.") -> None:
+        """
+        Initializes the mDNS discovery with the local agent's card.
+
+        Args:
+            local_card: The local agent's capabilities card.
+            service_type: The mDNS service type, defaults to "_a2a._tcp.local.".
+        """
+        self.local_card = local_card
+        self.service_type = service_type
+        if not self.service_type.endswith("."):
+            self.service_type += "."
+
+        self.aio_zc: Optional[AsyncZeroconf] = None
+        self.service_info: Optional[AsyncServiceInfo] = None
+        self.browser: Optional[AsyncServiceBrowser] = None
+        self.listener: Optional[A2AMDNSListener] = None
+
+        self._discovered_agents: Dict[str, AgentCard] = {}
+        self._service_name_to_agent_id: Dict[str, str] = {}
+
+    def _extract_port_from_endpoints(self) -> int:
+        """
+        Extracts a port number from the local card's endpoints, falling back to 8000.
+
+        Returns:
+            The parsed port number or 8000.
+        """
+        for url in self.local_card.endpoints.values():
+            if ":" in url:
+                try:
+                    parts = url.split(":")
+                    port_str = parts[-1].split("/")[0]
+                    return int(port_str)
+                except Exception:
+                    pass
+        return 8000
+
+    async def start(self) -> None:
+        """
+        Starts the mDNS discovery, registers the local service, and begins browsing.
+        """
+        logger.info(f"Starting A2A mDNS Discovery for agent: {self.local_card.name}")
+        self.aio_zc = AsyncZeroconf()
+
+        port = self._extract_port_from_endpoints()
+        properties = {
+            "card": self.local_card.to_json(),
+            "agent_id": self.local_card.agent_id,
+            "name": self.local_card.name,
+            "capabilities": ",".join(self.local_card.capabilities),
+        }
+
+        # Instance name must be unique: e.g., agent-id._a2a._tcp.local.
+        self.service_info = AsyncServiceInfo(
+            type_=self.service_type,
+            name=f"{self.local_card.agent_id}.{self.service_type}",
+            addresses=[socket.inet_aton("127.0.0.1")],
+            port=port,
+            properties=properties,
+        )
+
+        await self.aio_zc.register_service(self.service_info)
+
+        self.listener = A2AMDNSListener(self)
+        self.browser = AsyncServiceBrowser(
+            self.aio_zc.zeroconf,
+            self.service_type,
+            self.listener,
+        )
+
+    async def stop(self) -> None:
+        """
+        Stops browsing, unregisters the local service, and closes AsyncZeroconf.
+        """
+        logger.info(f"Stopping A2A mDNS Discovery for agent: {self.local_card.name}")
+        if self.browser:
+            # ServiceBrowser itself is closed synchronously or cleaned up by closing Zeroconf
+            self.browser = None
+
+        if self.aio_zc:
+            if self.service_info:
+                try:
+                    await self.aio_zc.unregister_service(self.service_info)
+                except Exception as e:
+                    logger.error(f"Error unregistering service: {e}")
+                self.service_info = None
+
+            try:
+                await self.aio_zc.close()
+            except Exception as e:
+                logger.error(f"Error closing AsyncZeroconf: {e}")
+            self.aio_zc = None
+
+        self.listener = None
+        self._discovered_agents.clear()
+        self._service_name_to_agent_id.clear()
+
+    async def process_discovered_service(self, info: AsyncServiceInfo) -> None:
+        """
+        Processes resolved service information and registers the peer.
+
+        Args:
+            info: The resolved ServiceInfo object.
+        """
+        properties: Dict[str, str] = {}
+        for k, v in info.properties.items():
+            key_str = k.decode("utf-8") if isinstance(k, bytes) else str(k)
+            val_str = v.decode("utf-8") if isinstance(v, bytes) else str(v)
+            properties[key_str] = val_str
+
+        card: Optional[AgentCard] = None
+        card_json = properties.get("card")
+        if card_json:
+            try:
+                card = AgentCard.from_json(card_json)
+            except Exception as e:
+                logger.warning(f"Failed to parse AgentCard JSON from card property: {e}")
+
+        if not card:
+            agent_id = properties.get("agent_id")
+            name = properties.get("name")
+            if agent_id and name:
+                capabilities_str = properties.get("capabilities", "")
+                capabilities = [c.strip() for c in capabilities_str.split(",") if c.strip()]
+                endpoints: Dict[str, str] = {}
+                if info.addresses:
+                    try:
+                        ip = socket.inet_ntoa(info.addresses[0])
+                        endpoints["rpc"] = f"http://{ip}:{info.port}"
+                    except Exception:
+                        pass
+                card = AgentCard(
+                    agent_id=agent_id,
+                    name=name,
+                    description=properties.get("description", f"mDNS discovered Agent {name}"),
+                    capabilities=capabilities,
+                    endpoints=endpoints,
+                )
+
+        if card:
+            if card.agent_id == self.local_card.agent_id:
+                return
+            self._discovered_agents[card.agent_id] = card
+            self._service_name_to_agent_id[info.name] = card.agent_id
+            logger.info(f"mDNS Discovered peer agent: {card.name} ({card.agent_id}) with capabilities {card.capabilities}")
+
+    async def process_removed_service(self, name: str) -> None:
+        """
+        Handles service removal.
+
+        Args:
+            name: Fully-qualified name of the service being removed.
+        """
+        agent_id = self._service_name_to_agent_id.pop(name, None)
+        if agent_id:
+            card = self._discovered_agents.pop(agent_id, None)
+            if card:
+                logger.info(f"mDNS Removed peer agent: {card.name} ({agent_id})")
+
+    def get_discovered_agents(self) -> List[AgentCard]:
+        """
+        Retrieves the list of currently discovered peer agents.
+
+        Returns:
+            A list of discovered AgentCards.
+        """
+        return list(self._discovered_agents.values())
+
+    def get_agent_by_id(self, agent_id: str) -> Optional[AgentCard]:
+        """
+        Retrieves a discovered agent's card by its ID.
+
+        Args:
+            agent_id: Unique identifier for the agent.
+
+        Returns:
+            The discovered AgentCard or None.
+        """
+        return self._discovered_agents.get(agent_id)
+
+    def find_agents_by_capability(self, capability: str) -> List[AgentCard]:
+        """
+        Returns a list of discovered Agent Cards that support the given capability.
+
+        Args:
+            capability: The capability to filter by.
+
+        Returns:
+            A list of matching AgentCards.
+        """
+        return [card for card in self._discovered_agents.values() if capability in card.capabilities]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ PyYAML
 discord.py>=2.3.2
 aiofiles==24.1.0
 datasets==2.21.0
+zeroconf

--- a/tests/test_a2a_mdns.py
+++ b/tests/test_a2a_mdns.py
@@ -1,0 +1,211 @@
+import socket
+import json
+import asyncio
+from typing import Any, AsyncGenerator, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+from magda_agent.integration.a2a_discovery import AgentCard
+from magda_agent.integration.a2a_mdns import A2AMDNSDiscovery, A2AMDNSListener
+
+
+@pytest.fixture
+def local_card() -> AgentCard:
+    """
+    Fixture returning a sample local AgentCard.
+    """
+    return AgentCard(
+        agent_id="magda-local",
+        name="Magda Local",
+        description="Local agent",
+        capabilities=["code_generation", "web_search"],
+        endpoints={"rpc": "http://127.0.0.1:9090/rpc"},
+    )
+
+
+@pytest.fixture
+def peer_card() -> AgentCard:
+    """
+    Fixture returning a sample peer AgentCard.
+    """
+    return AgentCard(
+        agent_id="peer-1",
+        name="Peer One",
+        description="A cool peer",
+        capabilities=["translation"],
+        endpoints={"rpc": "http://127.0.0.1:8081/rpc"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_mdns_discovery_init(local_card: AgentCard) -> None:
+    """
+    Verifies initialization and service_type normalization.
+    """
+    discovery = A2AMDNSDiscovery(local_card=local_card, service_type="_a2a._tcp.local")
+    assert discovery.service_type == "_a2a._tcp.local."
+    assert discovery.local_card == local_card
+    assert discovery.aio_zc is None
+
+
+@pytest.mark.asyncio
+async def test_extract_port_from_endpoints(local_card: AgentCard) -> None:
+    """
+    Verifies port extraction logic with different URL formats.
+    """
+    # Test valid port
+    discovery = A2AMDNSDiscovery(local_card=local_card)
+    assert discovery._extract_port_from_endpoints() == 9090
+
+    # Test fallback when endpoints is empty
+    empty_card = AgentCard(
+        agent_id="empty",
+        name="Empty",
+        description="",
+        capabilities=[],
+        endpoints={},
+    )
+    discovery_empty = A2AMDNSDiscovery(local_card=empty_card)
+    assert discovery_empty._extract_port_from_endpoints() == 8000
+
+
+@pytest.mark.asyncio
+async def test_mdns_discovery_start_stop(local_card: AgentCard) -> None:
+    """
+    Verifies that start() registers service and stop() unregisters and cleans up.
+    """
+    discovery = A2AMDNSDiscovery(local_card=local_card)
+
+    mock_async_zc = MagicMock()
+    mock_async_zc.register_service = AsyncMock()
+    mock_async_zc.unregister_service = AsyncMock()
+    mock_async_zc.close = AsyncMock()
+    mock_async_zc.zeroconf = MagicMock()
+
+    with patch("magda_agent.integration.a2a_mdns.AsyncZeroconf", return_value=mock_async_zc), \
+         patch("magda_agent.integration.a2a_mdns.AsyncServiceBrowser") as mock_browser_cls:
+
+        await discovery.start()
+
+        assert discovery.aio_zc == mock_async_zc
+        assert discovery.service_info is not None
+        assert discovery.listener is not None
+        assert discovery.browser is not None
+
+        mock_async_zc.register_service.assert_called_once_with(discovery.service_info)
+        mock_browser_cls.assert_called_once_with(
+            mock_async_zc.zeroconf,
+            discovery.service_type,
+            discovery.listener,
+        )
+
+        # Let's stop
+        await discovery.stop()
+
+        assert discovery.aio_zc is None
+        assert discovery.service_info is None
+        assert discovery.listener is None
+        assert discovery.browser is None
+        mock_async_zc.unregister_service.assert_called_once()
+        mock_async_zc.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_listener_add_remove_service(local_card: AgentCard, peer_card: AgentCard) -> None:
+    """
+    Verifies that A2AMDNSListener correctly handles addition, update, and removal of services.
+    """
+    discovery = A2AMDNSDiscovery(local_card=local_card)
+
+    mock_async_zc = MagicMock()
+    mock_async_zc.register_service = AsyncMock()
+    mock_async_zc.unregister_service = AsyncMock()
+    mock_async_zc.close = AsyncMock()
+    mock_async_zc.zeroconf = MagicMock()
+
+    # Create mock AsyncServiceInfo for peer
+    mock_info = MagicMock()
+    mock_info.name = "peer-1._a2a._tcp.local."
+    mock_info.properties = {
+        b"card": peer_card.to_json().encode("utf-8"),
+        b"agent_id": b"peer-1",
+        b"name": b"Peer One",
+        b"capabilities": b"translation",
+    }
+    mock_info.port = 8081
+    mock_info.addresses = [socket.inet_aton("127.0.0.1")]
+
+    mock_async_zc.get_service_info = AsyncMock(return_value=mock_info)
+
+    with patch("magda_agent.integration.a2a_mdns.AsyncZeroconf", return_value=mock_async_zc), \
+         patch("magda_agent.integration.a2a_mdns.AsyncServiceBrowser"):
+
+        await discovery.start()
+        listener = discovery.listener
+        assert listener is not None
+
+        # Simulate add_service
+        listener.add_service(None, discovery.service_type, "peer-1._a2a._tcp.local.")
+
+        # Give small sleep for async task to run
+        await asyncio.sleep(0.01)
+
+        # Verify peer was registered
+        discovered_agents = discovery.get_discovered_agents()
+        assert len(discovered_agents) == 1
+        assert discovered_agents[0].agent_id == "peer-1"
+        assert discovered_agents[0].name == "Peer One"
+        assert "translation" in discovered_agents[0].capabilities
+
+        # Verify retrieval by capability
+        matching = discovery.find_agents_by_capability("translation")
+        assert len(matching) == 1
+        assert matching[0].agent_id == "peer-1"
+
+        # Verify retrieval by ID
+        found_card = discovery.get_agent_by_id("peer-1")
+        assert found_card is not None
+        assert found_card.agent_id == "peer-1"
+
+        # Simulate update_service
+        listener.update_service(None, discovery.service_type, "peer-1._a2a._tcp.local.")
+        await asyncio.sleep(0.01)
+        assert len(discovery.get_discovered_agents()) == 1
+
+        # Simulate remove_service
+        listener.remove_service(None, discovery.service_type, "peer-1._a2a._tcp.local.")
+        await asyncio.sleep(0.01)
+
+        # Verify peer was removed
+        assert len(discovery.get_discovered_agents()) == 0
+        await discovery.stop()
+
+
+@pytest.mark.asyncio
+async def test_fallback_parsing(local_card: AgentCard) -> None:
+    """
+    Verifies fallback parsing works when "card" property is not present in properties dict.
+    """
+    discovery = A2AMDNSDiscovery(local_card=local_card)
+
+    mock_info = MagicMock()
+    mock_info.name = "peer-fallback._a2a._tcp.local."
+    # No "card" property, only individual fields
+    mock_info.properties = {
+        b"agent_id": b"peer-fallback",
+        b"name": b"Peer Fallback",
+        b"capabilities": b"web_search,translation",
+        b"description": b"A fallback mDNS peer",
+    }
+    mock_info.port = 8085
+    mock_info.addresses = [socket.inet_aton("127.0.0.1")]
+
+    await discovery.process_discovered_service(mock_info)
+
+    discovered = discovery.get_discovered_agents()
+    assert len(discovered) == 1
+    card = discovered[0]
+    assert card.agent_id == "peer-fallback"
+    assert card.name == "Peer Fallback"
+    assert card.description == "A fallback mDNS peer"
+    assert set(card.capabilities) == {"web_search", "translation"}
+    assert card.endpoints == {"rpc": "http://127.0.0.1:8085"}


### PR DESCRIPTION
This pull request implements the requested 'A2A local network mDNS discovery' task to enable decentralized agent-to-agent peer discovery on local networks without a central registry, using pure Python's `zeroconf.asyncio` package. It fully registers the local agent's capability card and dynamically resolves discovered peer cards, with robust fallback parsing for direct TXT fields. It includes a comprehensive async pytest suite. It also completes task management updates by marking the task 'done' and introducing 3 new high-quality June 2026 trending todo tasks.

---
*PR created automatically by Jules for task [6951095268983603333](https://jules.google.com/task/6951095268983603333) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mDNS-based peer discovery for A2A local network agent communication
> - Introduces [`A2AMDNSDiscovery`](https://github.com/kazah4359-lgtm/Magda-agent/pull/509/files#diff-54dade730d1bbb1101ae6a8b7b0364da3eb00307ee381c643d3c60dc0ca3666b) and `A2AMDNSListener` classes using the `zeroconf` library to register the local agent over mDNS and browse for peer agents on the local network.
> - Discovered peers are parsed into `AgentCard` records and tracked in memory, with lookup by agent ID and capability filtering via `get_agent_by_id` and `find_agents_by_capability`.
> - Service add/update/remove events from Zeroconf are dispatched as asyncio tasks to avoid blocking the Zeroconf callback thread.
> - Adds `zeroconf` to [requirements.txt](https://github.com/kazah4359-lgtm/Magda-agent/pull/509/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552) and async test coverage in [tests/test_a2a_mdns.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/509/files#diff-fc967d5c67445f6dab83e867a1efa02a698900775cc2d1c7957059bacda3aae1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a655ecf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->