### PR TITLE
A2A Peer Delegation Discovery V5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9015,7 +9015,7 @@
     },
     {
       "id": "a2a-peer-delegation-discovery-v5-unique-12345",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "high",
       "title": "A2A Peer Delegation Discovery V5",
@@ -20267,6 +20267,57 @@
       "acceptance": [
         "Skill usage tracker is implemented with SQLite persistence.",
         "Tests verify that tool executions correctly update usage counts and success rates."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-paging-pattern-246b8242",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Paging Pattern",
+      "description": "Inspired by MemGPT and OpenClaw trends: Implement a Context Engine Paging Pattern to selectively page older working memory entries into long-term storage when context exceeds bounds.",
+      "allowed_paths": [
+        "magda_agent/memory/context_paging_v1.py",
+        "tests/test_context_paging_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ContextPaging module is implemented.",
+        "Tests verify that paging correctly moves tokens from working memory to long-term storage."
+      ]
+    },
+    {
+      "id": "mcp-tool-sandboxing-enhancements-v2-58287845",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Tool Sandboxing Enhancements V2",
+      "description": "Inspired by MCP kernel trends: Implement enhanced sandboxing for MCP tools to isolate their execution context and limit filesystem and network access dynamically.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_sandbox_v2.py",
+        "tests/test_mcp_sandbox_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP sandbox V2 implemented with resource limitations.",
+        "Tests verify isolated execution and restricted accesses."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-compression-v1-79b263c9",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Claude Subagent Spawning Context Compression",
+      "description": "Inspired by Claude Agent Teams trends: Compress the main agent context into a dense state representation before spawning a subagent to reduce token overhead during delegation.",
+      "allowed_paths": [
+        "magda_agent/agents/context_compression_v1.py",
+        "tests/test_context_compression_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context compression logic is implemented.",
+        "Tests verify token reduction before subagent execution."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_discovery_v5.py
+++ b/magda_agent/integration/a2a_discovery_v5.py
@@ -1,0 +1,151 @@
+import json
+import logging
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Optional
+import httpx
+from magda_agent.integration.a2a_security import A2ASecurityContext
+
+
+@dataclass
+class AgentCardV5:
+    """
+    Represents the capabilities and identity of an agent in the network, version 5.
+    Inspired by trend: A2A (Agent-to-Agent Protocol).
+    """
+    agent_id: str
+    name: str
+    description: str
+    capabilities: List[str]
+    endpoints: Dict[str, str]
+    protocol_version: str = "v5"
+
+    def to_json(self) -> str:
+        """
+        Serializes the AgentCardV5 to a JSON string.
+        """
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "AgentCardV5":
+        """
+        Deserializes an AgentCardV5 from a JSON string.
+        """
+        data = json.loads(json_str)
+        return cls(**data)
+
+
+class A2ADiscoveryServiceV5:
+    """
+    A registry to manage external agent discovery using Agent Cards (V5).
+    """
+
+    def __init__(self, security_context: Optional[A2ASecurityContext] = None) -> None:
+        """
+        Initializes the A2ADiscoveryServiceV5.
+        """
+        self._registry: Dict[str, AgentCardV5] = {}
+        self.security_context = security_context or A2ASecurityContext()
+
+    def register_agent(self, card: AgentCardV5) -> None:
+        """
+        Registers an AgentCardV5 in the registry.
+
+        Args:
+            card (AgentCardV5): The agent card to register.
+        """
+        self._registry[card.agent_id] = card
+        logging.info(f"Registered AgentCardV5 for agent_id: {card.agent_id}")
+
+    def unregister_agent(self, agent_id: str) -> None:
+        """
+        Unregisters an agent from the registry by its ID.
+
+        Args:
+            agent_id (str): The ID of the agent to unregister.
+        """
+        if agent_id in self._registry:
+            del self._registry[agent_id]
+            logging.info(f"Unregistered agent_id: {agent_id}")
+        else:
+            logging.warning(f"Attempted to unregister non-existent agent_id: {agent_id}")
+
+    def parse_and_register_cards(self, raw_cards: List[str]) -> List[AgentCardV5]:
+        """
+        Parses a list of JSON string representations of Agent Cards
+        and registers them in the internal store.
+
+        Args:
+            raw_cards (List[str]): A list of JSON strings representing AgentCardV5s.
+
+        Returns:
+            List[AgentCardV5]: A list of successfully parsed and registered AgentCardV5 objects.
+        """
+        successfully_parsed: List[AgentCardV5] = []
+        for card_json in raw_cards:
+            try:
+                card = AgentCardV5.from_json(card_json)
+                self.register_agent(card)
+                successfully_parsed.append(card)
+            except (json.JSONDecodeError, TypeError, ValueError, KeyError) as e:
+                logging.error(f"Failed to parse AgentCardV5. Error: {str(e)}, Raw Data: {card_json}")
+        return successfully_parsed
+
+    def get_agent_card(self, agent_id: str) -> Optional[AgentCardV5]:
+        """
+        Retrieves a registered AgentCardV5 by its agent_id.
+
+        Args:
+            agent_id (str): The ID of the agent to retrieve.
+
+        Returns:
+            Optional[AgentCardV5]: The AgentCardV5 if found, otherwise None.
+        """
+        return self._registry.get(agent_id)
+
+    def get_all_agents(self) -> List[AgentCardV5]:
+        """
+        Returns a list of all discovered agent cards.
+
+        Returns:
+            List[AgentCardV5]: A list of all AgentCardV5 objects in the registry.
+        """
+        return list(self._registry.values())
+
+    async def discover_from_network(self, network_endpoint: str, auth_token: Optional[str] = None) -> List[AgentCardV5]:
+        """
+        Discovers peers from a network endpoint and parses Agent Cards, maintaining an internal registry of discovered agents.
+
+        Args:
+            network_endpoint (str): The endpoint to discover agents from.
+            auth_token (Optional[str]): An optional authentication token for secure discovery.
+
+        Returns:
+            List[AgentCardV5]: A list of newly discovered AgentCardV5 objects.
+        """
+        if auth_token and not self.security_context.validate_token(auth_token):
+            logging.error("Invalid auth token for discover_from_network")
+            raise ValueError("Invalid authentication token")
+
+        self.security_context.trace_action("discover_from_network_v5", {"endpoint": network_endpoint})
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(f"{network_endpoint}", headers=headers)
+                response.raise_for_status()
+                cards_data = response.json()
+
+                # Assume cards_data is a list of json strings or dicts
+                raw_cards = []
+                for item in cards_data:
+                    if isinstance(item, str):
+                        raw_cards.append(item)
+                    else:
+                        raw_cards.append(json.dumps(item))
+
+                return self.parse_and_register_cards(raw_cards)
+        except Exception as e:
+            logging.error(f"Failed to discover from network {network_endpoint}: {e}")
+            return []

--- a/tests/test_a2a_discovery_v5.py
+++ b/tests/test_a2a_discovery_v5.py
@@ -1,0 +1,159 @@
+import pytest
+import json
+from unittest.mock import patch, AsyncMock
+from magda_agent.integration.a2a_discovery_v5 import AgentCardV5, A2ADiscoveryServiceV5
+
+@pytest.fixture
+def valid_card_dict() -> dict:
+    """Fixture for valid AgentCard dictionary."""
+    return {
+        "agent_id": "test-agent-005",
+        "name": "TestAgentV5",
+        "description": "A test agent card v5",
+        "capabilities": ["test_capability_1", "test_capability_2"],
+        "endpoints": {"rpc": "http://localhost:8080/rpc"},
+        "protocol_version": "v5"
+    }
+
+@pytest.fixture
+def valid_card_json(valid_card_dict: dict) -> str:
+    """Fixture for valid AgentCard JSON string."""
+    return json.dumps(valid_card_dict)
+
+def test_agent_card_v5_serialization(valid_card_dict: dict, valid_card_json: str) -> None:
+    """
+    Test that AgentCardV5 successfully serializes and deserializes from JSON.
+    """
+    # Deserialize
+    card = AgentCardV5.from_json(valid_card_json)
+    assert card.agent_id == "test-agent-005"
+    assert card.name == "TestAgentV5"
+    assert "test_capability_1" in card.capabilities
+    assert card.endpoints["rpc"] == "http://localhost:8080/rpc"
+    assert card.protocol_version == "v5"
+
+    # Serialize
+    re_serialized = card.to_json()
+    re_dict = json.loads(re_serialized)
+    assert re_dict["agent_id"] == "test-agent-005"
+    assert re_dict["name"] == "TestAgentV5"
+    assert re_dict["protocol_version"] == "v5"
+
+def test_service_register_and_get(valid_card_json: str) -> None:
+    """
+    Test registering and retrieving an agent card from the service.
+    """
+    service = A2ADiscoveryServiceV5()
+    card = AgentCardV5.from_json(valid_card_json)
+
+    service.register_agent(card)
+
+    retrieved_card = service.get_agent_card("test-agent-005")
+    assert retrieved_card is not None
+    assert retrieved_card.name == "TestAgentV5"
+
+    all_agents = service.get_all_agents()
+    assert len(all_agents) == 1
+    assert all_agents[0].agent_id == "test-agent-005"
+
+def test_service_unregister(valid_card_json: str) -> None:
+    """
+    Test unregistering an agent card from the service.
+    """
+    service = A2ADiscoveryServiceV5()
+    card = AgentCardV5.from_json(valid_card_json)
+
+    service.register_agent(card)
+    assert service.get_agent_card("test-agent-005") is not None
+
+    service.unregister_agent("test-agent-005")
+    assert service.get_agent_card("test-agent-005") is None
+
+    # Unregistering non-existent agent should not crash
+    service.unregister_agent("non-existent")
+
+def test_service_parse_and_register_cards(valid_card_json: str) -> None:
+    """
+    Test bulk parsing and registration of valid and invalid card strings.
+    """
+    service = A2ADiscoveryServiceV5()
+
+    invalid_card_json = '{"agent_id": "bad", "name": "bad"}' # missing description, capabilities, endpoints
+    malformed_json = '{"agent_id": "bad", "name":' # Syntax error
+
+    cards_to_parse = [valid_card_json, invalid_card_json, malformed_json]
+
+    successfully_parsed = service.parse_and_register_cards(cards_to_parse)
+
+    assert len(successfully_parsed) == 1
+    assert successfully_parsed[0].agent_id == "test-agent-005"
+
+    assert len(service.get_all_agents()) == 1
+
+@patch('magda_agent.integration.a2a_discovery_v5.logging.error')
+def test_service_parse_logging_errors(mock_logging_error) -> None:
+    """
+    Test that invalid cards log an error during parsing.
+    """
+    service = A2ADiscoveryServiceV5()
+    malformed_json = '{"not": json}'
+
+    service.parse_and_register_cards([malformed_json])
+
+    assert mock_logging_error.called
+    assert "Failed to parse AgentCardV5" in mock_logging_error.call_args[0][0]
+
+@pytest.mark.asyncio
+async def test_discover_from_network(valid_card_dict: dict) -> None:
+    """
+    Test discover_from_network fetches and registers cards correctly using respx.
+    """
+    import respx
+    from httpx import Response
+
+    service = A2ADiscoveryServiceV5()
+    endpoint = "http://fake-registry.local/cards"
+
+    with respx.mock:
+        # Mock successful response
+        respx.get(endpoint).mock(return_value=Response(200, json=[valid_card_dict, valid_card_dict]))
+
+        cards = await service.discover_from_network(endpoint)
+
+        assert len(cards) == 2
+        assert cards[0].agent_id == "test-agent-005"
+
+        # Check registry
+        assert len(service.get_all_agents()) == 1 # duplicate agent_id overwrites
+        assert service.get_agent_card("test-agent-005") is not None
+
+@pytest.mark.asyncio
+async def test_discover_from_network_invalid_token() -> None:
+    """
+    Test discover_from_network with invalid auth token.
+    """
+    service = A2ADiscoveryServiceV5()
+    endpoint = "http://fake-registry.local/cards"
+
+    with patch.object(service.security_context, 'validate_token', return_value=False):
+        with pytest.raises(ValueError, match="Invalid authentication token"):
+            await service.discover_from_network(endpoint, auth_token="bad-token")
+
+@pytest.mark.asyncio
+async def test_discover_from_network_http_error() -> None:
+    """
+    Test discover_from_network handling http errors.
+    """
+    import respx
+    from httpx import Response
+
+    service = A2ADiscoveryServiceV5()
+    endpoint = "http://fake-registry.local/cards"
+
+    with respx.mock:
+        respx.get(endpoint).mock(return_value=Response(500))
+
+        cards = await service.discover_from_network(endpoint)
+
+        assert cards == []
+        assert len(service.get_all_agents()) == 0


### PR DESCRIPTION
This PR introduces the `A2ADiscoveryServiceV5` allowing Magda to asynchronously discover capabilities of peer agents via Agent Cards, aligning with recent trends in A2A (Agent-to-Agent Protocol). It also updates the persistent task backlog with new feature plans.

---
*PR created automatically by Jules for task [4512291914597458690](https://jules.google.com/task/4512291914597458690) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A peer delegation discovery service v5 with network card registration
> - Adds [`A2ADiscoveryServiceV5`](https://github.com/kazah4359-lgtm/Magda-agent/pull/561/files#diff-f920842da39d72fd3351e26147947c6927a8b1b138195c994f8fe6b5be6e0918) with an in-memory registry for `AgentCardV5` instances, supporting register, unregister, bulk parse-and-register, and lookup operations.
> - Adds async `discover_from_network` that fetches agent cards from a remote HTTP endpoint, optionally validates an auth token via `A2ASecurityContext`, and registers all valid cards returned.
> - Invalid cards in a batch are skipped and logged rather than failing the whole operation; an invalid auth token raises `ValueError`.
> - Adds tests covering serialization, registry operations, batch parsing, and network discovery with mocked HTTP responses.
> - Risk: network discovery failures return an empty list silently (logged only), so callers have no structured error to distinguish auth failures from connectivity issues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84dbb7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->