### PR TITLE
feat(skills): implement MCP Context Export Tool and add trend tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -41,6 +41,60 @@
   },
   "tasks": [
     {
+      "id": "openclaw-rl-behavior-plugin",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw RL Behavior Plugin",
+      "description": "Inspired by trend: Online reinforcement learning from user feedback. Implement a ContextEngine lifecycle plugin that logs multi-turn trajectories to update User behavior weights.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_behavior_plugin.py",
+        "tests/test_openclaw_behavior_plugin.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ContextPlugin implementation created for RL trajectory buffering.",
+        "Plugin hooks into before_write and on_context_update lifecycle events.",
+        "Unit tests verify correct hook integration using mocks."
+      ]
+    },
+    {
+      "id": "acs-security-evaluation-task",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Security Evaluation Task",
+      "description": "Inspired by trend: ACS Agent Control Specification. Implement a periodic daily cron task that evaluates the ACS checkpoint persistence DB for policy violation trends.",
+      "allowed_paths": [
+        "magda_agent/scheduler/acs_evaluation_task.py",
+        "tests/test_acs_evaluation_task.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluation task logic queries acs_checkpoints_log_v12 DB for failures.",
+        "Alerting mechanism implemented if failure rates exceed a threshold.",
+        "Unit tests mock the SQLite backend and verify correct alerting logic."
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent-gitworktree",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Claude Evaluator Subagent Spawn",
+      "description": "Inspired by trend: Multi-Agent Git Worktrees and Planner/Evaluator pattern. Implement an Evaluator subagent factory utilizing GitWorktreeMultiManager.",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_subagent.py",
+        "tests/test_evaluator_subagent.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "EvaluatorSubagent class spawns in isolated Git worktree.",
+        "Agent runs review against Planner graphs.",
+        "Unit tests simulate Worktree creation using mocks."
+      ]
+    },
+    {
       "id": "openai-agents-sdk-concurrency-router-v5",
       "title": "OpenAI Agents SDK Concurrency Router V5",
       "description": "Inspired by OpenAI Agents SDK trend: Implement a concurrent tool router that optimizes parallel execution of server-prefixed tools and maintains safety isolation.",
@@ -8580,7 +8634,7 @@
     },
     {
       "id": "mcp-context-export-tool-v2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "MCP Context Export Tool",

--- a/magda_agent/skills/mcp_context_export.py
+++ b/magda_agent/skills/mcp_context_export.py
@@ -1,0 +1,109 @@
+import json
+from typing import Dict, Any, List, Optional
+import inspect
+
+class MCPContextExportTool:
+    """
+    Exports the current state of Context Engine or Working Memory as an MCP-compatible tool.
+    This allows external visualization applications like OpenClaw Canvas to retrieve the context state.
+    """
+    def __init__(self, memory_source: Any) -> None:
+        """
+        Initializes the export tool.
+
+        Args:
+            memory_source: An instance of WorkingMemory, ContextEngine, or similar
+                           object that has a `get_entries` or `get_all_entries` method.
+        """
+        self.memory_source = memory_source
+        self.name = "export_context_state"
+        self.description = "Export the current working memory or context engine state."
+
+    def _get_json_schema(self) -> Dict[str, Any]:
+        """
+        Returns the MCP tool input schema.
+        """
+        return {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "integer",
+                    "description": "Optional user ID to filter the context. If omitted, exports all available context."
+                }
+            },
+            "required": []
+        }
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists this tool in MCP format.
+        """
+        return [{
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self._get_json_schema()
+        }]
+
+    def _extract_entries(self, user_id: Optional[int] = None) -> List[Any]:
+        """
+        Extracts entries from the memory source depending on its interface.
+        """
+        if hasattr(self.memory_source, "get_entries"):
+            if user_id is not None:
+                return self.memory_source.get_entries(user_id=user_id)
+            elif hasattr(self.memory_source, "get_all_entries"):
+                return self.memory_source.get_all_entries()
+            else:
+                return self.memory_source.get_entries()
+        return []
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Invokes the tool via the MCP protocol format.
+        """
+        if name != self.name:
+            return {
+                "content": [{"type": "text", "text": f"Error: Tool '{name}' not found."}],
+                "isError": True
+            }
+
+        try:
+            user_id = arguments.get("user_id")
+            entries = self._extract_entries(user_id)
+
+            # Serialize entries to dicts for JSON
+            serialized_entries = []
+            for entry in entries:
+                entry_dict = {}
+                if hasattr(entry, "id"):
+                    entry_dict["id"] = entry.id
+                if hasattr(entry, "content"):
+                    entry_dict["content"] = entry.content
+                if hasattr(entry, "importance"):
+                    entry_dict["importance"] = entry.importance
+                if hasattr(entry, "timestamp"):
+                    entry_dict["timestamp"] = entry.timestamp
+                if hasattr(entry, "tags"):
+                    entry_dict["tags"] = entry.tags
+                if hasattr(entry, "user_id"):
+                    entry_dict["user_id"] = entry.user_id
+
+                serialized_entries.append(entry_dict)
+
+            json_payload = json.dumps(serialized_entries)
+
+            return {
+                "content": [{"type": "text", "text": json_payload}],
+                "isError": False
+            }
+        except Exception as e:
+            return {
+                "content": [{"type": "text", "text": f"Error executing tool {name}: {e}"}],
+                "isError": True
+            }
+
+    async def call_tool_async(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Async version of call_tool.
+        """
+        return self.call_tool(name, arguments)

--- a/tests/test_mcp_context_export.py
+++ b/tests/test_mcp_context_export.py
@@ -1,0 +1,96 @@
+import pytest
+import json
+from unittest.mock import MagicMock
+from magda_agent.skills.mcp_context_export import MCPContextExportTool
+from typing import Any, Dict, List, Optional
+
+class MockMemoryEntry:
+    """Mock implementation of a memory entry for testing."""
+    def __init__(self, id: str, content: str, importance: float, timestamp: float, tags: List[str], user_id: int) -> None:
+        """Initialize mock memory entry attributes."""
+        self.id = id
+        self.content = content
+        self.importance = importance
+        self.timestamp = timestamp
+        self.tags = tags
+        self.user_id = user_id
+
+@pytest.fixture
+def mock_memory_source() -> MagicMock:
+    """Fixture providing a mock memory source representing a ContextEngine."""
+    source = MagicMock()
+
+    # Mock data
+    entries = [
+        MockMemoryEntry("1", "Hello World", 0.9, 1234567890.0, ["greeting"], 42),
+        MockMemoryEntry("2", "Test Entry", 0.5, 1234567891.0, ["test"], 42)
+    ]
+
+    def get_entries(user_id: Optional[int] = None) -> List[MockMemoryEntry]:
+        """Mock get_entries method filtering by user_id if provided."""
+        if user_id == 42:
+            return entries
+        elif user_id is None:
+            return entries
+        return []
+
+    def get_all_entries() -> List[MockMemoryEntry]:
+        """Mock get_all_entries method returning all entries."""
+        return entries
+
+    source.get_entries = get_entries
+    source.get_all_entries = get_all_entries
+
+    return source
+
+def test_list_tools(mock_memory_source: MagicMock) -> None:
+    """Test that the tool correctly lists itself with the proper schema."""
+    tool = MCPContextExportTool(mock_memory_source)
+    tools = tool.list_tools()
+
+    assert len(tools) == 1
+    assert tools[0]["name"] == "export_context_state"
+    assert "user_id" in tools[0]["inputSchema"]["properties"]
+
+def test_call_tool_valid(mock_memory_source: MagicMock) -> None:
+    """Test calling the tool with a valid tool name and arguments."""
+    tool = MCPContextExportTool(mock_memory_source)
+    result = tool.call_tool("export_context_state", {"user_id": 42})
+
+    assert not result["isError"]
+
+    # Parse the JSON payload inside the content
+    payload = json.loads(result["content"][0]["text"])
+
+    assert len(payload) == 2
+    assert payload[0]["id"] == "1"
+    assert payload[0]["content"] == "Hello World"
+    assert payload[0]["importance"] == 0.9
+    assert payload[0]["user_id"] == 42
+
+def test_call_tool_invalid_name(mock_memory_source: MagicMock) -> None:
+    """Test calling the tool with an invalid name returns an error format."""
+    tool = MCPContextExportTool(mock_memory_source)
+    result = tool.call_tool("unknown_tool", {})
+
+    assert result["isError"]
+    assert "not found" in result["content"][0]["text"]
+
+def test_call_tool_all_entries(mock_memory_source: MagicMock) -> None:
+    """Test calling the tool without filtering arguments exports all entries."""
+    tool = MCPContextExportTool(mock_memory_source)
+    result = tool.call_tool("export_context_state", {})
+
+    assert not result["isError"]
+    payload = json.loads(result["content"][0]["text"])
+    assert len(payload) == 2
+
+@pytest.mark.asyncio
+async def test_call_tool_async(mock_memory_source: MagicMock) -> None:
+    """Test calling the tool async correctly wraps the synchronous call."""
+    tool = MCPContextExportTool(mock_memory_source)
+    result = await tool.call_tool_async("export_context_state", {"user_id": 42})
+
+    assert not result["isError"]
+    payload = json.loads(result["content"][0]["text"])
+    assert len(payload) == 2


### PR DESCRIPTION
This PR completes the `mcp-context-export-tool-v2` task from the agent backlog. 

It implements a self-contained module `magda_agent/skills/mcp_context_export.py` which provides the `MCPContextExportTool` class. This class adapts a `ContextEngine` or `WorkingMemory` instance into an MCP-compatible export format, enabling external visualization tools like OpenClaw Canvas to seamlessly read the agent's internal memory state. 

Comprehensive unit tests using `pytest` and `MagicMock` have been added to `tests/test_mcp_context_export.py`, fully enforcing type hinting (`-> None`, etc.) and comprehensive docstrings across all testing utilities and functions.

Finally, 3 new contextually relevant tasks based on June 2026 AI trends have been pushed to the `agent_tasks.json` manifest backlog, fully passing the internal JSON schema validations.

---
*PR created automatically by Jules for task [13775257863176903623](https://jules.google.com/task/13775257863176903623) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP-compatible `export_context_state` tool for working-memory export
> - Introduces [`MCPContextExportTool`](https://github.com/kazah4359-lgtm/Magda-agent/pull/531/files#diff-bae9f090809dd187dd76b312ff7def98d56f8e1bead824b2a4f8ef9c47da4b3a) — an MCP-compatible tool that lists itself via `list_tools` and returns serialized memory entries as a JSON payload when invoked.
> - Adapts to different memory source interfaces (`get_entries(user_id=...)`, `get_all_entries`, or bare `get_entries`) to support optional per-user filtering.
> - Adds full test coverage in [`tests/test_mcp_context_export.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/531/files#diff-dfa6515feeac51c0195c9c283832c19b79587569c494d7241b1df69314d06edf) covering tool discovery, valid/invalid invocation, default behavior, and the async wrapper.
> - Adds three new task entries and marks one existing task as done in [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/531/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c86c7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->