### PR TITLE
feat(agents): implement EvaluatorSubagentV2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8791,7 +8791,7 @@
     },
     {
       "id": "claude-code-evaluation-subagent-v2",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "high",
       "title": "Claude SDK Evaluator Subagent",
@@ -19865,6 +19865,60 @@
       "acceptance": [
         "Implement A2ADiscovery service reading Agent Cards",
         "Tests mock discovery and filtering by capabilities"
+      ]
+    },
+    {
+      "id": "openclaw-canvas-context-lens-v1",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Context Lens",
+      "description": "Inspired by OpenClaw Live Visualization trend: Create a 'Context Lens' feature in CanvasServer that isolates and highlights the exact token spans in Working Memory responsible for triggering the current action, improving explainability.",
+      "allowed_paths": [
+        "magda_agent/visualization/context_lens_v1.py",
+        "tests/test_context_lens_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context Lens tracks token spans and maps them to emitted actions.",
+        "CanvasServer broadcasts these mapped spans via JSON Patch.",
+        "Tests mock token mapping and verify correct highlighting data is exported."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-security-clearance-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Dynamic Security Clearance Tokens",
+      "description": "Inspired by MCP Auth and enterprise safety trends: Implement a dynamic clearance token system that issues temporary, cryptographically-signed access tokens for specific MCP actions, validated by the ACS Checkpoints before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_clearance_v1.py",
+        "tests/test_mcp_clearance_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The system issues signed clearance tokens for MCP action tools.",
+        "ACS Checkpoints strictly validate the token signature and expiration.",
+        "Tests verify token generation, valid execution, and rejection of expired/tampered tokens."
+      ]
+    },
+    {
+      "id": "claude-subagent-cost-allocation-v1",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "title": "Claude Subagent Cost Allocation Tracker",
+      "description": "Inspired by Claude Agent Teams multi-agent architectures: Implement a token tracking component that allocates LLM token usage and estimated costs hierarchically to the specific spawned subagent, rolling up to the parent orchestrator.",
+      "allowed_paths": [
+        "magda_agent/operations/cost_allocation_v1.py",
+        "tests/test_cost_allocation_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cost allocator hooks into the LLM Client to intercept token counts per SubAgent execution.",
+        "Creates a hierarchical breakdown of tokens/costs (Parent -> Child Subagents).",
+        "Tests mock LLM completions and verify correct sum and hierarchical allocation."
       ]
     }
   ]

--- a/magda_agent/agents/evaluator_subagent_v2.py
+++ b/magda_agent/agents/evaluator_subagent_v2.py
@@ -1,0 +1,168 @@
+import json
+import logging
+from typing import Optional, Dict, Any, List
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+from magda_agent.emotions.engine import PADState
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.isolation.git_worktree_multi import GitWorktreeMultiManager
+from magda_agent.planning.dependency_graph import DependencyGraph
+
+class EvaluatorSubagentV2:
+    """
+    Evaluator implemented as a SubAgent with isolation.
+    Evaluates the agent's responses based on usefulness, accuracy, completeness, and emotional adequacy.
+    Inspired by Claude Agent SDK Subagent evaluation pattern.
+    """
+    def __init__(self, llm: LLMClient, memory: MemorySystem, worktree_manager: Optional[GitWorktreeMultiManager] = None):
+        """
+        Initializes the EvaluatorSubagentV2.
+
+        Args:
+            llm: The Language Model client.
+            memory: The memory system to store evaluations.
+            worktree_manager: Optional GitWorktreeMultiManager for multi-agent isolation.
+        """
+        self.llm = llm
+        self.memory = memory
+        self.worktree_manager = worktree_manager or GitWorktreeMultiManager()
+        self.last_evaluation: Optional[Dict[str, Any]] = None
+        self.sub_agent = SubAgent(
+            llm=llm,
+            system_prompt="You are an isolated SubAgent responsible for strictly evaluating responses and plans.",
+            use_isolation=True
+        )
+
+    async def evaluate_response(self, user_input: str, agent_response: str, policies: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
+        """
+        Evaluates the generated response using the LLM via SubAgent execute and stores the result in memory.
+
+        Args:
+            user_input: The user's original input message.
+            agent_response: The agent's generated response to evaluate.
+            policies: Optional list of policies to evaluate against.
+
+        Returns:
+            The evaluation dictionary or None if evaluation fails.
+        """
+        policy_str = ""
+        if policies:
+            policy_str = "\nEvaluate against these specific policies:\n" + "\n".join([f"- {p}" for p in policies])
+
+        task = (
+            "Evaluate the response given by an AI to a user's input.\n"
+            "Score the response from 1 to 10 on the following criteria:\n"
+            "- usefulness\n"
+            "- accuracy\n"
+            "- completeness\n"
+            "- emotional_adequacy\n"
+            f"{policy_str}\n\n"
+            "Respond ONLY with a JSON object in this format:\n"
+            "{\n"
+            '  "usefulness": 8,\n'
+            '  "accuracy": 9,\n'
+            '  "completeness": 7,\n'
+            '  "emotional_adequacy": 8,\n'
+            '  "policy_evaluations": {"policy_name": {"score": 8, "feedback": "reasoning"}},\n'
+            '  "average_score": 8.0,\n'
+            '  "feedback": "A short sentence explaining the overall score"\n'
+            "}"
+        )
+
+        context = (
+            f"User input: {user_input}\n"
+            f"AI Response: {agent_response}"
+        )
+
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.sub_agent.execute(task=task, context=context, temperature=0.1)
+
+                # Remove any markdown formatting (e.g. ```json)
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+
+                # Store in memory
+                content = f"Evaluation of response to '{user_input[:20]}...': Avg Score: {evaluation.get('average_score')} - {evaluation.get('feedback')}"
+                await self.memory.add_memory(
+                    content=content,
+                    importance=0.6,
+                    emotional_state=PADState(0.0, 0.0, 0.0), # Neutral PAD state for evaluation
+                    tags=["evaluation", "metacognition", "subagent"]
+                )
+
+                self.last_evaluation = evaluation
+                return evaluation
+            except json.JSONDecodeError as e:
+                logging.warning(f"JSON decoding error in evaluator attempt {attempt + 1}/{max_retries}: {e}. Retrying...")
+                if attempt == max_retries - 1:
+                    logging.error("Max retries reached for evaluate_response JSON parsing.")
+                    return None
+            except Exception as e:
+                logging.error(f"Failed to evaluate response: {e}")
+                return None
+
+    def get_feedback_for_prompt(self) -> str:
+        """
+        Returns feedback to be included in the next system prompt if the previous evaluation was low.
+
+        Returns:
+            Feedback string or empty string if no evaluation or high score.
+        """
+        if not self.last_evaluation:
+            return ""
+
+        avg_score = self.last_evaluation.get("average_score", 10.0)
+        if avg_score < 7.0:
+            feedback = self.last_evaluation.get("feedback", "Improve response quality.")
+            return f"Note: Your previous response received a low evaluation score ({avg_score}/10). Feedback: {feedback}. Please improve your response quality, accuracy, and emotional adequacy."
+        return ""
+
+    async def evaluate_planner_graph(self, plan: Dict[str, Any]) -> List[Any]:
+        """
+        Spawns a subagent in an isolated git worktree via GitWorktreeMultiManager
+        to review a Planner dependency graph.
+
+        Args:
+            plan: The plan containing steps and dependencies.
+
+        Returns:
+            A list of evaluation results.
+        """
+        # Validate dependency graph
+        steps = plan.get("steps", [])
+        try:
+            DependencyGraph.topological_sort(steps)
+            structural_status = "Valid topological sort."
+        except ValueError as e:
+            structural_status = f"Cycle detected: {e}"
+
+        context = f"Plan structural validation: {structural_status}\nSteps:\n" + json.dumps(steps, indent=2)
+        task = (
+            "Review the provided AI Agent dependency graph for logical soundness and parallelization opportunities. "
+            "Evaluate if steps with missing dependencies can lead to failure. "
+            "Output your findings as a JSON object."
+        )
+
+        # Create a SubAgent that doesn't use its own worktree manager since we are
+        # wrapping it in GitWorktreeMultiManager.execute_concurrently
+        graph_evaluator = SubAgent(
+            llm=self.llm,
+            system_prompt="You are an isolated SubAgent responsible for strictly evaluating responses and plans.",
+            use_isolation=False
+        )
+
+        async def evaluation_task(worktree_path: str) -> str:
+            # Inject worktree path context
+            full_context = context + f"\nIsolated Worktree Context: {worktree_path}"
+            return await graph_evaluator.execute(task=task, context=full_context, temperature=0.1)
+
+        results = await self.worktree_manager.execute_concurrently([evaluation_task])
+        return results

--- a/tests/test_evaluator_subagent_v2.py
+++ b/tests/test_evaluator_subagent_v2.py
@@ -1,0 +1,92 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.agents.evaluator_subagent_v2 import EvaluatorSubagentV2
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.storage import MemorySystem
+
+@pytest.fixture
+def mock_llm():
+    return AsyncMock(spec=LLMClient)
+
+@pytest.fixture
+def mock_memory():
+    return AsyncMock(spec=MemorySystem)
+
+@pytest.mark.asyncio
+async def test_evaluate_response_success(mock_llm, mock_memory):
+    evaluator = EvaluatorSubagentV2(llm=mock_llm, memory=mock_memory)
+
+    # Mock the sub_agent execute to return a valid JSON evaluation
+    evaluator.sub_agent.execute = AsyncMock(return_value="""```json
+{
+  "usefulness": 8,
+  "accuracy": 9,
+  "completeness": 7,
+  "emotional_adequacy": 8,
+  "policy_evaluations": {},
+  "average_score": 8.0,
+  "feedback": "Good response"
+}
+```""")
+
+    result = await evaluator.evaluate_response("hello", "hi there")
+
+    assert result is not None
+    assert result["average_score"] == 8.0
+    assert result["feedback"] == "Good response"
+
+    # Check that memory was updated
+    mock_memory.add_memory.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_evaluate_response_retry_and_fail(mock_llm, mock_memory):
+    evaluator = EvaluatorSubagentV2(llm=mock_llm, memory=mock_memory)
+
+    # Mock sub_agent execute to always return invalid JSON
+    evaluator.sub_agent.execute = AsyncMock(return_value="invalid json")
+
+    result = await evaluator.evaluate_response("hello", "hi there")
+
+    assert result is None
+    # Should retry 3 times
+    assert evaluator.sub_agent.execute.call_count == 3
+    # Memory should not be updated
+    mock_memory.add_memory.assert_not_called()
+
+def test_get_feedback_for_prompt(mock_llm, mock_memory):
+    evaluator = EvaluatorSubagentV2(llm=mock_llm, memory=mock_memory)
+
+    # No evaluation yet
+    assert evaluator.get_feedback_for_prompt() == ""
+
+    # High score
+    evaluator.last_evaluation = {"average_score": 9.0, "feedback": "Great"}
+    assert evaluator.get_feedback_for_prompt() == ""
+
+    # Low score
+    evaluator.last_evaluation = {"average_score": 5.0, "feedback": "Needs work"}
+    feedback = evaluator.get_feedback_for_prompt()
+    assert "low evaluation score (5.0/10)" in feedback
+    assert "Needs work" in feedback
+
+@pytest.mark.asyncio
+async def test_evaluate_planner_graph(mock_llm, mock_memory):
+    evaluator = EvaluatorSubagentV2(llm=mock_llm, memory=mock_memory)
+
+    # Mock worktree manager
+    evaluator.worktree_manager = MagicMock()
+    evaluator.worktree_manager.execute_concurrently = AsyncMock(return_value=['{"status": "graph evaluated"}'])
+
+    plan = {
+        "steps": [
+            {"id": "step1", "dependencies": []},
+            {"id": "step2", "dependencies": ["step1"]}
+        ]
+    }
+
+    result = await evaluator.evaluate_planner_graph(plan)
+
+    assert result == ['{"status": "graph evaluated"}']
+    evaluator.worktree_manager.execute_concurrently.assert_called_once()


### PR DESCRIPTION
Implemented the Claude SDK Evaluator Subagent as requested in `agent_tasks.json`.

Changes:
1. Created `EvaluatorSubagentV2` in `magda_agent/agents/evaluator_subagent_v2.py`. It uses `SubAgent` for evaluating inputs/responses (with retries for JSON parsing) and `GitWorktreeMultiManager` for running isolated dependency graph evaluations.
2. Created test suite in `tests/test_evaluator_subagent_v2.py` utilizing `pytest`, `pytest-asyncio`, and `unittest.mock.AsyncMock`. All tests pass successfully.
3. Updated `agent_tasks.json` to mark `claude-code-evaluation-subagent-v2` as `done`.
4. Added 3 new actionable `todo` tasks to `agent_tasks.json` inspired by 2026 AI Agent trends:
   - `openclaw-canvas-context-lens-v1`: Context Lens for visual explainability.
   - `mcp-dynamic-security-clearance-v1`: Dynamic Security Clearance Tokens for MCP Actions.
   - `claude-subagent-cost-allocation-v1`: Hierarchical Subagent Cost Allocation Tracker.
5. Successfully ran the `scripts/validate_agent_tasks.py` validation script.

---
*PR created automatically by Jules for task [5877428449936094185](https://jules.google.com/task/5877428449936094185) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `EvaluatorSubagentV2` for scoring responses and validating planner graphs
> - Introduces [`EvaluatorSubagentV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/544/files#diff-3655543c500e2129650e00f7113f416a50c5e9c0a217457d95a45d89fff88e13) which composes an isolated `SubAgent` and a `GitWorktreeMultiManager` to evaluate LLM responses and planner graphs.
> - `evaluate_response` parses JSON from the subagent output, writes a memory entry on success, and retries up to 3 times on `JSONDecodeError` before returning `None`.
> - `get_feedback_for_prompt` returns an improvement hint when the last evaluation's average score is below 7.0.
> - `evaluate_planner_graph` validates plan steps with a topological sort to detect cycles, then runs LLM-based analysis concurrently in isolated worktree contexts.
> - Adds pytest coverage in [`tests/test_evaluator_subagent_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/544/files#diff-286efad2c8f414626f73fef2f83e23bbbeda2ae7b8637800ebdca46078708496) for success, retry/failure, feedback thresholds, and concurrent graph evaluation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 584fe2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->