### PR TITLE
feat(safety): Implement Agent Guard Policy Extension

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8859,7 +8859,7 @@
     },
     {
       "id": "agent-guard-policy-extension-v1",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Agent Guard Policy Extension",
@@ -20041,6 +20041,57 @@
       "acceptance": [
         "Implement peer-to-peer task delegation client logic.",
         "Write pytest tests verifying task delegation flow."
+      ]
+    },
+    {
+      "id": "agent-teams-isolation-v1",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Agent Teams Git Worktree Isolation",
+      "description": "Inspired by trend: Agent Teams (Claude) git worktree isolation. Implement an isolation layer where each spawned subagent operates in its own git worktree to prevent conflict.",
+      "allowed_paths": [
+        "magda_agent/isolation/git_worktree_manager.py",
+        "tests/test_git_worktree_manager.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Git worktree manager implemented.",
+        "Tests verify subagent execution within isolated git worktrees."
+      ]
+    },
+    {
+      "id": "openclaw-rl-next-state-processor",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Next-State Feedback Processor",
+      "description": "Inspired by trend: OpenClaw-RL online reinforcement learning. Implement a processor that extracts next-state signals (e.g. user replies or tool outputs) and routes them as reinforcement signals to the behavior module.",
+      "allowed_paths": [
+        "magda_agent/learning/next_state_processor.py",
+        "tests/test_next_state_processor.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Next-state feedback processor implemented.",
+        "Tests pass validating signal extraction and routing."
+      ]
+    },
+    {
+      "id": "a2a-agent-discovery-service",
+      "status": "todo",
+      "area": "integration",
+      "risk": "low",
+      "title": "A2A Protocol Agent Discovery Service",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol). Build a basic agent discovery service using Agent Cards that allows peering with other agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery.py",
+        "tests/test_a2a_discovery.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A discovery service module added.",
+        "Agent card generation and resolution verified in tests."
       ]
     }
   ]

--- a/magda_agent/safety/policy_layer.py
+++ b/magda_agent/safety/policy_layer.py
@@ -1,0 +1,95 @@
+"""Agent Guard Policy Extension for granular runtime governance."""
+
+import logging
+from typing import Any, Callable, Dict, List, Tuple
+
+from magda_agent.safety.policy import PolicyLayer
+
+# A granular rule evaluates a tool execution.
+# Returns (True, "") if allowed, or (False, "Reason...") if denied.
+GranularRule = Callable[[str, Dict[str, Any]], Tuple[bool, str]]
+
+
+class AgentGuardPolicyLayer(PolicyLayer):
+    """
+    Extended PolicyLayer inspired by Agent Guard runtime governance.
+    Supports granular runtime checks in addition to base policies.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the extended policy layer with empty rulesets."""
+        super().__init__()
+        self._global_rules: List[GranularRule] = []
+        self._tool_rules: Dict[str, List[GranularRule]] = {}
+
+    def add_global_rule(self, rule: GranularRule) -> None:
+        """
+        Add a global rule that applies to all tool executions.
+
+        Args:
+            rule: A callable rule evaluating the tool name and arguments.
+        """
+        self._global_rules.append(rule)
+
+    def add_tool_rule(self, tool_name: str, rule: GranularRule) -> None:
+        """
+        Add a rule specific to a canonical tool name.
+
+        Args:
+            tool_name: The canonical tool name.
+            rule: A callable rule evaluating the tool name and arguments.
+        """
+        canonical = self._canonical_tool_name(tool_name)
+        if canonical not in self._tool_rules:
+            self._tool_rules[canonical] = []
+        self._tool_rules[canonical].append(rule)
+
+    def evaluate(self, tool_name: str, **kwargs: Any) -> Tuple[bool, str]:
+        """
+        Evaluate an action by first running granular rules, then falling back to base policy.
+
+        Args:
+            tool_name: The tool or action being executed.
+            kwargs: Arguments provided to the tool.
+
+        Returns:
+            A tuple containing a boolean (allow/deny) and an explanation string.
+        """
+        # 1. Run global rules
+        for rule in self._global_rules:
+            allow, explanation = rule(tool_name, kwargs)
+            if not allow:
+                self._log_decision(tool_name, kwargs, explanation)
+                return allow, explanation
+
+        # 2. Run tool-specific rules
+        canonical_tool = self._canonical_tool_name(tool_name)
+        for rule in self._tool_rules.get(canonical_tool, []):
+            allow, explanation = rule(tool_name, kwargs)
+            if not allow:
+                self._log_decision(tool_name, kwargs, explanation)
+                return allow, explanation
+
+        # 3. Fallback to base PolicyLayer checks
+        return super().evaluate(tool_name, **kwargs)
+
+    def _log_decision(
+        self, tool_name: str, kwargs: Dict[str, Any], explanation: str
+    ) -> None:
+        """
+        Log a denied action via the AuditLogger.
+
+        Args:
+            tool_name: Name of the tool.
+            kwargs: Tool arguments.
+            explanation: Reason for the decision.
+        """
+        self.audit_logger.log_call(
+            tool_name=tool_name,
+            kwargs=kwargs,
+            why=kwargs.get("why", "Granular rule intervention"),
+            result={"allowed": False, "explanation": explanation},
+            duration=0.0,
+        )
+
+        logging.warning(f"AgentGuardPolicyLayer: DENY - {tool_name} with args {kwargs}. Reason: {explanation}")

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,51 @@
+--- magda_agent/safety/policy_layer.py
++++ magda_agent/safety/policy_layer.py
+@@ -62,7 +62,6 @@
+         # 1. Run global rules
+         for rule in self._global_rules:
+             allow, explanation = rule(tool_name, kwargs)
+             if not allow:
+-                self._log_decision(tool_name, kwargs, allow, explanation)
++                self._log_decision(tool_name, kwargs, explanation)
+                 return allow, explanation
+
+         # 2. Run tool-specific rules
+         canonical_tool = self._canonical_tool_name(tool_name)
+         for rule in self._tool_rules.get(canonical_tool, []):
+             allow, explanation = rule(tool_name, kwargs)
+             if not allow:
+-                self._log_decision(tool_name, kwargs, allow, explanation)
++                self._log_decision(tool_name, kwargs, explanation)
+                 return allow, explanation
+
+         # 3. Fallback to base PolicyLayer checks
+         return super().evaluate(tool_name, **kwargs)
+
+     def _log_decision(
+-        self, tool_name: str, kwargs: Dict[str, Any], allow: bool, explanation: str
++        self, tool_name: str, kwargs: Dict[str, Any], explanation: str
+     ) -> None:
+         """
+-        Log an allowed or denied action via the AuditLogger.
++        Log a denied action via the AuditLogger.
+
+         Args:
+             tool_name: Name of the tool.
+             kwargs: Tool arguments.
+-            allow: True if allowed, False if denied.
+             explanation: Reason for the decision.
+         """
+         self.audit_logger.log_call(
+             tool_name=tool_name,
+             kwargs=kwargs,
+             why=kwargs.get("why", "Granular rule intervention"),
+-            result={"allowed": allow, "explanation": explanation},
++            result={"allowed": False, "explanation": explanation},
+             duration=0.0,
+         )
+
+-        if allow:
+-            logging.info(f"AgentGuardPolicyLayer: ALLOW - {tool_name} with args {kwargs}")
+-        else:
+-            logging.warning(f"AgentGuardPolicyLayer: DENY - {tool_name} with args {kwargs}. Reason: {explanation}")
++        logging.warning(f"AgentGuardPolicyLayer: DENY - {tool_name} with args {kwargs}. Reason: {explanation}")

--- a/tests/test_policy_layer.py
+++ b/tests/test_policy_layer.py
@@ -1,0 +1,107 @@
+import pytest
+from typing import Any, Dict, Tuple
+
+from magda_agent.safety.policy_layer import AgentGuardPolicyLayer
+
+
+def allow_rule(tool_name: str, kwargs: Dict[str, Any]) -> Tuple[bool, str]:
+    return True, "Always allowed by rule."
+
+
+def deny_rule(tool_name: str, kwargs: Dict[str, Any]) -> Tuple[bool, str]:
+    return False, "Always denied by rule."
+
+
+def arg_based_rule(tool_name: str, kwargs: Dict[str, Any]) -> Tuple[bool, str]:
+    if kwargs.get("dangerous") is True:
+        return False, "Argument 'dangerous' is True."
+    return True, "Argument 'dangerous' is not True."
+
+
+def test_no_rules_fallback_to_base_allow() -> None:
+    """Test that with no granular rules, an allowed tool falls back to the base policy and is allowed."""
+    policy = AgentGuardPolicyLayer()
+    allow, explanation = policy.evaluate("safe_tool", arg="value")
+
+    assert allow is True
+    assert "allowed" in explanation.lower()
+
+    trail = policy.get_audit_trail()
+    assert len(trail) == 1
+    assert trail[0]["tool_name"] == "safe_tool"
+    assert trail[0]["result"]["allowed"] is True
+
+
+def test_no_rules_fallback_to_base_deny() -> None:
+    """Test that with no granular rules, a denied tool falls back to the base policy and is denied."""
+    policy = AgentGuardPolicyLayer()
+    allow, explanation = policy.evaluate("system_execute_code", code="cat .env")
+
+    assert allow is False
+    assert "denied" in explanation.lower()
+
+
+def test_global_rule_deny() -> None:
+    """Test that a global rule denying an action takes precedence over the base policy."""
+    policy = AgentGuardPolicyLayer()
+    policy.add_global_rule(deny_rule)
+
+    allow, explanation = policy.evaluate("safe_tool", arg="value")
+
+    assert allow is False
+    assert explanation == "Always denied by rule."
+
+    trail = policy.get_audit_trail()
+    assert len(trail) == 1
+    assert trail[0]["tool_name"] == "safe_tool"
+    assert trail[0]["result"]["allowed"] is False
+    assert trail[0]["result"]["explanation"] == explanation
+
+
+def test_tool_rule_deny() -> None:
+    """Test that a tool-specific rule denying an action works for that tool only."""
+    policy = AgentGuardPolicyLayer()
+    policy.add_tool_rule("specific_tool", deny_rule)
+
+    # specific_tool is denied
+    allow1, explanation1 = policy.evaluate("specific_tool", arg="value")
+    assert allow1 is False
+    assert explanation1 == "Always denied by rule."
+
+    # other_tool falls back to base allow
+    allow2, explanation2 = policy.evaluate("other_tool", arg="value")
+    assert allow2 is True
+
+
+def test_tool_rule_alias_resolution() -> None:
+    """Test that tool rules are applied correctly for aliases (e.g., programmer -> system_execute_code)."""
+    policy = AgentGuardPolicyLayer()
+    # Add rule for canonical name
+    policy.add_tool_rule("programmer", arg_based_rule)
+
+    # Evaluate using alias 'system_execute_code'
+    allow1, explanation1 = policy.evaluate("system_execute_code", dangerous=True)
+    assert allow1 is False
+    assert explanation1 == "Argument 'dangerous' is True."
+
+    # Evaluate using canonical name
+    allow2, _ = policy.evaluate("programmer", dangerous=False)
+    assert allow2 is True
+
+
+def test_rule_evaluation_order() -> None:
+    """Test that global rules are evaluated before tool rules."""
+    policy = AgentGuardPolicyLayer()
+
+    def global_deny(t: str, k: Dict[str, Any]) -> Tuple[bool, str]:
+        return False, "Global deny."
+
+    def tool_allow(t: str, k: Dict[str, Any]) -> Tuple[bool, str]:
+        return True, "Tool allow."
+
+    policy.add_global_rule(global_deny)
+    policy.add_tool_rule("some_tool", tool_allow)
+
+    allow, explanation = policy.evaluate("some_tool")
+    assert allow is False
+    assert explanation == "Global deny."


### PR DESCRIPTION
Implements granular runtime rule validation via `AgentGuardPolicyLayer`, completing the `agent-guard-policy-extension-v1` task. This allows external systems to inject both global and tool-specific rules that execute prior to falling back onto base safety mechanisms. Updated agent tasks appropriately with 3 new actionable goals.

---
*PR created automatically by Jules for task [7905264646980571817](https://jules.google.com/task/7905264646980571817) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AgentGuardPolicyLayer` for granular global and per-tool runtime governance
> - Introduces [`AgentGuardPolicyLayer`](https://github.com/kazah4359-lgtm/Magda-agent/pull/548/files#diff-f32a04f56438ccab2de47a2df0da1ccfc871cefb57431033c96b30fe609599cf), a `PolicyLayer` subclass that supports registering global rules (applied to all tool executions) and per-tool rules (keyed by canonical tool name).
> - Global rules are evaluated first, then tool-specific rules; if no rule denies, evaluation falls back to the parent `PolicyLayer.evaluate`.
> - Denials are recorded to `AuditLogger` with `allowed=False` and emit a warning log via `_log_decision`.
> - Unit tests in [`tests/test_policy_layer.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/548/files#diff-cc90562296e44b85fa8a231511d785d27e2e376c6241e20a95e854cf6a65f721) cover fallback behavior, global/tool rule precedence, alias resolution, and evaluation order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 540f385.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->