### PR TITLE
Implement Channel Hub Rate Limiter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8495,7 +8495,7 @@
     },
     {
       "id": "channel-hub-rate-limiter",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Channel Hub Rate Limiter",

--- a/magda_agent/channels/hub.py
+++ b/magda_agent/channels/hub.py
@@ -1,13 +1,21 @@
 from typing import Any, Dict, Optional
 from magda_agent.channels.base import ChannelAdapter
+from magda_agent.channels.rate_limiter import ChannelRateLimiter
 
 class ChannelHub:
     """
     Centralized messaging hub that abstracts multiple channel adapters.
     Manages a collection of ChannelAdapter instances and allows receiving and sending messages across them.
     """
-    def __init__(self):
+    def __init__(self, rate_limiter: Optional[ChannelRateLimiter] = None):
         self._adapters: Dict[str, ChannelAdapter] = {}
+        self.rate_limiter = rate_limiter
+
+    def set_rate_limiter(self, rate_limiter: ChannelRateLimiter) -> None:
+        """
+        Set or update the active rate limiter for this hub.
+        """
+        self.rate_limiter = rate_limiter
 
     def register_adapter(self, adapter: ChannelAdapter) -> None:
         """
@@ -61,5 +69,7 @@ class ChannelHub:
         """
         adapter = self.get_adapter(channel_id)
         if adapter:
+            if self.rate_limiter:
+                await self.rate_limiter.acquire(channel_id)
             return await adapter.send(recipient_id, text, metadata)
         return f"Error: Channel '{channel_id}' not found."

--- a/magda_agent/channels/rate_limiter.py
+++ b/magda_agent/channels/rate_limiter.py
@@ -1,0 +1,94 @@
+import asyncio
+import time
+from typing import Dict, Any, Tuple, Callable, Optional
+
+class RateLimitExceeded(Exception):
+    """Exception raised when the rate limit is exceeded in block mode."""
+    pass
+
+class ChannelRateLimiter:
+    """
+    Token-bucket based rate limiter for communication channels.
+    Supports both delay mode (throttling/sleeping) and block mode (raising RateLimitExceeded).
+    """
+    def __init__(
+        self,
+        default_rate_limit: int = 5,
+        default_window: float = 10.0,
+        block_mode: bool = False,
+        channel_limits: Optional[Dict[str, Tuple[int, float]]] = None,
+        time_func: Callable[[], float] = time.time,
+        sleep_func: Callable[[float], Any] = asyncio.sleep,
+    ):
+        """
+        Args:
+            default_rate_limit: Default max tokens.
+            default_window: Default window duration in seconds.
+            block_mode: If True, raises RateLimitExceeded on violation. If False, delays.
+            channel_limits: Dict mapping channel_id -> (rate_limit, window).
+            time_func: Function to get the current time.
+            sleep_func: Async function to perform sleep/delay.
+        """
+        self.default_rate_limit = default_rate_limit
+        self.default_window = default_window
+        self.block_mode = block_mode
+        self.channel_limits = channel_limits or {}
+        self.time_func = time_func
+        self.sleep_func = sleep_func
+
+        # State storage: channel_id -> { "tokens": float, "last_updated": float }
+        self._states: Dict[str, Dict[str, float]] = {}
+
+    def _get_limit_and_refill_rate(self, channel_id: str) -> Tuple[float, float]:
+        """Returns (max_tokens, refill_rate) for a given channel."""
+        limit, window = self.channel_limits.get(channel_id, (self.default_rate_limit, self.default_window))
+        max_tokens = float(limit)
+        refill_rate = max_tokens / float(window) if window > 0 else float('inf')
+        return max_tokens, refill_rate
+
+    def _init_state_if_needed(self, channel_id: str, max_tokens: float, now: float) -> None:
+        if channel_id not in self._states:
+            self._states[channel_id] = {
+                "tokens": max_tokens,
+                "last_updated": now
+            }
+
+    async def acquire(self, channel_id: str) -> None:
+        """
+        Attempt to acquire a token for the given channel_id.
+        Delays or blocks depending on block_mode.
+        """
+        max_tokens, refill_rate = self._get_limit_and_refill_rate(channel_id)
+        if refill_rate == float('inf'):
+            return
+
+        now = self.time_func()
+        self._init_state_if_needed(channel_id, max_tokens, now)
+
+        state = self._states[channel_id]
+        elapsed = max(0.0, now - state["last_updated"])
+
+        # Refill tokens based on elapsed time
+        refilled_tokens = state["tokens"] + (elapsed * refill_rate)
+        state["tokens"] = min(max_tokens, refilled_tokens)
+        state["last_updated"] = now
+
+        if state["tokens"] >= 1.0:
+            # Token available immediately
+            state["tokens"] -= 1.0
+        else:
+            # Token not available
+            needed = 1.0 - state["tokens"]
+            wait_time = needed / refill_rate
+
+            if self.block_mode:
+                raise RateLimitExceeded(
+                    f"Rate limit exceeded for channel '{channel_id}'. "
+                    f"Needs {wait_time:.2f}s to recover."
+                )
+            else:
+                # Delay mode: wait for token to become available
+                await self.sleep_func(wait_time)
+                # After sleeping, update our tokens state as if wait_time has elapsed
+                state["tokens"] = 0.0
+                state["last_updated"] = now + wait_time

--- a/tests/test_channel_rate_limiter.py
+++ b/tests/test_channel_rate_limiter.py
@@ -1,0 +1,145 @@
+import pytest
+import asyncio
+from typing import Any, Dict, Optional, Tuple
+from magda_agent.channels.base import ChannelAdapter
+from magda_agent.channels.hub import ChannelHub
+from magda_agent.channels.rate_limiter import ChannelRateLimiter, RateLimitExceeded
+from magda_agent.gateway.router import GatewayRouter
+
+class MockAdapterForRateLimit(ChannelAdapter):
+    """Simple mock adapter for rate limit testing."""
+    def __init__(self, channel_id: str, gateway: GatewayRouter) -> None:
+        super().__init__(channel_id, gateway)
+        self.sent_messages = []
+
+    async def receive(self, raw_data: Any) -> Any:
+        pass
+
+    async def send(self, recipient_id: str, text: str, metadata: Dict[str, Any] = None) -> str:
+        self.sent_messages.append((recipient_id, text))
+        return f"Sent: {text}"
+
+@pytest.fixture
+def gateway() -> GatewayRouter:
+    return GatewayRouter()
+
+@pytest.mark.asyncio
+async def test_block_mode(gateway: GatewayRouter) -> None:
+    """Verify rate limiter in block mode raises RateLimitExceeded when exceeded."""
+    virtual_time = 100.0
+
+    def mock_time_func() -> float:
+        return virtual_time
+
+    # Rate limit: 2 messages per 10 seconds. Block mode.
+    limiter = ChannelRateLimiter(
+        default_rate_limit=2,
+        default_window=10.0,
+        block_mode=True,
+        time_func=mock_time_func
+    )
+
+    hub = ChannelHub(rate_limiter=limiter)
+    adapter = MockAdapterForRateLimit("telegram", gateway)
+    hub.register_adapter(adapter)
+
+    # First send - consumes 1 token (1 token remaining)
+    res = await hub.send_to_channel("telegram", "user1", "msg1")
+    assert res == "Sent: msg1"
+
+    # Second send - consumes 1 token (0 tokens remaining)
+    res = await hub.send_to_channel("telegram", "user1", "msg2")
+    assert res == "Sent: msg2"
+
+    # Third send - should raise RateLimitExceeded
+    with pytest.raises(RateLimitExceeded) as excinfo:
+        await hub.send_to_channel("telegram", "user1", "msg3")
+    assert "Rate limit exceeded" in str(excinfo.value)
+
+    # Advance virtual time by 5 seconds -> refills 5 * (2/10) = 1 token
+    virtual_time += 5.0
+    res = await hub.send_to_channel("telegram", "user1", "msg3")
+    assert res == "Sent: msg3"
+
+    # Now 0 tokens again, next send raises RateLimitExceeded
+    with pytest.raises(RateLimitExceeded):
+        await hub.send_to_channel("telegram", "user1", "msg4")
+
+
+@pytest.mark.asyncio
+async def test_delay_mode(gateway: GatewayRouter) -> None:
+    """Verify rate limiter in delay mode waits the correct duration."""
+    virtual_time = 100.0
+    sleeps = []
+
+    def mock_time_func() -> float:
+        return virtual_time
+
+    async def mock_sleep_func(seconds: float) -> None:
+        nonlocal virtual_time
+        sleeps.append(seconds)
+        virtual_time += seconds
+
+    # Rate limit: 1 message per 5 seconds. Delay mode.
+    limiter = ChannelRateLimiter(
+        default_rate_limit=1,
+        default_window=5.0,
+        block_mode=False,
+        time_func=mock_time_func,
+        sleep_func=mock_sleep_func
+    )
+
+    hub = ChannelHub(rate_limiter=limiter)
+    adapter = MockAdapterForRateLimit("telegram", gateway)
+    hub.register_adapter(adapter)
+
+    # First send - consumes 1 token immediately (0 remaining)
+    res = await hub.send_to_channel("telegram", "user1", "msg1")
+    assert res == "Sent: msg1"
+    assert len(sleeps) == 0
+
+    # Second send - needs 1 token. Wait time = 1 / refill_rate = 1 / (1/5) = 5.0s.
+    res = await hub.send_to_channel("telegram", "user1", "msg2")
+    assert res == "Sent: msg2"
+    assert len(sleeps) == 1
+    assert sleeps[0] == 5.0
+    assert virtual_time == 105.0
+
+
+@pytest.mark.asyncio
+async def test_per_channel_limits(gateway: GatewayRouter) -> None:
+    """Verify that channel-specific limits override default limits."""
+    virtual_time = 100.0
+
+    def mock_time_func() -> float:
+        return virtual_time
+
+    # Default: 1 message per 10s.
+    # Discord specific override: 3 messages per 10s.
+    limiter = ChannelRateLimiter(
+        default_rate_limit=1,
+        default_window=10.0,
+        block_mode=True,
+        channel_limits={
+            "discord": (3, 10.0)
+        },
+        time_func=mock_time_func
+    )
+
+    hub = ChannelHub(rate_limiter=limiter)
+    adapter1 = MockAdapterForRateLimit("telegram", gateway)
+    adapter2 = MockAdapterForRateLimit("discord", gateway)
+    hub.register_adapter(adapter1)
+    hub.register_adapter(adapter2)
+
+    # Telegram uses default: 1 msg/10s
+    await hub.send_to_channel("telegram", "user1", "t1")
+    with pytest.raises(RateLimitExceeded):
+        await hub.send_to_channel("telegram", "user1", "t2")
+
+    # Discord uses override: 3 msg/10s
+    await hub.send_to_channel("discord", "user1", "d1")
+    await hub.send_to_channel("discord", "user1", "d2")
+    await hub.send_to_channel("discord", "user1", "d3")
+    with pytest.raises(RateLimitExceeded):
+        await hub.send_to_channel("discord", "user1", "d4")


### PR DESCRIPTION
This change implements a channel hub rate limiter to protect external communication channels from flooding. Using the Token Bucket algorithm, ChannelRateLimiter can run in blocking mode (raising RateLimitExceeded exception on over-limit messages) or delay mode (gracefully pausing execution using custom sleep/delay functions). The limiter has been seamlessly integrated into ChannelHub, and robust unit tests have been added.

---
*PR created automatically by Jules for task [14580577249814316261](https://jules.google.com/task/14580577249814316261) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement token-bucket rate limiting for `ChannelHub` message sends
> - Adds `ChannelRateLimiter` in [`rate_limiter.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/526/files#diff-279421b215801ef2e6ab56ad562b3d534a0e1d52d568848d50e329f2076d7c39): a token-bucket rate limiter with configurable defaults and per-channel overrides.
> - `ChannelHub.send_to_channel` in [`hub.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/526/files#diff-9293e380c95499807dc7338390df25bb4a40d68dc277a48f9aecffa4506ab748) now calls `rate_limiter.acquire(channel_id)` before delegating to the adapter, when a rate limiter is set.
> - Supports two modes: `block_mode` raises `RateLimitExceeded` when tokens are exhausted; delay mode awaits until a token is available.
> - Risk: callers of `ChannelHub.send_to_channel` may now receive `RateLimitExceeded` or experience added latency depending on the configured mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 572fd19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->