### PR TITLE
feat: implement Claude Agent Teams Dependency Graph

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8689,7 +8689,7 @@
     },
     {
       "id": "claude-agent-teams-dependency-graph-a5bf63e6",
-      "status": "todo",
+      "status": "done",
       "area": "planning",
       "risk": "medium",
       "title": "Claude Agent Teams Dependency Graph",
@@ -19568,6 +19568,40 @@
         "Context engine lifecycle correctly prioritizes high-salience tokens during context truncation.",
         "Module implements hook interfaces accurately.",
         "Tests verify truncation skips prioritized context items."
+      ]
+    },
+    {
+      "id": "mcp-tool-sandboxing-enhancements",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "MCP Tool Sandboxing Enhancements",
+      "description": "Inspired by MCPKernel: taint tracking + sandboxed execution trend. Implement stricter validation and isolation for MCP tools.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_sandbox_strict.py",
+        "tests/test_mcp_sandbox_strict.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Strict sandbox restricts network and filesystem access for MCP tools",
+        "Integration tests confirm malicious tool execution is blocked"
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-paging-pattern",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Paging Pattern",
+      "description": "Inspired by OpenClaw virtual context management trend. Implement a paging mechanism to automatically swap inactive context blocks out of working memory.",
+      "allowed_paths": [
+        "magda_agent/memory/context_paging.py",
+        "tests/test_context_paging.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Inactive context blocks are successfully paged to storage",
+        "Unit tests confirm memory threshold triggers correctly"
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -184,6 +184,10 @@
 
 * [ ] BUG: `Brainstem` integration in `Consciousness.process_input` does not halt long-running skills gracefully upon a 'stop' command. Need to implement a cancellation token or mechanism for active background tasks when a stop reflex is triggered. (2026-06-04)
 * [x] FEATURE: Claude Task System with Dependency Graphs v3 (claude-dependency-graph-planner-v3)
+* [x] FEATURE: Claude Agent Teams Dependency Graph (claude-agent-teams-dependency-graph-a5bf63e6)
+* [ ] FEATURE: MCP Tool Sandboxing Enhancements (mcp-tool-sandboxing-enhancements)
+* [ ] FEATURE: Context Engine Paging Pattern (openclaw-context-engine-paging-pattern)
+
 ## 🛠️ Запланированные Skills
 * [x] FEATURE: OpenClaw Canvas Live Visualization (2026-06-15)
 * [x] FEATURE: OpenClaw RL Next-State Signals

--- a/magda_agent/planning/dependency_graph.py
+++ b/magda_agent/planning/dependency_graph.py
@@ -80,3 +80,113 @@ class DependencyGraph:
             raise ValueError("Cycle detected in plan dependencies")
 
         return [step_map[node] for node in sorted_ids]
+
+    @staticmethod
+    def get_execution_layers(plan_steps: List[Dict[str, Any]]) -> List[List[Dict[str, Any]]]:
+        """
+        Computes the execution layers of the task graph. Each layer contains tasks that can be
+        executed in parallel (i.e. all their dependencies are in previous layers).
+        Raises ValueError if a cycle is detected.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries.
+
+        Returns:
+            List[List[Dict[str, Any]]]: A list of layers, where each layer is a list of steps.
+        """
+        adj: Dict[str, List[str]] = {step.get("id", ""): [] for step in plan_steps if step.get("id")}
+        in_degree: Dict[str, int] = {step.get("id", ""): 0 for step in plan_steps if step.get("id")}
+        step_map: Dict[str, Dict[str, Any]] = {step.get("id", ""): step for step in plan_steps if step.get("id")}
+
+        for step in plan_steps:
+            step_id: Optional[str] = step.get("id")
+            if not step_id:
+                continue
+            dependencies: List[str] = step.get("dependencies", [])
+            for dep in dependencies:
+                if dep in adj:
+                    adj[dep].append(step_id)
+                    in_degree[step_id] += 1
+                else:
+                    logging.warning(f"Dependency {dep} for step {step_id} not found in plan steps.")
+
+        layers: List[List[Dict[str, Any]]] = []
+        queue: List[str] = [node for node, deg in in_degree.items() if deg == 0]
+        processed_count = 0
+
+        while queue:
+            current_layer_nodes = list(queue)
+            current_layer = [step_map[node] for node in current_layer_nodes]
+            layers.append(current_layer)
+            queue = []
+
+            for node in current_layer_nodes:
+                processed_count += 1
+                for neighbor in adj.get(node, []):
+                    in_degree[neighbor] -= 1
+                    if in_degree[neighbor] == 0:
+                        queue.append(neighbor)
+
+        if processed_count != len(adj):
+            raise ValueError("Cycle detected in plan dependencies")
+
+        return layers
+
+    @staticmethod
+    def get_critical_path(plan_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Finds the critical path (longest dependency chain) in the task graph.
+        Assumes all steps take unit time.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries.
+
+        Returns:
+            List[Dict[str, Any]]: The sequence of steps that form the longest path.
+        """
+        # First ensure there are no cycles and get a valid topological sort
+        sorted_steps = DependencyGraph.topological_sort(plan_steps)
+        step_map = {step.get("id", ""): step for step in plan_steps if step.get("id")}
+
+        # Create adjacency list for dependencies (forward edges)
+        adj: Dict[str, List[str]] = {step.get("id", ""): [] for step in plan_steps if step.get("id")}
+        for step in plan_steps:
+            step_id: Optional[str] = step.get("id")
+            if not step_id:
+                continue
+            for dep in step.get("dependencies", []):
+                if dep in adj:
+                    adj[dep].append(step_id)
+
+        # Distances and predecessors
+        dist: Dict[str, int] = {step.get("id", ""): 0 for step in plan_steps if step.get("id")}
+        prev: Dict[str, Optional[str]] = {step.get("id", ""): None for step in plan_steps if step.get("id")}
+
+        # Process in topological order
+        for step in sorted_steps:
+            u = step.get("id", "")
+            for v in adj.get(u, []):
+                if dist[u] + 1 > dist[v]:
+                    dist[v] = dist[u] + 1
+                    prev[v] = u
+
+        # Find the node with the maximum distance
+        max_dist = -1
+        end_node = None
+        for node, d in dist.items():
+            if d > max_dist:
+                max_dist = d
+                end_node = node
+
+        if not end_node:
+            return []
+
+        # Reconstruct path
+        path = []
+        curr = end_node
+        while curr is not None:
+            path.append(step_map[curr])
+            curr = prev[curr]
+
+        path.reverse()
+        return path

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,5 +1,5 @@
 import pytest
-from magda_agent.architecture.dependency_graph import DependencyGraph
+from magda_agent.planning.dependency_graph import DependencyGraph
 
 def test_topological_sort_empty():
     """Test that topological sort works on an empty list of tasks."""
@@ -65,3 +65,46 @@ def test_topological_sort_missing_dependency():
     sorted_steps = DependencyGraph.topological_sort(plan_steps)
     assert len(sorted_steps) == 1
     assert sorted_steps[0]["id"] == "step1"
+
+def test_get_execution_layers():
+    plan_steps = [
+        {"id": "A", "dependencies": []},
+        {"id": "B", "dependencies": ["A"]},
+        {"id": "C", "dependencies": ["A"]},
+        {"id": "D", "dependencies": ["B", "C"]},
+        {"id": "E", "dependencies": ["C"]},
+        {"id": "F", "dependencies": ["D", "E"]}
+    ]
+    layers = DependencyGraph.get_execution_layers(plan_steps)
+    # Expected layers:
+    # Layer 0: A
+    # Layer 1: B, C
+    # Layer 2: D, E
+    # Layer 3: F
+    assert len(layers) == 4
+    assert [step["id"] for step in layers[0]] == ["A"]
+    assert set(step["id"] for step in layers[1]) == {"B", "C"}
+    assert set(step["id"] for step in layers[2]) == {"D", "E"}
+    assert [step["id"] for step in layers[3]] == ["F"]
+
+def test_get_execution_layers_cycle():
+    plan_steps = [
+        {"id": "A", "dependencies": ["B"]},
+        {"id": "B", "dependencies": ["A"]}
+    ]
+    with pytest.raises(ValueError, match="Cycle detected"):
+        DependencyGraph.get_execution_layers(plan_steps)
+
+def test_get_critical_path():
+    plan_steps = [
+        {"id": "A", "dependencies": []},
+        {"id": "B", "dependencies": ["A"]},
+        {"id": "C", "dependencies": ["A"]},
+        {"id": "D", "dependencies": ["B"]},
+        {"id": "E", "dependencies": ["D"]},
+        {"id": "F", "dependencies": ["C", "E"]}
+    ]
+    path = DependencyGraph.get_critical_path(plan_steps)
+    # The longest path is A -> B -> D -> E -> F (length 5)
+    # A -> C -> F is length 3
+    assert [step["id"] for step in path] == ["A", "B", "D", "E", "F"]


### PR DESCRIPTION
This PR implements the "Claude Agent Teams Dependency Graph" task by enriching the `DependencyGraph` class with the ability to resolve execution layers for concurrent subagent spawning and identify the critical path in the task graph. Tests have been updated and corrected. `agent_tasks.json` has been updated with its status set to `done`, and two new medium-risk tasks inspired by recent AI trends have been added to the manifest and the markdown backlog.

---
*PR created automatically by Jules for task [4556671933670097702](https://jules.google.com/task/4556671933670097702) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `get_execution_layers` and `get_critical_path` to `DependencyGraph`
> - Adds `get_execution_layers` to [`dependency_graph.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/537/files#diff-4623f39142c18d13cd5d3491a814055ce813b36e801914a75eb26c44975375a7), which uses a Kahn-style BFS to group plan steps into parallelizable layers, raising `ValueError` on cycle detection.
> - Adds `get_critical_path`, which uses topological sort and dynamic programming to return the longest dependency chain as an ordered list of step dicts.
> - Adds tests covering parallel layer composition, cycle detection, and critical path correctness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36e834b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->