### PR TITLE
feat: MCPKernel Taint Tracking DB V1

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8808,7 +8808,7 @@
     },
     {
       "id": "mcpkernel-taint-tracking-db-v1",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCPKernel Taint Tracking Enhancements",
@@ -19920,6 +19920,41 @@
         "Creates a hierarchical breakdown of tokens/costs (Parent -> Child Subagents).",
         "Tests mock LLM completions and verify correct sum and hierarchical allocation."
       ]
+    },
+    {
+      "id": "openclaw-rl-tone-adaptation-v6",
+      "title": "Online RL Tone Adaptation V6",
+      "description": "Inspired by OpenClaw-RL trend (June 2026): Implement a behavior modifier that uses online reinforcement learning to adjust the agent's response tone based on user PAD shifts.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_tone_adaptation_v6.py",
+        "tests/test_rl_tone_adaptation_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent tone shifts in response to positive/negative user feedback.",
+        "Tests verify weight adjustments."
+      ],
+      "risk": "medium",
+      "area": "learning",
+      "status": "todo"
+    },
+    {
+      "id": "claude-subagent-spawning-v3",
+      "title": "Subagent Context Compression V3",
+      "description": "Inspired by Claude Agent Teams multi-agent architectures: Implement a feature that compresses subagent context windows significantly before sending results back to the parent orchestrator.",
+      "allowed_paths": [
+        "magda_agent/agents/context_compression_v3.py",
+        "tests/test_context_compression_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent context is compressed without losing key data.",
+        "Parent receives summarized data.",
+        "Tests verify correct compression ratio and data loss bounds."
+      ],
+      "risk": "medium",
+      "area": "agents",
+      "status": "todo"
     }
   ]
 }

--- a/magda_agent/safety/taint_tracking_db.py
+++ b/magda_agent/safety/taint_tracking_db.py
@@ -1,0 +1,157 @@
+"""Persistent storage for tainted tool execution logs."""
+import sqlite3
+import json
+import time
+from typing import Any, Callable, Dict, List, Optional
+from magda_agent.safety.taint import MCPKernel, PolicyViolationError
+
+class TaintTrackingDB:
+    """Manages an SQLite database for storing taint tracking logs."""
+
+    def __init__(self, db_path: str = "taint_tracking.db", timeout: float = 10.0):
+        self.db_path = db_path
+        self.timeout = timeout
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the database schema."""
+        if self.db_path == ":memory:":
+            return # Let the caller manage memory DB connections
+
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                '''
+                CREATE TABLE IF NOT EXISTS taint_logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    inputs TEXT NOT NULL,
+                    is_sensitive BOOLEAN NOT NULL,
+                    violation_raised BOOLEAN NOT NULL,
+                    error_message TEXT
+                )
+                '''
+            )
+            conn.commit()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Returns a configured SQLite connection."""
+        # Using timeout for concurrent access
+        return sqlite3.connect(self.db_path, timeout=self.timeout)
+
+    def log_execution(self, tool_name: str, inputs: Dict[str, Any], is_sensitive: bool, violation_raised: bool, error_message: Optional[str] = None, conn: Optional[sqlite3.Connection] = None) -> None:
+        """Logs an execution attempt."""
+        timestamp = time.time()
+
+        # Simple serialization; in real systems use recursive sanitization,
+        # but here we follow the task requirements. We stringify safely.
+        try:
+            # We convert it to a string rather than full json dump to handle TaintedString objects
+            inputs_str = str(inputs)
+        except Exception:
+            inputs_str = "<unserializable>"
+
+        insert_query = '''
+            INSERT INTO taint_logs (timestamp, tool_name, inputs, is_sensitive, violation_raised, error_message)
+            VALUES (?, ?, ?, ?, ?, ?)
+        '''
+        params = (timestamp, tool_name, inputs_str, is_sensitive, violation_raised, error_message)
+
+        if conn is not None:
+             cursor = conn.cursor()
+             # If caller passed a connection, use it (useful for :memory: testing)
+             cursor.execute(
+                '''
+                CREATE TABLE IF NOT EXISTS taint_logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    inputs TEXT NOT NULL,
+                    is_sensitive BOOLEAN NOT NULL,
+                    violation_raised BOOLEAN NOT NULL,
+                    error_message TEXT
+                )
+                '''
+             )
+             cursor.execute(insert_query, params)
+             conn.commit()
+             return
+
+        with self._get_connection() as c:
+            cursor = c.cursor()
+            cursor.execute(insert_query, params)
+            c.commit()
+
+    def query(self, tool_name: Optional[str] = None, conn: Optional[sqlite3.Connection] = None) -> List[Dict[str, Any]]:
+        """Queries the logs."""
+        query_sql = "SELECT id, timestamp, tool_name, inputs, is_sensitive, violation_raised, error_message FROM taint_logs"
+        params: List[Any] = []
+
+        if tool_name:
+            query_sql += " WHERE tool_name = ?"
+            params.append(tool_name)
+
+        def execute_query(c: sqlite3.Connection):
+            cursor = c.cursor()
+            # ensure table exists for memory db if query is called first
+            cursor.execute(
+                '''
+                CREATE TABLE IF NOT EXISTS taint_logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    inputs TEXT NOT NULL,
+                    is_sensitive BOOLEAN NOT NULL,
+                    violation_raised BOOLEAN NOT NULL,
+                    error_message TEXT
+                )
+                '''
+            )
+            cursor.execute(query_sql, tuple(params))
+            rows = cursor.fetchall()
+            results = []
+            for row in rows:
+                results.append({
+                    "id": row[0],
+                    "timestamp": row[1],
+                    "tool_name": row[2],
+                    "inputs": row[3],
+                    "is_sensitive": bool(row[4]),
+                    "violation_raised": bool(row[5]),
+                    "error_message": row[6]
+                })
+            return results
+
+        if conn is not None:
+            return execute_query(conn)
+
+        with self._get_connection() as c:
+            return execute_query(c)
+
+def execute_with_tracking(kernel: MCPKernel, db: TaintTrackingDB, tool_name: str, tool_func: Callable[..., Any], inputs: Dict[str, Any], is_sensitive: bool = False, conn: Optional[sqlite3.Connection] = None) -> Any:
+    """Wraps MCPKernel execute_tool with DB tracking."""
+    violation_raised = False
+    error_message = None
+
+    try:
+        result = kernel.execute_tool(tool_func, inputs, is_sensitive=is_sensitive)
+        return result
+    except PolicyViolationError as e:
+        violation_raised = True
+        error_message = str(e)
+        raise
+    except Exception as e:
+        error_message = str(e)
+        raise
+    finally:
+        # We always log the attempt, regardless of whether it succeeded, failed policy, or failed otherwise.
+        # But we only mark violation_raised if it was a PolicyViolationError
+        db.log_execution(
+            tool_name=tool_name,
+            inputs=inputs,
+            is_sensitive=is_sensitive,
+            violation_raised=violation_raised,
+            error_message=error_message,
+            conn=conn
+        )

--- a/tests/test_taint_tracking_db.py
+++ b/tests/test_taint_tracking_db.py
@@ -1,0 +1,126 @@
+"""Tests for Taint Tracking DB."""
+import sqlite3
+import concurrent.futures
+import pytest
+from typing import Any, Dict
+from magda_agent.safety.taint import MCPKernel, PolicyViolationError
+from magda_agent.safety.taint_tracking_db import TaintTrackingDB, execute_with_tracking
+
+def sample_tool(data: Any) -> str:
+    """A simple tool for testing."""
+    return f"Processed {data}"
+
+def test_db_initialization_and_logging():
+    """Test that the DB is initialized and can log items."""
+    conn = sqlite3.connect(":memory:")
+    db = TaintTrackingDB(db_path=":memory:")
+
+    db.log_execution(
+        tool_name="test_tool",
+        inputs={"data": "test"},
+        is_sensitive=False,
+        violation_raised=False,
+        error_message=None,
+        conn=conn
+    )
+
+    results = db.query(conn=conn)
+    assert len(results) == 1
+    assert results[0]["tool_name"] == "test_tool"
+    assert "test" in results[0]["inputs"]
+    assert not results[0]["is_sensitive"]
+    assert not results[0]["violation_raised"]
+
+    conn.close()
+
+def test_execute_with_tracking_success():
+    """Test successful execution tracking."""
+    conn = sqlite3.connect(":memory:")
+    db = TaintTrackingDB(db_path=":memory:")
+    kernel = MCPKernel()
+
+    result = execute_with_tracking(
+        kernel=kernel,
+        db=db,
+        tool_name="sample_tool",
+        tool_func=sample_tool,
+        inputs={"data": "safe"},
+        is_sensitive=True,
+        conn=conn
+    )
+
+    assert result == "Processed safe"
+
+    logs = db.query(conn=conn)
+    assert len(logs) == 1
+    assert logs[0]["tool_name"] == "sample_tool"
+    assert logs[0]["violation_raised"] is False
+    assert logs[0]["is_sensitive"] is True
+
+    conn.close()
+
+def test_execute_with_tracking_violation():
+    """Test violation execution tracking."""
+    conn = sqlite3.connect(":memory:")
+    db = TaintTrackingDB(db_path=":memory:")
+    kernel = MCPKernel()
+
+    tainted_input = kernel.tracker.taint("bad_data")
+
+    with pytest.raises(PolicyViolationError):
+        execute_with_tracking(
+            kernel=kernel,
+            db=db,
+            tool_name="sample_tool_sensitive",
+            tool_func=sample_tool,
+            inputs={"data": tainted_input},
+            is_sensitive=True,
+            conn=conn
+        )
+
+    logs = db.query(conn=conn)
+    assert len(logs) == 1
+    assert logs[0]["tool_name"] == "sample_tool_sensitive"
+    assert logs[0]["violation_raised"] is True
+    assert logs[0]["is_sensitive"] is True
+    assert "Tainted input" in logs[0]["error_message"]
+
+    conn.close()
+
+def test_execute_with_tracking_concurrent():
+    """Test concurrent logging to SQLite."""
+    import tempfile
+    import os
+
+    # We need a file DB for concurrent access testing, memory DBs don't share well across threads easily
+    fd, temp_db_path = tempfile.mkstemp()
+    os.close(fd)
+
+    try:
+        db = TaintTrackingDB(db_path=temp_db_path, timeout=10.0)
+        kernel = MCPKernel()
+
+        def run_tool(i):
+            try:
+                execute_with_tracking(
+                    kernel=kernel,
+                    db=db,
+                    tool_name=f"tool_{i}",
+                    tool_func=sample_tool,
+                    inputs={"data": f"input_{i}"},
+                    is_sensitive=False
+                )
+            except Exception:
+                pass
+
+        num_threads = 20
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+            futures = [executor.submit(run_tool, i) for i in range(num_threads)]
+            concurrent.futures.wait(futures)
+
+        logs = db.query()
+        assert len(logs) == num_threads
+
+    finally:
+        if os.path.exists(temp_db_path):
+            os.remove(temp_db_path)


### PR DESCRIPTION
Inspired by the MCPKernel sandboxed execution trend, this PR introduces a persistent storage mechanism for tainted tool execution logs. \n\n### Changes\n- Created `magda_agent/safety/taint_tracking_db.py` to handle SQLite `TaintTrackingDB` setup and concurrent insertion.\n- Created `tests/test_taint_tracking_db.py` to mock and verify DB insertions under concurrent multi-threaded execution environments safely.\n- Updated `agent_tasks.json` to mark the task done and added two new tasks (`openclaw-rl-tone-adaptation-v6` and `claude-subagent-spawning-v3`) based on AI trends.

---
*PR created automatically by Jules for task [1095289657010334784](https://jules.google.com/task/1095289657010334784) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SQLite-backed taint tracking DB for MCPKernel tool execution logging
> - Introduces `TaintTrackingDB` in [`taint_tracking_db.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/545/files#diff-6d2b592785f286116529446450f63afaf71dcbac6da7dcdcf5d085c82bb9acab), a SQLite-backed store that persists tool execution attempts with sensitivity flags, policy violation flags, and error messages.
> - Adds `execute_with_tracking`, a wrapper around `MCPKernel.execute_tool` that always logs to the DB (via `finally`), marks `violation_raised` only for `PolicyViolationError`, and re-raises all exceptions unchanged.
> - Supports both file-backed and `:memory:` SQLite connections, with configurable timeout for concurrent access.
> - Adds tests covering single-record insert/query, success and policy-violation paths, and multi-threaded concurrent inserts on a file-backed DB.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c31f68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->