### PR TITLE
feat(learning): implement OpenClaw RL Behavior Plugin

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -42,7 +42,7 @@
   "tasks": [
     {
       "id": "openclaw-rl-behavior-plugin",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw RL Behavior Plugin",
@@ -19323,6 +19323,57 @@
         "Dynamically routes control flow between agents upon handover execution.",
         "Tests verify state preservation and successful routing across different handoffs.",
         "No external APIs are called, everything is mock-tested."
+      ]
+    },
+    {
+      "id": "agentskills-io-export-v1",
+      "title": "Hermes agentskills.io Format Exporter v1",
+      "description": "Inspired by Hermes Agent trend 'Открытый стандарт skills: agentskills.io', implement an exporter to convert internal magda skills to the agentskills.io open standard.",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/skills/agentskills_exporter.py",
+        "tests/test_agentskills_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter implemented for agentskills.io format",
+        "Tests verify JSON output schema matches standard via mock"
+      ]
+    },
+    {
+      "id": "claude-agent-teams-subagent-spawner-v1",
+      "title": "Claude Agent Teams Subagent Spawner",
+      "description": "Inspired by Claude Agent SDK trend 'Agent Teams: multi-agent с git worktree isolation', implement a subagent spawner for parallel tasks.",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/agents/subagent_spawner.py",
+        "tests/test_subagent_spawner.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Spawner can spawn independent agents",
+        "Tests mock worktree provisioning and agent execution"
+      ]
+    },
+    {
+      "id": "mcpkernel-taint-tracking-v1",
+      "title": "MCPKernel Taint Tracking Sandbox v1",
+      "description": "Inspired by trend 'MCPKernel: taint tracking + sandboxed execution', implement a sandbox boundary module for MCP tool execution to enforce strict taint tracking.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_kernel_sandbox.py",
+        "tests/test_mcp_kernel_sandbox.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox blocks execution of tainted arguments",
+        "Tests verify sandboxed behavior using mock policies"
       ]
     }
   ]

--- a/magda_agent/learning/openclaw_behavior_plugin.py
+++ b/magda_agent/learning/openclaw_behavior_plugin.py
@@ -1,0 +1,69 @@
+import logging
+from typing import Any
+
+from magda_agent.learning.openclaw_rl_rollout import OpenClawRLTrajectoryRolloutV6
+from magda_agent.memory.context_engine import ContextPlugin
+
+
+class OpenClawBehaviorPlugin(ContextPlugin):
+    """
+    Context Engine lifecycle plugin that logs multi-turn trajectories to update
+    User behavior weights via OpenClawRLTrajectoryRolloutV6.
+    """
+
+    def __init__(self, rollout: OpenClawRLTrajectoryRolloutV6) -> None:
+        """
+        Initialize the plugin with the rollout tracker.
+
+        Args:
+            rollout: The RL rollout buffer and updater.
+        """
+        self.rollout = rollout
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """
+        Logs multi-turn trajectories to the rollout buffer.
+
+        Args:
+            context: The memory context being written.
+            user_id: The user ID.
+
+        Returns:
+            The unmodified context.
+        """
+        skill_id = "unknown_skill"
+        content = ""
+
+        if isinstance(context, dict):
+            skill_id = context.get("skill_id", skill_id)
+            content = str(context.get("content", ""))
+        elif hasattr(context, "skill_id") or hasattr(context, "content"):
+            skill_id = getattr(context, "skill_id", skill_id)
+            content = str(getattr(context, "content", ""))
+        else:
+            content = str(context)
+
+        self.rollout.record_step(str(user_id), skill_id, content)
+        return context
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """
+        Checks for a reward signal and updates behavior weights.
+
+        Args:
+            new_context: The new context update containing potential rewards.
+            user_id: The user ID.
+        """
+        reward = None
+
+        if isinstance(new_context, dict):
+            reward = new_context.get("reward")
+        elif hasattr(new_context, "reward"):
+            reward = getattr(new_context, "reward")
+
+        if reward is not None:
+            try:
+                reward_val = float(reward)
+                self.rollout.process_delayed_reward(str(user_id), reward_val)
+            except (ValueError, TypeError):
+                logging.warning(f"Invalid reward value: {reward}")

--- a/tests/test_openclaw_behavior_plugin.py
+++ b/tests/test_openclaw_behavior_plugin.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import MagicMock
+
+from magda_agent.learning.openclaw_behavior_plugin import OpenClawBehaviorPlugin
+from magda_agent.learning.openclaw_rl_rollout import OpenClawRLTrajectoryRolloutV6
+
+
+class TestOpenClawBehaviorPlugin(unittest.TestCase):
+    def setUp(self):
+        self.mock_rollout = MagicMock(spec=OpenClawRLTrajectoryRolloutV6)
+        self.plugin = OpenClawBehaviorPlugin(rollout=self.mock_rollout)
+        self.user_id = 123
+
+    def test_before_write_dict_context(self):
+        context = {"skill_id": "test_skill", "content": "test_content"}
+        result = self.plugin.before_write(context, self.user_id)
+
+        self.assertEqual(result, context)
+        self.mock_rollout.record_step.assert_called_once_with(str(self.user_id), "test_skill", "test_content")
+
+    def test_before_write_object_context(self):
+        class DummyContext:
+            skill_id = "obj_skill"
+            content = "obj_content"
+
+        context = DummyContext()
+        result = self.plugin.before_write(context, self.user_id)
+
+        self.assertEqual(result, context)
+        self.mock_rollout.record_step.assert_called_once_with(str(self.user_id), "obj_skill", "obj_content")
+
+    def test_before_write_string_context(self):
+        context = "just some string"
+        result = self.plugin.before_write(context, self.user_id)
+
+        self.assertEqual(result, context)
+        self.mock_rollout.record_step.assert_called_once_with(str(self.user_id), "unknown_skill", "just some string")
+
+    def test_on_context_update_dict_with_reward(self):
+        context = {"reward": 0.75}
+        self.plugin.on_context_update(context, self.user_id)
+
+        self.mock_rollout.process_delayed_reward.assert_called_once_with(str(self.user_id), 0.75)
+
+    def test_on_context_update_object_with_reward(self):
+        class DummyContext:
+            reward = 0.5
+
+        context = DummyContext()
+        self.plugin.on_context_update(context, self.user_id)
+
+        self.mock_rollout.process_delayed_reward.assert_called_once_with(str(self.user_id), 0.5)
+
+    def test_on_context_update_no_reward(self):
+        context = {"other_key": "value"}
+        self.plugin.on_context_update(context, self.user_id)
+
+        self.mock_rollout.process_delayed_reward.assert_not_called()
+
+    def test_on_context_update_invalid_reward(self):
+        context = {"reward": "not_a_number"}
+        self.plugin.on_context_update(context, self.user_id)
+
+        self.mock_rollout.process_delayed_reward.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements the OpenClaw RL Behavior Plugin as requested in the first "todo" task from `agent_tasks.json`.

**Changes included:**
- Created `OpenClawBehaviorPlugin` class tracking contextual trajectory states and extracting reward signals from updates.
- Added comprehensive unit testing with `unittest.mock.MagicMock` to isolate and verify the ContextEngine lifecycle hook interactions.
- Added 3 new actionable, trend-inspired "todo" tasks to `agent_tasks.json` based on current AI Agent trends from June 2026.
- Assured code adheres strictly to type hinting and documentation requirements.
- Pre-commit validation scripts (`validate_agent_tasks.py` and full suite `pytest`) run locally and pass with no regressions.

---
*PR created automatically by Jules for task [1388334243815424401](https://jules.google.com/task/1388334243815424401) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement OpenClaw RL behavior plugin for trajectory recording and delayed reward processing
> - Adds [`OpenClawBehaviorPlugin`](https://github.com/kazah4359-lgtm/Magda-agent/pull/532/files#diff-eec17d2df20d7c91f5e2bdd0d9443eaff6d4e79a385a9878bc644c921b9f55f0), a `ContextPlugin` that integrates with `OpenClawRLTrajectoryRolloutV6` to record RL trajectory steps during `before_write` and process delayed rewards during `on_context_update`.
> - `before_write` extracts `skill_id` and `content` from the context (supporting dicts, objects, or raw strings) and calls `rollout.record_step(user_id, skill_id, content)`.
> - `on_context_update` detects a numeric reward in the new context and calls `rollout.process_delayed_reward(user_id, reward_val)`; invalid reward values are silently ignored with a warning log.
> - Unit tests cover all context types and reward edge cases using `MagicMock` for the rollout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6abd4a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->