### PR TITLE
feat: Implement MCP Dynamic Tool Registration V7

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -8998,7 +8998,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registration-v7-unique-12345",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registration V7",
@@ -20216,6 +20216,57 @@
         "Rate limiter tracks tool executions per session using a token bucket approach.",
         "Exceeding the limit raises a RateLimitExceeded error.",
         "Tests verify the rate limiting logic and error raising."
+      ]
+    },
+    {
+      "id": "git-worktree-cleanup-manager-v2-10492",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Git Worktree Cleanup Manager V2",
+      "description": "Inspired by Claude Teams trends: Implement an explicit fallback cleanup mechanism for GitWorktreeManager that periodically scans and removes detached worktrees exceeding their timeout limits to prevent disk exhaustion.",
+      "allowed_paths": [
+        "magda_agent/isolation/git_worktree_cleanup_v2.py",
+        "tests/test_git_worktree_cleanup_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "GitWorktreeCleanupV2 module is implemented.",
+        "Tests verify detached worktrees are correctly identified and removed."
+      ]
+    },
+    {
+      "id": "a2a-peer-capability-cache-v1-9391",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "medium",
+      "title": "A2A Peer Capability Cache V1",
+      "description": "Inspired by A2A trends: Implement a capability cache for discovered A2A peers to reduce network broadcasts during task delegation, with TTL invalidation.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_capability_cache_v1.py",
+        "tests/test_a2a_capability_cache_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2ACapabilityCache class implemented with TTL invalidation.",
+        "Tests mock peer discovery and verify cache hits/misses."
+      ]
+    },
+    {
+      "id": "openclaw-rl-skill-usage-tracker-v1-4029",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "title": "OpenClaw RL Skill Usage Tracker",
+      "description": "Inspired by OpenClaw trends: Implement a skill usage tracker that logs the frequency and success rate of tool executions to a persistent SQLite metric table for long-term skill pruning.",
+      "allowed_paths": [
+        "magda_agent/learning/skill_usage_tracker_v1.py",
+        "tests/test_skill_usage_tracker_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill usage tracker is implemented with SQLite persistence.",
+        "Tests verify that tool executions correctly update usage counts and success rates."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_registry_v7.py
+++ b/magda_agent/skills/mcp_registry_v7.py
@@ -1,0 +1,94 @@
+import logging
+from typing import Dict, Any, List
+
+class MCPRegistryV7:
+    """
+    Registry specialized in handling tools exported via the Model Context Protocol (MCP) version 7.
+    Allows for dynamic registration and unregistration of tools at runtime.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the MCP Registry V7."""
+        self.mcp_tools: Dict[str, Dict[str, Any]] = {}
+
+    def register_tool(self, tool_schema: Dict[str, Any]) -> bool:
+        """
+        Dynamically registers and verifies an external MCP tool schema.
+
+        Args:
+            tool_schema (Dict[str, Any]): The MCP tool schema dictionary.
+
+        Returns:
+            bool: True if registered successfully, False otherwise.
+        """
+        if not self._is_valid_schema(tool_schema):
+            logging.error(f"Failed to register MCP tool: Invalid schema {tool_schema}")
+            return False
+
+        name: str = tool_schema["name"]
+        self.mcp_tools[name] = tool_schema
+        logging.info(f"Successfully registered MCP tool: {name}")
+        return True
+
+    def _is_valid_schema(self, schema: Dict[str, Any]) -> bool:
+        """
+        Verifies if the schema complies with MCP tool standards.
+        Also validates that 'inputSchema' is a dictionary if provided.
+
+        Args:
+            schema (Dict[str, Any]): The MCP tool schema.
+
+        Returns:
+            bool: True if valid, False otherwise.
+        """
+        if not isinstance(schema, dict):
+            return False
+
+        required_fields = ["name", "description"]
+        for field in required_fields:
+            if field not in schema or not isinstance(schema[field], str) or not schema[field]:
+                return False
+
+        # Validate inputSchema if it exists
+        if "inputSchema" in schema and not isinstance(schema["inputSchema"], dict):
+            return False
+
+        return True
+
+    def get_tool(self, name: str) -> Dict[str, Any]:
+        """
+        Retrieve a registered MCP tool by name.
+
+        Args:
+            name (str): The name of the MCP tool.
+
+        Returns:
+            Dict[str, Any]: The tool schema, or an empty dictionary if not found.
+        """
+        return self.mcp_tools.get(name, {})
+
+    def list_tools(self) -> List[str]:
+        """
+        List all available registered MCP tools.
+
+        Returns:
+            List[str]: A list of tool names.
+        """
+        return list(self.mcp_tools.keys())
+
+    def unregister_tool(self, name: str) -> bool:
+        """
+        Dynamically unregisters and removes an MCP tool from the registry.
+
+        Args:
+            name (str): The name of the MCP tool to unregister.
+
+        Returns:
+            bool: True if the tool was successfully unregistered, False if not found.
+        """
+        if name in self.mcp_tools:
+            del self.mcp_tools[name]
+            logging.info(f"Successfully unregistered MCP tool: {name}")
+            return True
+        logging.warning(f"Failed to unregister MCP tool: {name} not found in registry.")
+        return False

--- a/tests/test_mcp_registry_v7.py
+++ b/tests/test_mcp_registry_v7.py
@@ -1,0 +1,64 @@
+import pytest
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+
+@pytest.fixture
+def registry():
+    return MCPRegistryV7()
+
+def test_register_tool_valid(registry):
+    tool_schema = {
+        "name": "test_tool",
+        "description": "A test tool",
+        "inputSchema": {
+            "type": "object",
+            "properties": {}
+        }
+    }
+    assert registry.register_tool(tool_schema) is True
+    assert "test_tool" in registry.list_tools()
+    assert registry.get_tool("test_tool") == tool_schema
+
+def test_register_tool_invalid_missing_name(registry):
+    tool_schema = {
+        "description": "A test tool"
+    }
+    assert registry.register_tool(tool_schema) is False
+    assert len(registry.list_tools()) == 0
+
+def test_register_tool_invalid_missing_description(registry):
+    tool_schema = {
+        "name": "test_tool"
+    }
+    assert registry.register_tool(tool_schema) is False
+
+def test_register_tool_invalid_wrong_input_schema(registry):
+    tool_schema = {
+        "name": "test_tool",
+        "description": "A test tool",
+        "inputSchema": "not a dictionary"
+    }
+    assert registry.register_tool(tool_schema) is False
+
+def test_unregister_tool(registry):
+    tool_schema = {
+        "name": "test_tool",
+        "description": "A test tool"
+    }
+    registry.register_tool(tool_schema)
+    assert registry.unregister_tool("test_tool") is True
+    assert "test_tool" not in registry.list_tools()
+
+def test_unregister_tool_not_found(registry):
+    assert registry.unregister_tool("nonexistent") is False
+
+def test_list_tools(registry):
+    assert registry.list_tools() == []
+    registry.register_tool({"name": "tool1", "description": "desc1"})
+    registry.register_tool({"name": "tool2", "description": "desc2"})
+    tools = registry.list_tools()
+    assert "tool1" in tools
+    assert "tool2" in tools
+    assert len(tools) == 2
+
+def test_get_tool_not_found(registry):
+    assert registry.get_tool("nonexistent") == {}


### PR DESCRIPTION
Implemented `MCPRegistryV7` in `magda_agent/skills/mcp_registry_v7.py` to allow dynamic registration, deregistration, and retrieval of MCP tools at runtime, including basic schema validation.

Added comprehensive unit tests in `tests/test_mcp_registry_v7.py` covering valid and invalid schemas and registry operations.

Updated `agent_tasks.json` to mark `mcp-dynamic-tool-registration-v7-unique-12345` as done and appended 3 new trending AI agent tasks.

---
*PR created automatically by Jules for task [11277269994776283385](https://jules.google.com/task/11277269994776283385) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPRegistryV7` in-memory tool registry with schema validation
> Introduces [`mcp_registry_v7.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/560/files#diff-1e968fd7d696748ac0bebb7eaf9e40da105136d3ae7b9a8f8845fa355a64401f) with the `MCPRegistryV7` class, which provides runtime registration, retrieval, listing, and removal of MCP v7 tool schemas. Schemas are validated to require non-empty `name` and `description` strings and an optional dict-typed `inputSchema`. Full test coverage is added in [`tests/test_mcp_registry_v7.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/560/files#diff-c2a7096816defdaaa019ee5be83c492ed0ad01d3db2e94bb2dab8fe34b6709ea).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83ef18a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->