### PR TITLE
Implement ACSPersistenceV10

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -17760,7 +17760,7 @@
     },
     {
       "id": "acs-safety-checkpoints-persistence-v10-def34",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "ACS Safety Checkpoints Persistence V10",
@@ -20648,6 +20648,57 @@
         "Tool deprecation module deregisters tools exceeding failure thresholds.",
         "Logs deprecation events into the audit trail.",
         "Tests verify tools are correctly disabled under simulated failures."
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent-isolation-v2",
+      "title": "Claude Evaluator Subagent Isolation V2",
+      "description": "Inspired by Claude Agent SDK: Implement Git worktree isolation for spawned evaluator subagents to avoid context bleeding when reviewing planner outputs concurrently.",
+      "area": "agents",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_subagent_isolation.py",
+        "tests/test_evaluator_subagent_isolation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagents run inside isolated Git worktrees.",
+        "Tests verify clean execution and cleanup."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-evaluation-v4-abc12",
+      "title": "OpenClaw RL Trajectory Quality Evaluation v4",
+      "description": "Inspired by OpenClaw RL Trend: Enhance trajectory evaluation to include user sentiment shifts specifically from image multimodal outputs.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_quality_v4.py",
+        "tests/test_trajectory_quality_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory Evaluator assesses multimodal rollouts.",
+        "Tests mock trajectory parsing and multimodal feedback."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v8",
+      "title": "MCP Dynamic Capability Negotiation V8",
+      "description": "Inspired by MCP Trends: Introduce multi-turn capability negotiation resolving capability mismatch using LLM fallback inference when strict schema fails.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v8.py",
+        "tests/test_mcp_negotiation_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Negotiation protocol handles multi-turn fallback resolution.",
+        "Tests mock the negotiation fallback loop."
       ]
     }
   ]

--- a/magda_agent/safety/acs_guard_v6.py
+++ b/magda_agent/safety/acs_guard_v6.py
@@ -6,6 +6,7 @@ from magda_agent.safety.audit_trail import AuditTrail
 from magda_agent.safety.taint import is_tainted
 from magda_agent.safety.acs_sandboxing import ACSToolSandbox
 from magda_agent.safety.acs_persistence import ACSPersistence
+from magda_agent.safety.acs_persistence_v10 import ACSPersistenceV10
 
 _SENSITIVE_PATTERNS = (
     re.compile(r"api[_-]?key|token|password|private[_-]?key|secret[_-]?key", re.IGNORECASE),
@@ -43,6 +44,7 @@ class ACSGuardV6:
         self.policy_layer = policy_layer or PolicyLayer()
         self.audit_trail = audit_trail or AuditTrail()
         self.persistence = persistence or ACSPersistence()
+        self.persistence_v10 = ACSPersistenceV10()
         self.tool_sandbox = ACSToolSandbox()
 
     def checkpoint_1_input_validation(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:

--- a/magda_agent/safety/acs_persistence_v10.py
+++ b/magda_agent/safety/acs_persistence_v10.py
@@ -1,0 +1,164 @@
+import sqlite3
+import json
+import time
+import logging
+from typing import Dict, Any, Optional, List, Tuple
+
+class ACSPersistenceV10:
+    """
+    ACS (Agent Control Specification) Safety Checkpoints Persistence V10.
+    Implements persistent SQL-based logging to record historical outcomes
+    for the 5 standard safety checkpoints:
+    1: Input Validation
+    2: Intent Authorization
+    3: Tool Policy
+    4: State Transition
+    5: Output Sanitization
+    """
+
+    def __init__(self, db_path: str = "acs_persistence_v10.db") -> None:
+        """
+        Initializes the ACSPersistenceV10 layer and creates the table if it doesn't exist.
+
+        Args:
+            db_path: Path to the SQLite database file.
+        """
+        self.db_path = db_path
+        self.logger = logging.getLogger(__name__)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the SQLite database schema for V10 log table."""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    CREATE TABLE IF NOT EXISTS acs_checkpoints_log_v10 (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp REAL NOT NULL,
+                        checkpoint_id INTEGER NOT NULL,
+                        status TEXT NOT NULL,
+                        reason TEXT,
+                        workflow_context TEXT
+                    )
+                    '''
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to initialize ACS V10 persistence database at {self.db_path}: {e}")
+
+    def log_checkpoint(
+        self,
+        checkpoint_id: int,
+        status: str,
+        reason: Optional[str] = None,
+        workflow_context: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """
+        Logs the result of an ACS checkpoint.
+
+        Args:
+            checkpoint_id: The ID of the checkpoint (1-5).
+            status: The status of the checkpoint ("passed" or "failed").
+            reason: Optional reason for the status.
+            workflow_context: Optional context data related to the workflow.
+        """
+        timestamp = time.time()
+        context_json = json.dumps(workflow_context) if workflow_context else None
+
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    INSERT INTO acs_checkpoints_log_v10 (timestamp, checkpoint_id, status, reason, workflow_context)
+                    VALUES (?, ?, ?, ?, ?)
+                    ''',
+                    (timestamp, checkpoint_id, status, reason, context_json)
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to log ACS V10 checkpoint {checkpoint_id} to database: {e}")
+
+    def get_logs(self, checkpoint_id: Optional[int] = None) -> List[Tuple[Any, ...]]:
+        """
+        Retrieves logs from the V10 database.
+
+        Args:
+            checkpoint_id: Optional filter by checkpoint ID (1-5).
+
+        Returns:
+            A list of log tuple entries.
+        """
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                if checkpoint_id is not None:
+                    cursor.execute(
+                        "SELECT id, timestamp, checkpoint_id, status, reason, workflow_context FROM acs_checkpoints_log_v10 WHERE checkpoint_id = ? ORDER BY id ASC",
+                        (checkpoint_id,)
+                    )
+                else:
+                    cursor.execute(
+                        "SELECT id, timestamp, checkpoint_id, status, reason, workflow_context FROM acs_checkpoints_log_v10 ORDER BY id ASC"
+                    )
+                return cursor.fetchall()
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to retrieve ACS V10 logs: {e}")
+            return []
+
+    def calculate_failure_rate(self, checkpoint_id: Optional[int] = None) -> float:
+        """
+        Calculates the failure rate of a specific checkpoint or all checkpoints.
+
+        Args:
+            checkpoint_id: Optional filter by checkpoint ID (1-5).
+
+        Returns:
+            Float representing the failure rate (from 0.0 to 1.0). Returns 0.0 if there are no logs.
+        """
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                if checkpoint_id is not None:
+                    cursor.execute(
+                        "SELECT COUNT(*) FROM acs_checkpoints_log_v10 WHERE checkpoint_id = ?",
+                        (checkpoint_id,)
+                    )
+                    total = cursor.fetchone()[0]
+                    if total == 0:
+                        return 0.0
+                    cursor.execute(
+                        "SELECT COUNT(*) FROM acs_checkpoints_log_v10 WHERE checkpoint_id = ? AND status = 'failed'",
+                        (checkpoint_id,)
+                    )
+                    failed = cursor.fetchone()[0]
+                    return float(failed) / total
+                else:
+                    cursor.execute("SELECT COUNT(*) FROM acs_checkpoints_log_v10")
+                    total = cursor.fetchone()[0]
+                    if total == 0:
+                        return 0.0
+                    cursor.execute("SELECT COUNT(*) FROM acs_checkpoints_log_v10 WHERE status = 'failed'")
+                    failed = cursor.fetchone()[0]
+                    return float(failed) / total
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to calculate failure rate: {e}")
+            return 0.0
+
+    def count_total_runs(self) -> int:
+        """
+        Counts total checkpoint runs stored in the database.
+
+        Returns:
+            Total count of run entries.
+        """
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT COUNT(*) FROM acs_checkpoints_log_v10")
+                return int(cursor.fetchone()[0])
+        except sqlite3.Error as e:
+            self.logger.error(f"Failed to count total runs: {e}")
+            return 0

--- a/magda_agent/scheduler/acs_evaluation_task.py
+++ b/magda_agent/scheduler/acs_evaluation_task.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, Any, List
 
 from magda_agent.safety.acs_persistence_v12 import ACSPersistenceV12
+from magda_agent.safety.acs_persistence_v10 import ACSPersistenceV10
 
 class ACSSecurityEvaluationTask:
     """
@@ -18,6 +19,7 @@ class ACSSecurityEvaluationTask:
         """
         self.logger = logging.getLogger(__name__)
         self.persistence = ACSPersistenceV12(db_path=db_path)
+        self.persistence_v10 = ACSPersistenceV10(db_path=db_path.replace('_v12', '_v10'))
 
     def run_evaluation(self, threshold: float = 0.1) -> List[Dict[str, Any]]:
         """

--- a/tests/test_acs_persistence_v10.py
+++ b/tests/test_acs_persistence_v10.py
@@ -1,0 +1,84 @@
+import pytest
+import os
+import sqlite3
+from magda_agent.safety.acs_persistence_v10 import ACSPersistenceV10
+
+@pytest.fixture
+def temp_db(tmp_path) -> str:
+    db_path = tmp_path / "test_acs_v10.db"
+    return str(db_path)
+
+def test_acs_persistence_v10_logging(temp_db: str) -> None:
+    """Tests basic logging of safety checkpoints in ACSPersistenceV10."""
+    persistence = ACSPersistenceV10(db_path=temp_db)
+    context = {"tool": "test_tool_v10", "action": "execute", "kwargs": {"param": 123}}
+
+    persistence.log_checkpoint(1, "passed", "Input validation passed on param", context)
+    persistence.log_checkpoint(2, "failed", "Unauthorized intent detected", context)
+
+    logs = persistence.get_logs()
+    assert len(logs) == 2
+
+    # Verify ID, timestamp, checkpoint_id, status, reason, workflow_context
+    # Entry 1
+    assert logs[0][0] == 1  # ID
+    assert logs[0][2] == 1  # checkpoint_id
+    assert logs[0][3] == "passed"
+    assert logs[0][4] == "Input validation passed on param"
+    assert "test_tool_v10" in logs[0][5]
+
+    # Entry 2
+    assert logs[1][0] == 2
+    assert logs[1][2] == 2
+    assert logs[1][3] == "failed"
+    assert logs[1][4] == "Unauthorized intent detected"
+    assert "test_tool_v10" in logs[1][5]
+
+def test_get_logs_filtering_v10(temp_db: str) -> None:
+    """Tests filtering of logs by checkpoint_id."""
+    persistence = ACSPersistenceV10(db_path=temp_db)
+    persistence.log_checkpoint(1, "passed", "Check 1")
+    persistence.log_checkpoint(2, "passed", "Check 2")
+    persistence.log_checkpoint(1, "failed", "Check 1 failed")
+
+    logs_cp1 = persistence.get_logs(checkpoint_id=1)
+    assert len(logs_cp1) == 2
+    assert logs_cp1[0][4] == "Check 1"
+    assert logs_cp1[1][4] == "Check 1 failed"
+
+    logs_cp2 = persistence.get_logs(checkpoint_id=2)
+    assert len(logs_cp2) == 1
+    assert logs_cp2[0][4] == "Check 2"
+
+def test_calculate_failure_rate_v10(temp_db: str) -> None:
+    """Tests the failure rate calculation logic."""
+    persistence = ACSPersistenceV10(db_path=temp_db)
+
+    # Empty DB failure rate should be 0.0
+    assert persistence.calculate_failure_rate() == 0.0
+    assert persistence.calculate_failure_rate(checkpoint_id=1) == 0.0
+
+    # Populate checkpoint 1 logs: 1 passed, 1 failed (50% failure rate)
+    persistence.log_checkpoint(1, "passed")
+    persistence.log_checkpoint(1, "failed")
+
+    # Populate checkpoint 2 logs: 1 passed (0% failure rate)
+    persistence.log_checkpoint(2, "passed")
+
+    # Calculate individual failure rates
+    assert persistence.calculate_failure_rate(checkpoint_id=1) == 0.5
+    assert persistence.calculate_failure_rate(checkpoint_id=2) == 0.0
+
+    # Calculate overall failure rate (1 failed / 3 total = ~33.33%)
+    assert pytest.approx(persistence.calculate_failure_rate(), 0.01) == 1.0 / 3.0
+
+def test_count_total_runs_v10(temp_db: str) -> None:
+    """Tests counting of total checkpoint runs."""
+    persistence = ACSPersistenceV10(db_path=temp_db)
+    assert persistence.count_total_runs() == 0
+
+    persistence.log_checkpoint(1, "passed")
+    persistence.log_checkpoint(2, "failed")
+    persistence.log_checkpoint(3, "passed")
+
+    assert persistence.count_total_runs() == 3


### PR DESCRIPTION
Implemented `ACSPersistenceV10` to log ACS safety checkpoint outcomes. Integrated this class into `ACSGuardV6` and `ACSSecurityEvaluationTask`. Tests added and all pass. Marked task as done and added three new tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [1710932598789575830](https://jules.google.com/task/1710932598789575830) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ACSPersistenceV10` SQLite-backed checkpoint logging for ACS guard
> - Adds [`acs_persistence_v10.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/574/files#diff-a7c8a91275a61dbbc594e157a788a5afcb2bf3fdd531370e9281ae252748b012) with `ACSPersistenceV10`, a new class that manages a SQLite database (`acs_persistence_v10.db`) for ACS checkpoint logs, exposing `log_checkpoint`, `get_logs`, `calculate_failure_rate`, and `count_total_runs`.
> - [`ACSGuardV6`](https://github.com/kazah4359-lgtm/Magda-agent/pull/574/files#diff-71e9c69ddc5fa3cdd6978a914b1f02cda615a18100456aaaba4cf3bfd3c13094) and [`ACSSecurityEvaluationTask`](https://github.com/kazah4359-lgtm/Magda-agent/pull/574/files#diff-04f8957439f838658be0ef26d1202eddc90555d381962002fdfd65c06cd96638) each instantiate `ACSPersistenceV10` on construction, initializing the DB and schema if absent.
> - Adds four pytest tests in [`tests/test_acs_persistence_v10.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/574/files#diff-e6bb188b54bf834d57499e392a2e143db1749226db28ec222e03a530eca7ac5c) covering logging, filtering, failure rate calculation, and run counting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15f1301.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->