### PR TITLE
Implement online RL from interactions (OpenClaw-RL)

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8723,7 +8723,7 @@
     },
     {
       "id": "openclaw-rl-interactions-v3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "Online RL from Interactions (OpenClaw-RL)",

--- a/magda_agent/learning/openclaw_rl_v3.py
+++ b/magda_agent/learning/openclaw_rl_v3.py
@@ -1,5 +1,7 @@
 import logging
-from typing import Dict, Any
+import re
+from typing import Dict, Any, Optional
+from magda_agent.llm_client import LLMClient
 
 class OnlineRLFeedbackLoop:
     """
@@ -8,15 +10,17 @@ class OnlineRLFeedbackLoop:
     Inspired by OpenClaw-RL.
     """
 
-    def __init__(self, db_path: str = ":memory:") -> None:
+    def __init__(self, db_path: str = ":memory:", llm_client: Optional[LLMClient] = None) -> None:
         """
         Initializes the OnlineRLFeedbackLoop.
 
         Args:
             db_path (str): The path to the SQLite database. Defaults to in-memory.
+            llm_client (Optional[LLMClient]): Optional LLMClient to extract rewards using LLM.
         """
         self.q_table: Dict[str, float] = {}
-        logging.info("Initialized OnlineRLFeedbackLoop")
+        self.llm_client = llm_client
+        logging.info("Initialized OnlineRLFeedbackLoop with LLM Support")
 
     def process_feedback(self, skill_id: str, user_reply: str) -> None:
         """
@@ -36,6 +40,72 @@ class OnlineRLFeedbackLoop:
 
         self.q_table[skill_id] = new_q
         logging.info(f"Updated Q-value for {skill_id}: {new_q:.2f} (Reward: {reward})")
+
+    async def process_feedback_async(
+        self,
+        skill_id: str,
+        user_reply: str,
+        tool_output: Optional[str] = None
+    ) -> None:
+        """
+        Asynchronously processes user feedback, utilizing LLM to evaluate the reward
+        from next-state signals (user reply and optional tool output).
+
+        Args:
+            skill_id (str): The identifier of the skill used.
+            user_reply (str): The text of the user's reply.
+            tool_output (Optional[str]): Optional output from the tool execution.
+        """
+        reward = await self.extract_reward_llm(user_reply, tool_output)
+
+        current_q = self.get_q_value(skill_id)
+        alpha = 0.1
+        new_q = current_q + alpha * (reward - current_q)
+
+        self.q_table[skill_id] = new_q
+        logging.info(f"Updated Q-value for {skill_id} asynchronously: {new_q:.2f} (Reward: {reward})")
+
+    async def extract_reward_llm(self, user_reply: str, tool_output: Optional[str] = None) -> float:
+        """
+        Uses LLM to evaluate conversational next-state signals (user reply and optional tool output)
+        to extract a reward between -1.0 and 1.0 representing user satisfaction / success.
+        If no LLMClient is available, falls back to the heuristic mapping.
+
+        Args:
+            user_reply (str): The user reply text.
+            tool_output (Optional[str]): The optional tool output text.
+
+        Returns:
+            float: A reward score between -1.0 and 1.0.
+        """
+        if not self.llm_client:
+            return self._map_reply_to_reward(user_reply)
+
+        prompt = (
+            "Analyze the following user response and optional tool output to determine user satisfaction.\n"
+            f"User Reply: {user_reply}\n"
+        )
+        if tool_output:
+            prompt += f"Tool Output: {tool_output}\n"
+        prompt += (
+            "Based on the interaction, output a single floating-point number representing the reward "
+            "from -1.0 (extremely dissatisfied, incorrect result, angry user) to 1.0 (very satisfied, "
+            "thankful user, successful tool execution).\n"
+            "If neutral, return 0.0.\n"
+            "Return ONLY the floating point number as your response, nothing else."
+        )
+
+        try:
+            response = await self.llm_client.generate(prompt)
+            cleaned = response.strip()
+            match = re.search(r"[-+]?\d*\.\d+|\d+", cleaned)
+            if match:
+                reward = float(match.group())
+                return max(-1.0, min(1.0, reward))
+            return 0.0
+        except Exception as e:
+            logging.error(f"Error extracting reward via LLM: {e}")
+            return self._map_reply_to_reward(user_reply)
 
     def _map_reply_to_reward(self, reply: str) -> float:
         """

--- a/tests/test_openclaw_rl_v3.py
+++ b/tests/test_openclaw_rl_v3.py
@@ -1,5 +1,7 @@
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 from magda_agent.learning.openclaw_rl_v3 import OnlineRLFeedbackLoop
+from magda_agent.llm_client import LLMClient
 
 def test_map_reply_to_reward_positive() -> None:
     """Tests parsing positive user replies to reward scores."""
@@ -40,3 +42,68 @@ def test_process_feedback() -> None:
     # Test negative feedback
     loop.process_feedback("skill_2", "Bad")
     assert loop.get_q_value("skill_2") == -0.1 # 0 + 0.1 * (-1 - 0)
+
+@pytest.mark.asyncio
+async def test_extract_reward_llm_positive() -> None:
+    """Tests that a mocked LLM returning a positive reward is processed correctly."""
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.generate = AsyncMock(return_value="0.85")
+
+    loop = OnlineRLFeedbackLoop(llm_client=mock_llm)
+    reward = await loop.extract_reward_llm("The response was fantastic!", "Successfully fetched data")
+
+    assert reward == 0.85
+    mock_llm.generate.assert_called_once()
+    assert "The response was fantastic!" in mock_llm.generate.call_args[0][0]
+    assert "Successfully fetched data" in mock_llm.generate.call_args[0][0]
+
+@pytest.mark.asyncio
+async def test_extract_reward_llm_negative_out_of_bounds() -> None:
+    """Tests that a mocked LLM returning an out of bounds value gets capped correctly."""
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.generate = AsyncMock(return_value="-1.5")
+
+    loop = OnlineRLFeedbackLoop(llm_client=mock_llm)
+    reward = await loop.extract_reward_llm("This is total garbage.", "Error: 500")
+
+    assert reward == -1.0
+    mock_llm.generate.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_extract_reward_llm_malformed_text() -> None:
+    """Tests that a mocked LLM returning text with a number embedded gets extracted correctly."""
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.generate = AsyncMock(return_value="The reward is: 0.5 points.")
+
+    loop = OnlineRLFeedbackLoop(llm_client=mock_llm)
+    reward = await loop.extract_reward_llm("Nice work", "Printed output")
+
+    assert reward == 0.5
+
+@pytest.mark.asyncio
+async def test_extract_reward_llm_error_fallback() -> None:
+    """Tests that the system falls back to heuristics if the LLM generate call fails."""
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.generate = AsyncMock(side_effect=Exception("API Error"))
+
+    loop = OnlineRLFeedbackLoop(llm_client=mock_llm)
+    reward = await loop.extract_reward_llm("thanks", "some output")
+
+    # Should fall back to heuristic, "thanks" maps to 1.0
+    assert reward == 1.0
+
+@pytest.mark.asyncio
+async def test_process_feedback_async() -> None:
+    """Tests async processing of feedback and verifying Q-value updates."""
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.generate = AsyncMock(return_value="0.5")
+
+    loop = OnlineRLFeedbackLoop(llm_client=mock_llm)
+
+    # First async feedback: reward is 0.5
+    await loop.process_feedback_async("skill_async_1", "quite good", "success context")
+    assert loop.get_q_value("skill_async_1") == 0.05  # 0 + 0.1 * (0.5 - 0)
+
+    # Second async feedback: reward is 0.5
+    await loop.process_feedback_async("skill_async_1", "quite good", "success context")
+    assert abs(loop.get_q_value("skill_async_1") - 0.095) < 1e-6  # 0.05 + 0.1 * (0.5 - 0.05)


### PR DESCRIPTION
This PR implements the task `openclaw-rl-interactions-v3`, introducing online reinforcement learning from conversational interactions (OpenClaw-RL).

Key changes:
1. Updated `OnlineRLFeedbackLoop` class to optionally accept `LLMClient` during initialization.
2. Implemented `extract_reward_llm` to asynchronously evaluate conversational next-state signals (user responses and optional tool execution outputs) using an LLM to produce a reward bounded in `[-1.0, 1.0]`.
3. Created a robust fallback to existing rule-based heuristic parser if LLM generate call raises an error or is unavailable.
4. Added `process_feedback_async` to perform Q-value updates using the extracted LLM-driven reward dynamically.
5. Added comprehensive unit tests in `tests/test_openclaw_rl_v3.py` verifying all paths: positive/negative rewards, bounds capping, malformed string parsing, API error fallbacks, and multi-step async Q-value updates.
6. Updated `agent_tasks.json` manifest status to 'done'.

---
*PR created automatically by Jules for task [927909551747365991](https://jules.google.com/task/927909551747365991) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement online RL feedback loop with LLM-extracted rewards in `OnlineRLFeedbackLoop`
> - Adds `extract_reward_llm` to [`openclaw_rl_v3.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/540/files#diff-8edbea7231534e850fa73c8cddc3a09a1cbda1811302b114f8c6922b40efae48), which prompts an LLM to score user replies as a reward in [-1.0, 1.0], with regex extraction and clamping; falls back to heuristic mapping on errors or missing client.
> - Adds `process_feedback_async`, which calls `extract_reward_llm` and applies a Q-learning update (α=0.1) to the relevant Q-value.
> - The `__init__` constructor now accepts an optional `LLMClient`; behavior is unchanged when omitted.
> - Adds async tests covering positive rewards, out-of-bounds clamping, malformed LLM output, error fallback, and Q-value update correctness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b27fb70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->