### PR TITLE
MCP Tool Concurrency v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9222,7 +9222,7 @@
     },
     {
       "id": "mcp-action-tool-concurrency-v2-d30c8711",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Tool Concurrency v2",
@@ -20804,6 +20804,59 @@
         "Bridge correctly maps MCP schemas to A2A capability signatures.",
         "Sub-agents can invoke peer's MCP tools via A2A.",
         "Tests confirm standard schemas convert successfully."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-permissions-v1-unique",
+      "title": "MCP Dynamic Tool Permissions v1",
+      "description": "Inspired by MCP and A2A trends: Implement a dynamic tool permission system where specific Magda skills can be selectively exported or granted to remote A2A agents based on role-based access control.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_permissions_v1.py",
+        "tests/test_mcp_permissions_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Role-based access control implemented for MCP tools.",
+        "Tests verify tool execution blocking for unauthorized agents."
+      ]
+    },
+    {
+      "id": "openclaw-rl-engagement-feedback-v1-unique",
+      "title": "OpenClaw RL Engagement Feedback v1",
+      "description": "Inspired by OpenClaw RL online learning trend: Expand implicit feedback extraction to monitor user engagement metrics (like response delay or interaction length) to tune conversational brevity weights.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/learning/engagement_feedback_v1.py",
+        "tests/test_engagement_feedback_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Engagement metrics extracted from user interactions.",
+        "RL weights adjusted dynamically based on engagement trends.",
+        "Tests verify habit weight shifts."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-context-distillation-v1-unique",
+      "title": "Claude Agent Teams Context Distillation v1",
+      "description": "Inspired by Claude Agent Teams trend: Implement a context distillation mechanism where subagents compress their final outputs into dense semantic representations before returning them to the parent agent, minimizing context window explosion.",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/agents/context_distillation_v1.py",
+        "tests/test_context_distillation_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent output is distilled before returning.",
+        "Parent agent receives and parses compressed context successfully.",
+        "Tests verify compression and parsing functionality."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_concurrent_v2.py
+++ b/magda_agent/skills/mcp_concurrent_v2.py
@@ -1,0 +1,50 @@
+"""
+MCP Concurrent Execution v2
+
+This module provides support for executing multiple independent Model Context Protocol (MCP)
+action tools concurrently, inspired by OpenAI Agents SDK capabilities.
+"""
+
+import asyncio
+from typing import Any, Callable, Coroutine, Dict, List, Optional
+
+class MCPConcurrentExecutorV2:
+    """
+    Executes multiple independent MCP tools concurrently using asyncio.gather.
+    """
+    def __init__(self, max_concurrency: Optional[int] = None):
+        """
+        Initialize the executor.
+
+        Args:
+            max_concurrency: Optional maximum number of concurrent tasks. If None, unlimited.
+        """
+        self.max_concurrency = max_concurrency
+        self._semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else None
+
+    async def execute_tools(self, tools: List[Callable[..., Coroutine[Any, Any, Any]]], kwargs_list: List[Dict[str, Any]]) -> List[Any]:
+        """
+        Execute a list of MCP tools concurrently.
+
+        Args:
+            tools: List of async tool functions to execute.
+            kwargs_list: List of keyword arguments corresponding to each tool.
+
+        Returns:
+            List of results corresponding to the tools executed.
+
+        Raises:
+            ValueError: If lengths of tools and kwargs_list do not match.
+        """
+        if len(tools) != len(kwargs_list):
+            raise ValueError("Lengths of tools and kwargs_list must match.")
+
+        if self._semaphore:
+            async def _run_with_semaphore(tool: Callable, kwargs: Dict[str, Any]) -> Any:
+                async with self._semaphore:
+                    return await tool(**kwargs)
+            tasks = [_run_with_semaphore(tool, kwargs) for tool, kwargs in zip(tools, kwargs_list)]
+        else:
+            tasks = [tool(**kwargs) for tool, kwargs in zip(tools, kwargs_list)]
+
+        return await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_mcp_concurrent_v2.py
+++ b/tests/test_mcp_concurrent_v2.py
@@ -1,0 +1,75 @@
+import asyncio
+import pytest
+from magda_agent.skills.mcp_concurrent_v2 import MCPConcurrentExecutorV2
+
+@pytest.mark.asyncio
+async def test_execute_tools_concurrently():
+    """Test that multiple tools are executed concurrently and return expected results."""
+    executor = MCPConcurrentExecutorV2()
+
+    async def mock_tool(name: str, delay: float) -> str:
+        await asyncio.sleep(delay)
+        return f"result_{name}"
+
+    tools = [mock_tool, mock_tool, mock_tool]
+    kwargs_list = [
+        {"name": "A", "delay": 0.1},
+        {"name": "B", "delay": 0.2},
+        {"name": "C", "delay": 0.1}
+    ]
+
+    results = await executor.execute_tools(tools, kwargs_list)
+    assert results == ["result_A", "result_B", "result_C"]
+
+@pytest.mark.asyncio
+async def test_execute_tools_mismatched_lengths():
+    """Test that mismatched lists raise ValueError."""
+    executor = MCPConcurrentExecutorV2()
+    async def mock_tool(): pass
+
+    with pytest.raises(ValueError, match="Lengths of tools and kwargs_list must match."):
+        await executor.execute_tools([mock_tool], [])
+
+@pytest.mark.asyncio
+async def test_execute_tools_with_exceptions():
+    """Test that exceptions are caught and returned when return_exceptions=True."""
+    executor = MCPConcurrentExecutorV2()
+
+    async def mock_tool_success(val: str) -> str:
+        return val
+
+    async def mock_tool_fail() -> None:
+        raise RuntimeError("tool failed")
+
+    tools = [mock_tool_success, mock_tool_fail, mock_tool_success]
+    kwargs_list = [{"val": "1"}, {}, {"val": "3"}]
+
+    results = await executor.execute_tools(tools, kwargs_list)
+
+    assert results[0] == "1"
+    assert isinstance(results[1], RuntimeError)
+    assert str(results[1]) == "tool failed"
+    assert results[2] == "3"
+
+@pytest.mark.asyncio
+async def test_execute_tools_with_semaphore():
+    """Test that the concurrency limit is respected."""
+    executor = MCPConcurrentExecutorV2(max_concurrency=2)
+    active_tasks = 0
+    max_active_tasks = 0
+
+    async def mock_tool() -> int:
+        nonlocal active_tasks, max_active_tasks
+        active_tasks += 1
+        max_active_tasks = max(max_active_tasks, active_tasks)
+        await asyncio.sleep(0.1)
+        active_tasks -= 1
+        return 1
+
+    tools = [mock_tool] * 5
+    kwargs_list = [{}] * 5
+
+    results = await executor.execute_tools(tools, kwargs_list)
+
+    assert sum(results) == 5
+    assert max_active_tasks <= 2

--- a/update_tasks.py
+++ b/update_tasks.py
@@ -1,70 +1,71 @@
 import json
 
-tasks_file = 'agent_tasks.json'
-with open(tasks_file, 'r') as f:
+with open('agent_tasks.json', 'r') as f:
     data = json.load(f)
 
-# Update current task
 for task in data['tasks']:
-    if task['id'] == 'openclaw-online-rl-dialogue-v6-e9301cfc':
+    if task['id'] == 'mcp-action-tool-concurrency-v2-d30c8711':
         task['status'] = 'done'
 
-# Add 3 new tasks
 new_tasks = [
     {
-        "id": "claude-agent-teams-subagent-spawner-v2",
-        "status": "todo",
-        "area": "agents",
-        "risk": "medium",
-        "title": "Claude Agent Teams Subagent Spawner V2",
-        "description": "Inspired by Claude Agent Teams: Implement a robust subagent spawner for parallel tasks.",
-        "allowed_paths": [
-            "magda_agent/agents/subagent_spawner_v2.py",
-            "tests/test_subagent_spawner_v2.py",
-            "agent_tasks.json"
-        ],
-        "acceptance": [
-            "Spawner can spawn independent agents",
-            "Tests mock worktree provisioning and agent execution"
-        ]
+      "id": "mcp-dynamic-tool-permissions-v1-unique",
+      "title": "MCP Dynamic Tool Permissions v1",
+      "description": "Inspired by MCP and A2A trends: Implement a dynamic tool permission system where specific Magda skills can be selectively exported or granted to remote A2A agents based on role-based access control.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_permissions_v1.py",
+        "tests/test_mcp_permissions_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Role-based access control implemented for MCP tools.",
+        "Tests verify tool execution blocking for unauthorized agents."
+      ]
     },
     {
-        "id": "openclaw-context-engine-hooks-v6",
-        "status": "todo",
-        "area": "memory",
-        "risk": "medium",
-        "title": "OpenClaw Context Engine Hooks V6",
-        "description": "Inspired by OpenClaw trends: Implement advanced Context Engine hooks to manage token truncation dynamically.",
-        "allowed_paths": [
-            "magda_agent/memory/advanced_context_hooks_v6.py",
-            "tests/test_advanced_context_hooks_v6.py",
-            "agent_tasks.json"
-        ],
-        "acceptance": [
-            "Context engine lifecycle correctly prioritizes high-salience tokens during context truncation.",
-            "Tests verify truncation skips prioritized context items."
-        ]
+      "id": "openclaw-rl-engagement-feedback-v1-unique",
+      "title": "OpenClaw RL Engagement Feedback v1",
+      "description": "Inspired by OpenClaw RL online learning trend: Expand implicit feedback extraction to monitor user engagement metrics (like response delay or interaction length) to tune conversational brevity weights.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/learning/engagement_feedback_v1.py",
+        "tests/test_engagement_feedback_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Engagement metrics extracted from user interactions.",
+        "RL weights adjusted dynamically based on engagement trends.",
+        "Tests verify habit weight shifts."
+      ]
     },
     {
-        "id": "mcp-dynamic-capability-negotiation-v7",
-        "status": "todo",
-        "area": "integration",
-        "risk": "medium",
-        "title": "MCP Dynamic Capability Negotiation V7",
-        "description": "Inspired by MCP trends: Implement robust capability negotiation logic for tool handshakes.",
-        "allowed_paths": [
-            "magda_agent/integration/mcp_negotiation_v7.py",
-            "tests/test_mcp_negotiation_v7.py",
-            "agent_tasks.json"
-        ],
-        "acceptance": [
-            "MCP negotiation logic handles capabilities handshake.",
-            "Tests mock negotiation and verify fallback behaviors."
-        ]
+      "id": "claude-agent-teams-context-distillation-v1-unique",
+      "title": "Claude Agent Teams Context Distillation v1",
+      "description": "Inspired by Claude Agent Teams trend: Implement a context distillation mechanism where subagents compress their final outputs into dense semantic representations before returning them to the parent agent, minimizing context window explosion.",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/agents/context_distillation_v1.py",
+        "tests/test_context_distillation_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent output is distilled before returning.",
+        "Parent agent receives and parses compressed context successfully.",
+        "Tests verify compression and parsing functionality."
+      ]
     }
 ]
 
 data['tasks'].extend(new_tasks)
 
-with open(tasks_file, 'w') as f:
+with open('agent_tasks.json', 'w', encoding='utf-8') as f:
     f.write(json.dumps(data, ensure_ascii=False, indent=2) + '\n')
+
+print("Updated agent_tasks.json")


### PR DESCRIPTION
Implement runtime tool execution by executing multiple unrelated MCP actions concurrently, as inspired by MCP Compatibility and OpenAI Agents SDK trends.

- Introduced `MCPConcurrentExecutorV2` in `magda_agent/skills/mcp_concurrent_v2.py`.
- Wrote thorough unit tests covering concurrency, mismatch constraints, exception handling, and semaphore limits.
- Marked task `mcp-action-tool-concurrency-v2-d30c8711` as done in `agent_tasks.json`.
- Appended 3 new trend-inspired tasks to `agent_tasks.json` targeting multi-agent context distillation, MCP tool role-based access, and OpenClaw RL engagement metrics.

---
*PR created automatically by Jules for task [7354138123656685143](https://jules.google.com/task/7354138123656685143) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add concurrent MCP tool execution via `MCPConcurrentExecutorV2`
> - Adds [`mcp_concurrent_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/577/files#diff-cf47b738e88f95e598bf7a651c3eac237adcbece6a722e1d50b4886272b2082a) with `MCPConcurrentExecutorV2`, which runs multiple async MCP tool calls concurrently using `asyncio.gather(return_exceptions=True)`.
> - Accepts an optional `max_concurrency` argument that gates execution with an `asyncio.Semaphore`.
> - Raises `ValueError` when the `tools` and `kwargs_list` arguments differ in length; otherwise returns results in the original call order with exceptions captured as values rather than raised.
> - Four async pytest tests cover ordered results, mismatched input validation, exception capture, and semaphore enforcement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c44292.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->