### PR TITLE
feat: Implement Shannon entropy calculation for skill distributions in CanvasMetrics and replenish task pool

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8287,7 +8287,7 @@
     },
     {
       "id": "openclaw-rl-canvas-ui-metrics",
-      "status": "todo",
+      "status": "done",
       "area": "UI",
       "risk": "low",
       "title": "OpenClaw Canvas Visualization Metrics",
@@ -18463,6 +18463,59 @@
         "Sentiment decay calculation is applied to past sentiment scores over conversation turns.",
         "RL habit weights adjust dynamically to newer sentiment signals faster than old ones.",
         "Tests verify decay factor correctness over multi-turn simulation."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-session-v1-a1b2c3d4",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Session Management",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a session management layer that dynamically spins up isolated MCP sessions per user to maintain conversational security and prevent context leakage across concurrent user interactions.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_session_v1.py",
+        "tests/test_mcp_session_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP sessions are instantiated per user",
+        "Context is completely isolated between user sessions",
+        "Tests verify proper session separation"
+      ]
+    },
+    {
+      "id": "claude-task-progress-v1-b5c6d7e8",
+      "status": "todo",
+      "area": "planning",
+      "risk": "low",
+      "title": "Claude Code Task Progress Tracker",
+      "description": "Inspired by Claude Code/CLI trends (June 2026): Implement an in-memory/JSON progress tracker for hierarchical task delegation plans, offering percentage completion metrics and step dependency status queries.",
+      "allowed_paths": [
+        "magda_agent/planning/progress_tracker_v1.py",
+        "tests/test_progress_tracker_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tracks progress of plans containing dependent and parallel tasks",
+        "Calculates completion percentages dynamically",
+        "Tests verify progress computation correctness"
+      ]
+    },
+    {
+      "id": "openclaw-rl-cognitive-overload-v1-f9e8d7c6",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Cognitive Overload Mitigator",
+      "description": "Inspired by OpenClaw-RL trend: Implement a feedback mechanism that monitors RL-associated memory consumption and reduces prompt token overhead when the agent detects a negative reward trend or high action complexity.",
+      "allowed_paths": [
+        "magda_agent/learning/cognitive_overload_v1.py",
+        "tests/test_cognitive_overload_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Triggers prompt/context pruning when negative rewards signal high cognitive load",
+        "Tests mock RL trends and verify reduction in simulated prompt size"
       ]
     }
   ]

--- a/magda_agent/learning/canvas_metrics.py
+++ b/magda_agent/learning/canvas_metrics.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import Dict, List, Any, Optional
 from magda_agent.learning.openclaw_rl_metrics import OpenClawRLMetrics
 
@@ -120,6 +121,31 @@ class RLCanvasMetricsExporter:
 
         return formatted_stats
 
+    def get_skill_entropy(self) -> float:
+        """
+        Calculates the Shannon entropy of skill selections from recent rewards
+        to measure policy exploration or concentration.
+
+        Returns:
+            float: Shannon entropy in bits, or 0.0 if no skills are recorded.
+        """
+        rewards = self.metrics.recent_rewards
+        if not rewards:
+            return 0.0
+
+        counts: Dict[str, int] = {}
+        for entry in rewards:
+            skill = entry.get("skill_id", "unknown")
+            counts[skill] = counts.get(skill, 0) + 1
+
+        total = len(rewards)
+        entropy = 0.0
+        for count in counts.values():
+            p = count / total
+            entropy -= p * math.log2(p)
+
+        return entropy
+
     def export_canvas_payload(self) -> Dict[str, Any]:
         """
         Transforms and packages the metrics into a highly-structured payload
@@ -134,6 +160,7 @@ class RLCanvasMetricsExporter:
             moving_avg_5 = self.get_moving_average_reward(window_size=5)
             trend = self.detect_reward_trend()
             skill_stats = self.get_skill_activity_metrics()
+            entropy = self.get_skill_entropy()
 
             return {
                 "status": raw_data.get("status", "active"),
@@ -141,6 +168,7 @@ class RLCanvasMetricsExporter:
                 "global_average_q": raw_data.get("average_q", 0.0),
                 "moving_average_reward_5": moving_avg_5,
                 "trajectory_trend": trend,
+                "skill_distribution_entropy": entropy,
                 "skills_coverage": {
                     skill: {
                         "q_value": raw_val,

--- a/tests/test_canvas_metrics.py
+++ b/tests/test_canvas_metrics.py
@@ -1,4 +1,5 @@
 import pytest
+import math
 from magda_agent.learning.openclaw_rl_metrics import OpenClawRLMetrics
 from magda_agent.learning.canvas_metrics import RLCanvasMetricsExporter
 
@@ -11,11 +12,13 @@ def test_exporter_empty_metrics() -> None:
     assert exporter.get_moving_average_reward() == 0.0
     assert exporter.detect_reward_trend() == "insufficient_data"
     assert exporter.get_skill_activity_metrics() == {}
+    assert exporter.get_skill_entropy() == 0.0
 
     payload = exporter.export_canvas_payload()
     assert payload["status"] == "active"
     assert payload["total_rewards_received"] == 0
     assert payload["trajectory_trend"] == "insufficient_data"
+    assert payload["skill_distribution_entropy"] == 0.0
     assert payload["skills_coverage"] == {}
     assert payload["raw_rewards_trajectory"] == []
 
@@ -100,6 +103,26 @@ def test_exporter_skill_activity_metrics() -> None:
     assert stats["skill_alpha"] == {"count": 2, "average_reward": 1.5}
     assert stats["skill_beta"] == {"count": 1, "average_reward": 4.0}
 
+def test_exporter_skill_entropy() -> None:
+    """Test the computation of Shannon entropy of skill selections."""
+    metrics = OpenClawRLMetrics()
+    exporter = RLCanvasMetricsExporter(metrics)
+
+    # 1. Zero skills
+    assert exporter.get_skill_entropy() == 0.0
+
+    # 2. Single skill selected multiple times (perfect concentration, entropy 0)
+    metrics.add_reward("skill_alpha", 1.0)
+    metrics.add_reward("skill_alpha", 2.0)
+    assert exporter.get_skill_entropy() == 0.0
+
+    # 3. Two skills equally distributed (maximum uncertainty, entropy 1.0 bit)
+    metrics.add_reward("skill_beta", 3.0)
+    metrics.add_reward("skill_beta", 4.0)
+    # Counts: alpha=2, beta=2. Total=4. Probability alpha=0.5, beta=0.5.
+    # Entropy = -2 * (0.5 * math.log2(0.5)) = 1.0
+    assert math.isclose(exporter.get_skill_entropy(), 1.0)
+
 def test_exporter_canvas_payload_schema() -> None:
     """Test the structure and values of the complete Canvas payload."""
     metrics = OpenClawRLMetrics()
@@ -116,6 +139,7 @@ def test_exporter_canvas_payload_schema() -> None:
     assert payload["global_average_q"] == 1.5
     assert payload["moving_average_reward_5"] == 2.0
     assert payload["trajectory_trend"] == "insufficient_data"
+    assert payload["skill_distribution_entropy"] == 1.0
     assert "skill_a" in payload["skills_coverage"]
     assert "skill_b" in payload["skills_coverage"]
 


### PR DESCRIPTION
This PR implements Shannon entropy (get_skill_entropy) inside RLCanvasMetricsExporter for live visualization tracking of policy exploration/concentration, adds corresponding comprehensive unit tests, marks openclaw-rl-canvas-ui-metrics as done in agent_tasks.json, and replenishes the task manifest with 3 high-quality trend todo tasks.

---
*PR created automatically by Jules for task [10295632496113082272](https://jules.google.com/task/10295632496113082272) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Shannon entropy calculation for skill distributions to `RLCanvasMetricsExporter`
> - Adds `get_skill_entropy()` to [`RLCanvasMetricsExporter`](https://github.com/kazah4359-lgtm/Magda-agent/pull/513/files#diff-8889fce922d154a9f82d24482ec23be1914735ef9695f19094ab89758913297f), computing Shannon entropy (in bits) of skill selections from recent rewards; returns `0.0` for empty inputs.
> - Includes `skill_distribution_entropy` in the payload returned by `export_canvas_payload()`.
> - Adds test coverage in [`tests/test_canvas_metrics.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/513/files#diff-6a1ca46b941d457d75270c2a42c51de26f5966ba5a630d2e6092cd9e3863aca0) for empty, single-skill, and two-skill distributions, and extends the payload schema test to assert the new field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a9cf23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->