### PR TITLE
feat(learning): implement OpenClaw Online RL Loop V7 for delayed rewards

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9205,7 +9205,7 @@
     },
     {
       "id": "openclaw-online-rl-dialogue-v7-af571aae",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "OpenClaw Online RL Loop v7",
@@ -20750,6 +20750,60 @@
       "acceptance": [
         "MCP Capability Negotiation V5 module is created.",
         "Tests verify multi-turn negotiation and fallback."
+      ]
+    },
+    {
+      "id": "hermes-nightly-background-skills-creator-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Nightly Background Skills Creator V1",
+      "description": "Inspired by Hermes Agent trend: Implement a background job that extracts experiences from the trajectory logs and auto-generates Python skills using an LLM during nightly scheduled downtime.",
+      "allowed_paths": [
+        "magda_agent/skills/nightly_skills_creator.py",
+        "tests/test_nightly_skills_creator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Nightly skills creator analyzes trajectory logs.",
+        "Generates minimal valid skills and registers them.",
+        "Tests confirm mock skills are extracted correctly."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-lifecycle-manager-v2",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Context Lifecycle Manager V2",
+      "description": "Inspired by MemGPT/Letta patterns (2026): Create a Plugin for separating Episodic vs Semantic memory during eviction so only episodic logs are summarized while semantic facts are preserved uncompressed.",
+      "allowed_paths": [
+        "magda_agent/memory/context_lifecycle_manager_v2.py",
+        "tests/test_context_lifecycle_manager_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context plugin accurately identifies memory types.",
+        "Semantic facts are bypassed during eviction hooks.",
+        "Tests verify correct routing of eviction blocks."
+      ]
+    },
+    {
+      "id": "mcp-to-a2a-bridge-protocol-v1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "MCP to A2A Bridge Protocol V1",
+      "description": "Inspired by MCP & A2A convergence: Implement a dynamic bridge allowing A2A sub-agents to advertise their local MCP tools seamlessly to peer discovery networks.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_a2a_bridge_v1.py",
+        "tests/test_mcp_a2a_bridge_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Bridge correctly maps MCP schemas to A2A capability signatures.",
+        "Sub-agents can invoke peer's MCP tools via A2A.",
+        "Tests confirm standard schemas convert successfully."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -300,3 +300,7 @@
 * [ ] FEATURE: Claude Agent Teams Subagent Spawner V2 (claude-agent-teams-subagent-spawner-v2)
 * [ ] FEATURE: OpenClaw Context Engine Hooks V6 (openclaw-context-engine-hooks-v6)
 * [ ] FEATURE: MCP Dynamic Capability Negotiation V7 (mcp-dynamic-capability-negotiation-v7)
+* [x] FEATURE: OpenClaw Online RL Loop v7 (openclaw-online-rl-dialogue-v7-af571aae)
+* [ ] FEATURE: Hermes Nightly Background Skills Creator V1 (hermes-nightly-background-skills-creator-v1)
+* [ ] FEATURE: OpenClaw Virtual Context Lifecycle Manager V2 (openclaw-virtual-context-lifecycle-manager-v2)
+* [ ] FEATURE: MCP to A2A Bridge Protocol V1 (mcp-to-a2a-bridge-protocol-v1)

--- a/magda_agent/learning/online_rl_loop_v7.py
+++ b/magda_agent/learning/online_rl_loop_v7.py
@@ -1,0 +1,125 @@
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+logger = logging.getLogger(__name__)
+
+class OnlineRLFeedbackLoopV7:
+    """
+    Online reinforcement learning loop v7.
+    Adjusts internal action weights based on parsed next-state user feedback.
+    Extends v6 with capabilities for delayed rewards via explicit user actions (e.g., click-throughs).
+    Trains agent simply by talking. Inspired by OpenClaw-RL.
+    """
+
+    def __init__(self, mirror_neurons: Optional[MirrorNeurons] = None) -> None:
+        """
+        Initializes the online RL loop.
+
+        Args:
+            mirror_neurons (Optional[MirrorNeurons]): MirrorNeurons instance for extracting sentiment shifts.
+        """
+        self.mirror_neurons = mirror_neurons or MirrorNeurons()
+        self.weights: Dict[str, float] = {
+            "verbosity": 1.0,
+            "directness": 1.0,
+            "empathy": 1.0
+        }
+        self.trajectory_log: List[Dict[str, Any]] = []
+        self.pending_interactions: Dict[str, Dict[str, Any]] = {}
+        logger.info("OnlineRLFeedbackLoopV7 initialized.")
+
+    async def adjust_behavior(self, current_user_message: str, last_context: str, user_id: Optional[str] = None) -> None:
+        """
+        Adjusts internal action weights based on parsed next-state user feedback.
+
+        Args:
+            current_user_message (str): The current message from the user, acting as the next-state signal.
+            last_context (str): The context of the previous state/action.
+            user_id (Optional[str]): The ID of the user.
+        """
+        # Extract sentiment shifts from user's message using MirrorNeurons
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(current_user_message)
+
+        # Log the trajectory
+        self.trajectory_log.append({
+            "state": last_context,
+            "next_state": current_user_message,
+            "reward": p_shift,
+            "user_id": user_id
+        })
+
+        # Adjust weights based on the primary reward signal (Pleasure shift)
+        self._apply_reward(p_shift)
+
+    def _apply_reward(self, reward: float) -> None:
+        """
+        Applies a reward to adjust the weights.
+
+        Args:
+            reward (float): The reward to apply.
+        """
+        if reward > 0.1:
+            self.weights["verbosity"] = min(2.0, self.weights["verbosity"] + 0.05)
+            self.weights["empathy"] = min(2.0, self.weights["empathy"] + 0.05)
+            logger.info(f"Positive feedback detected (Reward: {reward:.2f}). Increasing verbosity and empathy.")
+        elif reward < -0.1:
+            self.weights["verbosity"] = max(0.5, self.weights["verbosity"] - 0.05)
+            self.weights["directness"] = min(2.0, self.weights["directness"] + 0.05)
+            logger.info(f"Negative feedback detected (Reward: {reward:.2f}). Decreasing verbosity, increasing directness.")
+
+    def register_interaction(self, state_context: str, expected_action_type: str, user_id: Optional[str] = None) -> str:
+        """
+        Registers an interaction that may receive delayed feedback.
+
+        Args:
+            state_context (str): The context of the interaction.
+            expected_action_type (str): The type of action expected (e.g., 'click', 'purchase').
+            user_id (Optional[str]): The ID of the user.
+
+        Returns:
+            str: The unique interaction ID.
+        """
+        interaction_id = str(uuid.uuid4())
+        self.pending_interactions[interaction_id] = {
+            "state": state_context,
+            "expected_action_type": expected_action_type,
+            "user_id": user_id
+        }
+        logger.info(f"Registered interaction {interaction_id} for delayed feedback.")
+        return interaction_id
+
+    async def apply_delayed_feedback(self, interaction_id: str, reward: float) -> None:
+        """
+        Applies a delayed reward for a previously registered interaction.
+
+        Args:
+            interaction_id (str): The ID of the interaction.
+            reward (float): The reward value to apply.
+        """
+        if interaction_id not in self.pending_interactions:
+            logger.warning(f"Interaction {interaction_id} not found for delayed feedback.")
+            return
+
+        interaction = self.pending_interactions.pop(interaction_id)
+
+        # Log the delayed trajectory
+        self.trajectory_log.append({
+            "state": interaction["state"],
+            "next_state": f"Delayed Action: {interaction['expected_action_type']}",
+            "reward": reward,
+            "user_id": interaction["user_id"]
+        })
+
+        self._apply_reward(reward)
+        logger.info(f"Applied delayed reward {reward} for interaction {interaction_id}.")
+
+    def get_weights(self) -> Dict[str, float]:
+        """
+        Returns the current internal action weights.
+
+        Returns:
+            Dict[str, float]: A dictionary containing current weights.
+        """
+        return self.weights.copy()

--- a/tests/test_online_rl_loop_v7.py
+++ b/tests/test_online_rl_loop_v7.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.online_rl_loop_v7 import OnlineRLFeedbackLoopV7
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+@pytest.fixture
+def mock_mirror_neurons():
+    mock = MagicMock(spec=MirrorNeurons)
+    # Default to neutral feedback
+    mock.empathize.return_value = (0.0, 0.0, 0.0)
+    return mock
+
+@pytest.fixture
+def rl_loop(mock_mirror_neurons):
+    return OnlineRLFeedbackLoopV7(mirror_neurons=mock_mirror_neurons)
+
+@pytest.mark.asyncio
+async def test_adjust_behavior_positive(rl_loop, mock_mirror_neurons):
+    """Test weight adjustments for positive feedback."""
+    mock_mirror_neurons.empathize.return_value = (0.2, 0.1, 0.0)
+
+    await rl_loop.adjust_behavior("Great job!", "Hello, how are you?")
+
+    weights = rl_loop.get_weights()
+    assert weights["verbosity"] == 1.05
+    assert weights["empathy"] == 1.05
+    assert weights["directness"] == 1.0
+
+    assert len(rl_loop.trajectory_log) == 1
+    assert rl_loop.trajectory_log[0]["reward"] == 0.2
+
+@pytest.mark.asyncio
+async def test_adjust_behavior_negative(rl_loop, mock_mirror_neurons):
+    """Test weight adjustments for negative feedback."""
+    mock_mirror_neurons.empathize.return_value = (-0.2, 0.1, 0.0)
+
+    await rl_loop.adjust_behavior("This is terrible.", "Here is the result.")
+
+    weights = rl_loop.get_weights()
+    assert weights["verbosity"] == 0.95
+    assert weights["directness"] == 1.05
+    assert weights["empathy"] == 1.0
+
+    assert len(rl_loop.trajectory_log) == 1
+    assert rl_loop.trajectory_log[0]["reward"] == -0.2
+
+@pytest.mark.asyncio
+async def test_delayed_feedback_positive(rl_loop):
+    """Test delayed positive feedback via registered interaction."""
+    # Register an interaction
+    interaction_id = rl_loop.register_interaction(
+        state_context="Recommended link to user.",
+        expected_action_type="click",
+        user_id="user123"
+    )
+
+    assert interaction_id in rl_loop.pending_interactions
+
+    # Apply delayed positive feedback
+    await rl_loop.apply_delayed_feedback(interaction_id, reward=0.3)
+
+    # Interaction should be removed
+    assert interaction_id not in rl_loop.pending_interactions
+
+    weights = rl_loop.get_weights()
+    assert weights["verbosity"] == 1.05
+    assert weights["empathy"] == 1.05
+
+    assert len(rl_loop.trajectory_log) == 1
+    assert rl_loop.trajectory_log[0]["reward"] == 0.3
+    assert rl_loop.trajectory_log[0]["next_state"] == "Delayed Action: click"
+
+@pytest.mark.asyncio
+async def test_delayed_feedback_negative(rl_loop):
+    """Test delayed negative feedback via registered interaction."""
+    interaction_id = rl_loop.register_interaction(
+        state_context="Shown ad.",
+        expected_action_type="dismiss"
+    )
+
+    # Apply delayed negative feedback
+    await rl_loop.apply_delayed_feedback(interaction_id, reward=-0.5)
+
+    weights = rl_loop.get_weights()
+    assert weights["verbosity"] == 0.95
+    assert weights["directness"] == 1.05
+
+@pytest.mark.asyncio
+async def test_delayed_feedback_not_found(rl_loop):
+    """Test applying feedback for an unknown interaction id does not error."""
+    # Should not raise exception
+    await rl_loop.apply_delayed_feedback("invalid-id", reward=0.5)
+
+    # Weights should be unchanged
+    weights = rl_loop.get_weights()
+    assert weights["verbosity"] == 1.0
+    assert weights["empathy"] == 1.0
+    assert weights["directness"] == 1.0


### PR DESCRIPTION
This PR implements the `openclaw-online-rl-dialogue-v7-af571aae` task. It extends the online RL loop to adjust weights dynamically from delayed user actions, inspired by the OpenClaw-RL trend.

Changes:
- Implement `OnlineRLFeedbackLoopV7` which introduces `register_interaction` and `apply_delayed_feedback`.
- Add test coverage using Pytest to ensure correct behavior without live API dependency (`MagicMock` used).
- Transition the task status in `agent_tasks.json` from `todo` to `done`.
- Introduce three new tasks to `agent_tasks.json` based on the trends documentation.
- Align `backlog.md` to reflect completed and newly planned work.

---
*PR created automatically by Jules for task [16571847186850459816](https://jules.google.com/task/16571847186850459816) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add online RL feedback loop with delayed reward support to `OnlineRLFeedbackLoopV7`
> - Implements [`online_rl_loop_v7.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/576/files#diff-674da07ecea9854a579cf7410c4f28ffec86b45c22de084fe4d9d7bf8651a4f7) with a new `OnlineRLFeedbackLoopV7` class that adjusts three behavior weights (verbosity, directness, empathy) using sentiment-derived rewards from `MirrorNeurons.empathize`.
> - Supports delayed rewards via `register_interaction`, which stores interaction context under a UUID and allows feedback to be applied later via `apply_delayed_feedback`.
> - Reward thresholds (`>0.1` / `< -0.1`) determine weight update direction, with clamping to prevent unbounded drift.
> - Adds pytest async tests covering positive/negative immediate and delayed feedback, and safe handling of unknown interaction IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b274616.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->