### PR TITLE
Implement OpenClaw Live Canvas Streaming

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8236,7 +8236,7 @@
     },
     {
       "id": "openclaw-live-canvas-streaming",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw Live Canvas Streaming",
@@ -18358,6 +18358,57 @@
         "Pruner daemon identifies inactive, timed-out, or orphaned subagent worktrees.",
         "Safely prunes workspaces and deletes associated directories.",
         "Tests mock subagent timelines and verify automatic cleanup."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-auto-refinement-v6-ef92",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Agent Skills Auto-Refinement v6",
+      "description": "Inspired by Hermes self-improving agents trend (June 2026): Implement an automated routine within the ProceduralMemory system to refine and optimize skill execution schemas by parsing post-execution evaluation ratings and adjusting execution parameters.",
+      "allowed_paths": [
+        "magda_agent/skills/refinement_v6.py",
+        "tests/test_refinement_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill refinement successfully parses ratings and adjusts parameters.",
+        "Tests verify automated parameter adjustment logic."
+      ]
+    },
+    {
+      "id": "openai-agents-concurrency-prioritization-v4-bc5a",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI Agents SDK Concurrency Prioritization v4",
+      "description": "Inspired by OpenAI Agents SDK concurrent tool execution trend: Develop a priority-aware tool execution router that schedules and executes concurrent tool calls based on their priority and energy requirements.",
+      "allowed_paths": [
+        "magda_agent/skills/priority_concurrency_v4.py",
+        "tests/test_priority_concurrency_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Priority router executes high-priority tools first.",
+        "Tests verify concurrent scheduling and priority execution rules."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-custom-state-triggers-v5-df3a",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas Custom State Triggers v5",
+      "description": "Inspired by OpenClaw Canvas visualization trend: Implement customizable state thresholds and dynamic change triggers in the Canvas streaming backend to selectively stream specific high-priority cognitive state mutations.",
+      "allowed_paths": [
+        "magda_agent/visualization/state_triggers_v5.py",
+        "tests/test_state_triggers_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Streamer selectively triggers WebSocket updates based on state changes.",
+        "Tests mock triggers and verify selective JSON delta streaming."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -184,7 +184,7 @@
 * [ ] BUG: `Brainstem` integration in `Consciousness.process_input` does not halt long-running skills gracefully upon a 'stop' command. Need to implement a cancellation token or mechanism for active background tasks when a stop reflex is triggered. (2026-06-04)
 * [x] FEATURE: Claude Task System with Dependency Graphs v3 (claude-dependency-graph-planner-v3)
 ## 🛠️ Запланированные Skills
-* [x] FEATURE: OpenClaw Canvas Live Visualization
+* [x] FEATURE: OpenClaw Canvas Live Visualization (2026-06-15)
 * [x] FEATURE: OpenClaw RL Next-State Signals
 * [x] FEATURE: Claude Subagent Spawning
 

--- a/magda_agent/visualization/live_canvas.py
+++ b/magda_agent/visualization/live_canvas.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import logging
+from typing import List, Dict, Any, Optional
+from fastapi import WebSocket
+
+from magda_agent.consciousness.core import Consciousness
+from magda_agent.visualization.canvas_v3 import CanvasVisualizerV3
+
+logger = logging.getLogger(__name__)
+
+class LiveCanvasStreamer:
+    """
+    LiveCanvasStreamer manages WebSocket streaming of Magda's internal cognitive state,
+    providing realtime visualizations of memory layers and attention focus.
+    """
+    def __init__(self, consciousness: Consciousness, interval: float = 1.0) -> None:
+        """
+        Initializes the LiveCanvasStreamer with consciousness and interval.
+
+        Args:
+            consciousness: The main Consciousness instance.
+            interval: The periodic interval (in seconds) at which state is streamed.
+        """
+        self.consciousness: Consciousness = consciousness
+        self.interval: float = interval
+        self.visualizer: CanvasVisualizerV3 = CanvasVisualizerV3(consciousness)
+        self.active_connections: List[WebSocket] = []
+        self._running: bool = False
+        self._streaming_task: Optional[asyncio.Task] = None
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """
+        Accepts an incoming WebSocket connection and adds it to the active pool,
+        sending the initial full state immediately.
+
+        Args:
+            websocket: The FastAPI WebSocket connection.
+        """
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info(f"Canvas client connected. Active connections: {len(self.active_connections)}")
+        try:
+            current_state = self.visualizer.get_state_json()
+            await websocket.send_text(current_state)
+        except Exception as e:
+            logger.error(f"Failed to send initial state to canvas client: {e}")
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        """
+        Removes a WebSocket connection from the active pool.
+
+        Args:
+            websocket: The WebSocket connection to remove.
+        """
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+            logger.info(f"Canvas client disconnected. Active connections: {len(self.active_connections)}")
+
+    async def broadcast(self, message: str) -> None:
+        """
+        Broadcasts a text message to all active WebSocket connections.
+
+        Args:
+            message: The message string to broadcast.
+        """
+        failed_connections: List[WebSocket] = []
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(message)
+            except Exception as e:
+                logger.error(f"Failed to send message to canvas client: {e}")
+                failed_connections.append(connection)
+
+        for conn in failed_connections:
+            self.disconnect(conn)
+
+    async def start_streaming(self) -> None:
+        """
+        Starts the background loop that periodically broadcasts the cognitive state.
+        """
+        self._running = True
+        logger.info("Live Canvas streaming started.")
+        while self._running:
+            try:
+                if self.active_connections:
+                    state_json = self.visualizer.get_state_json()
+                    await self.broadcast(state_json)
+            except Exception as e:
+                logger.error(f"Error in Live Canvas streaming loop: {e}")
+            await asyncio.sleep(self.interval)
+
+    async def stop_streaming(self) -> None:
+        """
+        Stops the periodic streaming of cognitive state.
+        """
+        self._running = False
+        logger.info("Live Canvas streaming stopped.")

--- a/tests/test_live_canvas.py
+++ b/tests/test_live_canvas.py
@@ -1,0 +1,111 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import WebSocket
+from magda_agent.visualization.live_canvas import LiveCanvasStreamer
+
+@pytest.fixture
+def mock_consciousness() -> MagicMock:
+    """
+    Creates a mocked Consciousness instance to avoid real database/external dependencies.
+    """
+    mock = MagicMock()
+    mock.emotions = None
+    mock.mental_states = None
+    mock.memory = None
+    mock.skills = None
+    mock.planner = None
+    mock.hypothalamus = None
+    mock.global_workspace = None
+    mock.openclaw_rl_metrics = None
+    return mock
+
+@pytest.fixture
+def live_canvas_streamer(mock_consciousness: MagicMock) -> LiveCanvasStreamer:
+    """
+    Provides a LiveCanvasStreamer instance with 0.1s update interval.
+    """
+    return LiveCanvasStreamer(consciousness=mock_consciousness, interval=0.1)
+
+@pytest.mark.asyncio
+async def test_live_canvas_connect(live_canvas_streamer: LiveCanvasStreamer) -> None:
+    """
+    Tests that a client connection is accepted and initial full state is immediately sent.
+    """
+    mock_ws = AsyncMock(spec=WebSocket)
+    await live_canvas_streamer.connect(mock_ws)
+
+    # Check connection added and accepted
+    assert mock_ws in live_canvas_streamer.active_connections
+    mock_ws.accept.assert_awaited_once()
+
+    # Verify initial state sent
+    mock_ws.send_text.assert_awaited_once()
+    sent_text = mock_ws.send_text.await_args[0][0]
+    sent_data = json.loads(sent_text)
+    assert "emotions" in sent_data
+    assert "memory" in sent_data
+
+@pytest.mark.asyncio
+async def test_live_canvas_disconnect(live_canvas_streamer: LiveCanvasStreamer) -> None:
+    """
+    Tests that a client connection is removed from active pool on disconnect.
+    """
+    mock_ws = MagicMock(spec=WebSocket)
+    live_canvas_streamer.active_connections.append(mock_ws)
+    live_canvas_streamer.disconnect(mock_ws)
+    assert mock_ws not in live_canvas_streamer.active_connections
+
+@pytest.mark.asyncio
+async def test_live_canvas_broadcast(live_canvas_streamer: LiveCanvasStreamer) -> None:
+    """
+    Tests that state update broadcasts are correctly sent to all active connections.
+    """
+    mock_ws1 = AsyncMock(spec=WebSocket)
+    mock_ws2 = AsyncMock(spec=WebSocket)
+
+    live_canvas_streamer.active_connections.extend([mock_ws1, mock_ws2])
+    test_msg = json.dumps({"test": "data"})
+    await live_canvas_streamer.broadcast(test_msg)
+
+    mock_ws1.send_text.assert_awaited_once_with(test_msg)
+    mock_ws2.send_text.assert_awaited_once_with(test_msg)
+
+@pytest.mark.asyncio
+async def test_live_canvas_broadcast_failures(live_canvas_streamer: LiveCanvasStreamer) -> None:
+    """
+    Tests that a failing WebSocket connection during broadcast is automatically disconnected.
+    """
+    mock_ws1 = AsyncMock(spec=WebSocket)
+    mock_ws2 = AsyncMock(spec=WebSocket)
+    mock_ws2.send_text.side_effect = Exception("WebSocket closed by remote host")
+
+    live_canvas_streamer.active_connections.extend([mock_ws1, mock_ws2])
+    test_msg = json.dumps({"test": "data"})
+    await live_canvas_streamer.broadcast(test_msg)
+
+    mock_ws1.send_text.assert_awaited_once_with(test_msg)
+    assert mock_ws1 in live_canvas_streamer.active_connections
+    assert mock_ws2 not in live_canvas_streamer.active_connections
+
+@pytest.mark.asyncio
+async def test_live_canvas_streaming_loop(live_canvas_streamer: LiveCanvasStreamer) -> None:
+    """
+    Tests that the background streaming loop periodically sends state updates to clients.
+    """
+    mock_ws = AsyncMock(spec=WebSocket)
+    live_canvas_streamer.active_connections.append(mock_ws)
+
+    # Start the background task
+    task = asyncio.create_task(live_canvas_streamer.start_streaming())
+
+    # Yield control to the event loop
+    await asyncio.sleep(0.15)
+
+    # Stop streaming and await task completion
+    await live_canvas_streamer.stop_streaming()
+    await task
+
+    # Assert that a broadcast occurred
+    assert mock_ws.send_text.await_count >= 1


### PR DESCRIPTION
This PR implements the Live Canvas WebSocket streaming backend for Magda AI Agent.

Changes include:
- A complete, type-annotated and documented `LiveCanvasStreamer` class under `magda_agent/visualization/live_canvas.py` that utilizes `CanvasVisualizerV3` to periodically broadcast state updates over WebSockets.
- A full suite of unit tests with robust mocking of WebSockets in `tests/test_live_canvas.py`.
- Mark 'openclaw-live-canvas-streaming' as done.
- Append three new detailed 'todo' tasks inspired by June 2026 agentic trends to `agent_tasks.json`.
- Verification of manifest constraints and all tests.

---
*PR created automatically by Jules for task [406392997214132268](https://jules.google.com/task/406392997214132268) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WebSocket-based live canvas streaming via `LiveCanvasStreamer`
> - Introduces [`LiveCanvasStreamer`](https://github.com/kazah4359-lgtm/Magda-agent/pull/510/files#diff-7eed45ba795be0430572824b161232830ff7c0484dd16e564359c264132870b2) to manage WebSocket connections and periodically broadcast visualization state JSON from `CanvasVisualizerV3`.
> - On connect, the client immediately receives the current state snapshot; the background loop then pushes updates at a configurable interval while connections are active.
> - Failed connections are pruned automatically during each broadcast cycle.
> - Adds pytest async tests in [`tests/test_live_canvas.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/510/files#diff-c44659ccfde0a71fa6bca1b60f17f9912b7b1ac0df15e21bea592743705d1053) covering connect, disconnect, broadcast, failure pruning, and the streaming loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24d127d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->