### PR TITLE
feat: A2A Async-first Tracing V4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -28,7 +28,7 @@
       "low",
       "medium"
     ],
-    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks — never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
+    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks \u2014 never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
     "max_todo_tasks": 5000
   },
   "autonomous_loop_policy": {
@@ -778,7 +778,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from user replies (next-state signal)",
-      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed — use simple reward heuristics.",
+      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed \u2014 use simple reward heuristics.",
       "allowed_paths": [
         "magda_agent/learning/**",
         "magda_agent/metacognition/**",
@@ -996,7 +996,7 @@
       "area": "attention",
       "risk": "medium",
       "title": "Global Workspace broadcast mechanism",
-      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic — workspace should mediate.",
+      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic \u2014 workspace should mediate.",
       "allowed_paths": [
         "magda_agent/attention/**",
         "magda_agent/consciousness/**",
@@ -1055,7 +1055,7 @@
       "status": "done",
       "area": "memory",
       "risk": "low",
-      "title": "Periodic consolidation of episodic → semantic memory",
+      "title": "Periodic consolidation of episodic \u2192 semantic memory",
       "description": "Subconsciousness periodically reviews episodic memories, extracts stable facts, and promotes them to semantic memory. Decay irrelevant episodes. Inspired by sleep consolidation in neuroscience.",
       "allowed_paths": [
         "magda_agent/subconsciousness/**",
@@ -1096,7 +1096,7 @@
       "area": "metacognition",
       "risk": "low",
       "title": "Confidence calibration for responses",
-      "description": "Agent should estimate confidence in its responses. Low confidence → add caveats, suggest verification. High confidence → direct answer. Track calibration accuracy over time.",
+      "description": "Agent should estimate confidence in its responses. Low confidence \u2192 add caveats, suggest verification. High confidence \u2192 direct answer. Track calibration accuracy over time.",
       "allowed_paths": [
         "magda_agent/metacognition/**",
         "magda_agent/consciousness/**",
@@ -1797,7 +1797,7 @@
       "area": "UI",
       "risk": "low",
       "title": "Context Engine Canvas Visualization",
-      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent’s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
+      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent\u2019s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
       "allowed_paths": [
         "magda_agent/memory/canvas.py",
         "tests/test_canvas*.py",
@@ -2942,7 +2942,7 @@
       "area": "operations",
       "risk": "medium",
       "title": "Scheduled operations cron-like tasks",
-      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement cron-like scheduled tasks that the agent can run autonomously.",
+      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement cron-like scheduled tasks that the agent can run autonomously.",
       "allowed_paths": [
         "magda_agent/operations/cron.py",
         "tests/test_cron.py",
@@ -2961,7 +2961,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Skill marketplace compatibility",
-      "description": "Inspired by trend: Skill marketplace — совместимость с agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
+      "description": "Inspired by trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
       "allowed_paths": [
         "magda_agent/integration/skill_marketplace.py",
         "tests/test_skill_marketplace_integration.py",
@@ -3016,7 +3016,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine plugin architecture",
-      "description": "Inspired by trend 'Context Engine — plugin-архитектура для управления контекстом': Implement a plugin interface with lifecycle hooks for managing working memory context.",
+      "description": "Inspired by trend 'Context Engine \u2014 plugin-\u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 \u0434\u043b\u044f \u0443\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u044f \u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442\u043e\u043c': Implement a plugin interface with lifecycle hooks for managing working memory context.",
       "allowed_paths": [
         "magda_agent/memory/context_engine.py",
         "tests/test_context_engine*.py",
@@ -3034,7 +3034,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams sub-agents spawning",
-      "description": "Inspired by trend 'Agent Teams — порождение sub-agents для параллельных задач': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
+      "description": "Inspired by trend 'Agent Teams \u2014 \u043f\u043e\u0440\u043e\u0436\u0434\u0435\u043d\u0438\u0435 sub-agents \u0434\u043b\u044f \u043f\u0430\u0440\u0430\u043b\u043b\u0435\u043b\u044c\u043d\u044b\u0445 \u0437\u0430\u0434\u0430\u0447': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
       "allowed_paths": [
         "magda_agent/agents/teams.py",
         "tests/test_agent_teams*.py",
@@ -3052,7 +3052,7 @@
       "area": "gateway",
       "risk": "low",
       "title": "Cross-platform reach across channels",
-      "description": "Inspired by trend 'Cross-platform reach — один агент, много каналов': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
+      "description": "Inspired by trend 'Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
       "allowed_paths": [
         "magda_agent/gateway/channels.py",
         "tests/test_gateway_channels*.py",
@@ -3087,7 +3087,7 @@
       "area": "gateway",
       "risk": "medium",
       "title": "Canvas live visualization support",
-      "description": "Inspired by trend: OpenClaw - Canvas для live визуализации. Add visualization capabilities and state streaming to the context engine.",
+      "description": "Inspired by trend: OpenClaw - Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Add visualization capabilities and state streaming to the context engine.",
       "allowed_paths": [
         "magda_agent/gateway/canvas.py",
         "tests/test_canvas*.py",
@@ -3238,7 +3238,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Hermes agentskills.io export compatibility",
-      "description": "Inspired by Hermes Agent trend: Skill marketplace — совместимость с agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
+      "description": "Inspired by Hermes Agent trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
       "allowed_paths": [
         "magda_agent/skills/agentskills_export.py",
         "tests/test_agentskills_export.py",
@@ -3343,7 +3343,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Hermes Persistent Memory",
-      "description": "Inspired by Hermes Agent trend: Persistent memory: чем дольше работает, тем лучше знает пользователя. Implement a persistent user profile memory.",
+      "description": "Inspired by Hermes Agent trend: Persistent memory: \u0447\u0435\u043c \u0434\u043e\u043b\u044c\u0448\u0435 \u0440\u0430\u0431\u043e\u0442\u0430\u0435\u0442, \u0442\u0435\u043c \u043b\u0443\u0447\u0448\u0435 \u0437\u043d\u0430\u0435\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement a persistent user profile memory.",
       "allowed_paths": [
         "magda_agent/memory/hermes_persistent.py",
         "tests/test_hermes_persistent.py",
@@ -3360,7 +3360,7 @@
       "area": "architecture",
       "risk": "high",
       "title": "OpenClaw Context Engine Lifecycle Hooks",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Implement lifecycle hooks for plugins.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Implement lifecycle hooks for plugins.",
       "allowed_paths": [
         "magda_agent/architecture/context_hooks.py",
         "tests/test_context_hooks.py",
@@ -3378,7 +3378,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "A2A Discovery via Agent Cards",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
       "allowed_paths": [
         "magda_agent/architecture/a2a_discovery.py",
         "tests/test_a2a_discovery*.py",
@@ -3414,7 +3414,7 @@
       "area": "ui",
       "risk": "medium",
       "title": "OpenClaw Canvas Live Visualization",
-      "description": "Inspired by trend: OpenClaw Canvas для live визуализации. Implement an interface for live visualization of the agent's internal state and working memory.",
+      "description": "Inspired by trend: OpenClaw Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement an interface for live visualization of the agent's internal state and working memory.",
       "allowed_paths": [
         "magda_agent/ui/canvas.py",
         "tests/test_canvas*.py",
@@ -3432,7 +3432,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams Subagent Spawning",
-      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
+      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
       "allowed_paths": [
         "magda_agent/multi_agent/team_spawner.py",
         "tests/test_team_spawner*.py",
@@ -3467,7 +3467,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Lifecycle Plugins",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
       "allowed_paths": [
         "magda_agent/memory/context_engine_lifecycle.py",
         "tests/test_context_engine_lifecycle.py",
@@ -3501,7 +3501,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach implementation",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
       "allowed_paths": [
         "magda_agent/integration/cross_platform.py",
         "tests/test_cross_platform.py",
@@ -3518,7 +3518,7 @@
       "area": "evaluation",
       "risk": "low",
       "title": "Quality metrics longitudinal tracking",
-      "description": "Inspired by trend: Quality metrics — longitudinal tracking, не одноразовый pytest. Implement longitudinal tracking of code quality metrics.",
+      "description": "Inspired by trend: Quality metrics \u2014 longitudinal tracking, \u043d\u0435 \u043e\u0434\u043d\u043e\u0440\u0430\u0437\u043e\u0432\u044b\u0439 pytest. Implement longitudinal tracking of code quality metrics.",
       "allowed_paths": [
         "magda_agent/evaluation/longitudinal_metrics.py",
         "tests/test_longitudinal_metrics.py",
@@ -3535,7 +3535,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Exporter v6",
-      "description": "Inspired by the MCP-совместимость trend: Magda должна уметь экспортировать skills как MCP tools.",
+      "description": "Inspired by the MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c trend: Magda \u0434\u043e\u043b\u0436\u043d\u0430 \u0443\u043c\u0435\u0442\u044c \u044d\u043a\u0441\u043f\u043e\u0440\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c skills \u043a\u0430\u043a MCP tools.",
       "allowed_paths": [
         "magda_agent/integration/mcp_exporter.py",
         "tests/test_mcp_exporter*.py",
@@ -3552,7 +3552,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A delegation v6",
-      "description": "Inspired by trend: A2A поддержка — возможность делегировать задачи другим агентам.",
+      "description": "Inspired by trend: A2A \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0430 \u2014 \u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e\u0441\u0442\u044c \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0437\u0430\u0434\u0430\u0447\u0438 \u0434\u0440\u0443\u0433\u0438\u043c \u0430\u0433\u0435\u043d\u0442\u0430\u043c.",
       "allowed_paths": [
         "magda_agent/multi_agent/a2a_delegator.py",
         "tests/test_a2a_delegator*.py",
@@ -3569,7 +3569,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning v6",
-      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections).",
+      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections).",
       "allowed_paths": [
         "magda_agent/learning/online_learning.py",
         "tests/test_online_learning*.py",
@@ -3637,7 +3637,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Creation from Experience",
-      "description": "Inspired by Hermes Agent trend: Self-improving agent с built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
+      "description": "Inspired by Hermes Agent trend: Self-improving agent \u0441 built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
       "allowed_paths": [
         "magda_agent/skills/skill_generator.py",
         "tests/test_skill_generator*.py",
@@ -3655,7 +3655,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Triad Architecture",
-      "description": "Inspired by Claude Agent SDK trend: Трёхагентная архитектура Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
+      "description": "Inspired by Claude Agent SDK trend: \u0422\u0440\u0451\u0445\u0430\u0433\u0435\u043d\u0442\u043d\u0430\u044f \u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
       "allowed_paths": [
         "magda_agent/agents/triad_coordinator.py",
         "tests/test_triad_coordinator*.py",
@@ -4001,7 +4001,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "MCP JSON-RPC Interface",
-      "description": "Inspired by trend: MCP-совместимость (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
+      "description": "Inspired by trend: MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
       "allowed_paths": [
         "magda_agent/integration/mcp_server.py",
         "tests/test_mcp_server*.py",
@@ -4018,7 +4018,7 @@
       "area": "evaluation",
       "risk": "medium",
       "title": "AgentBench Multi-Domain Evaluation",
-      "description": "Inspired by trend: Evaluation (бенчмарки) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
+      "description": "Inspired by trend: Evaluation (\u0431\u0435\u043d\u0447\u043c\u0430\u0440\u043a\u0438) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
       "allowed_paths": [
         "magda_agent/evaluation/agentbench.py",
         "tests/test_agentbench*.py",
@@ -4051,7 +4051,7 @@
       "area": "visualization",
       "risk": "low",
       "title": "Canvas Live Visualization API v2",
-      "description": "Inspired by OpenClaw trend: Canvas для live визуализации. Implement API endpoints for the canvas streaming.",
+      "description": "Inspired by OpenClaw trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement API endpoints for the canvas streaming.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_api_v2.py",
         "tests/test_canvas_api_v2.py",
@@ -4083,7 +4083,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "Scheduled operations: daily reports",
-      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement scheduled daily reports capability.",
+      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement scheduled daily reports capability.",
       "allowed_paths": [
         "magda_agent/scheduler/cron.py",
         "tests/test_cron*.py",
@@ -4100,7 +4100,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach: Telegram channel v2",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Add improved Telegram messenger integration.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Add improved Telegram messenger integration.",
       "allowed_paths": [
         "magda_agent/channels/telegram.py",
         "tests/test_telegram*.py",
@@ -4234,7 +4234,7 @@
       "area": "execution",
       "risk": "high",
       "title": "Agent Teams Worktree Isolation",
-      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
+      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
       "allowed_paths": [
         "magda_agent/agents/subagent.py",
         "magda_agent/isolation/git_worktree.py",
@@ -4253,7 +4253,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Control Checkpoints Interface",
-      "description": "Inspired by trend: ACS (Agent Control Specification) — 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
+      "description": "Inspired by trend: ACS (Agent Control Specification) \u2014 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
       "allowed_paths": [
         "magda_agent/safety/acs_guard.py",
         "tests/test_acs_guard.py",
@@ -4325,7 +4325,7 @@
       "area": "channels",
       "risk": "medium",
       "title": "Cross-platform reach channels",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Expand channel adapters for more platforms.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Expand channel adapters for more platforms.",
       "allowed_paths": [
         "magda_agent/channels/reach_v2.py",
         "tests/test_reach_v2.py",
@@ -4342,7 +4342,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from dialogue v3",
-      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections). Implement immediate context integration.",
+      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections). Implement immediate context integration.",
       "allowed_paths": [
         "magda_agent/learning/dialogue_v3.py",
         "tests/test_dialogue_v3.py",
@@ -4478,7 +4478,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Agent Discovery via Cards v2",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Add discovery components to the network layer.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Add discovery components to the network layer.",
       "allowed_paths": [
         "magda_agent/integration/a2a_discovery_v2.py",
         "tests/test_a2a_discovery_v2.py",
@@ -5488,7 +5488,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT Virtual Context Management v1",
-      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> стандарт)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
+      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
       "allowed_paths": [
         "magda_agent/memory/virtual_context.py",
         "tests/test_virtual_context.py",
@@ -5506,7 +5506,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Agent Control Specification Checkpoints v3",
-      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) — 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
+      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) \u2014 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
       "allowed_paths": [
         "magda_agent/safety/acs_checkpoints_v3.py",
         "tests/test_acs_checkpoints_v3.py",
@@ -8547,7 +8547,7 @@
     },
     {
       "id": "a2a-async-tracing-v4",
-      "status": "todo",
+      "status": "done",
       "area": "monitoring",
       "risk": "low",
       "title": "A2A Async-first Tracing V4",
@@ -8639,7 +8639,7 @@
       "area": "planning",
       "risk": "medium",
       "title": "Claude Agent Teams Dependency Graph",
-      "description": "Inspired by Claude Agent SDK trend: Task system с dependency graphs. Update planning to utilize dependency graphs.",
+      "description": "Inspired by Claude Agent SDK trend: Task system \u0441 dependency graphs. Update planning to utilize dependency graphs.",
       "allowed_paths": [
         "magda_agent/planning/dependency_graph.py",
         "tests/test_dependency_graph.py",
@@ -8792,7 +8792,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging",
-      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
+      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger.py",
         "tests/test_canvas_logger.py",
@@ -8931,7 +8931,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging V3",
-      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
+      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger_v3.py",
         "tests/test_canvas_logger_v3.py",
@@ -11810,7 +11810,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery Agent Cards v4",
-      "description": "Inspired by trend: Agent discovery через Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
+      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -12062,7 +12062,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Protocol Discovery Mesh",
-      "description": "Inspired by trend: Agent discovery через Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
+      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -19165,6 +19165,57 @@
       "area": "learning",
       "risk": "medium",
       "status": "todo"
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v5-34ab8e",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V5",
+      "description": "Inspired by MCP Trend: Implement multi-turn capability negotiation for MCP tools, allowing dynamic capability discovery at runtime.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_capability_negotiation_v5.py",
+        "tests/test_mcp_capability_negotiation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Capability Negotiation V5 module is created.",
+        "Tests verify multi-turn negotiation and fallback."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-evaluation-v2-12fc90",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Quality Evaluation",
+      "description": "Inspired by OpenClaw RL Trend: Implement trajectory quality evaluation module to assess full multi-turn conversational rollouts against standard metrics for online learning.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_quality_v2.py",
+        "tests/test_trajectory_quality_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory Quality Evaluator module is created.",
+        "Tests mock trajectory parsing and metric calculation."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v1-98acb4",
+      "status": "todo",
+      "area": "isolation",
+      "risk": "medium",
+      "title": "Claude Worktree Pruning and Resource Optimizer",
+      "description": "Inspired by Claude Agent Teams Trend: Create an optimizer to prune inactive Git worktrees and manage disk resources utilized by concurrent parallel subagents.",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_pruning_v1.py",
+        "tests/test_worktree_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worktree Pruning Optimizer module is created.",
+        "Tests mock disk operations and verify correct worktrees are pruned based on TTL."
+      ]
     }
   ]
 }

--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -28,7 +28,7 @@
       "low",
       "medium"
     ],
-    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks \u2014 never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
+    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks — never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
     "max_todo_tasks": 5000
   },
   "autonomous_loop_policy": {
@@ -778,7 +778,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from user replies (next-state signal)",
-      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed \u2014 use simple reward heuristics.",
+      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed — use simple reward heuristics.",
       "allowed_paths": [
         "magda_agent/learning/**",
         "magda_agent/metacognition/**",
@@ -996,7 +996,7 @@
       "area": "attention",
       "risk": "medium",
       "title": "Global Workspace broadcast mechanism",
-      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic \u2014 workspace should mediate.",
+      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic — workspace should mediate.",
       "allowed_paths": [
         "magda_agent/attention/**",
         "magda_agent/consciousness/**",
@@ -1055,7 +1055,7 @@
       "status": "done",
       "area": "memory",
       "risk": "low",
-      "title": "Periodic consolidation of episodic \u2192 semantic memory",
+      "title": "Periodic consolidation of episodic → semantic memory",
       "description": "Subconsciousness periodically reviews episodic memories, extracts stable facts, and promotes them to semantic memory. Decay irrelevant episodes. Inspired by sleep consolidation in neuroscience.",
       "allowed_paths": [
         "magda_agent/subconsciousness/**",
@@ -1096,7 +1096,7 @@
       "area": "metacognition",
       "risk": "low",
       "title": "Confidence calibration for responses",
-      "description": "Agent should estimate confidence in its responses. Low confidence \u2192 add caveats, suggest verification. High confidence \u2192 direct answer. Track calibration accuracy over time.",
+      "description": "Agent should estimate confidence in its responses. Low confidence → add caveats, suggest verification. High confidence → direct answer. Track calibration accuracy over time.",
       "allowed_paths": [
         "magda_agent/metacognition/**",
         "magda_agent/consciousness/**",
@@ -1797,7 +1797,7 @@
       "area": "UI",
       "risk": "low",
       "title": "Context Engine Canvas Visualization",
-      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent\u2019s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
+      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent’s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
       "allowed_paths": [
         "magda_agent/memory/canvas.py",
         "tests/test_canvas*.py",
@@ -2942,7 +2942,7 @@
       "area": "operations",
       "risk": "medium",
       "title": "Scheduled operations cron-like tasks",
-      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement cron-like scheduled tasks that the agent can run autonomously.",
+      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement cron-like scheduled tasks that the agent can run autonomously.",
       "allowed_paths": [
         "magda_agent/operations/cron.py",
         "tests/test_cron.py",
@@ -2961,7 +2961,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Skill marketplace compatibility",
-      "description": "Inspired by trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
+      "description": "Inspired by trend: Skill marketplace — совместимость с agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
       "allowed_paths": [
         "magda_agent/integration/skill_marketplace.py",
         "tests/test_skill_marketplace_integration.py",
@@ -3016,7 +3016,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine plugin architecture",
-      "description": "Inspired by trend 'Context Engine \u2014 plugin-\u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 \u0434\u043b\u044f \u0443\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u044f \u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442\u043e\u043c': Implement a plugin interface with lifecycle hooks for managing working memory context.",
+      "description": "Inspired by trend 'Context Engine — plugin-архитектура для управления контекстом': Implement a plugin interface with lifecycle hooks for managing working memory context.",
       "allowed_paths": [
         "magda_agent/memory/context_engine.py",
         "tests/test_context_engine*.py",
@@ -3034,7 +3034,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams sub-agents spawning",
-      "description": "Inspired by trend 'Agent Teams \u2014 \u043f\u043e\u0440\u043e\u0436\u0434\u0435\u043d\u0438\u0435 sub-agents \u0434\u043b\u044f \u043f\u0430\u0440\u0430\u043b\u043b\u0435\u043b\u044c\u043d\u044b\u0445 \u0437\u0430\u0434\u0430\u0447': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
+      "description": "Inspired by trend 'Agent Teams — порождение sub-agents для параллельных задач': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
       "allowed_paths": [
         "magda_agent/agents/teams.py",
         "tests/test_agent_teams*.py",
@@ -3052,7 +3052,7 @@
       "area": "gateway",
       "risk": "low",
       "title": "Cross-platform reach across channels",
-      "description": "Inspired by trend 'Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
+      "description": "Inspired by trend 'Cross-platform reach — один агент, много каналов': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
       "allowed_paths": [
         "magda_agent/gateway/channels.py",
         "tests/test_gateway_channels*.py",
@@ -3087,7 +3087,7 @@
       "area": "gateway",
       "risk": "medium",
       "title": "Canvas live visualization support",
-      "description": "Inspired by trend: OpenClaw - Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Add visualization capabilities and state streaming to the context engine.",
+      "description": "Inspired by trend: OpenClaw - Canvas для live визуализации. Add visualization capabilities and state streaming to the context engine.",
       "allowed_paths": [
         "magda_agent/gateway/canvas.py",
         "tests/test_canvas*.py",
@@ -3238,7 +3238,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Hermes agentskills.io export compatibility",
-      "description": "Inspired by Hermes Agent trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
+      "description": "Inspired by Hermes Agent trend: Skill marketplace — совместимость с agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
       "allowed_paths": [
         "magda_agent/skills/agentskills_export.py",
         "tests/test_agentskills_export.py",
@@ -3343,7 +3343,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Hermes Persistent Memory",
-      "description": "Inspired by Hermes Agent trend: Persistent memory: \u0447\u0435\u043c \u0434\u043e\u043b\u044c\u0448\u0435 \u0440\u0430\u0431\u043e\u0442\u0430\u0435\u0442, \u0442\u0435\u043c \u043b\u0443\u0447\u0448\u0435 \u0437\u043d\u0430\u0435\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement a persistent user profile memory.",
+      "description": "Inspired by Hermes Agent trend: Persistent memory: чем дольше работает, тем лучше знает пользователя. Implement a persistent user profile memory.",
       "allowed_paths": [
         "magda_agent/memory/hermes_persistent.py",
         "tests/test_hermes_persistent.py",
@@ -3360,7 +3360,7 @@
       "area": "architecture",
       "risk": "high",
       "title": "OpenClaw Context Engine Lifecycle Hooks",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Implement lifecycle hooks for plugins.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Implement lifecycle hooks for plugins.",
       "allowed_paths": [
         "magda_agent/architecture/context_hooks.py",
         "tests/test_context_hooks.py",
@@ -3378,7 +3378,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "A2A Discovery via Agent Cards",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
       "allowed_paths": [
         "magda_agent/architecture/a2a_discovery.py",
         "tests/test_a2a_discovery*.py",
@@ -3414,7 +3414,7 @@
       "area": "ui",
       "risk": "medium",
       "title": "OpenClaw Canvas Live Visualization",
-      "description": "Inspired by trend: OpenClaw Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement an interface for live visualization of the agent's internal state and working memory.",
+      "description": "Inspired by trend: OpenClaw Canvas для live визуализации. Implement an interface for live visualization of the agent's internal state and working memory.",
       "allowed_paths": [
         "magda_agent/ui/canvas.py",
         "tests/test_canvas*.py",
@@ -3432,7 +3432,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams Subagent Spawning",
-      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
+      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
       "allowed_paths": [
         "magda_agent/multi_agent/team_spawner.py",
         "tests/test_team_spawner*.py",
@@ -3467,7 +3467,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Lifecycle Plugins",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
       "allowed_paths": [
         "magda_agent/memory/context_engine_lifecycle.py",
         "tests/test_context_engine_lifecycle.py",
@@ -3501,7 +3501,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach implementation",
-      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
       "allowed_paths": [
         "magda_agent/integration/cross_platform.py",
         "tests/test_cross_platform.py",
@@ -3518,7 +3518,7 @@
       "area": "evaluation",
       "risk": "low",
       "title": "Quality metrics longitudinal tracking",
-      "description": "Inspired by trend: Quality metrics \u2014 longitudinal tracking, \u043d\u0435 \u043e\u0434\u043d\u043e\u0440\u0430\u0437\u043e\u0432\u044b\u0439 pytest. Implement longitudinal tracking of code quality metrics.",
+      "description": "Inspired by trend: Quality metrics — longitudinal tracking, не одноразовый pytest. Implement longitudinal tracking of code quality metrics.",
       "allowed_paths": [
         "magda_agent/evaluation/longitudinal_metrics.py",
         "tests/test_longitudinal_metrics.py",
@@ -3535,7 +3535,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Exporter v6",
-      "description": "Inspired by the MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c trend: Magda \u0434\u043e\u043b\u0436\u043d\u0430 \u0443\u043c\u0435\u0442\u044c \u044d\u043a\u0441\u043f\u043e\u0440\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c skills \u043a\u0430\u043a MCP tools.",
+      "description": "Inspired by the MCP-совместимость trend: Magda должна уметь экспортировать skills как MCP tools.",
       "allowed_paths": [
         "magda_agent/integration/mcp_exporter.py",
         "tests/test_mcp_exporter*.py",
@@ -3552,7 +3552,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A delegation v6",
-      "description": "Inspired by trend: A2A \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0430 \u2014 \u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e\u0441\u0442\u044c \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0437\u0430\u0434\u0430\u0447\u0438 \u0434\u0440\u0443\u0433\u0438\u043c \u0430\u0433\u0435\u043d\u0442\u0430\u043c.",
+      "description": "Inspired by trend: A2A поддержка — возможность делегировать задачи другим агентам.",
       "allowed_paths": [
         "magda_agent/multi_agent/a2a_delegator.py",
         "tests/test_a2a_delegator*.py",
@@ -3569,7 +3569,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning v6",
-      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections).",
+      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections).",
       "allowed_paths": [
         "magda_agent/learning/online_learning.py",
         "tests/test_online_learning*.py",
@@ -3637,7 +3637,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Creation from Experience",
-      "description": "Inspired by Hermes Agent trend: Self-improving agent \u0441 built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
+      "description": "Inspired by Hermes Agent trend: Self-improving agent с built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
       "allowed_paths": [
         "magda_agent/skills/skill_generator.py",
         "tests/test_skill_generator*.py",
@@ -3655,7 +3655,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Triad Architecture",
-      "description": "Inspired by Claude Agent SDK trend: \u0422\u0440\u0451\u0445\u0430\u0433\u0435\u043d\u0442\u043d\u0430\u044f \u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
+      "description": "Inspired by Claude Agent SDK trend: Трёхагентная архитектура Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
       "allowed_paths": [
         "magda_agent/agents/triad_coordinator.py",
         "tests/test_triad_coordinator*.py",
@@ -4001,7 +4001,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "MCP JSON-RPC Interface",
-      "description": "Inspired by trend: MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
+      "description": "Inspired by trend: MCP-совместимость (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
       "allowed_paths": [
         "magda_agent/integration/mcp_server.py",
         "tests/test_mcp_server*.py",
@@ -4018,7 +4018,7 @@
       "area": "evaluation",
       "risk": "medium",
       "title": "AgentBench Multi-Domain Evaluation",
-      "description": "Inspired by trend: Evaluation (\u0431\u0435\u043d\u0447\u043c\u0430\u0440\u043a\u0438) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
+      "description": "Inspired by trend: Evaluation (бенчмарки) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
       "allowed_paths": [
         "magda_agent/evaluation/agentbench.py",
         "tests/test_agentbench*.py",
@@ -4051,7 +4051,7 @@
       "area": "visualization",
       "risk": "low",
       "title": "Canvas Live Visualization API v2",
-      "description": "Inspired by OpenClaw trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement API endpoints for the canvas streaming.",
+      "description": "Inspired by OpenClaw trend: Canvas для live визуализации. Implement API endpoints for the canvas streaming.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_api_v2.py",
         "tests/test_canvas_api_v2.py",
@@ -4083,7 +4083,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "Scheduled operations: daily reports",
-      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement scheduled daily reports capability.",
+      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement scheduled daily reports capability.",
       "allowed_paths": [
         "magda_agent/scheduler/cron.py",
         "tests/test_cron*.py",
@@ -4100,7 +4100,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach: Telegram channel v2",
-      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Add improved Telegram messenger integration.",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Add improved Telegram messenger integration.",
       "allowed_paths": [
         "magda_agent/channels/telegram.py",
         "tests/test_telegram*.py",
@@ -4234,7 +4234,7 @@
       "area": "execution",
       "risk": "high",
       "title": "Agent Teams Worktree Isolation",
-      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
+      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
       "allowed_paths": [
         "magda_agent/agents/subagent.py",
         "magda_agent/isolation/git_worktree.py",
@@ -4253,7 +4253,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Control Checkpoints Interface",
-      "description": "Inspired by trend: ACS (Agent Control Specification) \u2014 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
+      "description": "Inspired by trend: ACS (Agent Control Specification) — 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
       "allowed_paths": [
         "magda_agent/safety/acs_guard.py",
         "tests/test_acs_guard.py",
@@ -4325,7 +4325,7 @@
       "area": "channels",
       "risk": "medium",
       "title": "Cross-platform reach channels",
-      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Expand channel adapters for more platforms.",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Expand channel adapters for more platforms.",
       "allowed_paths": [
         "magda_agent/channels/reach_v2.py",
         "tests/test_reach_v2.py",
@@ -4342,7 +4342,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from dialogue v3",
-      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections). Implement immediate context integration.",
+      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections). Implement immediate context integration.",
       "allowed_paths": [
         "magda_agent/learning/dialogue_v3.py",
         "tests/test_dialogue_v3.py",
@@ -4478,7 +4478,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Agent Discovery via Cards v2",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Add discovery components to the network layer.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Add discovery components to the network layer.",
       "allowed_paths": [
         "magda_agent/integration/a2a_discovery_v2.py",
         "tests/test_a2a_discovery_v2.py",
@@ -5488,7 +5488,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT Virtual Context Management v1",
-      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
+      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> стандарт)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
       "allowed_paths": [
         "magda_agent/memory/virtual_context.py",
         "tests/test_virtual_context.py",
@@ -5506,7 +5506,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Agent Control Specification Checkpoints v3",
-      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) \u2014 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
+      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) — 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
       "allowed_paths": [
         "magda_agent/safety/acs_checkpoints_v3.py",
         "tests/test_acs_checkpoints_v3.py",
@@ -8639,7 +8639,7 @@
       "area": "planning",
       "risk": "medium",
       "title": "Claude Agent Teams Dependency Graph",
-      "description": "Inspired by Claude Agent SDK trend: Task system \u0441 dependency graphs. Update planning to utilize dependency graphs.",
+      "description": "Inspired by Claude Agent SDK trend: Task system с dependency graphs. Update planning to utilize dependency graphs.",
       "allowed_paths": [
         "magda_agent/planning/dependency_graph.py",
         "tests/test_dependency_graph.py",
@@ -8792,7 +8792,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging",
-      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
+      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger.py",
         "tests/test_canvas_logger.py",
@@ -8931,7 +8931,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging V3",
-      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
+      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger_v3.py",
         "tests/test_canvas_logger_v3.py",
@@ -11810,7 +11810,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery Agent Cards v4",
-      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
+      "description": "Inspired by trend: Agent discovery через Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -12062,7 +12062,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Protocol Discovery Mesh",
-      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
+      "description": "Inspired by trend: Agent discovery через Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",

--- a/magda_agent/tracing/a2a_tracer_v4.py
+++ b/magda_agent/tracing/a2a_tracer_v4.py
@@ -1,0 +1,70 @@
+import contextvars
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+
+class A2AAsyncTracer:
+    """
+    A2A Async-first Tracing V4 for cross-agent workflows.
+    Uses contextvars to maintain correlation IDs across asynchronous tasks.
+    """
+
+    def __init__(self) -> None:
+        self._correlation_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+            f"a2a_correlation_id_{id(self)}", default=None
+        )
+        self.traces: Dict[str, List[Dict[str, Any]]] = {}
+
+    def set_correlation_id(self, correlation_id: Optional[str] = None) -> str:
+        """
+        Sets the correlation ID for the current async context.
+        If no ID is provided, generates a new UUID.
+        """
+        if not correlation_id:
+            correlation_id = str(uuid.uuid4())
+        self._correlation_id_ctx.set(correlation_id)
+        if correlation_id not in self.traces:
+            self.traces[correlation_id] = []
+        return correlation_id
+
+    def get_correlation_id(self) -> Optional[str]:
+        """
+        Retrieves the current correlation ID from the context.
+        """
+        return self._correlation_id_ctx.get()
+
+    def clear_correlation_id(self) -> None:
+        """
+        Clears the correlation ID from the current context.
+        """
+        self._correlation_id_ctx.set(None)
+
+    def log_action(self, action_name: str, payload: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Logs an action under the current correlation ID.
+        """
+        correlation_id = self.get_correlation_id()
+        if not correlation_id:
+            return
+
+        if correlation_id not in self.traces:
+            self.traces[correlation_id] = []
+
+        self.traces[correlation_id].append({
+            "timestamp": time.time(),
+            "action": action_name,
+            "payload": payload or {}
+        })
+
+    def get_traces(self, correlation_id: str) -> List[Dict[str, Any]]:
+        """
+        Returns all traces associated with a specific correlation ID.
+        """
+        return self.traces.get(correlation_id, [])
+
+    def clear_all_traces(self) -> None:
+        """
+        Clears all stored traces. Useful for testing.
+        """
+        self.traces.clear()

--- a/tests/test_a2a_tracer_v4.py
+++ b/tests/test_a2a_tracer_v4.py
@@ -1,0 +1,75 @@
+import asyncio
+import pytest
+from magda_agent.tracing.a2a_tracer_v4 import A2AAsyncTracer
+
+@pytest.fixture
+def tracer():
+    return A2AAsyncTracer()
+
+@pytest.mark.asyncio
+async def test_a2a_tracer_isolation(tracer):
+    """
+    Test that concurrent async tasks maintain their own correlation IDs
+    and correctly trace their actions without cross-contamination.
+    """
+    async def worker_1():
+        # Set correlation ID for this task context
+        cid = tracer.set_correlation_id("task_1_id")
+        tracer.log_action("start_task_1")
+        await asyncio.sleep(0.05)
+        tracer.log_action("end_task_1", {"status": "success"})
+        return cid
+
+    async def worker_2():
+        # Set a different correlation ID for this task context
+        cid = tracer.set_correlation_id("task_2_id")
+        tracer.log_action("start_task_2")
+        await asyncio.sleep(0.05)
+        tracer.log_action("end_task_2", {"status": "error"})
+        return cid
+
+    # Run tasks concurrently
+    results = await asyncio.gather(worker_1(), worker_2())
+    assert results == ["task_1_id", "task_2_id"]
+
+    # Verify trace for task 1
+    traces_1 = tracer.get_traces("task_1_id")
+    assert len(traces_1) == 2
+    assert traces_1[0]["action"] == "start_task_1"
+    assert traces_1[1]["action"] == "end_task_1"
+    assert traces_1[1]["payload"] == {"status": "success"}
+
+    # Verify trace for task 2
+    traces_2 = tracer.get_traces("task_2_id")
+    assert len(traces_2) == 2
+    assert traces_2[0]["action"] == "start_task_2"
+    assert traces_2[1]["action"] == "end_task_2"
+    assert traces_2[1]["payload"] == {"status": "error"}
+
+@pytest.mark.asyncio
+async def test_generate_correlation_id(tracer):
+    """
+    Test that a generated correlation ID is returned if none is provided.
+    """
+    cid = tracer.set_correlation_id()
+    assert cid is not None
+    assert tracer.get_correlation_id() == cid
+
+    tracer.log_action("test_action")
+    traces = tracer.get_traces(cid)
+    assert len(traces) == 1
+    assert traces[0]["action"] == "test_action"
+
+@pytest.mark.asyncio
+async def test_clear_correlation_id(tracer):
+    """
+    Test that correlation ID can be cleared from context.
+    """
+    tracer.set_correlation_id("test_id")
+    assert tracer.get_correlation_id() == "test_id"
+    tracer.clear_correlation_id()
+    assert tracer.get_correlation_id() is None
+
+    # Logging an action without a correlation ID should do nothing
+    tracer.log_action("ignored_action")
+    assert len(tracer.get_traces("test_id")) == 0


### PR DESCRIPTION
Implemented the `A2AAsyncTracer` within `magda_agent/tracing/a2a_tracer_v4.py` to facilitate async-first tracing capabilities required by the A2A spec. Tests were added and pass cleanly ensuring that parallel execution traces do not cross contaminate correlation ID domains. Task `a2a-async-tracing-v4` has been updated in `agent_tasks.json` and new tasks representing the latest June 2026 AI Agent trends have been appended.

---
*PR created automatically by Jules for task [10641188712313597132](https://jules.google.com/task/10641188712313597132) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add async-first A2A tracing with per-context correlation ID scoping
> - Adds [`A2AAsyncTracer`](https://github.com/kazah4359-lgtm/Magda-agent/pull/529/files#diff-b5b19809b71c0eeb072ebadfc54baeaafff3255fa7e61867ab660f7337b52e3c) using `contextvars` to isolate correlation IDs per async context, preventing trace cross-contamination between concurrent tasks.
> - Exposes methods to set/get/clear a correlation ID, log timestamped actions with optional payloads, and retrieve or reset stored traces.
> - Logging without an active correlation ID is a no-op; trace entries are keyed by correlation ID in an in-memory dict.
> - Adds async tests covering context isolation across concurrent workers, auto-generated IDs, and post-clear no-op behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f59cb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->