### PR TITLE
A2A Delegation Resiliency

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9239,7 +9239,7 @@
     },
     {
       "id": "a2a-delegation-retry-v1-33968cf9-506d-412d-b908-b180f27ea1ae",
-      "status": "todo",
+      "status": "done",
       "area": "agents",
       "risk": "medium",
       "title": "A2A Delegation Resiliency",
@@ -20857,6 +20857,62 @@
         "Subagent output is distilled before returning.",
         "Parent agent receives and parses compressed context successfully.",
         "Tests verify compression and parsing functionality."
+      ]
+    },
+    {
+      "id": "acs-guardrail-latency-metrics-2026",
+      "status": "todo",
+      "area": "safety",
+      "risk": "low",
+      "title": "ACS Guardrail Latency Metrics Tracking",
+      "description": "Inspired by trend: ACS (Agent Control Specification) standardization for safety controls. Track the latency of each ACS guardrail layer (INPUT, EXECUTION, OUTPUT) to monitor overhead and log metrics for longitudinal tracking.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_adaptive_v1.py",
+        "magda_agent/safety/acs_guardrails.py",
+        "tests/test_acs_latency.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Latency for each ACS validation checkpoint is measured.",
+        "Metrics are persistently tracked in a longitudinal store.",
+        "Tests pass verifying latency tracking logic."
+      ]
+    },
+    {
+      "id": "openclaw-rl-negative-feedback-2026",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Negative Feedback Decay",
+      "description": "Inspired by trend: OpenClaw-RL (online reinforcement learning from user feedback). Process negative user feedback ('stop', 'wrong', 'no') to rapidly decay associated behavior weights in procedural memory.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_metrics.py",
+        "magda_agent/learning/openclaw_behavior_plugin.py",
+        "tests/test_openclaw_negative_feedback.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Negative sentiment from user replies triggers weight decay.",
+        "Behavior plugins integrate with decay mechanisms.",
+        "Pytest coverage verifies RL weight modification."
+      ]
+    },
+    {
+      "id": "mcp-capabilities-negotiation-v2-2026",
+      "status": "todo",
+      "area": "integration",
+      "risk": "low",
+      "title": "Dynamic MCP Capabilities Renegotiation",
+      "description": "Inspired by trend: MCP tools proliferation. Enhance the MCP Capability Negotiator to allow dynamic renegotiation of capabilities without tearing down the existing context session.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v6.py",
+        "tests/test_mcp_negotiation_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Negotiation supports dynamic runtime renegotiation.",
+        "Existing sessions can upgrade or downgrade capabilities safely.",
+        "Tests correctly mock and pass renegotiation scenarios."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_delegator.py
+++ b/magda_agent/integration/a2a_delegator.py
@@ -1,0 +1,97 @@
+import asyncio
+import logging
+from typing import Dict, Any, Optional
+import httpx
+
+logger = logging.getLogger(__name__)
+
+class A2ADelegator:
+    """
+    A2A Delegator that handles peer-to-peer task delegation with automatic
+    retries for transient network failures. Inspired by A2A Protocol trends.
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+        max_delay: float = 10.0,
+        timeout: float = 10.0
+    ) -> None:
+        """
+        Initializes the A2ADelegator with retry parameters.
+
+        Args:
+            max_retries (int): Maximum number of retry attempts.
+            base_delay (float): Initial delay before the first retry in seconds.
+            max_delay (float): Maximum delay for backoff in seconds.
+            timeout (float): Request timeout in seconds.
+        """
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.timeout = timeout
+
+    async def delegate_task(
+        self,
+        endpoint: str,
+        payload: Dict[str, Any],
+        headers: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Delegates a task to a peer agent asynchronously with exponential backoff retries.
+
+        Args:
+            endpoint (str): The URL endpoint of the peer agent.
+            payload (Dict[str, Any]): The task payload to send.
+            headers (Optional[Dict[str, str]]): Optional HTTP headers for the request.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing the response from the peer.
+
+        Raises:
+            httpx.HTTPError: If the HTTP request fails after all retries.
+        """
+        headers = headers or {}
+        attempt = 0
+
+        while attempt <= self.max_retries:
+            try:
+                async with httpx.AsyncClient() as client:
+                    response = await client.post(
+                        endpoint,
+                        json=payload,
+                        headers=headers,
+                        timeout=self.timeout
+                    )
+                    # Raise an exception for 4xx and 5xx status codes
+                    response.raise_for_status()
+                    return response.json()
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                # Determine if the error is transient
+                is_transient = False
+
+                if isinstance(e, httpx.RequestError):
+                    # Network errors, timeouts, etc., are usually transient
+                    is_transient = True
+                elif isinstance(e, httpx.HTTPStatusError):
+                    status = e.response.status_code
+                    # 408 Request Timeout, 429 Too Many Requests
+                    # 500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout
+                    if status in {408, 429, 500, 502, 503, 504}:
+                        is_transient = True
+
+                if not is_transient or attempt >= self.max_retries:
+                    logger.error(f"Failed to delegate task to {endpoint} after {attempt} retries: {e}")
+                    raise
+
+                attempt += 1
+                delay = min(self.base_delay * (2 ** (attempt - 1)), self.max_delay)
+                logger.warning(
+                    f"Transient error delegating to {endpoint}: {e}. "
+                    f"Retrying in {delay}s (Attempt {attempt}/{self.max_retries})"
+                )
+                await asyncio.sleep(delay)
+
+        # Fallback raise (should not reach here ideally)
+        raise httpx.RequestError("Maximum retries exceeded", request=httpx.Request("POST", endpoint))

--- a/magda_agent/integration/a2a_discovery_v3_unique.py
+++ b/magda_agent/integration/a2a_discovery_v3_unique.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Any
 import json
 import logging
 import httpx
+from magda_agent.integration.a2a_delegator import A2ADelegator
 from magda_agent.integration.a2a_cards import AgentCardV3
 
 
@@ -96,10 +97,8 @@ class A2ADiscoveryServiceV3Unique:
 
         logging.info(f"Delegating task to {peer_agent_id} at {rpc_endpoint}")
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                f"{rpc_endpoint}/delegate",
-                json=task_payload
-            )
-            response.raise_for_status()
-            return response.json()
+        delegator = A2ADelegator()
+        return await delegator.delegate_task(
+            f"{rpc_endpoint}/delegate",
+            task_payload
+        )

--- a/tests/test_a2a_delegator.py
+++ b/tests/test_a2a_delegator.py
@@ -192,3 +192,59 @@ async def test_delegate_task_http_error(peer_card_json: str) -> None:
 
     assert result["status"] == "error"
     assert "500" in result["message"]
+
+from magda_agent.integration.a2a_delegator import A2ADelegator
+import httpx
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_a2a_delegator_retry_success() -> None:
+    """
+    Tests that A2ADelegator correctly retries on transient errors and eventually succeeds.
+    """
+    delegator = A2ADelegator(max_retries=3, base_delay=0.1)
+
+    # Mock 2 failures followed by 1 success
+    route = respx.post("http://peer-retry/rpc/delegate").mock(side_effect=[
+        httpx.ConnectError("Connection failed", request=httpx.Request("POST", "http://peer-retry/rpc/delegate")),
+        Response(503, json={"error": "Service Unavailable"}),
+        Response(200, json={"status": "success", "result": "Done"})
+    ])
+
+    result = await delegator.delegate_task("http://peer-retry/rpc/delegate", {"task": "do something"})
+
+    assert result == {"status": "success", "result": "Done"}
+    assert route.call_count == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_a2a_delegator_retry_exhausted() -> None:
+    """
+    Tests that A2ADelegator raises an error after exhausting maximum retries.
+    """
+    delegator = A2ADelegator(max_retries=2, base_delay=0.1)
+
+    # Mock consistent 500 errors
+    route = respx.post("http://peer-exhaust/rpc/delegate").mock(return_value=Response(500, json={"error": "Internal Server Error"}))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await delegator.delegate_task("http://peer-exhaust/rpc/delegate", {"task": "do something"})
+
+    assert route.call_count == 3  # 1 initial + 2 retries
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_a2a_delegator_no_retry_on_400() -> None:
+    """
+    Tests that A2ADelegator does not retry on non-transient client errors like 400 Bad Request.
+    """
+    delegator = A2ADelegator(max_retries=3, base_delay=0.1)
+
+    route = respx.post("http://peer-400/rpc/delegate").mock(return_value=Response(400, json={"error": "Bad Request"}))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await delegator.delegate_task("http://peer-400/rpc/delegate", {"task": "do something"})
+
+    assert route.call_count == 1  # No retries


### PR DESCRIPTION
Implements automatic retries for A2A task delegation on transient network failures as specified in `agent_tasks.json`. It includes exponential backoff logic, unit tests, and correctly updates the tasks JSON backlog with new trend-inspired action items.

---
*PR created automatically by Jules for task [1176366128292179924](https://jules.google.com/task/1176366128292179924) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add exponential backoff retry logic to A2A task delegation
> - Introduces [`A2ADelegator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/578/files#diff-39259d11f55ff088fc4a11e1409f4d9b9d50776ab052a7f27ddfc56fc42feb26), a new class that wraps async POST delegation with configurable retry/backoff (max retries, base/max delay, timeout).
> - Retries on transient errors (`httpx.RequestError`) and HTTP status codes 408, 429, 500, 502, 503, and 504 using exponential backoff; non-transient 4xx errors (e.g. 400) raise immediately without retry.
> - Updates [`A2ADiscoveryServiceV3Unique`](https://github.com/kazah4359-lgtm/Magda-agent/pull/578/files#diff-6362dd85b433748509dac102866dda18d8dd3f730e7348d3267b33756a238cdf) to use `A2ADelegator` instead of a bare `httpx.AsyncClient` POST, replacing single-attempt delegation with retry-backed calls.
> - Behavioral Change: delegation calls that previously failed immediately on transient errors will now introduce delay before raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c38aa51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->