### PR TITLE
Implement OpenAI Agents SDK Concurrency Router V5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -55,7 +55,7 @@
       ],
       "risk": "medium",
       "area": "skills",
-      "status": "todo"
+      "status": "done"
     },
     {
       "id": "claude-agent-teams-git-worktree-v13",
@@ -18784,6 +18784,41 @@
         "The loop recovery module correctly detects repetitive tool call loops.",
         "System falls back to a graceful error or user query upon loop detection.",
         "Tests verify loop detection and recovery flow."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v5",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V5",
+      "description": "Inspired by A2A standard and MCP trends: Implement a multi-turn capability negotiation protocol for MCP tools to handle complex and dynamic resource requirements during parallel task execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v5.py",
+        "tests/test_mcp_negotiation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Negotiation protocol handles multi-turn refinement of resource requirements.",
+        "Tests verify successful negotiation between mock client and server."
+      ]
+    },
+    {
+      "id": "openclaw-rl-interaction-loop-entropy-v4",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Interaction Loop Entropy Tracking V4",
+      "description": "Inspired by OpenClaw-RL trends: Track the entropy of agent behavior over multiple turns to detect repetitive loops, automatically adjusting habit weights to avoid conversational stalling.",
+      "allowed_paths": [
+        "magda_agent/learning/entropy_tracker_v4.py",
+        "tests/test_entropy_tracker_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Entropy tracker identifies repetitive behavior patterns.",
+        "High entropy score triggers a behavior adjustment or curiosity shift.",
+        "Tests verify tracking and adaptation using mocks."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -202,7 +202,7 @@
 * [ ] SKILL: **Crypto Prices (Курсы криптовалют)** — модуль `magda_agent/skills/crypto.py`. Получение актуальных курсов криптовалют с бирж (Binance, CoinMarketCap).
 * [ ] MODULE: **Agent Skills Self-Documentation** — `magda_agent/skills/documentation.py`. Generates natural language documentation for all registered skills.
 * [ ] MODULE: **A2A Delegation Cost Estimation** — `magda_agent/integration/a2a_cost_estimator.py`. Predicts token usage and latency for P2P delegation.
-* [ ] MODULE: **RL Interaction Loop Entropy Tracking** — `magda_agent/learning/entropy_tracker.py`. Tracks behavior entropy to detect loops.
+* [ ] MODULE: **RL Interaction Loop Entropy Tracking V4** — `magda_agent/learning/entropy_tracker_v4.py`. Tracks behavior entropy to detect loops.
 * [ ] MODULE: **Hermes Online Skill Pruning** — `magda_agent/skills/pruning_v1.py`. Automatically prunes under-used skills from the registry.
 * [ ] MODULE: **OpenClaw WebSockets Session Heartbeat** — `magda_agent/visualization/canvas_heartbeat_v1.py`. Keeps WebSocket connections active.
 * [ ] MODULE: **ACS Policy Performance Logger** — `magda_agent/safety/acs_perf_logger_v1.py`. Tracks overhead of ACS Checkpoints.
@@ -261,6 +261,7 @@
 
 
 ## 📡 A2A mDNS & Self-Improvement Loops (June 2026 Trends)
+* [ ] FEATURE: MCP Dynamic Capability Negotiation V5 (mcp-dynamic-capability-negotiation-v5) — multi-turn capability negotiation for MCP tools.
 * [x] FEATURE: A2A local network mDNS discovery (a2a-mdns-discovery)
 * [ ] FEATURE: A2A mDNS Discovery Secure Token Authentication (a2a-mdns-security-token-v1)
 * [ ] FEATURE: OpenClaw RL Trajectory Quality Evaluation (openclaw-rl-trajectory-evaluation-v2)

--- a/magda_agent/skills/concurrency_v5.py
+++ b/magda_agent/skills/concurrency_v5.py
@@ -1,0 +1,210 @@
+import asyncio
+import inspect
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class ConcurrentToolRouterV5:
+    """
+    Handles routing and concurrent execution of server-prefixed tool calls,
+    optimizing performance via asyncio.gather and ensuring safety and error isolation.
+    """
+
+    def __init__(
+        self,
+        registry: Any,
+        servers: Optional[Dict[str, Any]] = None,
+        max_concurrency_per_server: int = 5,
+        separators: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Initializes the ConcurrentToolRouterV5.
+
+        Args:
+            registry (Any): The default local skill registry.
+            servers (Optional[Dict[str, Any]]): Dict mapping server prefixes to their respective MCPServer/Registry instances.
+            max_concurrency_per_server (int): Max parallel tasks allowed per individual server prefix.
+            separators (Optional[List[str]]): List of separators to check when routing prefix-prefixed methods.
+        """
+        self.registry = registry
+        self.servers = servers or {}
+        self.separators = separators or ["__", "-", "_"]
+
+        # Concurrency Isolation: individual semaphores per prefix to prevent any single server prefix
+        # from starving others or overwhelming system resources.
+        self.semaphores: Dict[str, asyncio.Semaphore] = {
+            prefix: asyncio.Semaphore(max_concurrency_per_server)
+            for prefix in self.servers
+        }
+        self.default_semaphore = asyncio.Semaphore(max_concurrency_per_server)
+
+    def _resolve_tool(self, name: str) -> Tuple[Optional[str], Optional[Any], str]:
+        """
+        Resolves a tool name to its respective server prefix, mapped server instance,
+        and its stripped, unprefixed name.
+
+        Args:
+            name (str): The full tool/skill name.
+
+        Returns:
+            Tuple[Optional[str], Optional[Any], str]: (prefix, target_server, unprefixed_name)
+        """
+        if not name:
+            return None, None, ""
+
+        # Sort prefixes by length descending to match longest prefixes first
+        sorted_prefixes = sorted(self.servers.keys(), key=len, reverse=True)
+        for prefix in sorted_prefixes:
+            if not prefix:
+                continue
+            for sep in self.separators:
+                full_prefix = f"{prefix}{sep}"
+                if name.startswith(full_prefix):
+                    unprefixed = name[len(full_prefix):]
+                    return prefix, self.servers[prefix], unprefixed
+
+        return None, None, name
+
+    def _unwrap_result(self, result: Any) -> Any:
+        """
+        Unwraps and formats standard JSON-RPC or MCP response formats into clean outputs.
+
+        Args:
+            result (Any): The raw execution result object.
+
+        Returns:
+            Any: Cleaned unwrapped result text/data.
+        """
+        if isinstance(result, dict):
+            # Case 1: Full JSON-RPC response format
+            if "result" in result:
+                inner = result["result"]
+                if isinstance(inner, dict) and "content" in inner:
+                    content = inner["content"]
+                    if isinstance(content, list) and len(content) > 0:
+                        return content[0].get("text", result)
+                return inner
+            # Case 2: Direct MCP tool response format
+            if "content" in result:
+                content = result["content"]
+                if isinstance(content, list) and len(content) > 0:
+                    return content[0].get("text", result)
+        return result
+
+    async def _execute_single_call(self, name: Optional[str], kwargs: Dict[str, Any]) -> Any:
+        """
+        Executes a single tool call with safety and exception isolation.
+
+        Args:
+            name (Optional[str]): The tool/skill name.
+            kwargs (Dict[str, Any]): The arguments dictionary.
+
+        Returns:
+            Any: The execution result or an isolated error string.
+        """
+        if not name:
+            return "Error: Empty tool name provided."
+
+        prefix, server, unprefixed_name = self._resolve_tool(name)
+        sem = self.semaphores.get(prefix, self.default_semaphore) if prefix else self.default_semaphore
+
+        async with sem:
+            try:
+                if server is not None:
+                    # Case A: Execute on mapped server instance
+                    if hasattr(server, "exporter") and hasattr(server.exporter, "handle_rpc_request"):
+                        rpc_req = {
+                            "jsonrpc": "2.0",
+                            "id": "router-req",
+                            "method": unprefixed_name,
+                            "params": kwargs
+                        }
+                        res = await server.exporter.handle_rpc_request(rpc_req)
+                        if isinstance(res, dict) and "error" in res:
+                            err_msg = res["error"].get("message", "Unknown RPC error")
+                            return f"Error: {err_msg}"
+                        return self._unwrap_result(res)
+
+                    elif hasattr(server, "execute_skill") and hasattr(server, "skills"):
+                        if unprefixed_name not in server.skills:
+                            return f"Error: Skill '{unprefixed_name}' not found on server '{prefix}'."
+
+                        # Check if execute_skill itself is a coroutine function
+                        if inspect.iscoroutinefunction(server.execute_skill):
+                            res = await server.execute_skill(unprefixed_name, **kwargs)
+                        else:
+                            skill_func = server.skills[unprefixed_name]
+                            if inspect.iscoroutinefunction(skill_func):
+                                res = server.execute_skill(unprefixed_name, **kwargs)
+                            else:
+                                res = await asyncio.to_thread(server.execute_skill, unprefixed_name, **kwargs)
+
+                        if inspect.isawaitable(res):
+                            res = await res
+                        return self._unwrap_result(res)
+
+                    elif hasattr(server, "handle_request"):
+                        rpc_req = {
+                            "jsonrpc": "2.0",
+                            "id": "router-req",
+                            "method": name,
+                            "params": kwargs
+                        }
+                        res_str = await server.handle_request(json.dumps(rpc_req))
+                        res = json.loads(res_str)
+                        if isinstance(res, dict) and "error" in res:
+                            err_msg = res["error"].get("message", "Unknown RPC error")
+                            return f"Error: {err_msg}"
+                        return self._unwrap_result(res)
+
+                    elif callable(server):
+                        if inspect.iscoroutinefunction(server):
+                            res = await server(unprefixed_name, **kwargs)
+                        else:
+                            res = await asyncio.to_thread(server, unprefixed_name, **kwargs)
+                        return self._unwrap_result(res)
+
+                    else:
+                        return f"Error: Server '{prefix}' interface not supported."
+
+                else:
+                    # Case B: Execute locally against main default registry
+                    if not self.registry or not hasattr(self.registry, "skills") or name not in self.registry.skills:
+                        return f"Error: Skill '{name}' not found."
+
+                    skill_func = self.registry.skills[name]
+                    is_async = inspect.iscoroutinefunction(skill_func)
+
+                    if is_async:
+                        res = self.registry.execute_skill(name, **kwargs)
+                        if inspect.isawaitable(res):
+                            res = await res
+                    else:
+                        res = await asyncio.to_thread(self.registry.execute_skill, name, **kwargs)
+                        if inspect.isawaitable(res):
+                            res = await res
+
+                    return self._unwrap_result(res)
+
+            except Exception as e:
+                # Safety/Exception Isolation: Wrap and isolate error without breaking other tasks in the gather
+                return f"Error: Tool execution failed: {str(e)}"
+
+    async def execute_concurrently(self, tool_calls: List[Dict[str, Any]]) -> List[Any]:
+        """
+        Executes multiple tool calls concurrently using asyncio.gather.
+
+        Args:
+            tool_calls (List[Dict[str, Any]]): A list of dictionaries representing tool calls,
+                                              where each dict contains 'name' and optionally 'kwargs'.
+
+        Returns:
+            List[Any]: A list of results corresponding to the completed tasks.
+        """
+        tasks = []
+        for call in tool_calls:
+            name = call.get("name")
+            kwargs = call.get("kwargs", {})
+            tasks.append(self._execute_single_call(name, kwargs))
+
+        return await asyncio.gather(*tasks)

--- a/tests/test_concurrency_v5.py
+++ b/tests/test_concurrency_v5.py
@@ -1,0 +1,166 @@
+import asyncio
+import time
+import inspect
+import pytest
+from typing import Any, Dict, List
+from magda_agent.skills.concurrency_v5 import ConcurrentToolRouterV5
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.integration.mcp_exporter import MCPExporter
+
+
+class MockServerRegistry:
+    """Mock registry class resembling standard SkillRegistry."""
+
+    def __init__(self) -> None:
+        self.skills = {
+            "test_skill": self.test_skill,
+            "async_test_skill": self.async_test_skill,
+        }
+
+    def test_skill(self, val: str) -> str:
+        return f"result_sync_{val}"
+
+    async def async_test_skill(self, val: str) -> str:
+        await asyncio.sleep(0.05)
+        return f"result_async_{val}"
+
+    async def execute_skill(self, name: str, **kwargs: Any) -> Any:
+        res = self.skills[name](**kwargs)
+        if inspect.isawaitable(res):
+            return await res
+        return res
+
+
+@pytest.fixture
+def local_registry() -> SkillRegistry:
+    """Provides a local SkillRegistry with dummy tools."""
+    reg = SkillRegistry()
+
+    def local_sync(val: str) -> str:
+        time.sleep(0.05)
+        return f"local_sync_{val}"
+
+    async def local_async(val: str) -> str:
+        await asyncio.sleep(0.05)
+        return f"local_async_{val}"
+
+    reg.register_skill("local_sync", local_sync, "A local sync skill")
+    reg.register_skill("local_async", local_async, "A local async skill")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_router_local_only(local_registry: SkillRegistry) -> None:
+    """Tests executing local tools only (no prefixes)."""
+    router = ConcurrentToolRouterV5(local_registry)
+
+    tool_calls = [
+        {"name": "local_sync", "kwargs": {"val": "1"}},
+        {"name": "local_async", "kwargs": {"val": "2"}},
+    ]
+
+    start = time.time()
+    results = await router.execute_concurrently(tool_calls)
+    end = time.time()
+
+    assert results == ["local_sync_1", "local_async_2"]
+    # Should run in parallel taking ~0.05s
+    assert end - start < 0.08
+
+
+@pytest.mark.asyncio
+async def test_router_prefixed_routing(local_registry: SkillRegistry) -> None:
+    """Tests routing tools to prefix-matched servers with multiple separators."""
+    server1 = MockServerRegistry()
+    server2 = MockServerRegistry()
+
+    servers = {
+        "srv1": server1,
+        "srv2": server2,
+    }
+
+    router = ConcurrentToolRouterV5(
+        registry=local_registry,
+        servers=servers,
+        separators=["__", "-", "_"]
+    )
+
+    tool_calls = [
+        {"name": "srv1__test_skill", "kwargs": {"val": "a"}},
+        {"name": "srv2-async_test_skill", "kwargs": {"val": "b"}},
+        {"name": "srv1_test_skill", "kwargs": {"val": "c"}},
+        {"name": "local_async", "kwargs": {"val": "local"}},
+    ]
+
+    results = await router.execute_concurrently(tool_calls)
+    assert results == [
+        "result_sync_a",
+        "result_async_b",
+        "result_sync_c",
+        "local_async_local",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_exception_safety_isolation(local_registry: SkillRegistry) -> None:
+    """Tests safety/exception isolation. Failing tools shouldn't crash the entire list."""
+    router = ConcurrentToolRouterV5(local_registry)
+
+    def crashing_tool() -> str:
+        raise ValueError("Simulated crash")
+
+    local_registry.register_skill("crashing_tool", crashing_tool, "Fails always")
+
+    tool_calls = [
+        {"name": "local_async", "kwargs": {"val": "ok1"}},
+        {"name": "crashing_tool", "kwargs": {}},
+        {"name": "local_async", "kwargs": {"val": "ok2"}},
+    ]
+
+    results = await router.execute_concurrently(tool_calls)
+    assert len(results) == 3
+    assert results[0] == "local_async_ok1"
+    assert "Simulated crash" in results[1] or "Tool execution failed" in results[1]
+    assert results[2] == "local_async_ok2"
+
+
+@pytest.mark.asyncio
+async def test_router_missing_or_empty_tools(local_registry: SkillRegistry) -> None:
+    """Tests non-existent or empty tool name edge cases."""
+    router = ConcurrentToolRouterV5(local_registry)
+
+    tool_calls = [
+        {"name": "", "kwargs": {}},
+        {"name": "missing_tool", "kwargs": {}},
+    ]
+
+    results = await router.execute_concurrently(tool_calls)
+    assert len(results) == 2
+    assert "Empty tool name" in results[0]
+    assert "Skill 'missing_tool' not found" in results[1]
+
+
+@pytest.mark.asyncio
+async def test_router_with_mcp_server(local_registry: SkillRegistry) -> None:
+    """Tests routing to a registered MCPServer."""
+    mcp_registry = SkillRegistry()
+
+    async def mcp_async(val: str) -> str:
+        return f"mcp_ok_{val}"
+
+    mcp_registry.register_skill("mcp_async", mcp_async, "MCP dynamic tool")
+
+    mcp_server = MCPServer(MCPExporter(mcp_registry), server_id="")
+    servers = {
+        "mcp_srv": mcp_server,
+    }
+
+    router = ConcurrentToolRouterV5(registry=local_registry, servers=servers)
+
+    tool_calls = [
+        {"name": "mcp_srv__mcp_async", "kwargs": {"val": "hello"}},
+    ]
+
+    results = await router.execute_concurrently(tool_calls)
+    assert results == ["mcp_ok_hello"]


### PR DESCRIPTION
Implement `ConcurrentToolRouterV5` to optimize parallel execution of server-prefixed tool calls using `asyncio.gather`. Implements robust exception and safety isolation with per-server/prefix asyncio semaphores. Includes comprehensive unit tests, marks task as done, and replenishes task list with 2 new todo tasks from June 2026 AI Agent trends.

---
*PR created automatically by Jules for task [11916803396881868838](https://jules.google.com/task/11916803396881868838) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ConcurrentToolRouterV5` with prefix-based routing and per-server semaphores
> - Adds [`concurrency_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/519/files#diff-60501a40d6f968dd13d8988fd8230347e02a39d222066a323b1f6a558ebafb3f) implementing `ConcurrentToolRouterV5`, which routes tool calls to servers by longest-matching prefix using configurable separators (`__`, `-`, `_`).
> - Executes multiple tool calls concurrently via `asyncio.gather`, with per-prefix semaphores to limit concurrency per server and a default semaphore for local calls.
> - Supports four server interface styles: `exporter.handle_rpc_request` (MCP), `execute_skill`/`skills` (async/sync), `handle_request` (JSON-RPC string), and generic callables; falls back to a local `SkillRegistry` when no prefix matches.
> - Normalizes responses by unwrapping common JSON-RPC/MCP shapes (`result`, `content[0].text`) and isolates per-call exceptions as error strings so one failure does not cancel the batch.
> - Adds [`tests/test_concurrency_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/519/files#diff-c301c73e2bda672e9b7ced99343f71bb7a0708c72d4adce41f189d386285722a) covering local parallelism, prefix routing, exception isolation, missing tool validation, and MCP server integration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 024ed3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->