### PR TITLE
feat: implement Agent Teams Evaluator V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9188,7 +9188,7 @@
     },
     {
       "id": "anthropic-agent-teams-evaluator-3d382f01",
-      "status": "todo",
+      "status": "done",
       "area": "evaluation",
       "risk": "medium",
       "title": "Agent Teams Evaluator V2",
@@ -20699,6 +20699,57 @@
       "acceptance": [
         "Negotiation protocol handles multi-turn fallback resolution.",
         "Tests mock the negotiation fallback loop."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-evaluation-v2-xyz123",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Quality Evaluation",
+      "description": "Inspired by OpenClaw RL Trend: Implement trajectory quality evaluation module to assess full multi-turn conversational rollouts against standard metrics for online learning.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_quality_v2_xyz.py",
+        "tests/test_trajectory_quality_v2_xyz.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory Quality Evaluator module is created.",
+        "Tests mock trajectory parsing and metric calculation."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v1-xyz456",
+      "status": "todo",
+      "area": "isolation",
+      "risk": "medium",
+      "title": "Claude Worktree Pruning and Resource Optimizer",
+      "description": "Inspired by Claude Agent Teams Trend: Create an optimizer to prune inactive Git worktrees and manage disk resources utilized by concurrent parallel subagents.",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_pruning_v1_xyz.py",
+        "tests/test_worktree_pruning_v1_xyz.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worktree Pruning Optimizer module is created.",
+        "Tests mock disk operations and verify correct worktrees are pruned based on TTL."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v5-xyz789",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V5",
+      "description": "Inspired by MCP Trend: Implement multi-turn capability negotiation for MCP tools, allowing dynamic capability discovery at runtime.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_capability_negotiation_v5_xyz.py",
+        "tests/test_mcp_capability_negotiation_v5_xyz.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Capability Negotiation V5 module is created.",
+        "Tests verify multi-turn negotiation and fallback."
       ]
     }
   ]

--- a/magda_agent/evaluation/agent_evaluator_v2.py
+++ b/magda_agent/evaluation/agent_evaluator_v2.py
@@ -1,0 +1,87 @@
+import json
+import logging
+from typing import Dict, Any, List, Optional
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+
+class AgentEvaluatorV2:
+    """
+    Agent Teams Evaluator V2.
+    Evaluates the output of a specific generator agent against a dynamic rubric.
+    Inspired by Claude Agent SDK Agent Teams Evaluator pattern.
+    """
+    def __init__(self, llm: LLMClient) -> None:
+        """
+        Initializes the AgentEvaluatorV2.
+
+        Args:
+            llm: The LLM client for cognitive evaluation.
+        """
+        self.llm = llm
+        self.evaluator_agent = SubAgent(
+            llm=llm,
+            system_prompt="You are an isolated Evaluator Agent responsible for strictly evaluating the output of generator agents against a dynamic rubric.",
+            use_isolation=False
+        )
+
+    async def evaluate_generator_output(
+        self,
+        task_description: str,
+        generator_output: str,
+        rubric: Dict[str, str]
+    ) -> Dict[str, Any]:
+        """
+        Evaluates the generator output against the provided rubric.
+
+        Args:
+            task_description (str): The description of the task assigned to the generator.
+            generator_output (str): The output produced by the generator agent.
+            rubric (Dict[str, str]): A mapping of criteria names to their descriptions.
+
+        Returns:
+            Dict[str, Any]: Evaluation result containing scores per criteria, overall approved status, and feedback.
+        """
+        logging.info("Starting AgentEvaluatorV2 generator output review...")
+
+        rubric_str = "\n".join([f"- {criterion}: {description}" for criterion, description in rubric.items()])
+
+        task = (
+            "You are an Evaluator Agent. Your task is to evaluate the output of a generator agent against the provided rubric.\n\n"
+            f"Original Task Description: {task_description}\n\n"
+            f"Rubric:\n{rubric_str}\n\n"
+            "Evaluate the generator output for each criterion in the rubric. Score each criterion from 1 to 10.\n"
+            "Determine if the output is approved overall (e.g. average score >= 7 and no critical failures).\n"
+            "Respond ONLY with a JSON object in this exact format:\n"
+            "{\n"
+            '  "scores": {"criterion_1": 8, "criterion_2": 6},\n'
+            '  "approved": true,\n'
+            '  "feedback": "Detailed reasoning for the evaluation"\n'
+            "}"
+        )
+
+        context = (
+            f"Generator Output:\n{generator_output}"
+        )
+
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.evaluator_agent.execute(task=task, context=context, temperature=0.1)
+
+                # Remove any markdown formatting (e.g. ```json)
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+                return evaluation
+            except json.JSONDecodeError as e:
+                logging.warning(f"JSON decoding error in evaluator attempt {attempt + 1}/{max_retries}: {e}. Retrying...")
+                if attempt == max_retries - 1:
+                    logging.error("Max retries reached for evaluate_generator_output JSON parsing.")
+                    return {"scores": {}, "approved": False, "feedback": f"Failed to parse LLM evaluation: {e}"}
+            except Exception as e:
+                logging.error(f"Failed to evaluate generator output: {e}")
+                return {"scores": {}, "approved": False, "feedback": f"Error during evaluation: {e}"}

--- a/tests/test_agent_evaluator_v2.py
+++ b/tests/test_agent_evaluator_v2.py
@@ -1,0 +1,67 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, patch
+from magda_agent.evaluation.agent_evaluator_v2 import AgentEvaluatorV2
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_llm_client():
+    return AsyncMock(spec=LLMClient)
+
+@pytest.fixture
+def agent_evaluator(mock_llm_client):
+    return AgentEvaluatorV2(llm=mock_llm_client)
+
+@pytest.mark.asyncio
+async def test_evaluate_generator_output_success(agent_evaluator):
+    agent_evaluator.evaluator_agent.execute = AsyncMock()
+    mock_json_response = '''
+    ```json
+    {
+      "scores": {"accuracy": 8, "style": 9},
+      "approved": true,
+      "feedback": "Good output"
+    }
+    ```
+    '''
+    agent_evaluator.evaluator_agent.execute.return_value = mock_json_response
+
+    task_desc = "Write a python script."
+    gen_output = "print('hello')"
+    rubric = {"accuracy": "Code runs without errors.", "style": "Code follows pep8."}
+
+    result = await agent_evaluator.evaluate_generator_output(task_desc, gen_output, rubric)
+
+    agent_evaluator.evaluator_agent.execute.assert_called_once()
+    assert result["approved"] is True
+    assert result["scores"]["accuracy"] == 8
+    assert result["feedback"] == "Good output"
+
+@pytest.mark.asyncio
+async def test_evaluate_generator_output_retry_success(agent_evaluator):
+    agent_evaluator.evaluator_agent.execute = AsyncMock()
+    invalid_json = "this is not valid json"
+    valid_json = '''{
+      "scores": {"completeness": 10},
+      "approved": true,
+      "feedback": "Perfect"
+    }'''
+    agent_evaluator.evaluator_agent.execute.side_effect = [invalid_json, valid_json]
+
+    result = await agent_evaluator.evaluate_generator_output("task", "output", {"completeness": "desc"})
+
+    assert result["approved"] is True
+    assert result["scores"]["completeness"] == 10
+    assert agent_evaluator.evaluator_agent.execute.call_count == 2
+
+@pytest.mark.asyncio
+async def test_evaluate_generator_output_retry_failure(agent_evaluator):
+    agent_evaluator.evaluator_agent.execute = AsyncMock()
+    invalid_json = "this is not valid json"
+    agent_evaluator.evaluator_agent.execute.side_effect = [invalid_json, invalid_json, invalid_json]
+
+    result = await agent_evaluator.evaluate_generator_output("task", "output", {"completeness": "desc"})
+
+    assert result["approved"] is False
+    assert "Failed to parse" in result["feedback"]
+    assert agent_evaluator.evaluator_agent.execute.call_count == 3


### PR DESCRIPTION
Inspired by Claude Agent SDK: Add a new agent node that evaluates the output of a specific generator agent against a dynamic rubric. Also updates the agent_tasks manifest with the done state and new trend-inspired tasks.

---
*PR created automatically by Jules for task [974954562701159453](https://jules.google.com/task/974954562701159453) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `AgentEvaluatorV2` to score generator outputs against a dynamic rubric
> - Adds [agent_evaluator_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/575/files#diff-de7cb851e39ac43e607ed706ff2b1c03e885de0530cb815df4badfc0d21df462) with a new `AgentEvaluatorV2` class that wraps a `SubAgent` to evaluate LLM generator output against caller-provided rubric criteria.
> - The `evaluate_generator_output` method calls the sub-agent at low temperature, strips markdown fences, parses the JSON response, and returns a dict with `scores`, `approved`, and `feedback` keys.
> - On `JSONDecodeError`, the method retries up to 3 times before returning `{'approved': False, 'feedback': ...}`.
> - Adds [tests/test_agent_evaluator_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/575/files#diff-eedea95b08471afae4a8a9551b2b521503ed97f7d0fc6ef5cea9a6e36b8b2478) covering success, retry-then-success, and full retry-failure scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cc8aa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->