### PR TITLE
Implement OpenClaw-RL Online Learner Task and Backlog Replenishment

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8357,7 +8357,7 @@
     },
     {
       "id": "openclaw-rl-online-learner",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "Implement OpenClaw-RL Online Learner",
@@ -18678,6 +18678,60 @@
       "acceptance": [
         "A stop reflex command can interrupt and cancel ongoing skill executions in Consciousness.",
         "Tests verify cancellation of simulated long-running skill tasks upon receiving the stop command."
+      ]
+    },
+    {
+      "id": "openclaw-rl-online-reward-decay-v12",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw Online RL Sentiment Decay Heuristic v12",
+      "description": "Implement a temporal sentiment decay heuristic in the reinforcement learning loop to prevent historical user sentiment from causing excessive rigidity in tone adjustments during multi-turn interactions.",
+      "allowed_paths": [
+        "magda_agent/learning/sentiment_decay_v12.py",
+        "tests/test_sentiment_decay_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sentiment decay calculation is applied to past sentiment scores over conversation turns.",
+        "RL habit weights adjust dynamically to newer sentiment signals faster than old ones.",
+        "Tests verify decay factor correctness over multi-turn simulation."
+      ]
+    },
+    {
+      "id": "claude-code-git-conflict-resolver-v12",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Code Git Conflict Auto-Resolver V12",
+      "description": "Inspired by Claude Code CLI trends (June 2026): Implement an automated Git conflict resolver capability for subagents working on parallel branches, allowing them to parse conflict markers and propose clean resolutions.",
+      "allowed_paths": [
+        "magda_agent/isolation/git_conflict_resolver_v12.py",
+        "tests/test_git_conflict_resolver_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The resolver parses and extracts Git conflict blocks from workspace files.",
+        "Proposes or applies resolution strategies cleanly based on simple rules.",
+        "Tests verify correct conflict block extraction and resolution."
+      ]
+    },
+    {
+      "id": "openai-agents-loop-recovery-v12",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI Agents SDK Tool Loop Recovery v12",
+      "description": "Inspired by OpenAI Agents SDK tool execution trends (June 2026): Implement an automatic execution loop recovery mechanism that can detect tool-routing infinite loops (such as calling the same tool with identical parameters repetitively) and fallback to graceful recovery.",
+      "allowed_paths": [
+        "magda_agent/skills/loop_recovery_v12.py",
+        "tests/test_loop_recovery_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The loop recovery module correctly detects repetitive tool call loops.",
+        "System falls back to a graceful error or user query upon loop detection.",
+        "Tests verify loop detection and recovery flow."
       ]
     }
   ]

--- a/magda_agent/learning/openclaw_rl.py
+++ b/magda_agent/learning/openclaw_rl.py
@@ -137,3 +137,37 @@ class OpenClawInteractiveLearner:
         # Save the updated user model back to disk
         self.user_model.save_model(user_id, model_data)
         logging.info(f"OpenClaw-RL: Updated user model for user {user_id}")
+
+    def get_behavior_weights_summary(self, user_id: Optional[str]) -> str:
+        """
+        Retrieves a natural language summary of the current behavior weights for a user.
+
+        Args:
+            user_id (Optional[str]): The user's ID.
+
+        Returns:
+            str: A formatted string summarizing exploration, verbosity, and directness weights.
+        """
+        model_data = self.user_model.get_model(user_id)
+        weights = model_data.get("behavior_weights", {
+            "exploration": 1.0,
+            "verbosity": 1.0,
+            "directness": 1.0
+        })
+        return f"Exploration: {weights.get('exploration', 1.0):.2f}, Verbosity: {weights.get('verbosity', 1.0):.2f}, Directness: {weights.get('directness', 1.0):.2f}"
+
+    def reset_behavior_weights(self, user_id: Optional[str]) -> None:
+        """
+        Resets the behavior weights to their default baseline values for a user.
+
+        Args:
+            user_id (Optional[str]): The user's ID.
+        """
+        model_data = self.user_model.get_model(user_id)
+        model_data["behavior_weights"] = {
+            "exploration": 1.0,
+            "verbosity": 1.0,
+            "directness": 1.0
+        }
+        self.user_model.save_model(user_id, model_data)
+        logging.info(f"OpenClaw-RL: Reset behavior weights for user {user_id}")

--- a/tests/test_openclaw_rl.py
+++ b/tests/test_openclaw_rl.py
@@ -208,3 +208,21 @@ async def test_openclaw_rl_integration_weights_to_planner(mock_habit_tracker: Ma
     system_msg = plan_call[0][0][0]["content"]
     assert "High exploration mode" in system_msg
     assert "Behavioral Parameters:" in system_msg
+
+@pytest.mark.asyncio
+async def test_openclaw_rl_behavior_helpers(mock_habit_tracker: MagicMock, mock_mirror_neurons: MagicMock, user_model: UserModel) -> None:
+    """Tests the get_behavior_weights_summary and reset_behavior_weights methods of OpenClawInteractiveLearner."""
+    learner = OpenClawInteractiveLearner(mock_habit_tracker, mock_mirror_neurons, user_model)
+
+    user_model.save_model("helper_user", {"behavior_weights": {"exploration": 1.5, "verbosity": 1.2, "directness": 0.8}})
+
+    summary = learner.get_behavior_weights_summary("helper_user")
+    assert "Exploration: 1.50" in summary
+    assert "Verbosity: 1.20" in summary
+    assert "Directness: 0.80" in summary
+
+    learner.reset_behavior_weights("helper_user")
+    summary_reset = learner.get_behavior_weights_summary("helper_user")
+    assert "Exploration: 1.00" in summary_reset
+    assert "Verbosity: 1.00" in summary_reset
+    assert "Directness: 1.00" in summary_reset


### PR DESCRIPTION
Implements the helper methods for behavior weight summary retrieval and resetting in `OpenClawInteractiveLearner` under `magda_agent/learning/openclaw_rl.py`, adds corresponding async tests to `tests/test_openclaw_rl.py`, updates task status to 'done', and replenishes the task queue in `agent_tasks.json` with three new todo tasks.

---
*PR created automatically by Jules for task [13349424695273503793](https://jules.google.com/task/13349424695273503793) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `get_behavior_weights_summary` and `reset_behavior_weights` methods to `OpenClawInteractiveLearner`
> - Adds `get_behavior_weights_summary` to [openclaw_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/517/files#diff-97cf6ce0be050f90c1268294aaba45efca5e6d006d2802e9455ecce9876f92e0), which fetches a user's model and returns a formatted string of exploration, verbosity, and directness weights (2 decimal places).
> - Adds `reset_behavior_weights` to overwrite a user's behavior weights to baseline defaults (1.0 for all three dimensions) and persist the change via `user_model.save_model`.
> - Adds an async test in [test_openclaw_rl.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/517/files#diff-60ecd10f73cb3d406902c93c229c0e66d5e2e15377ec865e376abc2aa004d2f1) covering both methods with mocked dependencies.
> - Appends three new task entries to [agent_tasks.json](https://github.com/kazah4359-lgtm/Magda-agent/pull/517/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cecb944.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->