### PR TITLE
MCP Server Compatibility Layer Upgrades and Task Replenishment

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8321,7 +8321,7 @@
     },
     {
       "id": "mcp-server-compatibility",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "Add MCP Server Compatibility Layer",
@@ -18570,6 +18570,61 @@
         "Sandbox successfully limits CPU time and throws a TimeoutError on limit breach.",
         "Limits file descriptor counts or memory and isolates dynamic execution.",
         "Tests verify resource-bound enforcement under simulated overload."
+      ]
+    },
+    {
+      "id": "openai-agents-sdk-handover-routing-a2b3c4d5",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI Agents SDK Dynamic Handover and Routing Module",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a specialized handover router that allows subagents to yield control back to the parent coordinator or delegate to another specialized subagent dynamically via structured 'handover' tool execution.",
+      "allowed_paths": [
+        "magda_agent/skills/handover_router.py",
+        "tests/test_handover_router.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "HandoverRouter allows registering agents and defining handover tool signatures.",
+        "Dynamically routes control flow between agents upon handover execution.",
+        "Tests verify state preservation and successful routing across different handoffs.",
+        "No external APIs are called, everything is mock-tested."
+      ]
+    },
+    {
+      "id": "hermes-agent-portal-nous-compatible-a1b2c3d4",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Hermes Agent Nous Portal Compatibility Adapter",
+      "description": "Inspired by Nous Portal trends: Implement an interface adapter that enables Magda to connect directly to Nous Portal-compliant external orchestrators, formatting inputs/outputs according to Nous Portal specifications.",
+      "allowed_paths": [
+        "magda_agent/integration/nous_portal.py",
+        "tests/test_nous_portal.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "NousPortalAdapter translates Magda's internal message structure into Nous Portal JSON format.",
+        "Supports token-based streaming/chunking simulation and capability mapping.",
+        "Tests verify formatting correctness and request/response handshake using mocks."
+      ]
+    },
+    {
+      "id": "improvement-pineal-gland-timezone-config-e7c6b5a4",
+      "status": "todo",
+      "area": "rhythms",
+      "risk": "low",
+      "title": "Pineal Gland Timezone Configuration Improvement",
+      "description": "Improvement: Currently PinealGland defaults to local system timezone which can lead to timezone mismatches in cloud-deployed multi-user environments. Refactor PinealGland to support per-user timezone configuration fetched from the UserModel or fallback config.",
+      "allowed_paths": [
+        "magda_agent/rhythms/pineal_gland.py",
+        "tests/test_pineal_gland_timezone.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "PinealGland supports an optional timezone parameter in get_time_context().",
+        "Integrates with UserModel timezone property if available.",
+        "Tests verify that different timezones result in correct time contexts relative to UTC."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_server.py
+++ b/magda_agent/integration/mcp_server.py
@@ -6,6 +6,7 @@ class MCPServer:
     """
     MCP JSON-RPC protocol server interface.
     Handles raw JSON-RPC string payloads and returns JSON string responses.
+    Supports single requests, notifications, and batch requests.
     """
     def __init__(self, exporter: MCPExporter, server_id: str = "magda") -> None:
         """Initializes the MCPServer with an MCPExporter and a server_id."""
@@ -33,22 +34,75 @@ class MCPServer:
     async def handle_request(self, payload: str) -> str:
         """
         Process a JSON-RPC payload string.
+        Supports single requests, notifications, and batch requests.
         Strips the server_id prefix from the method name if present.
 
         Args:
-            payload: A JSON string representing the RPC request.
+            payload: A JSON string representing the RPC request(s).
 
         Returns:
-            A JSON string representing the RPC response.
+            A JSON string representing the RPC response(s), or empty string if no response.
         """
         try:
-            request = json.loads(payload)
+            request_data = json.loads(payload)
         except json.JSONDecodeError:
             return json.dumps({
                 "jsonrpc": "2.0",
                 "id": None,
                 "error": {"code": -32700, "message": "Parse error"}
             })
+
+        if isinstance(request_data, list):
+            if not request_data:
+                return json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32600, "message": "Invalid Request"}
+                })
+
+            # Process batch requests
+            responses = []
+            for req in request_data:
+                if not isinstance(req, dict):
+                    responses.append({
+                        "jsonrpc": "2.0",
+                        "id": None,
+                        "error": {"code": -32600, "message": "Invalid Request"}
+                    })
+                    continue
+
+                resp = await self._handle_single_request(req)
+                if resp is not None:
+                    responses.append(resp)
+
+            if not responses:
+                return ""
+            return json.dumps(responses)
+
+        elif isinstance(request_data, dict):
+            resp = await self._handle_single_request(request_data)
+            if resp is None:
+                return ""
+            return json.dumps(resp)
+
+        else:
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request"}
+            })
+
+    async def _handle_single_request(self, request: Dict[str, Any]) -> Any:
+        """
+        Helper to process a single JSON-RPC request or notification.
+
+        Args:
+            request: A dictionary representing a single JSON-RPC request.
+
+        Returns:
+            A dictionary representing the JSON-RPC response, or None if it is a notification.
+        """
+        is_notification = "id" not in request
 
         method = request.get("method", "")
         if method and isinstance(method, str) and self.server_id:
@@ -57,4 +111,7 @@ class MCPServer:
                 request["method"] = method[len(prefix):]
 
         response = await self.exporter.handle_rpc_request(request)
-        return json.dumps(response)
+
+        if is_notification:
+            return None
+        return response

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -60,3 +60,38 @@ async def test_handle_request_invalid_json(mock_exporter: MCPExporter) -> None:
     assert response["error"]["code"] == -32700
     assert response["error"]["message"] == "Parse error"
     mock_exporter.handle_rpc_request.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_handle_request_notification(mock_exporter: MCPExporter) -> None:
+    """Tests handling of JSON-RPC notification (no 'id' field)."""
+    server = MCPServer(mock_exporter)
+    payload = json.dumps({"jsonrpc": "2.0", "method": "mock_tool"})
+    response_str = await server.handle_request(payload)
+    # Notifications should result in no response content
+    assert response_str == ""
+    mock_exporter.handle_rpc_request.assert_called_once_with({"jsonrpc": "2.0", "method": "mock_tool"})
+
+@pytest.mark.asyncio
+async def test_handle_request_batch_requests(mock_exporter: MCPExporter) -> None:
+    """Tests handling a batch of multiple JSON-RPC requests."""
+    server = MCPServer(mock_exporter)
+    payload = json.dumps([
+        {"jsonrpc": "2.0", "method": "mock_tool", "id": 1},
+        {"jsonrpc": "2.0", "method": "mock_tool", "id": 2}
+    ])
+    response_str = await server.handle_request(payload)
+    responses = json.loads(response_str)
+    assert isinstance(responses, list)
+    assert len(responses) == 2
+    assert responses[0]["result"] == "mock_result"
+    assert responses[1]["result"] == "mock_result"
+
+@pytest.mark.asyncio
+async def test_handle_request_empty_batch(mock_exporter: MCPExporter) -> None:
+    """Tests handling an empty batch list."""
+    server = MCPServer(mock_exporter)
+    payload = "[]"
+    response_str = await server.handle_request(payload)
+    response = json.loads(response_str)
+    assert response["error"]["code"] == -32600
+    assert "Invalid Request" in response["error"]["message"]


### PR DESCRIPTION
Upgrades the MCPServer compatibility layer to robustly handle JSON-RPC 2.0 batch requests and notifications in full compliance with the specification. Updates the mcp-server-compatibility task to done in agent_tasks.json, and appends three new AI agent trend-inspired tasks (OpenAI Agents SDK dynamic handover, Hermes Nous Portal adapter, Pineal Gland timezone config) to the task list. All unit tests collect and pass successfully.

---
*PR created automatically by Jules for task [18326584105181188154](https://jules.google.com/task/18326584105181188154) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add JSON-RPC batch request and notification support to `MCPServer`
> - Extends [`MCPServer.handle_request`](https://github.com/kazah4359-lgtm/Magda-agent/pull/515/files#diff-d8bbff3549c271dc4a43334c75b2f77fb5e6774432a2fde4b7c21a990c910b01) to handle three input shapes: batch arrays (returns a JSON array of responses, excluding notifications), single dict requests, and invalid top-level types (returns an Invalid Request error).
> - Introduces [`MCPServer._handle_single_request`](https://github.com/kazah4359-lgtm/Magda-agent/pull/515/files#diff-d8bbff3549c271dc4a43334c75b2f77fb5e6774432a2fde4b7c21a990c910b01) helper that detects notifications (no `id` field), strips the server ID prefix from `method`, delegates to the exporter, and returns `None` for notifications.
> - Adds three async tests in [`tests/test_mcp_server.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/515/files#diff-17c8e7f22653bec6c1a174647a95472a9689a7569031e4f9d5c92e32366438f6) covering notification handling, batch responses, and empty batch errors.
> - Behavioral Change: Notifications now return an empty string instead of a response object; empty batches and non-dict batch items return a structured Invalid Request error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9197dd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->