### PR TITLE
feat: MCP Server Prefixed Tool Names

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8706,7 +8706,7 @@
     },
     {
       "id": "openai-agents-sdk-mcp-server-prefixed-tool-names-04d16c9f",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "OpenAI Agents SDK MCP Server Prefixed Tool Names",
@@ -19653,6 +19653,60 @@
       "acceptance": [
         "ACS fallback heuristics process GuardrailViolationError exceptions and compute safe alternatives.",
         "Tests verify fallback generation logic."
+      ]
+    },
+    {
+      "id": "openai-agents-sdk-realtime-guardrail-metrics-29733803",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Realtime Guardrail Metrics Tracking",
+      "description": "Inspired by OpenAI Agents SDK trend: Realtime Guardrail Fallback. Implement metrics tracking for guardrail interceptions, capturing the frequency and context of tool execution overrides. Track moving averages and expose for visualization.",
+      "allowed_paths": [
+        "magda_agent/safety/guardrail_metrics_v2.py",
+        "tests/test_guardrail_metrics_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Metrics tracking class intercepts and logs guardrail overrides",
+        "Moving average calculation is implemented",
+        "Tests verify metrics aggregation and tracking logic"
+      ]
+    },
+    {
+      "id": "openclaw-rl-entropy-visualizer-dd742c2d",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Shannon Entropy Visualizer Export",
+      "description": "Inspired by OpenClaw RL trend: Live Visualization. Extend RLCanvasMetricsExporter to calculate and include Shannon Entropy of skill distributions in its structured export for Canvas UI ingestion.",
+      "allowed_paths": [
+        "magda_agent/learning/canvas_metrics_entropy.py",
+        "tests/test_canvas_metrics_entropy.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Shannon entropy calculation is implemented for skill distributions",
+        "Exporter includes entropy metrics in structured JSON output",
+        "Tests verify entropy calculation accuracy and edge cases"
+      ]
+    },
+    {
+      "id": "hermes-agent-cron-scheduler-diagnostics-5989c08b",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Hermes Agent Cron Diagnostics Reporter",
+      "description": "Inspired by Hermes Agent trend: Scheduled operations. Implement a background diagnostic reporter task that uses HermesCronSchedulerV3 to periodically compile system health and error density metrics into a structured report.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_diagnostics_reporter.py",
+        "tests/test_cron_diagnostics_reporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Diagnostic reporter gathers error density and health metrics",
+        "Reporter integrates with HermesCronSchedulerV3",
+        "Tests verify metric compilation logic with mocked scheduler"
       ]
     }
   ]

--- a/magda_agent/integration/mcp_server_names.py
+++ b/magda_agent/integration/mcp_server_names.py
@@ -1,0 +1,49 @@
+from typing import Optional, Tuple
+
+class MCPToolNameParser:
+    """
+    Parser for handling MCP (Model Context Protocol) server-prefixed tool names.
+    Extracts the server prefix and the underlying tool name from a prefixed string.
+    """
+
+    @staticmethod
+    def parse(tool_name: str) -> Tuple[Optional[str], str]:
+        """
+        Parses a server-prefixed tool name.
+
+        Args:
+            tool_name: The tool name, possibly prefixed with a server ID and an underscore.
+
+        Returns:
+            A tuple containing the server prefix (or None if no prefix is found) and the
+            actual tool name.
+        """
+        if not tool_name:
+            return None, ""
+
+        parts = tool_name.split("_", 1)
+        if len(parts) == 2 and parts[0] and parts[1]:
+            return parts[0], parts[1]
+
+        return None, tool_name
+
+    @staticmethod
+    def apply_prefix(server_id: str, tool_name: str) -> str:
+        """
+        Applies a server prefix to a tool name, ensuring no double prefixing occurs.
+
+        Args:
+            server_id: The server ID to prefix.
+            tool_name: The base tool name.
+
+        Returns:
+            The prefixed tool name.
+        """
+        if not server_id:
+            return tool_name
+
+        prefix = f"{server_id}_"
+        if tool_name.startswith(prefix):
+            return tool_name
+
+        return f"{prefix}{tool_name}"

--- a/tests/test_mcp_server_names.py
+++ b/tests/test_mcp_server_names.py
@@ -1,0 +1,52 @@
+import pytest
+from magda_agent.integration.mcp_server_names import MCPToolNameParser
+
+def test_parse_with_prefix():
+    """Test parsing a tool name with a valid server prefix."""
+    prefix, name = MCPToolNameParser.parse("weather_get_forecast")
+    assert prefix == "weather"
+    assert name == "get_forecast"
+
+def test_parse_without_prefix():
+    """Test parsing a tool name without an underscore (no prefix)."""
+    prefix, name = MCPToolNameParser.parse("getforecast")
+    assert prefix is None
+    assert name == "getforecast"
+
+def test_parse_empty_string():
+    """Test parsing an empty string."""
+    prefix, name = MCPToolNameParser.parse("")
+    assert prefix is None
+    assert name == ""
+
+def test_parse_leading_underscore():
+    """Test parsing a string with a leading underscore (invalid prefix)."""
+    prefix, name = MCPToolNameParser.parse("_get_forecast")
+    assert prefix is None
+    assert name == "_get_forecast"
+
+def test_parse_trailing_underscore():
+    """Test parsing a string with a trailing underscore (invalid name)."""
+    prefix, name = MCPToolNameParser.parse("weather_")
+    assert prefix is None
+    assert name == "weather_"
+
+def test_apply_prefix_normal():
+    """Test applying a prefix to a normal tool name."""
+    prefixed = MCPToolNameParser.apply_prefix("weather", "get_forecast")
+    assert prefixed == "weather_get_forecast"
+
+def test_apply_prefix_already_prefixed():
+    """Test applying a prefix to a tool name that already has it."""
+    prefixed = MCPToolNameParser.apply_prefix("weather", "weather_get_forecast")
+    assert prefixed == "weather_get_forecast"
+
+def test_apply_prefix_empty_server_id():
+    """Test applying an empty prefix."""
+    prefixed = MCPToolNameParser.apply_prefix("", "get_forecast")
+    assert prefixed == "get_forecast"
+
+def test_apply_prefix_different_prefix():
+    """Test applying a prefix to a tool name that has a different prefix."""
+    prefixed = MCPToolNameParser.apply_prefix("weather", "math_add")
+    assert prefixed == "weather_math_add"


### PR DESCRIPTION
This PR implements the MCP server-prefixed tool name parser, as inspired by the OpenAI Agents SDK trend. 

**Changes Include:**
- `magda_agent/integration/mcp_server_names.py`: New `MCPToolNameParser` class for safely extracting and appending server prefixes to tool names.
- `tests/test_mcp_server_names.py`: Pytest suite verifying prefix extraction, prefix application, and edge cases (e.g. invalid underscores, empty strings).
- `agent_tasks.json`: Marked task `openai-agents-sdk-mcp-server-prefixed-tool-names-04d16c9f` as done and appended 3 new AI trend tasks.

---
*PR created automatically by Jules for task [9764614754487492033](https://jules.google.com/task/9764614754487492033) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPToolNameParser` for parsing and applying MCP server-prefixed tool names
> Introduces [`mcp_server_names.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/539/files#diff-1ccd462966ad5c6c31142100af6caf866cf2a9d2e47c310725079c553df29073) with two static methods on `MCPToolNameParser`: `parse` splits a tool name on the first underscore to extract an optional server ID and base tool name, and `apply_prefix` prepends a server ID without double-prefixing. Unit tests cover normal, already-prefixed, empty, and malformed underscore cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c657512.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->