### PR TITLE
Implement Channel Hub Rate Limiter with Queue Serialization

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -28,7 +28,7 @@
       "low",
       "medium"
     ],
-    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks — never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
+    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks \u2014 never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
     "max_todo_tasks": 5000
   },
   "autonomous_loop_policy": {
@@ -778,7 +778,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from user replies (next-state signal)",
-      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed — use simple reward heuristics.",
+      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed \u2014 use simple reward heuristics.",
       "allowed_paths": [
         "magda_agent/learning/**",
         "magda_agent/metacognition/**",
@@ -996,7 +996,7 @@
       "area": "attention",
       "risk": "medium",
       "title": "Global Workspace broadcast mechanism",
-      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic — workspace should mediate.",
+      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic \u2014 workspace should mediate.",
       "allowed_paths": [
         "magda_agent/attention/**",
         "magda_agent/consciousness/**",
@@ -1055,7 +1055,7 @@
       "status": "done",
       "area": "memory",
       "risk": "low",
-      "title": "Periodic consolidation of episodic → semantic memory",
+      "title": "Periodic consolidation of episodic \u2192 semantic memory",
       "description": "Subconsciousness periodically reviews episodic memories, extracts stable facts, and promotes them to semantic memory. Decay irrelevant episodes. Inspired by sleep consolidation in neuroscience.",
       "allowed_paths": [
         "magda_agent/subconsciousness/**",
@@ -1096,7 +1096,7 @@
       "area": "metacognition",
       "risk": "low",
       "title": "Confidence calibration for responses",
-      "description": "Agent should estimate confidence in its responses. Low confidence → add caveats, suggest verification. High confidence → direct answer. Track calibration accuracy over time.",
+      "description": "Agent should estimate confidence in its responses. Low confidence \u2192 add caveats, suggest verification. High confidence \u2192 direct answer. Track calibration accuracy over time.",
       "allowed_paths": [
         "magda_agent/metacognition/**",
         "magda_agent/consciousness/**",
@@ -1797,7 +1797,7 @@
       "area": "UI",
       "risk": "low",
       "title": "Context Engine Canvas Visualization",
-      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent’s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
+      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent\u2019s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
       "allowed_paths": [
         "magda_agent/memory/canvas.py",
         "tests/test_canvas*.py",
@@ -2942,7 +2942,7 @@
       "area": "operations",
       "risk": "medium",
       "title": "Scheduled operations cron-like tasks",
-      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement cron-like scheduled tasks that the agent can run autonomously.",
+      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement cron-like scheduled tasks that the agent can run autonomously.",
       "allowed_paths": [
         "magda_agent/operations/cron.py",
         "tests/test_cron.py",
@@ -2961,7 +2961,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Skill marketplace compatibility",
-      "description": "Inspired by trend: Skill marketplace — совместимость с agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
+      "description": "Inspired by trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
       "allowed_paths": [
         "magda_agent/integration/skill_marketplace.py",
         "tests/test_skill_marketplace_integration.py",
@@ -3016,7 +3016,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine plugin architecture",
-      "description": "Inspired by trend 'Context Engine — plugin-архитектура для управления контекстом': Implement a plugin interface with lifecycle hooks for managing working memory context.",
+      "description": "Inspired by trend 'Context Engine \u2014 plugin-\u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 \u0434\u043b\u044f \u0443\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u044f \u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442\u043e\u043c': Implement a plugin interface with lifecycle hooks for managing working memory context.",
       "allowed_paths": [
         "magda_agent/memory/context_engine.py",
         "tests/test_context_engine*.py",
@@ -3034,7 +3034,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams sub-agents spawning",
-      "description": "Inspired by trend 'Agent Teams — порождение sub-agents для параллельных задач': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
+      "description": "Inspired by trend 'Agent Teams \u2014 \u043f\u043e\u0440\u043e\u0436\u0434\u0435\u043d\u0438\u0435 sub-agents \u0434\u043b\u044f \u043f\u0430\u0440\u0430\u043b\u043b\u0435\u043b\u044c\u043d\u044b\u0445 \u0437\u0430\u0434\u0430\u0447': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
       "allowed_paths": [
         "magda_agent/agents/teams.py",
         "tests/test_agent_teams*.py",
@@ -3052,7 +3052,7 @@
       "area": "gateway",
       "risk": "low",
       "title": "Cross-platform reach across channels",
-      "description": "Inspired by trend 'Cross-platform reach — один агент, много каналов': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
+      "description": "Inspired by trend 'Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
       "allowed_paths": [
         "magda_agent/gateway/channels.py",
         "tests/test_gateway_channels*.py",
@@ -3087,7 +3087,7 @@
       "area": "gateway",
       "risk": "medium",
       "title": "Canvas live visualization support",
-      "description": "Inspired by trend: OpenClaw - Canvas для live визуализации. Add visualization capabilities and state streaming to the context engine.",
+      "description": "Inspired by trend: OpenClaw - Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Add visualization capabilities and state streaming to the context engine.",
       "allowed_paths": [
         "magda_agent/gateway/canvas.py",
         "tests/test_canvas*.py",
@@ -3238,7 +3238,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Hermes agentskills.io export compatibility",
-      "description": "Inspired by Hermes Agent trend: Skill marketplace — совместимость с agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
+      "description": "Inspired by Hermes Agent trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
       "allowed_paths": [
         "magda_agent/skills/agentskills_export.py",
         "tests/test_agentskills_export.py",
@@ -3343,7 +3343,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Hermes Persistent Memory",
-      "description": "Inspired by Hermes Agent trend: Persistent memory: чем дольше работает, тем лучше знает пользователя. Implement a persistent user profile memory.",
+      "description": "Inspired by Hermes Agent trend: Persistent memory: \u0447\u0435\u043c \u0434\u043e\u043b\u044c\u0448\u0435 \u0440\u0430\u0431\u043e\u0442\u0430\u0435\u0442, \u0442\u0435\u043c \u043b\u0443\u0447\u0448\u0435 \u0437\u043d\u0430\u0435\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement a persistent user profile memory.",
       "allowed_paths": [
         "magda_agent/memory/hermes_persistent.py",
         "tests/test_hermes_persistent.py",
@@ -3360,7 +3360,7 @@
       "area": "architecture",
       "risk": "high",
       "title": "OpenClaw Context Engine Lifecycle Hooks",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Implement lifecycle hooks for plugins.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Implement lifecycle hooks for plugins.",
       "allowed_paths": [
         "magda_agent/architecture/context_hooks.py",
         "tests/test_context_hooks.py",
@@ -3378,7 +3378,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "A2A Discovery via Agent Cards",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
       "allowed_paths": [
         "magda_agent/architecture/a2a_discovery.py",
         "tests/test_a2a_discovery*.py",
@@ -3414,7 +3414,7 @@
       "area": "ui",
       "risk": "medium",
       "title": "OpenClaw Canvas Live Visualization",
-      "description": "Inspired by trend: OpenClaw Canvas для live визуализации. Implement an interface for live visualization of the agent's internal state and working memory.",
+      "description": "Inspired by trend: OpenClaw Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement an interface for live visualization of the agent's internal state and working memory.",
       "allowed_paths": [
         "magda_agent/ui/canvas.py",
         "tests/test_canvas*.py",
@@ -3432,7 +3432,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams Subagent Spawning",
-      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
+      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
       "allowed_paths": [
         "magda_agent/multi_agent/team_spawner.py",
         "tests/test_team_spawner*.py",
@@ -3467,7 +3467,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Lifecycle Plugins",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
       "allowed_paths": [
         "magda_agent/memory/context_engine_lifecycle.py",
         "tests/test_context_engine_lifecycle.py",
@@ -3501,7 +3501,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach implementation",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
       "allowed_paths": [
         "magda_agent/integration/cross_platform.py",
         "tests/test_cross_platform.py",
@@ -3518,7 +3518,7 @@
       "area": "evaluation",
       "risk": "low",
       "title": "Quality metrics longitudinal tracking",
-      "description": "Inspired by trend: Quality metrics — longitudinal tracking, не одноразовый pytest. Implement longitudinal tracking of code quality metrics.",
+      "description": "Inspired by trend: Quality metrics \u2014 longitudinal tracking, \u043d\u0435 \u043e\u0434\u043d\u043e\u0440\u0430\u0437\u043e\u0432\u044b\u0439 pytest. Implement longitudinal tracking of code quality metrics.",
       "allowed_paths": [
         "magda_agent/evaluation/longitudinal_metrics.py",
         "tests/test_longitudinal_metrics.py",
@@ -3535,7 +3535,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Exporter v6",
-      "description": "Inspired by the MCP-совместимость trend: Magda должна уметь экспортировать skills как MCP tools.",
+      "description": "Inspired by the MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c trend: Magda \u0434\u043e\u043b\u0436\u043d\u0430 \u0443\u043c\u0435\u0442\u044c \u044d\u043a\u0441\u043f\u043e\u0440\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c skills \u043a\u0430\u043a MCP tools.",
       "allowed_paths": [
         "magda_agent/integration/mcp_exporter.py",
         "tests/test_mcp_exporter*.py",
@@ -3552,7 +3552,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A delegation v6",
-      "description": "Inspired by trend: A2A поддержка — возможность делегировать задачи другим агентам.",
+      "description": "Inspired by trend: A2A \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0430 \u2014 \u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e\u0441\u0442\u044c \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0437\u0430\u0434\u0430\u0447\u0438 \u0434\u0440\u0443\u0433\u0438\u043c \u0430\u0433\u0435\u043d\u0442\u0430\u043c.",
       "allowed_paths": [
         "magda_agent/multi_agent/a2a_delegator.py",
         "tests/test_a2a_delegator*.py",
@@ -3569,7 +3569,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning v6",
-      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections).",
+      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections).",
       "allowed_paths": [
         "magda_agent/learning/online_learning.py",
         "tests/test_online_learning*.py",
@@ -3637,7 +3637,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Creation from Experience",
-      "description": "Inspired by Hermes Agent trend: Self-improving agent с built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
+      "description": "Inspired by Hermes Agent trend: Self-improving agent \u0441 built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
       "allowed_paths": [
         "magda_agent/skills/skill_generator.py",
         "tests/test_skill_generator*.py",
@@ -3655,7 +3655,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Triad Architecture",
-      "description": "Inspired by Claude Agent SDK trend: Трёхагентная архитектура Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
+      "description": "Inspired by Claude Agent SDK trend: \u0422\u0440\u0451\u0445\u0430\u0433\u0435\u043d\u0442\u043d\u0430\u044f \u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
       "allowed_paths": [
         "magda_agent/agents/triad_coordinator.py",
         "tests/test_triad_coordinator*.py",
@@ -4001,7 +4001,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "MCP JSON-RPC Interface",
-      "description": "Inspired by trend: MCP-совместимость (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
+      "description": "Inspired by trend: MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
       "allowed_paths": [
         "magda_agent/integration/mcp_server.py",
         "tests/test_mcp_server*.py",
@@ -4018,7 +4018,7 @@
       "area": "evaluation",
       "risk": "medium",
       "title": "AgentBench Multi-Domain Evaluation",
-      "description": "Inspired by trend: Evaluation (бенчмарки) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
+      "description": "Inspired by trend: Evaluation (\u0431\u0435\u043d\u0447\u043c\u0430\u0440\u043a\u0438) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
       "allowed_paths": [
         "magda_agent/evaluation/agentbench.py",
         "tests/test_agentbench*.py",
@@ -4051,7 +4051,7 @@
       "area": "visualization",
       "risk": "low",
       "title": "Canvas Live Visualization API v2",
-      "description": "Inspired by OpenClaw trend: Canvas для live визуализации. Implement API endpoints for the canvas streaming.",
+      "description": "Inspired by OpenClaw trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement API endpoints for the canvas streaming.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_api_v2.py",
         "tests/test_canvas_api_v2.py",
@@ -4083,7 +4083,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "Scheduled operations: daily reports",
-      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement scheduled daily reports capability.",
+      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement scheduled daily reports capability.",
       "allowed_paths": [
         "magda_agent/scheduler/cron.py",
         "tests/test_cron*.py",
@@ -4100,7 +4100,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach: Telegram channel v2",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Add improved Telegram messenger integration.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Add improved Telegram messenger integration.",
       "allowed_paths": [
         "magda_agent/channels/telegram.py",
         "tests/test_telegram*.py",
@@ -4234,7 +4234,7 @@
       "area": "execution",
       "risk": "high",
       "title": "Agent Teams Worktree Isolation",
-      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
+      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
       "allowed_paths": [
         "magda_agent/agents/subagent.py",
         "magda_agent/isolation/git_worktree.py",
@@ -4253,7 +4253,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Control Checkpoints Interface",
-      "description": "Inspired by trend: ACS (Agent Control Specification) — 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
+      "description": "Inspired by trend: ACS (Agent Control Specification) \u2014 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
       "allowed_paths": [
         "magda_agent/safety/acs_guard.py",
         "tests/test_acs_guard.py",
@@ -4325,7 +4325,7 @@
       "area": "channels",
       "risk": "medium",
       "title": "Cross-platform reach channels",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Expand channel adapters for more platforms.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Expand channel adapters for more platforms.",
       "allowed_paths": [
         "magda_agent/channels/reach_v2.py",
         "tests/test_reach_v2.py",
@@ -4342,7 +4342,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from dialogue v3",
-      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections). Implement immediate context integration.",
+      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections). Implement immediate context integration.",
       "allowed_paths": [
         "magda_agent/learning/dialogue_v3.py",
         "tests/test_dialogue_v3.py",
@@ -4478,7 +4478,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Agent Discovery via Cards v2",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Add discovery components to the network layer.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Add discovery components to the network layer.",
       "allowed_paths": [
         "magda_agent/integration/a2a_discovery_v2.py",
         "tests/test_a2a_discovery_v2.py",
@@ -5488,7 +5488,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT Virtual Context Management v1",
-      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> стандарт)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
+      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
       "allowed_paths": [
         "magda_agent/memory/virtual_context.py",
         "tests/test_virtual_context.py",
@@ -5506,7 +5506,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Agent Control Specification Checkpoints v3",
-      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) — 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
+      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) \u2014 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
       "allowed_paths": [
         "magda_agent/safety/acs_checkpoints_v3.py",
         "tests/test_acs_checkpoints_v3.py",
@@ -8495,7 +8495,7 @@
     },
     {
       "id": "channel-hub-rate-limiter",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Channel Hub Rate Limiter",
@@ -8639,7 +8639,7 @@
       "area": "planning",
       "risk": "medium",
       "title": "Claude Agent Teams Dependency Graph",
-      "description": "Inspired by Claude Agent SDK trend: Task system с dependency graphs. Update planning to utilize dependency graphs.",
+      "description": "Inspired by Claude Agent SDK trend: Task system \u0441 dependency graphs. Update planning to utilize dependency graphs.",
       "allowed_paths": [
         "magda_agent/planning/dependency_graph.py",
         "tests/test_dependency_graph.py",
@@ -8792,7 +8792,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging",
-      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
+      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger.py",
         "tests/test_canvas_logger.py",
@@ -8931,7 +8931,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging V3",
-      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
+      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger_v3.py",
         "tests/test_canvas_logger_v3.py",
@@ -11810,7 +11810,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery Agent Cards v4",
-      "description": "Inspired by trend: Agent discovery через Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
+      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -12062,7 +12062,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Protocol Discovery Mesh",
-      "description": "Inspired by trend: Agent discovery через Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
+      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -19079,6 +19079,59 @@
       "acceptance": [
         "Unregistering an adapter cleanly releases references.",
         "Tests verify adapter cleanup and absence of circular reference leaks."
+      ]
+    },
+    {
+      "id": "claude-code-git-conflict-resolver-v16-unique",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Code Git Conflict Auto-Resolver V16",
+      "description": "Inspired by Claude Code CLI trends (June 2026): Implement an automated Git conflict resolver capability for subagents working on parallel branches, allowing them to parse conflict markers and propose clean resolutions (v16 iteration).",
+      "allowed_paths": [
+        "magda_agent/isolation/git_conflict_resolver_v16.py",
+        "tests/test_git_conflict_resolver_v16.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The resolver parses and extracts Git conflict blocks from workspace files.",
+        "Proposes or applies resolution strategies cleanly based on simple rules.",
+        "Tests verify correct conflict block extraction and resolution."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-audio-feedback-v2-unique",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Audio Feedback Alignment v2",
+      "description": "Inspired by OpenClaw trends: Extend OpenClaw reinforcement learning to parse user audio tone/inflection shifts from voice inputs as next-state reward signals to adjust tone adaptation weights (v2).",
+      "allowed_paths": [
+        "magda_agent/learning/audio_sentiment_v2.py",
+        "tests/test_audio_sentiment_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audio sentiment signals successfully update habit weights.",
+        "Tests verify weight adjustments using mock audio signals."
+      ]
+    },
+    {
+      "id": "acs-compliance-report-v3-unique",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Compliance Real-time Report v3",
+      "description": "Inspired by Microsoft ACS safety standard trend (June 2026): Implement a real-time compliance reporting module that tracks check outcomes across the 5 validation checkpoints and generates a formatted Markdown report for continuous auditing.",
+      "allowed_paths": [
+        "magda_agent/safety/compliance_report_v3.py",
+        "tests/test_compliance_report_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Compliance module logs checkpoint details.",
+        "Generates structured Markdown compliance reports with success rates.",
+        "Tests verify correct report generation and formatting."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -276,3 +276,6 @@
 * [ ] FEATURE: OpenClaw RL Dynamic Habit Tuning V13 (openclaw-rl-dynamic-habit-tuning-v13-8d2f1b4c)
 * [ ] FEATURE: MCP Server Capability Discovery V13 (mcp-server-capability-discovery-v13-5c9e3a7b)
 * [ ] BUG: Working Memory Context Leak V13 (bug-working-memory-context-leak-v13-1a9b2c3d)
+* [ ] FEATURE: Claude Code Git Conflict Auto-Resolver V16 (claude-code-git-conflict-resolver-v16-unique)
+* [ ] FEATURE: OpenClaw RL Audio Feedback Alignment v2 (openclaw-rl-multimodal-audio-feedback-v2-unique)
+* [ ] FEATURE: ACS Compliance Real-time Report v3 (acs-compliance-report-v3-unique)

--- a/magda_agent/channels/hub.py
+++ b/magda_agent/channels/hub.py
@@ -6,8 +6,24 @@ class ChannelHub:
     Centralized messaging hub that abstracts multiple channel adapters.
     Manages a collection of ChannelAdapter instances and allows receiving and sending messages across them.
     """
-    def __init__(self):
+    def __init__(self, rate_limiter: Optional[Any] = None) -> None:
+        """
+        Initialize the centralized messaging hub.
+
+        Args:
+            rate_limiter (Optional[Any]): Rate limiter instance for outgoing messages.
+        """
         self._adapters: Dict[str, ChannelAdapter] = {}
+        self.rate_limiter: Optional[Any] = rate_limiter
+
+    def set_rate_limiter(self, rate_limiter: Any) -> None:
+        """
+        Set or replace the rate limiter for the hub.
+
+        Args:
+            rate_limiter (Any): The rate limiter instance.
+        """
+        self.rate_limiter = rate_limiter
 
     def register_adapter(self, adapter: ChannelAdapter) -> None:
         """
@@ -59,6 +75,9 @@ class ChannelHub:
         Returns:
             Any: The response from the channel adapter's send method, or an error string if the adapter is not found.
         """
+        if self.rate_limiter:
+            await self.rate_limiter.acquire(channel_id)
+
         adapter = self.get_adapter(channel_id)
         if adapter:
             return await adapter.send(recipient_id, text, metadata)

--- a/magda_agent/channels/rate_limiter.py
+++ b/magda_agent/channels/rate_limiter.py
@@ -1,0 +1,118 @@
+import asyncio
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+class RateLimitExceededError(Exception):
+    """Exception raised when a rate limit is exceeded and the strategy is set to block."""
+    pass
+
+class ChannelRateLimiter:
+    """
+    Rate limiter for outgoing channel messages.
+    Supports 'delay' (holds the coroutine until a slot is free) and 'block' (raises RateLimitExceededError) strategies.
+    """
+
+    def __init__(
+        self,
+        limits: Optional[Dict[str, Dict[str, Any]]] = None,
+        default_limit: Optional[Dict[str, Any]] = None,
+        time_func: Optional[Callable[[], float]] = None,
+        sleep_func: Optional[Callable[[float], Any]] = None
+    ) -> None:
+        """
+        Initialize the rate limiter.
+
+        Args:
+            limits (Optional[Dict[str, Dict[str, Any]]]): Configuration dictionary per channel.
+                Example: {"telegram": {"max_requests": 5, "period": 10.0, "strategy": "delay"}}
+            default_limit (Optional[Dict[str, Any]]): Fallback limit config for unconfigured channels.
+                Defaults to: {"max_requests": 5, "period": 1.0, "strategy": "delay"}
+            time_func (Optional[Callable[[], float]]): Function returning current time as float.
+            sleep_func (Optional[Callable[[float], Any]]): Async function to sleep/delay.
+        """
+        self.limits: Dict[str, Dict[str, Any]] = limits or {}
+        self.default_limit: Dict[str, Any] = default_limit or {
+            "max_requests": 5,
+            "period": 1.0,
+            "strategy": "delay"
+        }
+        self.time_func: Callable[[], float] = time_func or time.time
+        self.sleep_func: Callable[[float], Any] = sleep_func or asyncio.sleep
+
+        self._history: Dict[str, List[float]] = {}
+        self._locks: Dict[str, asyncio.Lock] = {}
+
+    def _get_config(self, channel_id: str) -> Dict[str, Any]:
+        """
+        Retrieve rate limit configuration for the given channel, falling back to default.
+
+        Args:
+            channel_id (str): The channel ID.
+
+        Returns:
+            Dict[str, Any]: The rate limit configuration.
+        """
+        return self.limits.get(channel_id, self.default_limit)
+
+    def _get_lock(self, channel_id: str) -> asyncio.Lock:
+        """
+        Retrieve or create an asyncio.Lock for the given channel to serialize requests.
+
+        Args:
+            channel_id (str): The channel ID.
+
+        Returns:
+            asyncio.Lock: The lock for the channel.
+        """
+        if channel_id not in self._locks:
+            self._locks[channel_id] = asyncio.Lock()
+        return self._locks[channel_id]
+
+    async def acquire(self, channel_id: str) -> None:
+        """
+        Acquire a slot in the rate limit for the specified channel.
+        Depending on the channel's strategy, this will either delay execution or raise RateLimitExceededError.
+
+        Args:
+            channel_id (str): The channel ID.
+
+        Raises:
+            RateLimitExceededError: If rate limit is exceeded and strategy is 'block'.
+        """
+        config = self._get_config(channel_id)
+        max_requests: int = config.get("max_requests", 5)
+        period: float = config.get("period", 1.0)
+        strategy: str = config.get("strategy", "delay")
+
+        lock = self._get_lock(channel_id)
+
+        async with lock:
+            if channel_id not in self._history:
+                self._history[channel_id] = []
+
+            now = self.time_func()
+            # Clean up old timestamps outside the current sliding window
+            self._history[channel_id] = [t for t in self._history[channel_id] if now - t < period]
+
+            if len(self._history[channel_id]) < max_requests:
+                self._history[channel_id].append(now)
+            else:
+                if strategy == "block":
+                    raise RateLimitExceededError(
+                        f"Rate limit exceeded on channel '{channel_id}'. "
+                        f"Limit is {max_requests} requests per {period}s."
+                    )
+                elif strategy == "delay":
+                    # Calculate the required delay time based on the oldest timestamp in the current window
+                    earliest_timestamp = self._history[channel_id][0]
+                    delay_time = (earliest_timestamp + period) - now
+                    if delay_time > 0:
+                        await self.sleep_func(delay_time)
+
+                    # Update history after delay
+                    now_after = self.time_func()
+                    self._history[channel_id] = [t for t in self._history[channel_id] if now_after - t < period]
+                    self._history[channel_id].append(now_after)
+                else:
+                    # Fallback to appending if strategy is unknown
+                    self._history[channel_id].append(now)

--- a/tests/test_channel_rate_limiter.py
+++ b/tests/test_channel_rate_limiter.py
@@ -1,0 +1,173 @@
+import asyncio
+import pytest
+from typing import Any, Dict, List
+from magda_agent.channels.base import ChannelAdapter
+from magda_agent.channels.hub import ChannelHub
+from magda_agent.channels.rate_limiter import ChannelRateLimiter, RateLimitExceededError
+from magda_agent.gateway.router import GatewayRouter, UnifiedMessage
+
+class MockClock:
+    """Mock clock for testing rate limiter without real-time delay."""
+
+    def __init__(self, start_time: float = 1000.0) -> None:
+        """Initialize mock clock with a starting time."""
+        self.current_time: float = start_time
+
+    def time(self) -> float:
+        """Return the current mock time."""
+        return self.current_time
+
+    def advance(self, duration: float) -> None:
+        """Advance the mock time."""
+        self.current_time += duration
+
+    async def sleep(self, duration: float) -> None:
+        """Simulate sleep by advancing mock time."""
+        self.advance(duration)
+
+
+class DummyChannel(ChannelAdapter):
+    """A dummy channel adapter to verify hub sending."""
+
+    def __init__(self, channel_id: str, gateway: GatewayRouter) -> None:
+        """Initialize the dummy channel."""
+        super().__init__(channel_id, gateway)
+        self.sent_messages: List[Dict[str, Any]] = []
+
+    async def receive(self, raw_data: Any) -> Any:
+        """Mock receive method."""
+        return None
+
+    async def send(self, recipient_id: str, text: str, metadata: Dict[str, Any] = None) -> str:
+        """Record and return sent message confirmation."""
+        self.sent_messages.append({"recipient": recipient_id, "text": text, "metadata": metadata})
+        return f"Sent to {recipient_id}: {text}"
+
+
+@pytest.fixture
+def gateway() -> GatewayRouter:
+    """Fixture providing a GatewayRouter."""
+    return GatewayRouter()
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_block_strategy() -> None:
+    """Verify that the block strategy raises RateLimitExceededError immediately on limit breach."""
+    clock = MockClock()
+    # 2 requests per 5 seconds, strategy block
+    limiter = ChannelRateLimiter(
+        limits={"telegram": {"max_requests": 2, "period": 5.0, "strategy": "block"}},
+        time_func=clock.time,
+        sleep_func=clock.sleep
+    )
+
+    # First request
+    await limiter.acquire("telegram")
+    # Second request
+    await limiter.acquire("telegram")
+
+    # Third request should fail immediately
+    with pytest.raises(RateLimitExceededError) as exc_info:
+        await limiter.acquire("telegram")
+    assert "Rate limit exceeded on channel 'telegram'" in str(exc_info.value)
+
+    # If we advance the clock by 5.1 seconds, the sliding window clears and we can send again
+    clock.advance(5.1)
+    await limiter.acquire("telegram")
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_delay_strategy() -> None:
+    """Verify that the delay strategy correctly delays requests until a slot is free."""
+    clock = MockClock()
+    # 2 requests per 10 seconds, strategy delay
+    limiter = ChannelRateLimiter(
+        limits={"discord": {"max_requests": 2, "period": 10.0, "strategy": "delay"}},
+        time_func=clock.time,
+        sleep_func=clock.sleep
+    )
+
+    # First request at t = 1000.0
+    await limiter.acquire("discord")
+    assert clock.time() == 1000.0
+
+    # Second request at t = 1000.0
+    await limiter.acquire("discord")
+    assert clock.time() == 1000.0
+
+    # Third request should be delayed until first request expires (t = 1010.0)
+    await limiter.acquire("discord")
+    assert clock.time() == 1010.0
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_unconfigured_defaults() -> None:
+    """Verify rate limiter falls back to default_limit for unconfigured channels."""
+    clock = MockClock()
+    limiter = ChannelRateLimiter(
+        default_limit={"max_requests": 1, "period": 2.0, "strategy": "block"},
+        time_func=clock.time,
+        sleep_func=clock.sleep
+    )
+
+    # Unconfigured channel uses default_limit
+    await limiter.acquire("slack")
+
+    with pytest.raises(RateLimitExceededError):
+        await limiter.acquire("slack")
+
+    clock.advance(2.1)
+    # Now it works again
+    await limiter.acquire("slack")
+
+
+@pytest.mark.asyncio
+async def test_channel_hub_integration(gateway: GatewayRouter) -> None:
+    """Verify rate limiting integrated with ChannelHub send_to_channel."""
+    clock = MockClock()
+    limiter = ChannelRateLimiter(
+        limits={"whatsapp": {"max_requests": 1, "period": 5.0, "strategy": "block"}},
+        time_func=clock.time,
+        sleep_func=clock.sleep
+    )
+
+    hub = ChannelHub(rate_limiter=limiter)
+    adapter = DummyChannel("whatsapp", gateway)
+    hub.register_adapter(adapter)
+
+    # First message goes through
+    res1 = await hub.send_to_channel("whatsapp", "user1", "Hello 1")
+    assert res1 == "Sent to user1: Hello 1"
+
+    # Second message fails with RateLimitExceededError
+    with pytest.raises(RateLimitExceededError):
+        await hub.send_to_channel("whatsapp", "user1", "Hello 2")
+
+    # Dynamic setter test
+    hub.set_rate_limiter(None)
+    # Now it works because rate limiter is removed
+    res2 = await hub.send_to_channel("whatsapp", "user1", "Hello 2")
+    assert res2 == "Sent to user1: Hello 2"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_delay_serialization() -> None:
+    """Verify concurrent requests are serialized and delayed correctly under lock."""
+    clock = MockClock()
+    limiter = ChannelRateLimiter(
+        limits={"telegram": {"max_requests": 1, "period": 1.0, "strategy": "delay"}},
+        time_func=clock.time,
+        sleep_func=clock.sleep
+    )
+
+    # Trigger 3 concurrent acquires
+    await asyncio.gather(
+        limiter.acquire("telegram"),
+        limiter.acquire("telegram"),
+        limiter.acquire("telegram")
+    )
+
+    # First acquire completes at 1000.0.
+    # Second is delayed by 1.0s to 1001.0.
+    # Third is delayed by another 1.0s to 1002.0.
+    assert clock.time() == 1002.0


### PR DESCRIPTION
This submission implements the 'Channel Hub Rate Limiter' task under the safety area. It adds a highly robust `ChannelRateLimiter` supporting both 'delay' (async lock queue serialization) and 'block' strategies, completely integrated into `ChannelHub`. Comprehensive testing uses MockClock to keep tests fast and completely deterministic. Additionally, the task manifest and backlog have been replenished with 3 new modern AI agent trends todo tasks.

---
*PR created automatically by Jules for task [11689550520451953210](https://jules.google.com/task/11689550520451953210) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-channel rate limiting with sliding window and queue serialization to `ChannelHub`
> - Adds [`ChannelRateLimiter`](https://github.com/kazah4359-lgtm/Magda-agent/pull/525/files#diff-279421b215801ef2e6ab56ad562b3d534a0e1d52d568848d50e329f2076d7c39) with per-channel and default limits, a sliding-window counter, and two strategies: `block` (raises `RateLimitExceededError`) and `delay` (defers until a slot opens).
> - Extends [`ChannelHub`](https://github.com/kazah4359-lgtm/Magda-agent/pull/525/files#diff-9293e380c95499807dc7338390df25bb4a40d68dc277a48f9aecffa4506ab748) with an optional `rate_limiter` constructor parameter and a `set_rate_limiter()` method to attach or remove a limiter at runtime.
> - Per-channel asyncio locks serialize concurrent `acquire()` calls, ensuring deterministic slot ordering under the `delay` strategy.
> - Test coverage in [`tests/test_channel_rate_limiter.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/525/files#diff-56d63fbbfaacf4f8c5b1b182b8ac092543def7bb444280ea164baddcdd90c4c8) uses a mock clock to validate block, delay, default-config, integration, and concurrency behaviors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26c0e67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->