### PR TITLE
feat: online RL skill weight stability tracker

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -17180,7 +17180,7 @@
     },
     {
       "id": "rl-skill-weight-stability-v1",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "low",
       "title": "Online RL Skill Weight Stability Tracker",
@@ -20092,6 +20092,60 @@
       "acceptance": [
         "A2A discovery service module added.",
         "Agent card generation and resolution verified in tests."
+      ]
+    },
+    {
+      "id": "openclaw-rl-curiosity-exploration-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Curiosity Exploration Mechanism",
+      "description": "Inspired by OpenClaw trends: Implement a curiosity-driven exploration strategy that temporarily boosts exploration weights for rarely used skills to discover new efficient pathways in the reinforcement learning loop.",
+      "allowed_paths": [
+        "magda_agent/learning/curiosity_exploration_v1.py",
+        "tests/test_curiosity_exploration_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Curiosity module calculates the rarity of skills.",
+        "Temporarily adjusts the exploration behavior weight.",
+        "Tests mock usage metrics and verify weight boost logic."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-caching-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "MCP Action Tool Caching Layer",
+      "description": "Inspired by MCP trends: Implement an intelligent caching layer for deterministic read-only MCP action tools to reduce redundant external calls and improve context assembly speed.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_caching_v1.py",
+        "tests/test_mcp_caching_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Caching layer intercepts MCP calls and caches responses.",
+        "Respects TTL and cache-invalidation signals.",
+        "Tests verify cache hit and miss behavior with mock tools."
+      ]
+    },
+    {
+      "id": "acs-guardrail-context-awareness-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Guardrail Context Awareness",
+      "description": "Inspired by ACS and Prempti trends: Enhance the ACS runtime policy layer to be context-aware, allowing it to evaluate tool arguments against the active Working Memory to detect semantic-level hallucinations before execution.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_context_awareness_v1.py",
+        "tests/test_acs_context_awareness_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACS policy layer extracts semantic entities from Working Memory.",
+        "Flags tool arguments that semantically conflict with the active context.",
+        "Tests verify false positives and true positive detection."
       ]
     }
   ]

--- a/magda_agent/learning/rl_stability_v1.py
+++ b/magda_agent/learning/rl_stability_v1.py
@@ -1,0 +1,85 @@
+import logging
+from typing import Dict, List, Optional
+from magda_agent.evaluation.longitudinal_metrics import LongitudinalMetricsTracker
+
+class RLSkillWeightStabilityTracker:
+    """
+    Tracks the stability of skill weights in Procedural Memory.
+    Identifies rapid oscillations and logs stability metrics.
+    """
+
+    def __init__(self, metrics_tracker: LongitudinalMetricsTracker, window_size: int = 5, oscillation_threshold: int = 3) -> None:
+        """
+        Initializes the RLSkillWeightStabilityTracker.
+
+        Args:
+            metrics_tracker (LongitudinalMetricsTracker): The tracker for longitudinal metrics.
+            window_size (int): The number of recent updates to keep per skill.
+            oscillation_threshold (int): The number of direction changes to trigger an oscillation warning.
+        """
+        self.metrics_tracker = metrics_tracker
+        self.window_size = window_size
+        self.oscillation_threshold = oscillation_threshold
+        # Keeps track of recent deltas per skill
+        self.skill_deltas: Dict[str, List[float]] = {}
+        # Keeps track of the most recent weight per skill
+        self.skill_weights: Dict[str, float] = {}
+
+    def record_weight_update(self, skill_id: str, new_weight: float) -> bool:
+        """
+        Records a weight update, tracks deltas, and checks for rapid oscillations.
+
+        Args:
+            skill_id (str): The identifier for the skill.
+            new_weight (float): The newly updated weight.
+
+        Returns:
+            bool: True if a rapid oscillation is detected, False otherwise.
+        """
+        if skill_id not in self.skill_weights:
+            self.skill_weights[skill_id] = new_weight
+            self.skill_deltas[skill_id] = []
+            return False
+
+        old_weight = self.skill_weights[skill_id]
+        delta = new_weight - old_weight
+        self.skill_weights[skill_id] = new_weight
+
+        # We keep track of the change (delta)
+        self.skill_deltas[skill_id].append(delta)
+
+        if len(self.skill_deltas[skill_id]) > self.window_size:
+            self.skill_deltas[skill_id].pop(0)
+
+        is_oscillating = self._detect_oscillation(skill_id)
+
+        # Log metric: 0.0 for oscillating (unstable), 1.0 for stable
+        stability_score = 0.0 if is_oscillating else 1.0
+        self.metrics_tracker.record_metric(f"rl_stability_{skill_id}", stability_score)
+
+        if is_oscillating:
+            logging.warning(f"Rapid oscillation detected for skill weight: {skill_id}")
+
+        return is_oscillating
+
+    def _detect_oscillation(self, skill_id: str) -> bool:
+        """
+        Detects if there are frequent direction changes in recent deltas.
+
+        Args:
+            skill_id (str): The identifier for the skill.
+
+        Returns:
+            bool: True if direction changes meet or exceed the threshold.
+        """
+        deltas = self.skill_deltas.get(skill_id, [])
+        if len(deltas) < self.oscillation_threshold:
+            return False
+
+        direction_changes = 0
+        for i in range(1, len(deltas)):
+            # If the product of adjacent deltas is negative, the direction changed
+            if deltas[i-1] * deltas[i] < 0:
+                direction_changes += 1
+
+        return direction_changes >= self.oscillation_threshold

--- a/tests/test_rl_stability_v1.py
+++ b/tests/test_rl_stability_v1.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.rl_stability_v1 import RLSkillWeightStabilityTracker
+from magda_agent.evaluation.longitudinal_metrics import LongitudinalMetricsTracker
+
+@pytest.fixture
+def mock_metrics_tracker():
+    tracker = MagicMock(spec=LongitudinalMetricsTracker)
+    return tracker
+
+def test_rl_stability_tracker_initialization(mock_metrics_tracker):
+    tracker = RLSkillWeightStabilityTracker(metrics_tracker=mock_metrics_tracker)
+    assert tracker.window_size == 5
+    assert tracker.oscillation_threshold == 3
+    assert tracker.skill_weights == {}
+    assert tracker.skill_deltas == {}
+
+def test_rl_stability_tracker_no_oscillation(mock_metrics_tracker):
+    tracker = RLSkillWeightStabilityTracker(metrics_tracker=mock_metrics_tracker, window_size=5, oscillation_threshold=3)
+
+    skill_id = "test_skill"
+
+    # Initial weight
+    is_oscillating = tracker.record_weight_update(skill_id, 1.0)
+    assert not is_oscillating
+    assert mock_metrics_tracker.record_metric.call_count == 0
+
+    # Gradual increase (no direction changes)
+    is_oscillating = tracker.record_weight_update(skill_id, 1.1)
+    assert not is_oscillating
+    mock_metrics_tracker.record_metric.assert_called_with("rl_stability_test_skill", 1.0)
+
+    is_oscillating = tracker.record_weight_update(skill_id, 1.2)
+    assert not is_oscillating
+
+    is_oscillating = tracker.record_weight_update(skill_id, 1.3)
+    assert not is_oscillating
+
+    is_oscillating = tracker.record_weight_update(skill_id, 1.4)
+    assert not is_oscillating
+
+    # Verify the state
+    assert tracker.skill_weights[skill_id] == 1.4
+    assert len(tracker.skill_deltas[skill_id]) == 4
+    # All deltas should be positive
+    for d in tracker.skill_deltas[skill_id]:
+        assert d > 0
+
+def test_rl_stability_tracker_detects_oscillation(mock_metrics_tracker):
+    tracker = RLSkillWeightStabilityTracker(metrics_tracker=mock_metrics_tracker, window_size=5, oscillation_threshold=3)
+
+    skill_id = "oscillating_skill"
+
+    # 0. Initial weight
+    tracker.record_weight_update(skill_id, 1.0)
+
+    # 1. Delta: +0.2
+    is_oscillating = tracker.record_weight_update(skill_id, 1.2)
+    assert not is_oscillating
+
+    # 2. Delta: -0.2 (direction change 1)
+    is_oscillating = tracker.record_weight_update(skill_id, 1.0)
+    assert not is_oscillating
+
+    # 3. Delta: +0.2 (direction change 2)
+    is_oscillating = tracker.record_weight_update(skill_id, 1.2)
+    assert not is_oscillating
+
+    # 4. Delta: -0.2 (direction change 3) - threshold reached
+    is_oscillating = tracker.record_weight_update(skill_id, 1.0)
+    assert is_oscillating
+
+    # Verify metrics logged
+    mock_metrics_tracker.record_metric.assert_called_with("rl_stability_oscillating_skill", 0.0)
+
+def test_rl_stability_tracker_sliding_window(mock_metrics_tracker):
+    tracker = RLSkillWeightStabilityTracker(metrics_tracker=mock_metrics_tracker, window_size=3, oscillation_threshold=3)
+
+    skill_id = "window_skill"
+
+    # Insert more than window_size updates
+    tracker.record_weight_update(skill_id, 1.0)
+    tracker.record_weight_update(skill_id, 1.1)
+    tracker.record_weight_update(skill_id, 0.9)
+    tracker.record_weight_update(skill_id, 1.0)
+    tracker.record_weight_update(skill_id, 0.8)
+
+    assert len(tracker.skill_deltas[skill_id]) == 3


### PR DESCRIPTION
Implements the "Online RL Skill Weight Stability Tracker" from `agent_tasks.json`. This module monitors rapid oscillations in skill weights in procedural memory during openclaw-RL routines. Includes unit tests and updates tasks.

---
*PR created automatically by Jules for task [18031518038021467900](https://jules.google.com/task/18031518038021467900) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLSkillWeightStabilityTracker` to detect oscillations in online RL skill weights
> - Introduces [`rl_stability_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/549/files#diff-9eed25cdd9a867b54a172dbb57e701c20c2b508d43cc6c759ff704668409ae79) with `RLSkillWeightStabilityTracker`, which maintains a per-skill sliding window of weight deltas and counts sign changes to detect oscillation.
> - On each call to `record_weight_update`, emits a `rl_stability_{skill_id}` metric (1.0 = stable, 0.0 = oscillating) via `LongitudinalMetricsTracker` and returns a boolean indicating whether oscillation was detected.
> - Logs a warning when the sign-change count meets or exceeds `oscillation_threshold` within the window.
> - Unit tests cover monotonic (non-oscillating) sequences, oscillation detection, metric recording, and sliding-window truncation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3601562.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->