### PR TITLE
Implement Hermes Skill Marketplace Integration v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8911,7 +8911,7 @@
     },
     {
       "id": "hermes-skill-marketplace-sync-v1-new-suffix-789",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Marketplace Integration v4",
@@ -20146,6 +20146,60 @@
         "ACS policy layer extracts semantic entities from Working Memory.",
         "Flags tool arguments that semantically conflict with the active context.",
         "Tests verify false positives and true positive detection."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-caching-v2-unique",
+      "title": "MCP Action Tool Caching V2",
+      "description": "Inspired by MCP trends: Implement an intelligent caching layer for deterministic read-only MCP action tools to reduce redundant external calls.",
+      "area": "skills",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_caching_v2.py",
+        "tests/test_mcp_caching_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Caching layer intercepts MCP calls and caches responses.",
+        "Respects TTL and cache-invalidation signals.",
+        "Tests verify cache hit and miss behavior with mock tools."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-evaluation-v3-unique",
+      "title": "OpenClaw RL Trajectory Quality Evaluation V3",
+      "description": "Inspired by OpenClaw-RL trend: Implement a trajectory quality evaluator that analyzes conversational rollouts to detect repetitiveness, loops, or frustration signals.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_evaluator_v3.py",
+        "tests/test_trajectory_evaluator_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "TrajectoryEvaluator detects conversation loops and frustration patterns.",
+        "Fitted weights are updated online using reinforcement learning signals.",
+        "Tests verify feedback loop updates with mock conversation inputs."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v2-unique",
+      "title": "Claude Worktree Pruning and Resource Optimizer V2",
+      "description": "Inspired by Claude Agent SDK Agent Teams trend: Implement a daemon/worker class within GitWorktreeManager to monitor parallel subagent worktree allocations and aggressively prune abandoned or orphaned worktrees.",
+      "area": "architecture",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_pruner_v2.py",
+        "tests/test_worktree_pruner_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pruner daemon identifies inactive, timed-out, or orphaned subagent worktrees.",
+        "Safely prunes workspaces and deletes associated directories.",
+        "Tests mock subagent timelines and verify automatic cleanup."
       ]
     }
   ]

--- a/magda_agent/skills/__init__.py
+++ b/magda_agent/skills/__init__.py
@@ -138,10 +138,10 @@ def initialize_skills(policy_layer: Optional["PolicyLayer"] = None) -> SkillRegi
 
 
     # Register Marketplace Sync Routine
-    from magda_agent.skills.marketplace_sync import MarketplaceSyncRoutine
+    from magda_agent.skills.marketplace_sync_v4 import MarketplaceSyncRoutineV4
     def sync_marketplace_sync() -> int:
         import asyncio
-        routine = MarketplaceSyncRoutine(registry=registry)
+        routine = MarketplaceSyncRoutineV4(registry=registry)
         try:
             loop = asyncio.get_event_loop()
             if loop.is_running():

--- a/magda_agent/skills/marketplace_sync_v4.py
+++ b/magda_agent/skills/marketplace_sync_v4.py
@@ -1,0 +1,119 @@
+import asyncio
+import logging
+import httpx
+from typing import Optional, Any, Dict, List
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.agentskills_importer import AgentSkillsImporter
+
+logger = logging.getLogger(__name__)
+
+class MarketplaceSyncRoutineV4:
+    """
+    Routine for fetching, parsing, and synchronizing skills from an external marketplace periodically.
+    """
+
+    def __init__(
+        self,
+        registry: SkillRegistry,
+        marketplace_url: str = "https://agentskills.io/api/skills",
+        sync_interval_seconds: int = 3600
+    ) -> None:
+        """
+        Initializes the MarketplaceSyncRoutineV4.
+
+        Args:
+            registry: The SkillRegistry to sync skills into.
+            marketplace_url: The URL of the external marketplace to fetch from.
+            sync_interval_seconds: The interval in seconds to fetch the data.
+        """
+        self.registry = registry
+        self.marketplace_url = marketplace_url
+        self.sync_interval_seconds = sync_interval_seconds
+        self.importer = AgentSkillsImporter(registry=self.registry)
+        self._sync_task: Optional[asyncio.Task[None]] = None
+        self._stop_event = asyncio.Event()
+
+    async def fetch_marketplace_data(self) -> Optional[List[Dict[str, Any]]]:
+        """
+        Fetches the skills data from the marketplace URL.
+
+        Returns:
+            The parsed JSON data (expected as a list of skills) or None if fetching fails.
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(self.marketplace_url)
+                response.raise_for_status()
+                data = response.json()
+                if isinstance(data, list):
+                    return data
+                elif isinstance(data, dict) and "skills" in data:
+                    return data["skills"]
+                else:
+                    logger.error("Marketplace data format not recognized.")
+                    return None
+        except Exception as e:
+            logger.error(f"Failed to fetch marketplace data from {self.marketplace_url}: {e}")
+            return None
+
+    async def run_sync_cycle(self) -> int:
+        """
+        Runs a complete sync cycle: fetching data and importing skills.
+
+        Returns:
+            The number of skills successfully imported.
+        """
+        logger.info(f"Starting marketplace sync cycle from {self.marketplace_url}")
+
+        data = await self.fetch_marketplace_data()
+        if not data:
+            logger.warning("No data retrieved during marketplace sync.")
+            return 0
+
+        imported_funcs = self.importer.import_skills(data)
+        logger.info(f"Marketplace sync complete. Successfully imported {len(imported_funcs)} skills.")
+        return len(imported_funcs)
+
+    async def _periodic_sync_loop(self) -> None:
+        """
+        The background loop running the periodic syncs.
+        """
+        while not self._stop_event.is_set():
+            await self.run_sync_cycle()
+            try:
+                # Wait for the interval or until stop is requested
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self.sync_interval_seconds)
+            except asyncio.TimeoutError:
+                pass  # Timeout means we should run again
+            except asyncio.CancelledError:
+                break # Task was cancelled
+
+    def start_periodic_sync(self) -> None:
+        """
+        Starts the periodic synchronization in the background.
+        """
+        if self._sync_task is not None and not self._sync_task.done():
+            logger.warning("Periodic sync is already running.")
+            return
+
+        self._stop_event.clear()
+        self._sync_task = asyncio.create_task(self._periodic_sync_loop())
+        logger.info("Marketplace periodic sync started.")
+
+    async def stop_periodic_sync(self) -> None:
+        """
+        Stops the periodic synchronization.
+        """
+        if self._sync_task is None or self._sync_task.done():
+            logger.warning("Periodic sync is not running.")
+            return
+
+        self._stop_event.set()
+        if self._sync_task:
+            self._sync_task.cancel()
+            try:
+                await self._sync_task
+            except asyncio.CancelledError:
+                pass
+            self._sync_task = None
+            logger.info("Marketplace periodic sync stopped.")

--- a/tests/test_marketplace_sync_v4.py
+++ b/tests/test_marketplace_sync_v4.py
@@ -1,0 +1,104 @@
+import asyncio
+import pytest
+import respx
+import httpx
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.marketplace_sync_v4 import MarketplaceSyncRoutineV4
+
+@pytest.fixture
+def registry():
+    return SkillRegistry()
+
+@pytest.fixture
+def sync_routine(registry):
+    return MarketplaceSyncRoutineV4(registry=registry, sync_interval_seconds=1)
+
+@pytest.mark.asyncio
+async def test_run_sync_cycle_success_list(sync_routine, registry):
+    mock_data = [
+        {
+            "name": "test_skill_1",
+            "description": "A test skill 1",
+            "parameters": {}
+        },
+        {
+            "name": "test_skill_2",
+            "description": "A test skill 2",
+            "inputSchema": {}
+        }
+    ]
+
+    with respx.mock:
+        respx.get("https://agentskills.io/api/skills").mock(return_value=httpx.Response(200, json=mock_data))
+
+        imported_count = await sync_routine.run_sync_cycle()
+
+        assert imported_count == 2
+        assert registry.has_skill("test_skill_1")
+        assert registry.has_skill("test_skill_2")
+
+@pytest.mark.asyncio
+async def test_run_sync_cycle_success_dict(sync_routine, registry):
+    mock_data = {
+        "skills": [
+            {
+                "name": "test_skill_3",
+                "description": "A test skill 3",
+                "parameters": {}
+            }
+        ]
+    }
+
+    with respx.mock:
+        respx.get("https://agentskills.io/api/skills").mock(return_value=httpx.Response(200, json=mock_data))
+
+        imported_count = await sync_routine.run_sync_cycle()
+
+        assert imported_count == 1
+        assert registry.has_skill("test_skill_3")
+
+@pytest.mark.asyncio
+async def test_run_sync_cycle_invalid_format(sync_routine, registry):
+    mock_data = {"invalid": "data"}
+
+    with respx.mock:
+        respx.get("https://agentskills.io/api/skills").mock(return_value=httpx.Response(200, json=mock_data))
+
+        imported_count = await sync_routine.run_sync_cycle()
+
+        assert imported_count == 0
+        assert registry.get_skills_summary().strip() == "Available Skills:"
+
+@pytest.mark.asyncio
+async def test_run_sync_cycle_http_error(sync_routine, registry):
+    with respx.mock:
+        respx.get("https://agentskills.io/api/skills").mock(return_value=httpx.Response(500))
+
+        imported_count = await sync_routine.run_sync_cycle()
+
+        assert imported_count == 0
+        assert registry.get_skills_summary().strip() == "Available Skills:"
+
+@pytest.mark.asyncio
+async def test_periodic_sync(sync_routine, registry):
+    mock_data = [
+        {
+            "name": "test_periodic_skill",
+            "description": "periodic skill",
+            "parameters": {}
+        }
+    ]
+
+    with respx.mock:
+        respx.get("https://agentskills.io/api/skills").mock(return_value=httpx.Response(200, json=mock_data))
+
+        sync_routine.start_periodic_sync()
+
+        # Wait a short moment to allow the background task to execute at least once
+        await asyncio.sleep(0.1)
+
+        assert registry.has_skill("test_periodic_skill")
+
+        # Stop the periodic sync
+        await sync_routine.stop_periodic_sync()
+        assert sync_routine._sync_task is None


### PR DESCRIPTION
This PR implements the task `hermes-skill-marketplace-sync-v1-new-suffix-789`.

- Creates `magda_agent/skills/marketplace_sync_v4.py` with `MarketplaceSyncRoutineV4` to asynchronously fetch JSON skills data from an external marketplace URL and parse them using `AgentSkillsImporter`.
- Incorporates periodic sync capabilities (`start_periodic_sync`, `stop_periodic_sync`) using an `asyncio.Task` background loop.
- Modifies `magda_agent/skills/__init__.py` to initialize and export `sync_marketplace_sync` skill routing to the new implementation `MarketplaceSyncRoutineV4`.
- Adds `tests/test_marketplace_sync_v4.py` using `respx` and `pytest.mark.asyncio` to mock the remote endpoint and verify the JSON list parsing, single dict parsing, invalid payload fallback, HTTP error fallback, and background scheduling logic.
- Updates `agent_tasks.json` by marking the task status to "done" and adding 3 new AI-trend-inspired background items to the end of the list.

---
*PR created automatically by Jules for task [6620744786176619920](https://jules.google.com/task/6620744786176619920) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement Hermes Skill Marketplace sync using `MarketplaceSyncRoutineV4`
> - Adds [marketplace_sync_v4.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/553/files#diff-03ab2db77890a1f6b336cfae2ac3c02f09cbb92647fe71eae321ce4989e8d140) with `MarketplaceSyncRoutineV4`, which fetches skills from a configurable marketplace URL via `httpx.AsyncClient`, imports them into the skill registry, and supports a cancellable periodic background sync loop.
> - Updates [skills/__init__.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/553/files#diff-bfa99a5f255fc1d222418cb8c21dfa1cce609468589a12c95c937cd2b77bd315) to wire the `marketplace_sync` skill to `MarketplaceSyncRoutineV4.run_sync_cycle`, replacing the previous routine.
> - Adds tests covering list and dict response shapes, invalid formats, HTTP errors, and the periodic sync lifecycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b339a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->