### PR TITLE
Claude Subagent Token Compression Implementation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8253,7 +8253,7 @@
     },
     {
       "id": "claude-subagent-token-compression",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "Claude Subagent Token Compression",
@@ -18409,6 +18409,60 @@
       "acceptance": [
         "Streamer selectively triggers WebSocket updates based on state changes.",
         "Tests mock triggers and verify selective JSON delta streaming."
+      ]
+    },
+    {
+      "id": "mcp-server-side-streaming-v2-abc4ef71",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tool Server Server-Side Streaming Support",
+      "description": "Inspired by June 2026 OpenAI and Anthropic streaming trends: Implement server-side streaming output capabilities for exported MCP tools in Magda, enabling external clients to stream token chunks directly from LLM-driven skills instead of waiting for full execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_streaming_v2.py",
+        "tests/test_mcp_streaming_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP server supports exporting tool schemas with streaming response metadata.",
+        "The server correctly emits streaming chunks over JSON-RPC when a tool is executed in streaming mode.",
+        "Tests verify chunked output generation and transmission."
+      ]
+    },
+    {
+      "id": "acs-file-taint-sandbox-v3-e6f7b1c4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS File-Level Taint Tracking and Sandboxing",
+      "description": "Inspired by Prempti and ACS standards: Enhance the sandbox policy layer to track file-level taint propagation when subagents read tainted inputs, ensuring any subsequent tool invocations that write to external destinations are strictly blocked if tainted files are involved.",
+      "allowed_paths": [
+        "magda_agent/safety/file_taint_sandbox_v3.py",
+        "tests/test_file_taint_sandbox_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox environment tracks read-tainted files throughout the subagent lifecycle.",
+        "Write actions to external locations (like network or outside specified worktree) are blocked if they consume tainted files.",
+        "Tests verify file-level taint propagation and policy blocking."
+      ]
+    },
+    {
+      "id": "online-rl-emotion-decay-v4-d3a9f1b2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Online RL Sentiment Decay Heuristic for Response Tone",
+      "description": "Inspired by OpenClaw-RL trends: Implement a temporal sentiment decay heuristic in the reinforcement learning loop to prevent historical user sentiment from causing excessive rigidity in tone adjustments during multi-turn interactions.",
+      "allowed_paths": [
+        "magda_agent/learning/sentiment_decay_v4.py",
+        "tests/test_sentiment_decay_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sentiment decay calculation is applied to past sentiment scores over conversation turns.",
+        "RL habit weights adjust dynamically to newer sentiment signals faster than old ones.",
+        "Tests verify decay factor correctness over multi-turn simulation."
       ]
     }
   ]

--- a/magda_agent/agents/sub_agent.py
+++ b/magda_agent/agents/sub_agent.py
@@ -1,15 +1,22 @@
 import logging
-from typing import Optional
+from typing import Optional, Any
 from magda_agent.llm_client import LLMClient
 from magda_agent.isolation.git_worktree import GitWorktreeManager
 from magda_agent.memory.subagent_compression import SubagentContextCompressor
+from magda_agent.agents.token_compression import SubagentTokenCompressor
 
 class SubAgent:
     """
     SubAgent for executing isolated tasks in a separate context.
     Inspired by Claude Agent Teams and Hermes sub-agents.
     """
-    def __init__(self, llm: LLMClient, system_prompt: Optional[str] = None, use_isolation: bool = False):
+    def __init__(
+        self,
+        llm: LLMClient,
+        system_prompt: Optional[str] = None,
+        use_isolation: bool = False,
+        use_enhanced_compression: bool = True
+    ) -> None:
         """
         Initializes the SubAgent.
         """
@@ -17,9 +24,12 @@ class SubAgent:
         self.system_prompt = system_prompt or "You are an isolated Sub-Agent executing a specific task."
         self.use_isolation = use_isolation
         self.worktree_manager = GitWorktreeManager() if use_isolation else None
-        self.context_compressor = SubagentContextCompressor(llm=llm)
+        if use_enhanced_compression:
+            self.context_compressor = SubagentTokenCompressor(llm=llm)
+        else:
+            self.context_compressor = SubagentContextCompressor(llm=llm)
 
-    async def execute(self, task: str, context: str, **kwargs) -> str:
+    async def execute(self, task: str, context: str, **kwargs: Any) -> str:
         """
         Executes a task given the context.
         """
@@ -38,8 +48,12 @@ class SubAgent:
                 return f"Error: Failed to create isolated worktree - {e}"
 
         # Compress the combined context if it's too large
-        full_context = f"Parent Context:\n{current_context}\n\nAssigned Task:\n{task}"
-        full_context = await self.context_compressor.compress_context(full_context)
+        if isinstance(self.context_compressor, SubagentTokenCompressor):
+            full_context = await self.context_compressor.compress_context(current_context, task)
+        else:
+            full_context = f"Parent Context:\n{current_context}\n\nAssigned Task:\n{task}"
+            full_context = await self.context_compressor.compress_context(full_context)
+
         messages = [
             {"role": "system", "content": self.system_prompt},
             {"role": "user", "content": full_context}

--- a/magda_agent/agents/token_compression.py
+++ b/magda_agent/agents/token_compression.py
@@ -1,0 +1,173 @@
+import logging
+import re
+from typing import Optional, List, Dict, Any
+from magda_agent.llm_client import LLMClient
+
+class SubagentTokenCompressor:
+    """
+    Compresses large contexts dynamically for spawned subagents.
+    Optimizes token usage based on task relevance while strictly preserving
+    critical constraints and instructions.
+    """
+
+    def __init__(self, llm: LLMClient) -> None:
+        """
+        Initializes the SubagentTokenCompressor.
+
+        Args:
+            llm: Language Model client to be used for summarization.
+        """
+        self.llm = llm
+
+    def _extract_critical_constraints(self, text: str) -> List[str]:
+        """
+        Extracts sentences or lines that contain high-priority constraint keywords
+        to guarantee they are not lost during compression.
+
+        Args:
+            text: Raw input text.
+
+        Returns:
+            A list of extracted constraint strings.
+        """
+        keywords = ["must", "never", "strict", "required", "limit", "critical", "mandatory", "rule"]
+        pattern = re.compile(r"\b(" + "|".join(keywords) + r")\b", re.IGNORECASE)
+
+        constraints: List[str] = []
+        # Split by newline first, then by sentence markers if needed
+        lines = [line.strip() for line in text.split("\n") if line.strip()]
+        for line in lines:
+            if pattern.search(line):
+                constraints.append(line)
+        return list(dict.fromkeys(constraints))  # Deduplicate while preserving order
+
+    async def compress_context(self, context: str, task: str, max_length: int = 2000) -> str:
+        """
+        Selectively compresses context based on task relevance, retaining critical constraints.
+
+        Args:
+            context: The raw context string to compress.
+            task: The subagent task description.
+            max_length: The maximum allowed length of the context. Triggers compression if exceeded.
+
+        Returns:
+            The compressed context string.
+        """
+        if len(context) <= max_length:
+            logging.info("Context is within limits. Skipping compression.")
+            return f"Parent Context:\n{context}\n\nAssigned Task:\n{task}"
+
+        logging.info(f"Context length ({len(context)}) exceeds max_length ({max_length}). Compressing based on task relevance.")
+
+        # Identify critical constraints as a backup/validation check
+        constraints = self._extract_critical_constraints(context)
+
+        prompt = (
+            f"You are a context compression engine optimizing tokens for a spawned subagent.\n"
+            f"Your job is to compress the parent context below so that it fits within budget, "
+            f"keeping ONLY the information relevant to the subagent's assigned task, while "
+            f"STRICTLY preserving all critical constraints and rules (e.g., MUST, REQUIRED, NEVER, LIMIT, etc.).\n\n"
+            f"--- ASSIGNED SUBAGENT TASK ---\n"
+            f"{task}\n\n"
+            f"--- PARENT CONTEXT TO COMPRESS ---\n"
+            f"{context}\n\n"
+            f"Instructions:\n"
+            f"1. Extract and retain all key constraints, rules, and mandatory bounds from the Parent Context.\n"
+            f"2. Summarize or remove parts of the Parent Context that are irrelevant or secondary to the Assigned Subagent Task.\n"
+            f"3. Do not lose critical formatting, identifiers, or keys needed to execute the task.\n"
+            f"4. The output must be concise and optimized for token savings."
+        )
+
+        messages = [
+            {"role": "system", "content": "You are an advanced token compression system specializing in task-relevant summarization and constraint preservation."},
+            {"role": "user", "content": prompt}
+        ]
+
+        try:
+            compressed = await self.llm.chat_completion(messages, temperature=0.2)
+            compressed_str = compressed.strip()
+
+            if not compressed_str:
+                return context[:max_length]
+
+            # Double-check if constraints are preserved. If any constraint from original is missing, append it as metadata/safety.
+            missing_constraints = []
+            for const in constraints:
+                # Basic check: is a substantial portion of the constraint present?
+                # Lowercase clean check
+                const_clean = re.sub(r"\s+", " ", const.lower()).strip()
+                compressed_clean = re.sub(r"\s+", " ", compressed_str.lower()).strip()
+                if const_clean not in compressed_clean:
+                    missing_constraints.append(const)
+
+            if missing_constraints:
+                logging.info(f"Re-injecting {len(missing_constraints)} missing critical constraints.")
+                constraint_header = "\n\n--- PRESERVED CRITICAL CONSTRAINTS ---\n" + "\n".join(f"- {c}" for c in missing_constraints)
+                compressed_str += constraint_header
+
+            return compressed_str
+        except Exception as e:
+            logging.error(f"Failed to compress context dynamically: {e}")
+            return context[:max_length]
+
+    async def compress_messages(self, messages: List[Dict[str, Any]], task: str, max_messages: int = 5) -> List[Dict[str, Any]]:
+        """
+        Compresses a structured list of conversation messages by summarizing older messages
+        and preserving only the most recent/relevant ones.
+
+        Args:
+            messages: List of message dictionaries, each having 'role' and 'content'.
+            task: The assigned task of the subagent.
+            max_messages: Target number of messages to keep in the history.
+
+        Returns:
+            An optimized list of messages.
+        """
+        if len(messages) <= max_messages:
+            return messages
+
+        logging.info(f"Compressing message history of {len(messages)} items down to {max_messages}.")
+
+        # Keep system prompt and the most recent messages untouched
+        system_messages = [msg for msg in messages if msg.get("role") == "system"]
+        user_assistant_messages = [msg for msg in messages if msg.get("role") != "system"]
+
+        if len(user_assistant_messages) <= max_messages:
+            return messages
+
+        # Messages to compress/summarize
+        to_compress = user_assistant_messages[:-max_messages]
+        retained = user_assistant_messages[-max_messages:]
+
+        # Serialize history for compression
+        history_text = "\n".join([f"{msg.get('role', 'user')}: {msg.get('content', '')}" for msg in to_compress])
+
+        prompt = (
+            f"The following is a list of older conversational history entries.\n"
+            f"Please compress and summarize this history into a single concise paragraph. "
+            f"Focus especially on any constraints, preferences, or technical details relevant to the subagent task.\n\n"
+            f"--- SUBAGENT TASK ---\n"
+            f"{task}\n\n"
+            f"--- OLD CONVERSATION HISTORY ---\n"
+            f"{history_text}"
+        )
+
+        compress_msgs = [
+            {"role": "system", "content": "You are a context compression assistant. Concisely summarize old message history relevant to the current task."},
+            {"role": "user", "content": prompt}
+        ]
+
+        try:
+            summary = await self.llm.chat_completion(compress_msgs, temperature=0.2)
+            summary_str = summary.strip()
+
+            summary_message = {
+                "role": "system",
+                "content": f"[SYSTEM: Compressed Summary of Old History: {summary_str}]"
+            }
+
+            return system_messages + [summary_message] + retained
+        except Exception as e:
+            logging.error(f"Failed to compress message history: {e}")
+            # Fallback: simple truncation
+            return system_messages + retained

--- a/tests/test_token_compression.py
+++ b/tests/test_token_compression.py
@@ -1,0 +1,130 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict, List, Any
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.token_compression import SubagentTokenCompressor
+from magda_agent.agents.sub_agent import SubAgent
+
+@pytest.fixture
+def mock_llm() -> MagicMock:
+    """
+    Creates and returns a mocked LLM client.
+    """
+    llm = MagicMock(spec=LLMClient)
+    llm.chat_completion = AsyncMock(return_value="Compressed summary content.")
+    return llm
+
+@pytest.mark.asyncio
+async def test_compress_context_short(mock_llm: MagicMock) -> None:
+    """
+    Tests that context is returned as-is when it does not exceed max_length.
+    """
+    compressor = SubagentTokenCompressor(llm=mock_llm)
+    context = "Small context."
+    task = "Simple task."
+
+    result = await compressor.compress_context(context, task, max_length=100)
+
+    expected = f"Parent Context:\n{context}\n\nAssigned Task:\n{task}"
+    assert result == expected
+    mock_llm.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compress_context_long(mock_llm: MagicMock) -> None:
+    """
+    Tests that context is compressed using LLM when it exceeds max_length.
+    """
+    compressor = SubagentTokenCompressor(llm=mock_llm)
+    context = "This is a very long context that will exceed fifty characters because it is extremely verbose."
+    task = "Extract key action points."
+
+    result = await compressor.compress_context(context, task, max_length=50)
+
+    assert result == "Compressed summary content."
+    mock_llm.chat_completion.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_compress_context_with_critical_constraints(mock_llm: MagicMock) -> None:
+    """
+    Tests that critical constraints containing keywords like MUST, NEVER are preserved or re-injected.
+    """
+    # Let's mock LLM returning a summary that omits the MUST constraint
+    mock_llm.chat_completion = AsyncMock(return_value="General summary of context.")
+    compressor = SubagentTokenCompressor(llm=mock_llm)
+    context = "Background details. The agent MUST NOT write to root. Secure files only."
+    task = "Process files."
+
+    result = await compressor.compress_context(context, task, max_length=20)
+
+    assert "MUST NOT write to root" in result
+    assert "General summary of context." in result
+
+@pytest.mark.asyncio
+async def test_compress_messages_short(mock_llm: MagicMock) -> None:
+    """
+    Tests that message list is returned unchanged if message count is within limit.
+    """
+    compressor = SubagentTokenCompressor(llm=mock_llm)
+    messages = [
+        {"role": "system", "content": "Sys prompt"},
+        {"role": "user", "content": "Hello"}
+    ]
+    task = "Answer user hello."
+
+    result = await compressor.compress_messages(messages, task, max_messages=5)
+
+    assert result == messages
+    mock_llm.chat_completion.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_compress_messages_long(mock_llm: MagicMock) -> None:
+    """
+    Tests that older messages are summarized and combined with the system prompt and recent messages.
+    """
+    mock_llm.chat_completion = AsyncMock(return_value="Summarized discussion on files.")
+    compressor = SubagentTokenCompressor(llm=mock_llm)
+    messages = [
+        {"role": "system", "content": "Sys prompt"},
+        {"role": "user", "content": "Msg 1"},
+        {"role": "assistant", "content": "Reply 1"},
+        {"role": "user", "content": "Msg 2"},
+        {"role": "assistant", "content": "Reply 2"},
+        {"role": "user", "content": "Msg 3"},
+        {"role": "assistant", "content": "Reply 3"}
+    ]
+    task = "Complete file processing."
+
+    # We set max_messages to 2, so older messages should be compressed.
+    result = await compressor.compress_messages(messages, task, max_messages=2)
+
+    # Check that system prompt is kept
+    assert result[0] == {"role": "system", "content": "Sys prompt"}
+
+    # Check that compressed history message is injected
+    assert result[1]["role"] == "system"
+    assert "Summarized discussion on files." in result[1]["content"]
+
+    # Check that the last 2 messages are retained
+    assert result[-2] == {"role": "user", "content": "Msg 3"}
+    assert result[-1] == {"role": "assistant", "content": "Reply 3"}
+
+@pytest.mark.asyncio
+async def test_subagent_execution_with_token_compression(mock_llm: MagicMock) -> None:
+    """
+    Tests SubAgent execution with token compression enabled.
+    """
+    # Setup LLM response for subagent task execution
+    mock_llm.chat_completion.side_effect = [
+        "Compressed parent context details.",  # first call: context compression
+        "Final task execution response."        # second call: execution response
+    ]
+
+    subagent = SubAgent(llm=mock_llm, use_enhanced_compression=True)
+
+    context = "A very long parent context that will be compressed because it exceeds the length of 2000 characters. " * 30
+    task = "Summarize the findings."
+
+    result = await subagent.execute(task, context)
+
+    assert result == "Final task execution response."
+    assert mock_llm.chat_completion.call_count == 2


### PR DESCRIPTION
We have successfully implemented the Claude Subagent Token Compression feature. SubagentTokenCompressor provides task-relevant text and conversation history compression for spawned subagents. If any critical constraints (e.g. sentences containing MUST, NEVER, REQUIRED, STRICT, LIMIT) are omitted from the compression, they are automatically parsed and appended back to ensure security and execution correctness. The compressor is integrated as the default context compressor within SubAgent, and a comprehensive test suite covering all logic has been added and verified to pass. Finally, the task list is replenished with 3 trend-aligned tasks.

---
*PR created automatically by Jules for task [5883578797453622422](https://jules.google.com/task/5883578797453622422) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LLM-based token compression to `SubAgent` context handling
> - Introduces [`SubagentTokenCompressor`](https://github.com/kazah4359-lgtm/Magda-agent/pull/511/files#diff-883dc87a19f5b17ad1676543d1690fb3aa5885978301f0161b0816181244c68d) which uses an LLM to summarize subagent context and message history when they exceed configurable length thresholds.
> - Adds a heuristic `_extract_critical_constraints` helper that identifies lines containing keywords like `must`, `never`, and `required`, re-injecting any missing constraints after LLM summarization.
> - Updates [`SubAgent.__init__`](https://github.com/kazah4359-lgtm/Magda-agent/pull/511/files#diff-df53a1af21c739156ec01ab3f9e6fe116e387a785159253beb8287a93261cd89) to accept `use_enhanced_compression` (default `True`), switching new instances from `SubagentContextCompressor` to `SubagentTokenCompressor` by default.
> - Adds async unit tests in [`tests/test_token_compression.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/511/files#diff-307514194230ae37da447ad0a8e7fdd969727361887dbf05213af29dc84a0f4a) covering short/long context, constraint preservation, message compression, and `SubAgent` execution flow.
> - Risk: the new default causes an extra LLM call per subagent execution when context exceeds the threshold, increasing latency and token cost.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85bf0ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->