### PR TITLE
Implement Cross-Platform Unified Notification Broadcast Skill

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8478,7 +8478,7 @@
     },
     {
       "id": "unified-notification-broadcast",
-      "status": "todo",
+      "status": "done",
       "area": "channels",
       "risk": "low",
       "title": "Cross-Platform Unified Notification Broadcast",
@@ -19026,6 +19026,59 @@
       "acceptance": [
         "Unregistering an adapter cleanly releases reference.",
         "Tests verify adapter cleanup."
+      ]
+    },
+    {
+      "id": "openclaw-rl-interactive-rating-9e2a4b8f",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Interactive Conversation Rating Command",
+      "description": "Inspired by OpenClaw-RL trend: Implement an interactive reward parser that detects explicit user rating commands (e.g., /rate 5, /rate 1) in the user message, translating them into normalized reinforcement learning reward signals to update procedural skill selection weights.",
+      "allowed_paths": [
+        "magda_agent/learning/reward_rating_parser_9e2a4b8f.py",
+        "tests/test_reward_rating_parser_9e2a4b8f.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A parser correctly extracts rating commands from message strings.",
+        "Ratings are mapped thread-safely to update skill habit weights.",
+        "Tests verify weight adjustments based on user rating inputs."
+      ]
+    },
+    {
+      "id": "claude-code-git-conflict-resolver-v15-f8a7e3d2",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Code Git Conflict Auto-Resolver V15",
+      "description": "Inspired by Claude Code/CLI trends: Implement an automated Git conflict auto-resolver capability for subagents working on parallel branches, allowing them to parse conflict markers and propose/apply clean resolutions.",
+      "allowed_paths": [
+        "magda_agent/isolation/git_conflict_resolver_v15.py",
+        "tests/test_git_conflict_resolver_v15.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The resolver parses and extracts Git conflict blocks from workspace files.",
+        "Proposes or applies resolution strategies cleanly based on simple rules.",
+        "Tests verify correct conflict block extraction and resolution."
+      ]
+    },
+    {
+      "id": "bug-channelhub-unregistration-leak-7c6d8e5f",
+      "status": "todo",
+      "area": "stabilization",
+      "risk": "low",
+      "title": "Bug: ChannelHub Adapter Unregistration Circular Reference Leak",
+      "description": "Bug: Fix a potential memory leak in ChannelHub by ensuring adapters are cleanly cleared and circular references are resolved upon unregistration.",
+      "allowed_paths": [
+        "magda_agent/channels/hub_cleanup_7c6d8e5f.py",
+        "tests/test_hub_cleanup_7c6d8e5f.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Unregistering an adapter cleanly releases references.",
+        "Tests verify adapter cleanup and absence of circular reference leaks."
       ]
     }
   ]

--- a/magda_agent/skills/notification_broadcast.py
+++ b/magda_agent/skills/notification_broadcast.py
@@ -1,0 +1,141 @@
+"""
+Cross-Platform Unified Notification Broadcast Skill.
+Allows broadcasting critical notifications to a user across all their registered platforms via the ChannelHub.
+"""
+
+import asyncio
+import logging
+import threading
+from typing import Any, Dict, Optional, List
+from magda_agent.channels.hub import ChannelHub
+
+
+_BACKGROUND_LOOP: Optional[asyncio.AbstractEventLoop] = None
+_BACKGROUND_THREAD: Optional[threading.Thread] = None
+_BACKGROUND_LOCK = threading.Lock()
+
+
+def _get_background_loop() -> asyncio.AbstractEventLoop:
+    """
+    Retrieve or start a background asyncio event loop for running sync wrappers.
+
+    Returns:
+        asyncio.AbstractEventLoop: The background event loop instance.
+    """
+    global _BACKGROUND_LOOP, _BACKGROUND_THREAD
+    with _BACKGROUND_LOCK:
+        if _BACKGROUND_LOOP and _BACKGROUND_LOOP.is_running():
+            return _BACKGROUND_LOOP
+
+        loop = asyncio.new_event_loop()
+
+        def run_loop() -> None:
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        thread = threading.Thread(target=run_loop, name="magda-broadcast-loop", daemon=True)
+        thread.start()
+        _BACKGROUND_LOOP = loop
+        _BACKGROUND_THREAD = thread
+        return loop
+
+
+async def broadcast_notification_async(
+    message: str,
+    recipient_id: str,
+    hub: Optional[ChannelHub] = None,
+    recipients: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """
+    Asynchronously broadcasts a notification message to a user across all registered platforms in ChannelHub.
+
+    Args:
+        message (str): The critical notification message text.
+        recipient_id (str): The default recipient ID.
+        hub (Optional[ChannelHub]): The ChannelHub instance managing registered channel adapters.
+        recipients (Optional[Dict[str, str]]): Specific overrides for recipient IDs per channel (e.g. {"telegram": "uid1"}).
+        metadata (Optional[Dict[str, Any]]): Additional metadata to attach to the broadcast.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing overall status and detailed results per channel.
+    """
+    if not message:
+        return {"status": "error", "message": "Notification message cannot be empty."}
+
+    if not hub:
+        logging.warning("No ChannelHub provided to broadcast_notification_async.")
+        return {"status": "error", "message": "ChannelHub is required for broadcasting."}
+
+    channel_ids: List[str] = list(hub._adapters.keys())
+    if not channel_ids:
+        logging.warning("ChannelHub has no registered adapters.")
+        return {"status": "error", "message": "No registered channels available in the ChannelHub."}
+
+    results: Dict[str, Any] = {}
+    tasks = []
+
+    async def _send_to_single_channel(channel_id: str, target_rec_id: str) -> None:
+        try:
+            # We route the message via the hub's send_to_channel method
+            res = await hub.send_to_channel(channel_id, target_rec_id, message, metadata)
+            results[channel_id] = {"status": "success", "result": res}
+        except Exception as e:
+            logging.error(f"Error broadcasting to channel {channel_id}: {e}")
+            results[channel_id] = {"status": "error", "message": str(e)}
+
+    for cid in channel_ids:
+        target_recipient = recipient_id
+        if recipients and cid in recipients:
+            target_recipient = recipients[cid]
+
+        tasks.append(_send_to_single_channel(cid, target_recipient))
+
+    if tasks:
+        await asyncio.gather(*tasks)
+
+    # Determine overall status
+    any_success = any(res["status"] == "success" for res in results.values())
+    overall_status = "success" if any_success else "failed"
+
+    return {
+        "status": overall_status,
+        "results": results
+    }
+
+
+def broadcast_notification(
+    message: str,
+    recipient_id: str,
+    hub: Optional[ChannelHub] = None,
+    recipients: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """
+    Synchronous compatibility wrapper for broadcast_notification_async.
+
+    Args:
+        message (str): The critical notification message text.
+        recipient_id (str): The default recipient ID.
+        hub (Optional[ChannelHub]): The ChannelHub instance managing registered channel adapters.
+        recipients (Optional[Dict[str, str]]): Specific overrides for recipient IDs per channel.
+        metadata (Optional[Dict[str, Any]]): Additional metadata to attach to the broadcast.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing overall status and detailed results per channel.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        loop = _get_background_loop()
+        future = asyncio.run_coroutine_threadsafe(
+            broadcast_notification_async(message, recipient_id, hub=hub, recipients=recipients, metadata=metadata),
+            loop,
+        )
+        return future.result(timeout=30)
+
+    # If already running in an event loop, we must run the coroutine directly via a task or raise an error.
+    return {
+        "status": "error",
+        "message": "broadcast_notification called from an active event loop; use broadcast_notification_async instead."
+    }

--- a/tests/test_notification_broadcast.py
+++ b/tests/test_notification_broadcast.py
@@ -1,0 +1,215 @@
+"""
+Tests for the Cross-Platform Unified Notification Broadcast Skill.
+"""
+
+import pytest
+import asyncio
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.channels.hub import ChannelHub
+from magda_agent.channels.base import ChannelAdapter
+from magda_agent.gateway.router import GatewayRouter
+from magda_agent.skills.notification_broadcast import (
+    broadcast_notification_async,
+    broadcast_notification,
+)
+
+
+class DummyAdapter(ChannelAdapter):
+    """
+    A dummy channel adapter class for testing notification broadcasts.
+    """
+    def __init__(self, channel_id: str, gateway: GatewayRouter) -> None:
+        """
+        Initialize the dummy channel adapter.
+
+        Args:
+            channel_id (str): The ID of the channel.
+            gateway (GatewayRouter): The gateway router.
+        """
+        super().__init__(channel_id, gateway)
+        self.send_mock = AsyncMock(return_value="sent")
+
+    async def receive(self, raw_data: Any) -> Any:
+        """
+        Mock processing raw incoming data.
+
+        Args:
+            raw_data (Any): Raw incoming data.
+
+        Returns:
+            Any: Mocked output.
+        """
+        return "received"
+
+    async def send(self, recipient_id: str, text: str, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """
+        Mock sending a message.
+
+        Args:
+            recipient_id (str): The ID of the recipient.
+            text (str): The message text.
+            metadata (Optional[Dict[str, Any]]): Metadata.
+
+        Returns:
+            Any: Result of mock sending.
+        """
+        return await self.send_mock(recipient_id, text, metadata)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_no_message() -> None:
+    """
+    Verify that broadcasting an empty message returns an error status.
+    """
+    hub = ChannelHub()
+    result = await broadcast_notification_async("", "user123", hub)
+    assert result["status"] == "error"
+    assert "cannot be empty" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_no_hub() -> None:
+    """
+    Verify that broadcasting without a ChannelHub returns an error status.
+    """
+    result = await broadcast_notification_async("Hello", "user123", None)
+    assert result["status"] == "error"
+    assert "ChannelHub is required" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_empty_hub() -> None:
+    """
+    Verify that broadcasting with an empty ChannelHub returns an error status.
+    """
+    hub = ChannelHub()
+    result = await broadcast_notification_async("Hello", "user123", hub)
+    assert result["status"] == "error"
+    assert "No registered channels" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_async_success() -> None:
+    """
+    Verify that async broadcast successfully routes messages to all registered adapters.
+    """
+    gateway = GatewayRouter()
+    hub = ChannelHub()
+    adapter1 = DummyAdapter("telegram", gateway)
+    adapter2 = DummyAdapter("discord", gateway)
+    hub.register_adapter(adapter1)
+    hub.register_adapter(adapter2)
+
+    result = await broadcast_notification_async("Critical System Alert!", "default_user", hub)
+
+    assert result["status"] == "success"
+    assert "telegram" in result["results"]
+    assert "discord" in result["results"]
+    assert result["results"]["telegram"]["status"] == "success"
+    assert result["results"]["discord"]["status"] == "success"
+
+    adapter1.send_mock.assert_awaited_once_with("default_user", "Critical System Alert!", None)
+    adapter2.send_mock.assert_awaited_once_with("default_user", "Critical System Alert!", None)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_async_partial_failure() -> None:
+    """
+    Verify that dynamic error isolation works when one channel fails but another succeeds.
+    """
+    gateway = GatewayRouter()
+    hub = ChannelHub()
+    adapter1 = DummyAdapter("telegram", gateway)
+    adapter2 = DummyAdapter("discord", gateway)
+
+    # Make telegram fail, discord succeed
+    adapter1.send_mock.side_effect = RuntimeError("Telegram API is down")
+    hub.register_adapter(adapter1)
+    hub.register_adapter(adapter2)
+
+    result = await broadcast_notification_async("System Alert!", "default_user", hub)
+
+    # Since discord succeeded, overall status should be success
+    assert result["status"] == "success"
+    assert result["results"]["telegram"]["status"] == "error"
+    assert "Telegram API is down" in result["results"]["telegram"]["message"]
+    assert result["results"]["discord"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_async_full_failure() -> None:
+    """
+    Verify that when all channels fail, the overall status is failed.
+    """
+    gateway = GatewayRouter()
+    hub = ChannelHub()
+    adapter1 = DummyAdapter("telegram", gateway)
+    adapter2 = DummyAdapter("discord", gateway)
+
+    adapter1.send_mock.side_effect = RuntimeError("Telegram down")
+    adapter2.send_mock.side_effect = RuntimeError("Discord down")
+    hub.register_adapter(adapter1)
+    hub.register_adapter(adapter2)
+
+    result = await broadcast_notification_async("System Alert!", "default_user", hub)
+
+    assert result["status"] == "failed"
+    assert result["results"]["telegram"]["status"] == "error"
+    assert result["results"]["discord"]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_async_recipient_overrides() -> None:
+    """
+    Verify that recipient_id is overridden for specified channels when overrides are provided.
+    """
+    gateway = GatewayRouter()
+    hub = ChannelHub()
+    adapter1 = DummyAdapter("telegram", gateway)
+    adapter2 = DummyAdapter("discord", gateway)
+    hub.register_adapter(adapter1)
+    hub.register_adapter(adapter2)
+
+    overrides = {"telegram": "override_tg_user"}
+    result = await broadcast_notification_async(
+        "Critical Alert!", "default_user", hub, recipients=overrides
+    )
+
+    assert result["status"] == "success"
+    adapter1.send_mock.assert_awaited_once_with("override_tg_user", "Critical Alert!", None)
+    adapter2.send_mock.assert_awaited_once_with("default_user", "Critical Alert!", None)
+
+
+def test_broadcast_notification_sync_success() -> None:
+    """
+    Verify that the synchronous wrapper runs successfully from a synchronous thread context.
+    """
+    # This test runs in a synchronous thread (no active running event loop)
+    gateway = GatewayRouter()
+    hub = ChannelHub()
+    adapter1 = DummyAdapter("telegram", gateway)
+    hub.register_adapter(adapter1)
+
+    result = broadcast_notification("Sync Alert!", "sync_user", hub)
+
+    assert result["status"] == "success"
+    assert "telegram" in result["results"]
+    assert result["results"]["telegram"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_notification_sync_error_if_loop_running() -> None:
+    """
+    Verify that the synchronous wrapper returns an error when called from an active running event loop.
+    """
+    gateway = GatewayRouter()
+    hub = ChannelHub()
+    adapter1 = DummyAdapter("telegram", gateway)
+    hub.register_adapter(adapter1)
+
+    # Calling synchronous wrapper inside an active async test (where an event loop is running)
+    result = broadcast_notification("Alert!", "user", hub)
+
+    assert "status" in result and result["status"] == "error"
+    assert "called from an active event loop" in result["message"]


### PR DESCRIPTION
This PR implements the cross-platform unified notification broadcast skill, allowing broadcasting of critical alerts across multiple channel adapters via the ChannelHub. It also adds new modern AI-agent-inspired tasks to the replenishment pool.

---
*PR created automatically by Jules for task [9667257404112743952](https://jules.google.com/task/9667257404112743952) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **Notification Skill:**
    - Added `broadcast_notification_async` and synchronous wrapper to broadcast alerts across all `ChannelHub` adapters.
    - Implemented background thread management to support `broadcast_notification` in non-async contexts.
- **Task Management:**
    - Updated `agent_tasks.json` to mark `unified-notification-broadcast` as complete.
    - Added new pending tasks for `OpenClaw-RL` reward parsing, `Claude Code` conflict resolution, and `ChannelHub` memory leak fixes.
- **Testing:**
    - Added `test_notification_broadcast.py` covering success paths, partial failures, recipient overrides, and synchronous wrapper validation.

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-platform notification broadcast skill to ChannelHub
> - Adds [notification_broadcast.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/524/files#diff-5ddc54c90bfda51cbd4264f965a7c54a57a66373408d2ea03fe0ecb3c2d5c77b) with `broadcast_notification_async` that fans out a message to all adapters registered in `ChannelHub`, collecting per-channel success/error results and returning an overall `success`/`failed` status.
> - Adds a synchronous `broadcast_notification` wrapper that schedules the async broadcast on a persistent background event loop via `run_coroutine_threadsafe` with a 30s timeout; returns an error dict if called from within an already-running event loop.
> - Adds a test suite in [tests/test_notification_broadcast.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/524/files#diff-c6565c26060cb82beb75f7b575e51ff4c17b8e7162150722e2aaf573f270a330) covering empty message, missing hub, partial failures, recipient overrides, and sync/async context handling.
> - Updates `agent_tasks.json` with three new task entries and marks one existing task as done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ff5e4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->