### PR TITLE
feat: MCP dynamic capability negotiation v6 and new AI trend tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -20167,7 +20167,7 @@
     },
     {
       "id": "mcp-dynamic-capability-negotiation-v6",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Dynamic Capability Negotiation V6",
@@ -20354,6 +20354,42 @@
         "Guardrail timeout fallback logic implemented.",
         "Partial compliance states correctly audited.",
         "Tests verify timeout scenarios and logging."
+      ]
+    },
+    {
+      "id": "claude-evaluator-semantic-diff-v1-dc3ad5f0",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Claude Evaluator Semantic Diff Check",
+      "description": "Inspired by Claude Evaluator agent trend: Implement an evaluation module that performs semantic diff analysis of proposed code changes before merge, comparing the semantic intent against the generated DependencyGraph to ensure code aligns with the plan.",
+      "allowed_paths": [
+        "magda_agent/evaluation/semantic_diff_v1.py",
+        "tests/test_semantic_diff_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "SemanticDiffEvaluator is implemented.",
+        "It successfully identifies discrepancies between intent and actual diff using mocked LLM outputs.",
+        "Tests pass verifying correct mismatch detection."
+      ]
+    },
+    {
+      "id": "openclaw-rl-episodic-memory-pruning-v1-20ab53f9",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw RL Episodic Memory Pruning",
+      "description": "Inspired by OpenClaw virtual context management: Implement a reinforcement learning based pruning strategy for episodic memory that removes low-salience memories based on negative reward signals during long interactions.",
+      "allowed_paths": [
+        "magda_agent/memory/episodic_pruning_v1.py",
+        "tests/test_episodic_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Episodic memory pruning strategy based on RL weights is implemented.",
+        "Low-salience memories are correctly identified and removed.",
+        "Tests verify pruning logic with mocked reward matrices."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -290,5 +290,7 @@
 * [ ] FEATURE: A2A Agent Discovery via Agent Cards (a2a-agent-discovery-cards-v3-202606)
 * [ ] FEATURE: A2A Peer-to-Peer Task Delegation V7 (a2a-peer-task-delegation-v7-202606)
 * [ ] FEATURE: OpenAI Agents SDK Tool Schema Caching (openai-agents-schema-cache-v1-d24c8b9a)
-* [ ] FEATURE: MCP Dynamic Capability Negotiation V6 (mcp-dynamic-capability-negotiation-v6)
+* [x] FEATURE: MCP Dynamic Capability Negotiation V6 (mcp-dynamic-capability-negotiation-v6)
 * [ ] FEATURE: Hermes Online Skill Pruning V1 (hermes-online-skill-pruning-v1)
+* [ ] FEATURE: Claude Evaluator Semantic Diff Check (claude-evaluator-semantic-diff-v1)
+* [ ] FEATURE: OpenClaw RL Episodic Memory Pruning (openclaw-rl-episodic-memory-pruning-v1)

--- a/magda_agent/integration/mcp_negotiation_v6.py
+++ b/magda_agent/integration/mcp_negotiation_v6.py
@@ -1,0 +1,70 @@
+from typing import Dict, Any, List, Optional
+
+class CapabilityRejectedError(Exception):
+    """Raised when a required capability is rejected during negotiation."""
+    pass
+
+class MCPCapabilityNegotiatorV6:
+    """
+    Handles multi-turn capability negotiation for MCP tools to ensure both
+    client and server agree on supported features before execution.
+    """
+
+    def __init__(self, server_capabilities: Dict[str, Any]) -> None:
+        """
+        Initializes the negotiator with the server's supported capabilities.
+
+        Args:
+            server_capabilities: A dictionary of capabilities supported by the server.
+        """
+        self.server_capabilities = server_capabilities
+
+    def negotiate(self, client_capabilities: Dict[str, Any], required_capabilities: Optional[List[str]] = None) -> Dict[str, Any]:
+        """
+        Negotiates capabilities between client and server.
+
+        Args:
+            client_capabilities: The capabilities requested or supported by the client.
+            required_capabilities: A list of capabilities that MUST be supported by the server.
+
+        Returns:
+            A dictionary of the agreed-upon capabilities.
+
+        Raises:
+            CapabilityRejectedError: If a required capability is not supported by the server.
+        """
+        agreed_capabilities: Dict[str, Any] = {}
+
+        if required_capabilities:
+            for req in required_capabilities:
+                if req not in self.server_capabilities:
+                    raise CapabilityRejectedError(f"Required capability '{req}' is not supported by the server.")
+
+        for cap, details in client_capabilities.items():
+            if cap in self.server_capabilities:
+                agreed_capabilities[cap] = details
+
+        return agreed_capabilities
+
+    def get_fallback_capabilities(self, client_capabilities: Dict[str, Any], fallback_map: Dict[str, str]) -> Dict[str, Any]:
+        """
+        Attempts to find fallback capabilities if primary ones are not supported.
+
+        Args:
+            client_capabilities: The capabilities requested by the client.
+            fallback_map: A mapping from a requested capability to a fallback capability.
+
+        Returns:
+            A dictionary of capabilities including fallbacks where applicable.
+        """
+        agreed_capabilities: Dict[str, Any] = {}
+
+        for cap, details in client_capabilities.items():
+            if cap in self.server_capabilities:
+                agreed_capabilities[cap] = details
+            elif cap in fallback_map:
+                fallback_cap = fallback_map[cap]
+                if fallback_cap in self.server_capabilities:
+                    agreed_capabilities[fallback_cap] = details
+
+        return agreed_capabilities

--- a/tests/test_mcp_negotiation_v6.py
+++ b/tests/test_mcp_negotiation_v6.py
@@ -1,0 +1,48 @@
+import pytest
+from magda_agent.integration.mcp_negotiation_v6 import MCPCapabilityNegotiatorV6, CapabilityRejectedError
+
+def test_successful_negotiation():
+    """Test that mutually supported capabilities are agreed upon."""
+    server_caps = {"code_execution": {"version": "1.0"}, "file_read": {"version": "2.0"}}
+    client_caps = {"code_execution": {"version": "1.0"}, "unknown_cap": {}}
+
+    negotiator = MCPCapabilityNegotiatorV6(server_caps)
+    agreed = negotiator.negotiate(client_caps)
+
+    assert "code_execution" in agreed
+    assert "unknown_cap" not in agreed
+
+def test_required_capability_rejected():
+    """Test that if a required capability is missing, an error is raised."""
+    server_caps = {"file_read": {"version": "2.0"}}
+    client_caps = {"code_execution": {"version": "1.0"}}
+
+    negotiator = MCPCapabilityNegotiatorV6(server_caps)
+
+    with pytest.raises(CapabilityRejectedError, match="Required capability 'code_execution' is not supported by the server."):
+        negotiator.negotiate(client_caps, required_capabilities=["code_execution"])
+
+def test_fallback_behavior():
+    """Test that a fallback capability is used if the primary is missing."""
+    server_caps = {"legacy_code_execution": {"version": "0.9"}}
+    client_caps = {"code_execution": {"version": "1.0"}}
+    fallback_map = {"code_execution": "legacy_code_execution"}
+
+    negotiator = MCPCapabilityNegotiatorV6(server_caps)
+    agreed = negotiator.get_fallback_capabilities(client_caps, fallback_map)
+
+    assert "legacy_code_execution" in agreed
+    assert "code_execution" not in agreed
+
+def test_fallback_not_supported():
+    """Test behavior when neither primary nor fallback are supported."""
+    server_caps = {"file_read": {"version": "2.0"}}
+    client_caps = {"code_execution": {"version": "1.0"}}
+    fallback_map = {"code_execution": "legacy_code_execution"}
+
+    negotiator = MCPCapabilityNegotiatorV6(server_caps)
+    agreed = negotiator.get_fallback_capabilities(client_caps, fallback_map)
+
+    assert "code_execution" not in agreed
+    assert "legacy_code_execution" not in agreed
+    assert not agreed


### PR DESCRIPTION
This PR implements the `mcp-dynamic-capability-negotiation-v6` task and adds two new trend-inspired tasks to `agent_tasks.json` and `backlog.md`.

**Changes:**
1. Created `magda_agent/integration/mcp_negotiation_v6.py` containing `MCPCapabilityNegotiatorV6`. This class manages capability negotiation, verifies required capabilities, and provides a fallback mechanism when primary capabilities are missing.
2. Created comprehensive tests in `tests/test_mcp_negotiation_v6.py` to cover successful handshakes, rejected requirements, fallback handling, and failure states, using mock dictionaries instead of real API calls.
3. Updated `agent_tasks.json` to mark the current task as `done`.
4. Appended two new `todo` tasks to `agent_tasks.json` and `backlog.md` based on June 2026 AI trends:
   - **Claude Evaluator Semantic Diff Check**: Evaluator that compares semantic intent vs dependency graph diffs.
   - **OpenClaw RL Episodic Memory Pruning**: RL-based virtual context pruning of low-salience episodic memories.
5. Ran all tests using `poetry run pytest tests/` which passed successfully (1808 total tests).
6. Ran the validation script against `agent_tasks.json` which completed successfully with no warnings.

---
*PR created automatically by Jules for task [11213598390500212329](https://jules.google.com/task/11213598390500212329) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP dynamic capability negotiation via `MCPCapabilityNegotiatorV6`
> - Implements [`mcp_negotiation_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/565/files#diff-5f19e5201c07c3a6399e76eb9cfc448531314125fb27496a790c57bc872f7c5c) with `MCPCapabilityNegotiatorV6`, which intersects client and server capabilities and raises `CapabilityRejectedError` when a required capability is absent.
> - Adds `get_fallback_capabilities` to substitute supported fallback capabilities when primaries are unsupported; capabilities with no valid fallback are omitted from the result.
> - Covers both paths with four unit tests in [`tests/test_mcp_negotiation_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/565/files#diff-ed2d8531bd07a2869e60b3ac852f597213088dfbcb8f08d49f99c8f55d91eeeb).
> - Adds two new backlog tasks (`claude-evaluator-semantic-diff` and `openclaw-rl-episodic-memory-pruning`) to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/565/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205) and marks the MCP V6 task as done in [`backlog.md`](https://github.com/kazah4359-lgtm/Magda-agent/pull/565/files#diff-ce235019933f4611922cabf612af45cfea7b3b8c45725ae9c4cb784ac5298fa4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea02ca2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->