### PR TITLE
feat: implement Hermes-inspired agentskills.io sync CLI

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9151,7 +9151,7 @@
     },
     {
       "id": "hermes-skill-marketplace-sync-v1-d6be4114",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Hermes-inspired agentskills.io Sync CLI",
@@ -20593,6 +20593,60 @@
       "acceptance": [
         "MCP negotiation logic handles capabilities handshake.",
         "Tests mock negotiation and verify fallback behaviors."
+      ]
+    },
+    {
+      "id": "openclaw-rl-conversation-summarizer-v1-e5d4c3b2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw RL Conversation Summarizer V1",
+      "description": "Inspired by MemGPT and OpenClaw memory patterns: Implement a periodic summarizer that compresses old context and extracts semantic facts during idle time, storing them into EpisodicMemory.",
+      "allowed_paths": [
+        "magda_agent/memory/conversation_summarizer.py",
+        "tests/test_conversation_summarizer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ConversationSummarizer extracts semantic facts and updates episodic memory.",
+        "Old context is compressed dynamically based on limits.",
+        "Tests verify semantic fact extraction."
+      ]
+    },
+    {
+      "id": "acs-policy-dynamic-update-v1-a1b2c3d4",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS Policy Dynamic Update Module V1",
+      "description": "Inspired by ACS agent trends: Create an A2A-compatible endpoint that allows for dynamic reception and update of ACS guardrail policies without requiring application restart.",
+      "allowed_paths": [
+        "magda_agent/safety/policy_dynamic_updater.py",
+        "tests/test_policy_dynamic_updater.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dynamic policy updates are securely received and applied via an A2A endpoint.",
+        "Policy updates take effect immediately for subsequent tool calls.",
+        "Tests verify security verification and dynamic policy injection."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-deprecation-v1-8c7d6e5f",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Deprecation V1",
+      "description": "Inspired by MCP and Agent Teams trends: Implement an automated background routine to dynamically deprecate and deregister MCP tools if they consistently timeout or fail telemetry thresholds.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_tool_deprecation.py",
+        "tests/test_mcp_tool_deprecation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool deprecation module deregisters tools exceeding failure thresholds.",
+        "Logs deprecation events into the audit trail.",
+        "Tests verify tools are correctly disabled under simulated failures."
       ]
     }
   ]

--- a/magda_agent/skills/marketplace_sync_cli.py
+++ b/magda_agent/skills/marketplace_sync_cli.py
@@ -1,0 +1,71 @@
+"""CLI command for syncing external skills from agentskills.io into the local registry."""
+
+import argparse
+import asyncio
+import logging
+import sys
+from typing import Optional, List
+
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.marketplace_sync_v4 import MarketplaceSyncRoutineV4
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """
+    Parses command-line arguments for the marketplace sync CLI.
+
+    Args:
+        argv: Optional list of command-line arguments.
+
+    Returns:
+        The parsed arguments namespace.
+    """
+    parser = argparse.ArgumentParser(description="Sync external skills from agentskills.io into the local registry.")
+    parser.add_argument(
+        "--url",
+        default="https://agentskills.io/api/skills",
+        help="The URL of the marketplace to fetch from"
+    )
+    parser.add_argument(
+        "--cache",
+        default=".skill_cache_v4.json",
+        help="File path to save/cache fetched skill definitions locally"
+    )
+    return parser.parse_args(argv)
+
+
+async def main(argv: Optional[List[str]] = None) -> int:
+    """
+    Main entry point for the marketplace sync CLI.
+
+    Args:
+        argv: Optional list of command-line arguments.
+
+    Returns:
+        Integer representing the exit code (0 for success, 1 for failure).
+    """
+    args = parse_args(argv)
+
+    registry = SkillRegistry()
+    sync_routine = MarketplaceSyncRoutineV4(
+        registry=registry,
+        marketplace_url=args.url,
+        cache_path=args.cache
+    )
+
+    logger.info(f"Starting one-off sync from {args.url}")
+    imported_count = await sync_routine.run_sync_cycle()
+
+    if imported_count > 0:
+        logger.info(f"Successfully synced {imported_count} skills.")
+        return 0
+    else:
+        logger.error("Failed to sync any skills.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/test_marketplace_sync_cli.py
+++ b/tests/test_marketplace_sync_cli.py
@@ -1,0 +1,57 @@
+"""Tests for the marketplace sync CLI module."""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from magda_agent.skills.marketplace_sync_cli import main, parse_args
+
+
+@pytest.mark.asyncio
+@patch('magda_agent.skills.marketplace_sync_cli.MarketplaceSyncRoutineV4')
+@patch('magda_agent.skills.marketplace_sync_cli.SkillRegistry')
+async def test_marketplace_sync_cli_success(mock_registry_class, mock_sync_routine_class):
+    """Test the CLI script returns 0 on successful sync."""
+    mock_sync_routine_instance = mock_sync_routine_class.return_value
+    mock_sync_routine_instance.run_sync_cycle = AsyncMock(return_value=5)
+
+    argv = ["--url", "http://test.url", "--cache", ".test_cache.json"]
+    result = await main(argv)
+
+    assert result == 0
+    mock_sync_routine_class.assert_called_once_with(
+        registry=mock_registry_class.return_value,
+        marketplace_url="http://test.url",
+        cache_path=".test_cache.json"
+    )
+    mock_sync_routine_instance.run_sync_cycle.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch('magda_agent.skills.marketplace_sync_cli.MarketplaceSyncRoutineV4')
+@patch('magda_agent.skills.marketplace_sync_cli.SkillRegistry')
+async def test_marketplace_sync_cli_failure(mock_registry_class, mock_sync_routine_class):
+    """Test the CLI script returns 1 when no skills are synced."""
+    mock_sync_routine_instance = mock_sync_routine_class.return_value
+    mock_sync_routine_instance.run_sync_cycle = AsyncMock(return_value=0)
+
+    argv = []
+    result = await main(argv)
+
+    assert result == 1
+    mock_sync_routine_class.assert_called_once_with(
+        registry=mock_registry_class.return_value,
+        marketplace_url="https://agentskills.io/api/skills",
+        cache_path=".skill_cache_v4.json"
+    )
+    mock_sync_routine_instance.run_sync_cycle.assert_called_once()
+
+
+def test_parse_args():
+    """Test that command-line arguments are parsed correctly."""
+    args = parse_args(["--url", "test_url", "--cache", "test_cache"])
+    assert args.url == "test_url"
+    assert args.cache == "test_cache"
+
+    args = parse_args([])
+    assert args.url == "https://agentskills.io/api/skills"
+    assert args.cache == ".skill_cache_v4.json"


### PR DESCRIPTION
This PR completes the implementation of a CLI to sync external skills from agentskills.io into the local registry. It includes the required command-line tool logic inside `magda_agent/skills/marketplace_sync_cli.py`, alongside its comprehensive mock-based test suite. The `agent_tasks.json` manifest is successfully updated to mark this task as done and populate 3 new AI-trend inspired tasks: OpenClaw RL Conversation Summarizer, ACS Policy Dynamic Updater, and MCP Dynamic Tool Deprecation.

---
*PR created automatically by Jules for task [6496945529627020027](https://jules.google.com/task/6496945529627020027) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `marketplace_sync_cli.py` CLI for one-off agentskills.io marketplace sync
> - Adds [marketplace_sync_cli.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/570/files#diff-e8de159db971b6782d3fd655ff2e6d3a2bedb197c9406602e65940e10c975718) with a `parse_args` function supporting `--url` (default `https://agentskills.io/api/skills`) and `--cache` (default `.skill_cache_v4.json`).
> - The `main` async function instantiates `SkillRegistry` and `MarketplaceSyncRoutineV4`, runs one sync cycle, and returns exit code 0 if any skills were imported or 1 otherwise.
> - Adds tests covering success, failure, and argument parsing in [test_marketplace_sync_cli.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/570/files#diff-6a1bf536fdeec2771c4b7f67468e23135c6a05c402fe53bbccbbf89f7e5378c2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c36c48c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->