### PR TITLE
feat: MCP configuration hot-reload

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9256,7 +9256,7 @@
     },
     {
       "id": "mcp-config-reload-v1-5152d2ba-9858-4470-b742-f0071a62b5e7",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "low",
       "title": "MCP Configuration Hot-Reload",
@@ -20913,6 +20913,40 @@
         "MCP Negotiation supports dynamic runtime renegotiation.",
         "Existing sessions can upgrade or downgrade capabilities safely.",
         "Tests correctly mock and pass renegotiation scenarios."
+      ]
+    },
+    {
+      "id": "mcp-websocket-streaming-v1",
+      "title": "MCP WebSocket Streaming Protocol",
+      "description": "Inspired by MCP trend: Implement a WebSocket-based streaming mechanism for MCP actions to handle long-running tools and stream intermediate progress chunks.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_websocket_v1.py",
+        "tests/test_mcp_websocket_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP integration handles WebSocket connections.",
+        "Intermediate streaming updates are processed."
+      ]
+    },
+    {
+      "id": "hermes-cron-daily-reflection-v1",
+      "title": "Hermes Cron Daily Reflection Background Job",
+      "description": "Inspired by Hermes Agent trend: Create a persistent background cron job that aggregates daily episodic memories, condenses them into semantic rules, and saves them to procedural memory.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/memory/daily_reflection_cron.py",
+        "tests/test_daily_reflection_cron.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron job aggregates daily logs.",
+        "Episodic memory is condensed correctly."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_engine.py
+++ b/magda_agent/skills/mcp_engine.py
@@ -74,3 +74,26 @@ class MCPEngine:
         )
 
         logging.info(f"Dynamically wrapped MCP tool '{tool_name}' into Magda skill registry.")
+
+    def reload_mcp_tool(self, tool_def: Dict[str, Any], connection_info: Dict[str, Any], server_name: str = None) -> None:
+        """
+        Hot-reloads an existing MCP tool by dynamically re-importing its definition and connection info.
+
+        Args:
+            tool_def (Dict[str, Any]): Definition containing at least "name" and "description".
+                                       Optionally contains "inputSchema".
+            connection_info (Dict[str, Any]): Information needed to execute the remote tool.
+            server_name (str, optional): An optional server name to prefix the tool name to avoid conflicts.
+        """
+        tool_name = tool_def.get("name")
+        if not tool_name:
+            raise ValueError("MCP tool definition must include a 'name'.")
+
+        effective_name = f"{server_name}__{tool_name}" if server_name else tool_name
+
+        if self.registry.has_skill(effective_name):
+            logging.info(f"Reloading existing MCP tool '{effective_name}'.")
+        else:
+            logging.info(f"MCP tool '{effective_name}' not found. Registering as new.")
+
+        self.import_mcp_tool(tool_def, connection_info, server_name)

--- a/magda_agent/skills/mcp_registry.py
+++ b/magda_agent/skills/mcp_registry.py
@@ -107,6 +107,33 @@ class MCPRegistry:
         """
         return list(self.mcp_tools.keys())
 
+    def reload_tool(self, tool_schema: Dict[str, Any]) -> bool:
+        """
+        Dynamically hot-reloads an MCP tool configuration.
+
+        Args:
+            tool_schema (Dict[str, Any]): The updated MCP tool schema dictionary.
+
+        Returns:
+            bool: True if reloaded successfully, False otherwise.
+        """
+        if not isinstance(tool_schema, dict) or "name" not in tool_schema:
+            logging.error(f"Failed to reload MCP tool: Invalid schema {tool_schema}")
+            return False
+
+        name = tool_schema["name"]
+
+        if name in self.mcp_tools:
+            self.unload_tool(name)
+            logging.info(f"Unloaded existing MCP tool for reload: {name}")
+
+        success = self.load_tool(tool_schema)
+        if success:
+            logging.info(f"Successfully hot-reloaded MCP tool: {name}")
+        else:
+            logging.error(f"Failed to load MCP tool during reload: {name}")
+        return success
+
     def unload_tool(self, name: str) -> bool:
         """
         Dynamically unregisters and removes an MCP tool from the registry.

--- a/tests/test_mcp_hot_reload.py
+++ b/tests/test_mcp_hot_reload.py
@@ -1,0 +1,107 @@
+import pytest
+from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.skills.mcp_engine import MCPEngine
+from magda_agent.skills.mcp_client import MCPClient
+from magda_agent.skills.registry import SkillRegistry
+
+
+def test_mcp_registry_reload_tool_success():
+    """Test successful hot reload of a tool in MCPRegistry."""
+    registry = MCPRegistry()
+    initial_schema = {
+        "name": "test_tool",
+        "description": "Initial description"
+    }
+    updated_schema = {
+        "name": "test_tool",
+        "description": "Updated description"
+    }
+
+    assert registry.load_tool(initial_schema) is True
+    assert registry.get_tool("test_tool")["description"] == "Initial description"
+
+    assert registry.reload_tool(updated_schema) is True
+    assert registry.get_tool("test_tool")["description"] == "Updated description"
+
+
+def test_mcp_registry_reload_tool_new():
+    """Test hot reload handles new tools gracefully."""
+    registry = MCPRegistry()
+    schema = {
+        "name": "new_tool",
+        "description": "New description"
+    }
+
+    assert registry.reload_tool(schema) is True
+    assert registry.get_tool("new_tool")["description"] == "New description"
+
+
+def test_mcp_registry_reload_tool_invalid():
+    """Test hot reload handles invalid schemas appropriately."""
+    registry = MCPRegistry()
+    invalid_schema = {
+        "description": "Missing name"
+    }
+
+    assert registry.reload_tool(invalid_schema) is False
+
+
+def test_mcp_engine_reload_tool():
+    """Test successful hot reload of a tool in MCPEngine."""
+    skill_registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_engine = MCPEngine(skill_registry, mcp_client)
+
+    initial_def = {
+        "name": "dynamic_tool",
+        "description": "Dynamic initial"
+    }
+    updated_def = {
+        "name": "dynamic_tool",
+        "description": "Dynamic updated"
+    }
+    connection_info = {"url": "http://localhost:8000"}
+    updated_connection_info = {"url": "http://localhost:8001"}
+
+    # Import initially
+    mcp_engine.import_mcp_tool(initial_def, connection_info)
+    assert skill_registry.has_skill("dynamic_tool")
+    assert skill_registry.descriptions["dynamic_tool"] == "Dynamic initial"
+    assert mcp_client.registered_tools["dynamic_tool"] == {"url": "http://localhost:8000"}
+
+    # Reload tool
+    mcp_engine.reload_mcp_tool(updated_def, updated_connection_info)
+    assert skill_registry.has_skill("dynamic_tool")
+    assert skill_registry.descriptions["dynamic_tool"] == "Dynamic updated"
+    assert mcp_client.registered_tools["dynamic_tool"] == {"url": "http://localhost:8001"}
+
+
+def test_mcp_engine_reload_tool_with_server():
+    """Test successful hot reload of a tool in MCPEngine with a server name."""
+    skill_registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_engine = MCPEngine(skill_registry, mcp_client)
+
+    initial_def = {
+        "name": "server_tool",
+        "description": "Server initial"
+    }
+    updated_def = {
+        "name": "server_tool",
+        "description": "Server updated"
+    }
+    connection_info = {"url": "http://server:8000"}
+    updated_connection_info = {"url": "http://server:8001"}
+
+    # Import initially
+    mcp_engine.import_mcp_tool(initial_def, connection_info, server_name="test_server")
+    effective_name = "test_server__server_tool"
+    assert skill_registry.has_skill(effective_name)
+    assert skill_registry.descriptions[effective_name] == "Server initial"
+    assert mcp_client.registered_servers["test_server"] == {"url": "http://server:8000"}
+
+    # Reload tool
+    mcp_engine.reload_mcp_tool(updated_def, updated_connection_info, server_name="test_server")
+    assert skill_registry.has_skill(effective_name)
+    assert skill_registry.descriptions[effective_name] == "Server updated"
+    assert mcp_client.registered_servers["test_server"] == {"url": "http://server:8001"}


### PR DESCRIPTION
This pull request implements the MCP Configuration Hot-Reload feature as requested.

Changes:
- Implemented `reload_tool` in `magda_agent/skills/mcp_registry.py` to handle reloading MCP schemas.
- Implemented `reload_mcp_tool` in `magda_agent/skills/mcp_engine.py` to handle reloading connection definitions and dynamically re-registering tools.
- Wrote thorough unit tests in `tests/test_mcp_hot_reload.py` (which use mocks, with no real API calls).
- Updated `agent_tasks.json` to mark the current task as done and add new tasks for MCP WebSocket Streaming and Hermes Cron Daily Reflection.
- Adhered to all constraints including type hints, docstrings, validation, tests pass, and single-PR format.

---
*PR created automatically by Jules for task [1659792402617508429](https://jules.google.com/task/1659792402617508429) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP configuration hot-reload to `MCPRegistry` and `MCPEngine`
> - Adds `MCPRegistry.reload_tool` in [mcp_registry.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/579/files#diff-7bd31ee3bdddfbf36be0e971eb0b8b7c11b46ba4d33ad77f5f002b7cf127c7ee) that unloads an existing tool (if present) and re-registers it from a new schema, enabling in-place config updates without a restart.
> - Adds `MCPEngine.reload_mcp_tool` in [mcp_engine.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/579/files#diff-26572b42493a12c4ec9d8bfa23bfc751544330482e76b956aebd528de7d4c9df) as a higher-level entrypoint that validates the tool definition, resolves the effective name with an optional server prefix, and delegates to `import_mcp_tool` to update the `SkillRegistry`.
> - Adds tests in [test_mcp_hot_reload.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/579/files#diff-31f18df5af996e502fe2977547e1ca2029aec9c29d8926fbc8bb6318b996f642) covering reload of existing and new tools, invalid schema handling, and `MCPEngine` behavior with and without `server_name`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac88e23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->