### PR TITLE
feat: implement OpenClaw Canvas Detailed Logging plugin

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8842,7 +8842,7 @@
     },
     {
       "id": "openclaw-canvas-visualizer-v2",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging",
@@ -19990,6 +19990,57 @@
         "MCP tool execution pipeline is modified to integrate the ACS policy layer.",
         "Execution blocks on strict policy violation.",
         "Tests verify failure scenarios using mock inputs."
+      ]
+    },
+    {
+      "id": "acs-runtime-safety-controls-v7-202606",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Agent Control Specification - Runtime Safety Controls",
+      "description": "Implement robust runtime safety controls for the agent using the 5 validation checkpoints specified in ACS.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_checkpoints_v7.py",
+        "tests/test_acs_checkpoints_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Implement the 5 ACS validation checkpoints in acs_checkpoints_v7.py.",
+        "Write pytest tests verifying that policy violations correctly trigger guardrails."
+      ]
+    },
+    {
+      "id": "a2a-agent-discovery-cards-v3-202606",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "medium",
+      "title": "A2A Agent Discovery via Agent Cards",
+      "description": "Implement a discovery service module that parses and publishes A2A Agent Cards for local network peers.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_cards_v3.py",
+        "tests/test_a2a_discovery_cards_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Implement a discovery service reading and writing Agent Cards.",
+        "Write pytest tests mocking peer discovery via Agent Cards."
+      ]
+    },
+    {
+      "id": "a2a-peer-task-delegation-v7-202606",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "medium",
+      "title": "A2A Peer-to-Peer Task Delegation V7",
+      "description": "Implement a secure peer-to-peer task delegation client using the A2A spec.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_task_delegation_v7.py",
+        "tests/test_a2a_task_delegation_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Implement peer-to-peer task delegation client logic.",
+        "Write pytest tests verifying task delegation flow."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -284,3 +284,7 @@
 * [ ] FEATURE: MCP Dynamic Capability Negotiation V5 (mcp-dynamic-capability-negotiation-v5)
 * [ ] FEATURE: OpenClaw RL Trajectory Quality Evaluation (openclaw-rl-trajectory-evaluation-v2)
 * [ ] FEATURE: Claude Worktree Pruning and Resource Optimizer (claude-worktree-pruning-optimizer-v1)
+
+* [ ] FEATURE: ACS Agent Control Specification - Runtime Safety Controls (acs-runtime-safety-controls-v7-202606)
+* [ ] FEATURE: A2A Agent Discovery via Agent Cards (a2a-agent-discovery-cards-v3-202606)
+* [ ] FEATURE: A2A Peer-to-Peer Task Delegation V7 (a2a-peer-task-delegation-v7-202606)

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -68,6 +68,7 @@ from magda_agent.safety.guardrails import RealtimeGuardrail
 from magda_agent.memory.context_engine import ContextEngine
 from magda_agent.memory.default_context_plugin import DefaultContextPlugin
 from magda_agent.skills.compression_v2 import OpenClawContextCompressorV2
+from magda_agent.visualization.canvas_logger import CanvasLoggerPlugin
 from magda_agent.tracing.tracer import ThoughtChainTracer
 from magda_agent.architecture.sub_agents import SubAgentRPCManager
 from magda_agent.integration.cross_platform import CrossPlatformDispatcher
@@ -81,7 +82,8 @@ emotional_engine = EmotionalEngine()
 # Initialize ContextEngine with default plugin and OpenClaw compressor
 context_engine = ContextEngine(plugins=[
     DefaultContextPlugin(llm=llm_client),
-    OpenClawContextCompressorV2(llm=llm_client)
+    OpenClawContextCompressorV2(llm=llm_client),
+    CanvasLoggerPlugin()
 ])
 
 memory_system = MemorySystem(llm=llm_client, context_engine=context_engine)

--- a/magda_agent/visualization/canvas_logger.py
+++ b/magda_agent/visualization/canvas_logger.py
@@ -1,0 +1,47 @@
+import logging
+from typing import Dict, List, Any
+
+logger = logging.getLogger(__name__)
+
+class CanvasLoggerPlugin:
+    """
+    A context engine plugin that intercepts lifecycle hooks
+    (bootstrap, before_retrieval, after_retrieval) and logs
+    the events for Canvas visualization.
+    """
+
+    def __init__(self) -> None:
+        self.logs: List[Dict[str, Any]] = []
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin and log the config."""
+        event = {"event": "bootstrap", "config": config}
+        self.logs.append(event)
+        logger.debug(f"CanvasLoggerPlugin.bootstrap: {event}")
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Log the retrieval query."""
+        event = {"event": "before_retrieval", "query": query, "user_id": user_id}
+        self.logs.append(event)
+        logger.debug(f"CanvasLoggerPlugin.before_retrieval: {event}")
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """Log the retrieved context length."""
+        event = {
+            "event": "after_retrieval",
+            "context_length": len(context),
+            "query": query,
+            "user_id": user_id
+        }
+        self.logs.append(event)
+        logger.debug(f"CanvasLoggerPlugin.after_retrieval: {event}")
+        return context
+
+    def get_logs(self) -> List[Dict[str, Any]]:
+        """Return the captured logs."""
+        return self.logs
+
+    def clear_logs(self) -> None:
+        """Clear the captured logs."""
+        self.logs.clear()

--- a/tests/test_canvas_logger.py
+++ b/tests/test_canvas_logger.py
@@ -1,0 +1,54 @@
+import pytest
+import asyncio
+from typing import Dict, Any, List
+from magda_agent.visualization.canvas_logger import CanvasLoggerPlugin
+
+def test_canvas_logger_bootstrap():
+    plugin = CanvasLoggerPlugin()
+    config = {"setting": "value"}
+
+    # Run async function using asyncio
+    asyncio.run(plugin.bootstrap(config))
+
+    logs = plugin.get_logs()
+    assert len(logs) == 1
+    assert logs[0]["event"] == "bootstrap"
+    assert logs[0]["config"] == config
+
+def test_canvas_logger_before_retrieval():
+    plugin = CanvasLoggerPlugin()
+    query = "test query"
+    user_id = 42
+
+    result = plugin.before_retrieval(query, user_id)
+
+    assert result == query
+    logs = plugin.get_logs()
+    assert len(logs) == 1
+    assert logs[0]["event"] == "before_retrieval"
+    assert logs[0]["query"] == query
+    assert logs[0]["user_id"] == user_id
+
+def test_canvas_logger_after_retrieval():
+    plugin = CanvasLoggerPlugin()
+    context = ["item1", "item2", "item3"]
+    query = "test query"
+    user_id = 42
+
+    result = plugin.after_retrieval(context, query, user_id)
+
+    assert result == context
+    logs = plugin.get_logs()
+    assert len(logs) == 1
+    assert logs[0]["event"] == "after_retrieval"
+    assert logs[0]["context_length"] == 3
+    assert logs[0]["query"] == query
+    assert logs[0]["user_id"] == user_id
+
+def test_canvas_logger_clear_logs():
+    plugin = CanvasLoggerPlugin()
+    plugin.before_retrieval("test", 1)
+    assert len(plugin.get_logs()) == 1
+
+    plugin.clear_logs()
+    assert len(plugin.get_logs()) == 0


### PR DESCRIPTION
This PR implements the `OpenClaw Canvas Detailed Logging` feature, which expands the OpenClaw Canvas to intercept specific `ContextEngine` lifecycle hooks (`before_retrieval`, `after_retrieval`, and `bootstrap`) and logs them for live visualization.

It creates the `CanvasLoggerPlugin` class conforming to the `ContextPlugin` protocol, integrates it into the `ContextEngine` in `api.py`, and adds test coverage. Finally, it updates `agent_tasks.json` to mark the task as done and appends three new AI trend-inspired tasks, synchronizing these with `backlog.md`.

---
*PR created automatically by Jules for task [8464208072348389735](https://jules.google.com/task/8464208072348389735) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CanvasLoggerPlugin` to log ContextEngine lifecycle events
> - Adds a new [`CanvasLoggerPlugin`](https://github.com/kazah4359-lgtm/Magda-agent/pull/547/files#diff-2edb73f575db6f146749637f76ec45a1a4b008b947635a171bc174674b89764a) that records `bootstrap`, `before_retrieval`, and `after_retrieval` lifecycle events to an in-memory list and emits debug log output.
> - Registers the plugin in [`magda_agent/api.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/547/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d) alongside the existing `DefaultContextPlugin` and `OpenClawContextCompressorV2`.
> - Inputs (query, context) are passed through unmodified — the plugin is observe-only.
> - Four pytest tests in [`tests/test_canvas_logger.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/547/files#diff-1d6917d55a977414ca38c81f6516ed0388512ca64bf2f0a45b3a99330fc95d93) cover all lifecycle hooks and log clearing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d64d3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->