### PR TITLE
feat: implement a2a peer task delegation v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8530,7 +8530,7 @@
     },
     {
       "id": "a2a-peer-task-delegation-v4",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "A2A Peer Task Delegation V4",
@@ -19131,6 +19131,40 @@
         "Worktree Pruning Optimizer module is created.",
         "Tests mock disk operations and verify correct worktrees are pruned based on TTL."
       ]
+    },
+    {
+      "id": "a2a-swarm-intelligence-v1",
+      "title": "A2A Swarm Intelligence Strategy v1",
+      "description": "Inspired by Anthropic swarm patterns: Add dynamic task redistribution across peer agents when latency spikes are detected.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_swarm.py",
+        "tests/test_a2a_swarm.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Task redistribution triggers on high latency",
+        "Tests simulate latency and verify routing"
+      ],
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo"
+    },
+    {
+      "id": "openclaw-rl-multiagent-feedback-v1",
+      "title": "OpenClaw RL Multi-agent Feedback Exchange",
+      "description": "Inspired by OpenClaw trends: Enable agents to share RL habit weights to bootstrap new peers in an A2A network.",
+      "allowed_paths": [
+        "magda_agent/learning/a2a_rl_exchange.py",
+        "tests/test_a2a_rl_exchange.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL weights can be exported and imported",
+        "Tests verify cross-agent weight synchronization"
+      ],
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo"
     }
   ]
 }

--- a/magda_agent/integration/__init__.py
+++ b/magda_agent/integration/__init__.py
@@ -4,8 +4,9 @@ Integration module for Magda agent.
 
 from magda_agent.integration.a2a_discovery import AgentCard, A2ADiscovery
 from magda_agent.integration.a2a_delegation import A2ADelegator
+from magda_agent.integration.a2a_delegator_v4 import A2ADelegatorV4
 from magda_agent.integration.a2a import A2AManager
 from magda_agent.integration.cross_platform import CrossPlatformDispatcher
 from magda_agent.integration.discord_bridge import DiscordBridge
 
-__all__ = ["AgentCard", "A2ADiscovery", "A2ADelegator", "A2AManager", "CrossPlatformDispatcher", "DiscordBridge"]
+__all__ = ["AgentCard", "A2ADiscovery", "A2ADelegator", "A2ADelegatorV4", "A2AManager", "CrossPlatformDispatcher", "DiscordBridge"]

--- a/magda_agent/integration/a2a_delegator_v4.py
+++ b/magda_agent/integration/a2a_delegator_v4.py
@@ -1,0 +1,42 @@
+import httpx
+import logging
+from typing import Dict, Any
+
+class A2ADelegatorV4:
+    """
+    Handles peer-to-peer task delegation using the A2A spec.
+    """
+
+    def __init__(self, timeout: float = 10.0):
+        self.timeout = timeout
+
+    async def delegate_task(self, peer_endpoint: str, payload: Dict[str, Any], headers: Dict[str, str] = None) -> Dict[str, Any]:
+        """
+        Delegates a task to a peer agent asynchronously.
+
+        Args:
+            peer_endpoint: The URL endpoint of the peer agent.
+            payload: The task payload to send.
+            headers: Optional HTTP headers for the request.
+
+        Returns:
+            A dictionary containing the response from the peer.
+
+        Raises:
+            httpx.HTTPError: If the HTTP request fails.
+        """
+        logging.info(f"Delegating task to peer at {peer_endpoint}")
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    peer_endpoint,
+                    json=payload,
+                    headers=headers or {},
+                    timeout=self.timeout
+                )
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPError as e:
+                logging.error(f"Failed to delegate task to {peer_endpoint}: {e}")
+                raise

--- a/tests/test_a2a_delegator_v4.py
+++ b/tests/test_a2a_delegator_v4.py
@@ -1,0 +1,32 @@
+import pytest
+import httpx
+import respx
+
+from magda_agent.integration.a2a_delegator_v4 import A2ADelegatorV4
+
+@pytest.mark.asyncio
+async def test_delegate_task_success():
+    delegator = A2ADelegatorV4()
+    endpoint = "http://fake-peer/delegate"
+    payload = {"task": "do_something"}
+
+    mock_response = {"status": "success", "result": 42}
+
+    with respx.mock:
+        respx.post(endpoint).mock(return_value=httpx.Response(200, json=mock_response))
+
+        response = await delegator.delegate_task(endpoint, payload)
+
+        assert response == mock_response
+
+@pytest.mark.asyncio
+async def test_delegate_task_failure():
+    delegator = A2ADelegatorV4()
+    endpoint = "http://fake-peer/delegate"
+    payload = {"task": "do_something"}
+
+    with respx.mock:
+        respx.post(endpoint).mock(return_value=httpx.Response(500, json={"error": "Internal Server Error"}))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await delegator.delegate_task(endpoint, payload)


### PR DESCRIPTION
Resolves the `a2a-peer-task-delegation-v4` todo task. Implements the `A2ADelegatorV4` module using `httpx` and `respx` for mocking tests. It exports this delegator in the `__init__.py` of the integration module, effectively wiring it into the rest of the application. Also correctly updates the task manifest and adds two new trend-inspired tasks as requested.

---
*PR created automatically by Jules for task [1498650022567060892](https://jules.google.com/task/1498650022567060892) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `A2ADelegatorV4` class for async peer-to-peer task delegation
> - Introduces [`a2a_delegator_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/528/files#diff-cfe9e786490427b443e3020dbc13cfecb4813a7d4ca3f6bcc7744c52e73422da) with `A2ADelegatorV4`, which posts JSON payloads to a peer endpoint via `httpx.AsyncClient` with configurable timeout and optional headers.
> - On success, `delegate_task` returns parsed JSON; on non-2xx responses it logs the error and raises `httpx.HTTPStatusError`.
> - Exports `A2ADelegatorV4` from the `magda_agent.integration` package and adds async tests using `respx` to cover success and failure cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bfcede.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->