### PR TITLE
feat(learning): Implement DialogueOnlineLearnerV4 for online RL from dialog interactions

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8929,7 +8929,7 @@
     },
     {
       "id": "openclaw-online-rl-dialogue-v5-new-suffix-123",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "OpenClaw Online RL from Dialogue Interactions",
@@ -20146,6 +20146,40 @@
         "ACS policy layer extracts semantic entities from Working Memory.",
         "Flags tool arguments that semantically conflict with the active context.",
         "Tests verify false positives and true positive detection."
+      ]
+    },
+    {
+      "id": "hermes-online-skill-pruning-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Online Skill Pruning V1",
+      "description": "Inspired by Hermes trends: Automatically prune under-used skills from the registry based on usage frequency and success rate.",
+      "allowed_paths": [
+        "magda_agent/skills/pruning_v1.py",
+        "tests/test_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill pruning module is implemented.",
+        "Tests verify under-used skills are correctly identified and pruned."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v6",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V6",
+      "description": "Inspired by MCP trends: Implement multi-turn capability negotiation for MCP tools to ensure both client and server agree on supported features before execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v6.py",
+        "tests/test_mcp_negotiation_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP negotiation logic handles capabilities handshake.",
+        "Tests mock negotiation and verify fallback behaviors."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -288,3 +288,6 @@
 * [ ] FEATURE: ACS Agent Control Specification - Runtime Safety Controls (acs-runtime-safety-controls-v7-202606)
 * [ ] FEATURE: A2A Agent Discovery via Agent Cards (a2a-agent-discovery-cards-v3-202606)
 * [ ] FEATURE: A2A Peer-to-Peer Task Delegation V7 (a2a-peer-task-delegation-v7-202606)
+* [ ] FEATURE: OpenAI Agents SDK Tool Schema Caching (openai-agents-schema-cache-v1-d24c8b9a)
+* [ ] FEATURE: MCP Dynamic Capability Negotiation V6 (mcp-dynamic-capability-negotiation-v6)
+* [ ] FEATURE: Hermes Online Skill Pruning V1 (hermes-online-skill-pruning-v1)

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -27,6 +27,8 @@ from magda_agent.emotions.style_adapter import StyleAdapter
 from magda_agent.user_model.model import UserModel
 from magda_agent.learning.online import OnlineLearner
 from magda_agent.learning.dialogue_v3 import DialogueOnlineLearnerV3
+from magda_agent.learning.dialogue_online_learner_v4 import DialogueOnlineLearnerV4
+
 from magda_agent.learning.online_rl import OnlineRLIntegrator
 from magda_agent.learning.openclaw_rl_v5 import OnlineRLIntegrator as OpenClawRLV5Integrator
 from magda_agent.learning.online_rl_v6 import OnlineRLFeedbackLoopV6
@@ -115,6 +117,7 @@ class Consciousness:
         self.online_rl_v6 = online_rl_v6
         self.rl_user_behavior_v4 = rl_user_behavior_v4
         self.dialogue_online_learner_v3 = dialogue_online_learner_v3
+        self.dialogue_online_learner_v4 = kwargs.get('dialogue_online_learner_v4')
         self.openclaw_rl = openclaw_rl
         self.online_feedback_rl = OnlineFeedbackRL(habit_tracker, mirror_neurons) if habit_tracker and mirror_neurons else None
         self.feedback_loop = feedback_loop
@@ -198,6 +201,8 @@ class Consciousness:
 
         if getattr(self, 'dialogue_online_learner_v3', None):
             self.dialogue_online_learner_v3.process_turn(user_input, None)
+        if getattr(self, 'dialogue_online_learner_v4', None):
+            self.dialogue_online_learner_v4.process_turn(user_input, None)
 
 
         if self.thalamus and not self.thalamus.filter_input(user_input):
@@ -370,6 +375,10 @@ class Consciousness:
                 v3_mods = self.dialogue_online_learner_v3.get_context_modifiers()
                 if v3_mods:
                     system_prompt += f"\n\n{v3_mods}"
+            if getattr(self, 'dialogue_online_learner_v4', None):
+                v4_mods = self.dialogue_online_learner_v4.get_context_modifiers()
+                if v4_mods:
+                    system_prompt += f"\n\n{v4_mods}"
 
             if plan_str:
                 system_prompt += f"\n\n{plan_str}\nUse the plan results to generate the final response."
@@ -450,6 +459,9 @@ class Consciousness:
             tags=["conversation"],
             user_id=user_id
         )
+
+        if getattr(self, 'dialogue_online_learner_v4', None):
+            self.dialogue_online_learner_v4.capture_state_action(user_input, response)
 
         if self.online_rl_integrator:
             await self.online_rl_integrator.process_feedback(user_input, "last_action_context", user_id)

--- a/magda_agent/learning/dialogue_online_learner_v4.py
+++ b/magda_agent/learning/dialogue_online_learner_v4.py
@@ -1,0 +1,123 @@
+import logging
+from typing import Any, Dict, List, Optional
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+logger = logging.getLogger(__name__)
+
+class DialogueOnlineLearnerV4:
+    """
+    Online learning from dialogue v4.
+    Extracts immediate context from conversation and dynamically adjusts agent behavior.
+    Integrates learning loop into conversation processor to capture state-action-reward from next-state responses.
+    Inspired by OpenClaw-RL trend (June 2026).
+    """
+    def __init__(self, mirror_neurons: Optional[MirrorNeurons] = None) -> None:
+        self.mirror_neurons = mirror_neurons or MirrorNeurons()
+        self.active_modifiers: List[Dict[str, Any]] = []
+        # Initial behavior weights
+        self.weights = {
+            "verbosity": 1.0,
+            "directness": 1.0,
+            "empathy": 1.0
+        }
+        self.last_state_action: Optional[Dict[str, str]] = None
+        self.trajectory_log: List[Dict[str, Any]] = []
+
+    def capture_state_action(self, state_context: str, action_response: str) -> None:
+        """
+        Captures the current state and action for the next-state reward calculation.
+        """
+        self.last_state_action = {
+            "state": state_context,
+            "action": action_response
+        }
+        logger.info("Captured state-action pair for next-state learning loop.")
+
+    def process_turn(self, user_message: str, agent_response: Optional[str] = None) -> None:
+        """
+        Analyzes user message to extract immediate learning insights and adjust behavior weights.
+        Processes state-action-reward if a previous state-action exists.
+        """
+        msg_lower = user_message.lower()
+
+        # 1. Direct instructions/preferences extraction
+        if "always" in msg_lower or "must" in msg_lower:
+            insight = {
+                "type": "preference",
+                "trigger": user_message,
+                "effect": f"The user strongly prefers: '{user_message}'"
+            }
+            self.active_modifiers.append(insight)
+            logger.info(f"Learned preference from dialogue: {insight['effect']}")
+
+        elif "never" in msg_lower or "don't" in msg_lower or "do not" in msg_lower:
+            insight = {
+                "type": "constraint",
+                "trigger": user_message,
+                "effect": f"Constraint established: '{user_message}'"
+            }
+            self.active_modifiers.append(insight)
+            logger.info(f"Learned constraint from dialogue: {insight['effect']}")
+
+        # 2. Online RL from sentiment signals (MirrorNeurons) as Next-State Reward
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(user_message)
+
+        # State-Action-Reward logging
+        if self.last_state_action:
+            reward = p_shift
+            trajectory_entry = {
+                "state": self.last_state_action["state"],
+                "action": self.last_state_action["action"],
+                "next_state": user_message,
+                "reward": reward
+            }
+            self.trajectory_log.append(trajectory_entry)
+            logger.info(f"Logged trajectory with reward {reward:.2f}.")
+            self.last_state_action = None
+
+        # Adjust weights based on pleasure shift (P-shift) as a reward signal
+        if p_shift > 0:
+            # Positive reinforcement
+            self.weights["verbosity"] = min(2.0, self.weights["verbosity"] + 0.1)
+            self.weights["empathy"] = min(2.0, self.weights["empathy"] + 0.1)
+            logger.info(f"Positive dialogue signal (P={p_shift:.2f}). Reinforced verbosity and empathy.")
+        elif p_shift < 0:
+            # Negative reinforcement
+            self.weights["verbosity"] = max(0.5, self.weights["verbosity"] - 0.1)
+            self.weights["directness"] = min(2.0, self.weights["directness"] + 0.1)
+            logger.info(f"Negative dialogue signal (P={p_shift:.2f}). Reduced verbosity, increased directness.")
+
+    def get_context_modifiers(self) -> str:
+        """
+        Returns a formatted string of active behavioral modifiers and weights to be injected into prompts.
+        """
+        sections = []
+
+        if self.active_modifiers:
+            lines = ["--- Immediate Context Modifications ---"]
+            for mod in self.active_modifiers:
+                lines.append(f"- {mod['effect']}")
+            sections.append("\n".join(lines))
+
+        # Behavior weights section
+        weight_lines = ["--- Dynamic Behavior Adjustments ---"]
+        for key, value in self.weights.items():
+            if value > 1.2:
+                weight_lines.append(f"- Increase {key} (Strength: {value:.1f})")
+            elif value < 0.8:
+                weight_lines.append(f"- Decrease {key} (Strength: {value:.1f})")
+
+        if len(weight_lines) > 1:
+            sections.append("\n".join(weight_lines))
+
+        return "\n\n".join(sections) if sections else ""
+
+    def clear_session(self) -> None:
+        """
+        Clears the current dialogue modifiers and resets weights for a new session.
+        """
+        self.active_modifiers.clear()
+        self.weights = {"verbosity": 1.0, "directness": 1.0, "empathy": 1.0}
+        self.last_state_action = None
+        self.trajectory_log.clear()
+        logger.info("DialogueOnlineLearnerV4 session cleared.")

--- a/tests/test_dialogue_online_learner_v4.py
+++ b/tests/test_dialogue_online_learner_v4.py
@@ -1,0 +1,103 @@
+import pytest
+from magda_agent.learning.dialogue_online_learner_v4 import DialogueOnlineLearnerV4
+
+def test_process_turn_preference() -> None:
+    """Test extracting a preference from dialogue turn."""
+    learner = DialogueOnlineLearnerV4()
+    learner.process_turn("You must always reply in JSON format.")
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Immediate Context Modifications ---" in modifiers
+    assert "The user strongly prefers" in modifiers
+    assert "always reply in JSON format" in modifiers
+
+def test_process_turn_constraint() -> None:
+    """Test extracting a constraint from dialogue turn."""
+    learner = DialogueOnlineLearnerV4()
+    learner.process_turn("Please never use emojis.")
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Immediate Context Modifications ---" in modifiers
+    assert "Constraint established" in modifiers
+    assert "never use emojis" in modifiers
+
+def test_process_turn_positive_reinforcement() -> None:
+    """Test positive reinforcement from user message."""
+    learner = DialogueOnlineLearnerV4()
+    # Trigger positive sentiment
+    for _ in range(5):
+        learner.process_turn("This is great! I am so happy with your work!")
+
+    assert learner.weights["verbosity"] > 1.0
+    assert learner.weights["empathy"] > 1.0
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Dynamic Behavior Adjustments ---" in modifiers
+    assert "Increase verbosity" in modifiers
+    assert "Increase empathy" in modifiers
+
+def test_process_turn_negative_reinforcement() -> None:
+    """Test negative reinforcement from user message."""
+    learner = DialogueOnlineLearnerV4()
+    # Trigger negative sentiment
+    for _ in range(5):
+        learner.process_turn("This is terrible and bad. I am very angry.")
+
+    assert learner.weights["verbosity"] < 1.0
+    assert learner.weights["directness"] > 1.0
+
+    modifiers = learner.get_context_modifiers()
+    assert "--- Dynamic Behavior Adjustments ---" in modifiers
+    assert "Decrease verbosity" in modifiers
+    assert "Increase directness" in modifiers
+
+def test_process_turn_no_insight() -> None:
+    """Test when no learning insight is extracted."""
+    learner = DialogueOnlineLearnerV4()
+    learner.process_turn("Hello, how are you?")
+
+    modifiers = learner.get_context_modifiers()
+    assert modifiers == ""
+    assert len(learner.active_modifiers) == 0
+
+def test_capture_and_process_state_action_reward() -> None:
+    """Test state-action capturing and reward logging."""
+    learner = DialogueOnlineLearnerV4()
+
+    # 1. Capture state and action
+    learner.capture_state_action("User asked for a joke", "Here is a joke: Why did the chicken cross the road?")
+    assert learner.last_state_action is not None
+    assert learner.last_state_action["state"] == "User asked for a joke"
+    assert learner.last_state_action["action"] == "Here is a joke: Why did the chicken cross the road?"
+    assert len(learner.trajectory_log) == 0
+
+    # 2. Process next-state signal with positive sentiment
+    learner.process_turn("Haha, that is a great joke!")
+
+    # The last state action should be consumed
+    assert learner.last_state_action is None
+    # We should have a trajectory logged with positive reward
+    assert len(learner.trajectory_log) == 1
+    trajectory = learner.trajectory_log[0]
+    assert trajectory["state"] == "User asked for a joke"
+    assert trajectory["action"] == "Here is a joke: Why did the chicken cross the road?"
+    assert trajectory["next_state"] == "Haha, that is a great joke!"
+    assert trajectory["reward"] > 0
+
+def test_clear_session() -> None:
+    """Test clearing the active modifiers session."""
+    learner = DialogueOnlineLearnerV4()
+    learner.process_turn("You must always reply in JSON format.")
+    learner.process_turn("Great job!")
+    learner.capture_state_action("state", "action")
+
+    assert len(learner.active_modifiers) == 1
+    assert learner.weights["verbosity"] > 1.0
+    assert learner.last_state_action is not None
+
+    learner.clear_session()
+    assert len(learner.active_modifiers) == 0
+    assert learner.weights["verbosity"] == 1.0
+    assert learner.get_context_modifiers() == ""
+    assert learner.last_state_action is None
+    assert len(learner.trajectory_log) == 0


### PR DESCRIPTION
This PR implements the first task: OpenClaw Online RL from Dialogue Interactions.

Changes:
- Added `DialogueOnlineLearnerV4` to capture state-action-reward from next-state responses
- Wrote full unit tests for the module
- Updated `magda_agent/consciousness/core.py` to integrate the module and hook into process turns and context modifiers
- Appended 3 new tasks to `agent_tasks.json` inspired by June 2026 AI Agent trends
- Updated `backlog.md` with the new tasks
- Cleaned up local database tracking to keep PR clean

---
*PR created automatically by Jules for task [14146914865866920044](https://jules.google.com/task/14146914865866920044) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `DialogueOnlineLearnerV4` for online RL from dialogue interactions
> - Adds [`DialogueOnlineLearnerV4`](https://github.com/kazah4359-lgtm/Magda-agent/pull/555/files#diff-dc873ba2645927962e455fce0cf16a77c6b46c32761708a82830b81069627024) which extracts preference/constraint keywords from user turns, adjusts behavior weights (verbosity, empathy, directness) via sentiment computed by `MirrorNeurons`, and logs state-action trajectories with rewards.
> - Integrates the learner into [`Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/555/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a): each turn is processed through it, its context modifiers are appended to the system prompt, and state-action pairs are captured after each response.
> - Adds tests in [`tests/test_dialogue_online_learner_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/555/files#diff-d1cc292b3723a78b19deb8fe9bcd8aec32d8fb932178b3cdca56463ed03e95c4) covering preference/constraint extraction, weight reinforcement, trajectory logging, and session reset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2a100e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->