### PR TITLE
feat: Implement selective context compression

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8740,7 +8740,7 @@
     },
     {
       "id": "selective-context-compression-v1",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Compression + Selective Retrieval",
@@ -19707,6 +19707,60 @@
         "Diagnostic reporter gathers error density and health metrics",
         "Reporter integrates with HermesCronSchedulerV3",
         "Tests verify metric compilation logic with mocked scheduler"
+      ]
+    },
+    {
+      "id": "mcp-acs-telemetry-exporter",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Server ACS Telemetry Exporter",
+      "description": "Inspired by MCP and ACS trends: Implement an MCP tool within the MCPServer that securely exports ACS telemetry metrics (from ACSPersistenceV12) for external diagnostic consumption via JSON-RPC.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_acs_telemetry.py",
+        "tests/test_mcp_acs_telemetry.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP tool is correctly registered for telemetry export",
+        "Tool queries ACSPersistenceV12 and formats metrics properly",
+        "Tests verify tool execution using mocks"
+      ]
+    },
+    {
+      "id": "a2a-delegator-retry-circuit-breaker",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Delegator Retry Circuit Breaker",
+      "description": "Inspired by A2A Protocol and enterprise readiness trends: Add an explicit retry wrapper using A2ADelegationCircuitBreaker into A2ADelegatorV4 to prevent retry storms on peer agent timeout.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_delegator_v4_breaker.py",
+        "tests/test_a2a_delegator_v4_breaker.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2ADelegatorV4 utilizes A2ADelegationCircuitBreaker for task delegation",
+        "Retry logic respects circuit breaker states (HALF_OPEN, CLOSED)",
+        "Tests mock peer timeouts and verify circuit breaker opens correctly"
+      ]
+    },
+    {
+      "id": "openclaw-procedural-memory-rl-updater",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Procedural Memory RL Updater",
+      "description": "Inspired by OpenClaw RL trends: Extend ProceduralMemory to automatically update skill success rates and Q-values retrieved from OpenClawRLMetrics when recalling reusable successful procedures.",
+      "allowed_paths": [
+        "magda_agent/memory/procedural_rl_updater.py",
+        "tests/test_procedural_rl_updater.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ProceduralMemory uses Q-values from OpenClawRLMetrics to rank recalled skills",
+        "Module implements an update loop to cache these metrics",
+        "Tests verify Q-value ranking works successfully"
       ]
     }
   ]

--- a/magda_agent/memory/selective_retrieval.py
+++ b/magda_agent/memory/selective_retrieval.py
@@ -1,0 +1,119 @@
+import logging
+from typing import List
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+class SelectiveContextCompressor:
+    """
+    Context compressor module for virtual context management that selectively
+    compresses older working memory entries when the token limit is exceeded,
+    prior to semantic storage.
+    """
+    def __init__(self, llm: LLMClient):
+        """
+        Initialize the SelectiveContextCompressor.
+
+        Args:
+            llm: The LLM client used for summarizing text.
+        """
+        self.llm = llm
+
+    def _estimate_tokens(self, text: str) -> int:
+        """
+        Calculates a heuristic token length for the given text.
+        Roughly 1.3 tokens per word.
+        """
+        return int(len(text.split()) * 1.3)
+
+    def _estimate_memories_tokens(self, memories: List[MemoryEntry]) -> int:
+        """
+        Calculates a heuristic token length for a list of memory entries.
+        """
+        total_words = sum(len(e.content.split()) for e in memories)
+        return int(total_words * 1.3)
+
+    async def compress_old_memories(self, memories: List[MemoryEntry], max_tokens: int = 1000) -> List[MemoryEntry]:
+        """
+        Checks if the list of memories exceeds the token limit. If so, selectively
+        compresses the oldest memories while keeping newer ones intact.
+
+        Args:
+            memories: A list of memory entries, assumed to be chronologically ordered (oldest first).
+            max_tokens: The simulated maximum token limit.
+
+        Returns:
+            A list of memory entries, potentially with a compressed entry replacing older ones.
+        """
+        if not memories:
+            return []
+
+        current_tokens = self._estimate_memories_tokens(memories)
+        if current_tokens <= max_tokens:
+            return memories
+
+        logging.info(f"Context length ({current_tokens} tokens) exceeds limit ({max_tokens} tokens). Selectively compressing old memories...")
+
+        # Divide memories: Keep half of them (the newer ones), compress the older half
+        keep_count = len(memories) // 2
+        to_compress = memories[:-keep_count] if keep_count > 0 else memories
+        to_keep = memories[-keep_count:] if keep_count > 0 else []
+
+        if len(to_compress) <= 1 and not to_keep:
+            # Nothing meaningful to compress if only 1 item and we are keeping 0
+            # Just compress it if it's too large, but typically an entry shouldn't be larger than max_tokens
+            to_compress = memories
+            to_keep = []
+
+        combined_text = "\n".join(m.content for m in to_compress)
+        prompt = f"Please summarize the following older working memory context into a single concise bullet point:\n{combined_text}"
+        messages = [
+            {"role": "system", "content": "You are a context compression engine. Return only the compressed text."},
+            {"role": "user", "content": prompt}
+        ]
+
+        try:
+            compressed_text = await self.llm.chat_completion(messages, temperature=0.3)
+            compressed_text = compressed_text.strip()
+        except Exception as e:
+            logging.error(f"Failed to selectively compress text: {e}")
+            compressed_text = combined_text
+
+        # Average properties for the summary entry
+        avg_importance = sum(m.importance for m in to_compress) / len(to_compress)
+
+        # Calculate emotional state averages (using pleasure as proxy or full PAD)
+        avg_p = 0.0
+        avg_a = 0.0
+        avg_d = 0.0
+        has_state = False
+
+        for m in to_compress:
+            if m.emotional_state:
+                avg_p += m.emotional_state.pleasure
+                avg_a += m.emotional_state.arousal
+                avg_d += m.emotional_state.dominance
+                has_state = True
+
+        if has_state:
+            state = PADState(avg_p / len(to_compress), avg_a / len(to_compress), avg_d / len(to_compress))
+        else:
+            state = PADState(0, 0, 0)
+
+        first = to_compress[0]
+
+        # Merge tags safely
+        all_tags = set()
+        for m in to_compress:
+            if m.tags:
+                all_tags.update(m.tags)
+
+        summary_entry = MemoryEntry(
+            content=compressed_text,
+            importance=avg_importance,
+            emotional_state=state,
+            tags=list(all_tags),
+            user_id=first.user_id
+        )
+
+        return [summary_entry] + to_keep

--- a/tests/test_selective_retrieval.py
+++ b/tests/test_selective_retrieval.py
@@ -1,0 +1,70 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock
+from magda_agent.memory.selective_retrieval import SelectiveContextCompressor
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+@pytest.mark.asyncio
+async def test_selective_compressor_no_overflow():
+    """Test that if the token limit is not breached, original memories are returned."""
+    mock_llm = AsyncMock()
+    compressor = SelectiveContextCompressor(llm=mock_llm)
+
+    memories = [
+        MemoryEntry("A short memory", 0.5, PADState(0, 0, 0), ["tag1"], 1),
+        MemoryEntry("Another short memory", 0.6, PADState(0, 0, 0), ["tag2"], 1)
+    ]
+
+    # Very high max_tokens so it won't overflow
+    result = await compressor.compress_old_memories(memories, max_tokens=1000)
+
+    # Should not call LLM
+    mock_llm.chat_completion.assert_not_called()
+    assert result == memories
+    assert len(result) == 2
+
+@pytest.mark.asyncio
+async def test_selective_compressor_with_overflow():
+    """Test that if token limit is breached, older memories are summarized and newer are kept."""
+    mock_llm = AsyncMock()
+    mock_llm.chat_completion.return_value = "Compressed older memories."
+    compressor = SelectiveContextCompressor(llm=mock_llm)
+
+    # Create 4 memories. Let's say we set max_tokens very low,
+    # each word is ~1.3 tokens, so 4 words = 5 tokens. Total here is ~20 tokens.
+    memories = [
+        MemoryEntry("Old memory one", 0.4, PADState(0.1, 0, 0), ["t1"], 1),
+        MemoryEntry("Old memory two", 0.6, PADState(0.3, 0, 0), ["t2"], 1),
+        MemoryEntry("New memory one", 0.8, PADState(0.5, 0, 0), ["t3"], 1),
+        MemoryEntry("New memory two", 0.9, PADState(0.7, 0, 0), ["t4"], 1)
+    ]
+
+    # Max tokens = 10, will trigger compression
+    result = await compressor.compress_old_memories(memories, max_tokens=10)
+
+    mock_llm.chat_completion.assert_called_once()
+    args, kwargs = mock_llm.chat_completion.call_args
+    assert args[0][0]["role"] == "system"
+    assert "context compression engine" in args[0][0]["content"]
+
+    # We should have [compressed_summary] + [new_memory_one, new_memory_two]
+    assert len(result) == 3
+    assert result[0].content == "Compressed older memories."
+    assert result[0].importance == 0.5  # Average of 0.4 and 0.6
+    assert result[0].emotional_state.pleasure == pytest.approx(0.2) # Average of 0.1 and 0.3
+    assert "t1" in result[0].tags
+    assert "t2" in result[0].tags
+
+    assert result[1] == memories[2]
+    assert result[2] == memories[3]
+
+@pytest.mark.asyncio
+async def test_selective_compressor_empty_memories():
+    """Test with an empty list."""
+    mock_llm = AsyncMock()
+    compressor = SelectiveContextCompressor(llm=mock_llm)
+
+    result = await compressor.compress_old_memories([], max_tokens=10)
+    assert result == []
+    mock_llm.chat_completion.assert_not_called()


### PR DESCRIPTION
Inspired by virtual context trends, this PR introduces a selective context compression module. It estimates token sizes for working memory and offloads older entries by compressing them via the LLM into a single summary block, saving context space while retaining essential historical state. Test coverage is included.

---
*PR created automatically by Jules for task [14455008203905744806](https://jules.google.com/task/14455008203905744806) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **Module Implementation:**
    - Created `SelectiveContextCompressor` in `selective_retrieval.py` to manage memory via LLM-based summarization.
    - Added `test_selective_retrieval.py` to verify compression logic and memory state aggregation.
- **Task Management:**
    - Marked `selective-context-compression-v1` as done in `agent_tasks.json`.
    - Added three new roadmap items: `mcp-acs-telemetry-exporter`, `a2a-delegator-retry-circuit-breaker`, and `openclaw-procedural-memory-rl-updater`.

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add selective context compression for working memory entries via LLM summarization
> - Introduces `SelectiveContextCompressor` in [`magda_agent/memory/selective_retrieval.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/541/files#diff-faf4a73fead4906b66075a5a23e183b9f01d8af01adac05248dcb0fa300bc8b5) that compresses older working memory entries when a token budget is exceeded.
> - When over the token limit, the older half of memory entries is sent to an `LLMClient` for summarization and replaced with a single `MemoryEntry`; importance and PAD emotional state are averaged, tags are merged, and newer entries are preserved unchanged.
> - Falls back to concatenated raw text if the LLM call fails.
> - Three async tests cover the no-overflow, overflow, and empty-list cases.
> - Risk: Compression is lossy — older memory detail is permanently replaced by the LLM summary, which may affect downstream reasoning quality.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c882437.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->