### PR TITLE
feat(memory): Implement Virtual Context Pagination Plugin

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9326,7 +9326,7 @@
     },
     {
       "id": "openclaw-context-engine-virtual-context-ce0c6f0b",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Virtual Context",
@@ -21035,6 +21035,40 @@
       "acceptance": [
         "Auth requirements from MCP servers are correctly parsed and validated.",
         "Tests verify tool routing fails safely when auth is missing."
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent-isolation-v3",
+      "title": "Claude Evaluator Subagent Isolation V3",
+      "description": "Inspired by Claude Agent SDK: Implement deeper Git worktree isolation for spawned evaluator subagents, handling symlink verification and submodules to avoid context bleeding.",
+      "area": "agents",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_subagent_isolation_v3.py",
+        "tests/test_evaluator_subagent_isolation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagents run inside isolated Git worktrees mapping symlinks and submodules safely.",
+        "Tests verify clean execution and sub-repository handling."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-permissions-v2-unique",
+      "title": "MCP Dynamic Tool Permissions v2",
+      "description": "Inspired by MCP and A2A trends: Implement a dynamic tool permission system where specific Magda skills can be selectively exported or granted to remote A2A agents based on JWT or SAML role-based access control.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_permissions_v2.py",
+        "tests/test_mcp_permissions_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Role-based access control implemented for MCP tools via JWT validation.",
+        "Tests verify tool execution blocking for unauthorized agents missing scopes."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -304,3 +304,11 @@
 * [ ] FEATURE: Hermes Nightly Background Skills Creator V1 (hermes-nightly-background-skills-creator-v1)
 * [ ] FEATURE: OpenClaw Virtual Context Lifecycle Manager V2 (openclaw-virtual-context-lifecycle-manager-v2)
 * [ ] FEATURE: MCP to A2A Bridge Protocol V1 (mcp-to-a2a-bridge-protocol-v1)
+
+* [x] FEATURE: OpenClaw Online RL Loop v6 (openclaw-online-rl-dialogue-v6-e9301cfc)
+* [ ] FEATURE: Claude Agent Teams Subagent Spawner V2 (claude-agent-teams-subagent-spawner-v2)
+* [ ] FEATURE: OpenClaw Context Engine Hooks V6 (openclaw-context-engine-hooks-v6)
+* [ ] FEATURE: MCP Dynamic Capability Negotiation V7 (mcp-dynamic-capability-negotiation-v7)
+* [ ] FEATURE: Claude Evaluator Subagent Isolation V3 (claude-evaluator-subagent-isolation-v3)
+* [ ] FEATURE: MCP Dynamic Tool Permissions v2 (mcp-dynamic-tool-permissions-v2-unique)
+* [x] FEATURE: OpenClaw Context Engine Virtual Context (openclaw-context-engine-virtual-context-ce0c6f0b)

--- a/magda_agent/memory/virtual_context_pagination.py
+++ b/magda_agent/memory/virtual_context_pagination.py
@@ -1,0 +1,111 @@
+import logging
+import asyncio
+from typing import Any, Dict, List, Optional
+from magda_agent.memory.context_engine import ContextPlugin
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+
+class VirtualContextPaginationPlugin(ContextPlugin):
+    """
+    Virtual Context component inside Context Engine to handle long conversational memory
+    pagination by splitting it into pages of working memory and episodic memory.
+    """
+
+    def __init__(self, max_tokens: int = 4000) -> None:
+        """
+        Initializes the VirtualContextPaginationPlugin.
+
+        Args:
+            max_tokens: The maximum number of tokens allowed in working memory.
+        """
+        self.config: Dict[str, Any] = {}
+        self.working_memory: Optional[WorkingMemory] = None
+        self.episodic_memory: Optional[EpisodicMemory] = None
+        self.max_tokens = max_tokens
+        logging.debug(f"Initialized VirtualContextPaginationPlugin with max_tokens={max_tokens}")
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """
+        Bootstrap lifecycle hook. Initializes plugin state from config.
+
+        Args:
+            config: Configuration dictionary injected by ContextEngine.
+        """
+        self.config = config
+        self.working_memory = config.get("working_memory")
+        self.episodic_memory = config.get("episodic_memory")
+        if "max_tokens" in config:
+            self.max_tokens = config["max_tokens"]
+        logging.info("VirtualContextPaginationPlugin bootstrapped with config.")
+
+    def get_token_length(self, entries: List[MemoryEntry]) -> int:
+        """
+        Calculates a heuristic token length for the given memory entries.
+
+        Args:
+            entries: A list of MemoryEntry objects.
+
+        Returns:
+            The estimated token count.
+        """
+        total_words = sum(len(e.content.split()) for e in entries)
+        return int(total_words * 1.3)
+
+    def page_out_oldest(self, user_id: int) -> None:
+        """
+        Pages out the oldest half of working memory to episodic memory.
+        """
+        if not self.working_memory or not self.episodic_memory:
+            return
+
+        entries = self.working_memory.get_entries(user_id=user_id)
+        if not entries:
+            return
+
+        count_to_remove = max(1, len(entries) // 2)
+        to_remove = entries[:count_to_remove]
+
+        for entry in to_remove:
+            metadata = {
+                "paged_out_explicitly": True,
+                "importance": entry.importance,
+                "pad_p": entry.emotional_state.pleasure,
+                "pad_a": entry.emotional_state.arousal,
+                "pad_d": entry.emotional_state.dominance
+            }
+            if entry.tags:
+                metadata["tags"] = ",".join(entry.tags)
+
+            self.episodic_memory.store_event(
+                text=entry.content,
+                metadata=metadata,
+                user_id=user_id
+            )
+            logging.debug(f"Paged out memory entry {entry.id} for user {user_id}")
+            self.working_memory.remove(entry.id, user_id=user_id)
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """
+        Synchronous hook before context retrieval.
+        Checks if working memory size exceeds limits and paginates if necessary.
+
+        Args:
+            query: The original search query.
+            user_id: ID of the user requesting context.
+
+        Returns:
+            The original query.
+        """
+        if not self.working_memory or not self.episodic_memory:
+            return query
+
+        entries = self.working_memory.get_entries(user_id=user_id)
+        current_tokens = self.get_token_length(entries)
+
+        if current_tokens > self.max_tokens:
+            logging.info(f"VirtualContextPaginationPlugin: Working memory context length ({current_tokens} tokens) exceeds limit ({self.max_tokens} tokens). Paginating out...")
+            # Iteratively page out oldest entries until the total token count is within max_tokens
+            while self.get_token_length(self.working_memory.get_entries(user_id=user_id)) > self.max_tokens and len(self.working_memory.get_entries(user_id=user_id)) > 0:
+                self.page_out_oldest(user_id)
+
+        return query

--- a/tests/test_virtual_context_pagination.py
+++ b/tests/test_virtual_context_pagination.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.memory.virtual_context_pagination import VirtualContextPaginationPlugin
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.emotions.engine import PADState
+
+@pytest.mark.asyncio
+async def test_virtual_context_pagination_plugin_bootstrap() -> None:
+    plugin = VirtualContextPaginationPlugin(max_tokens=20)
+    wm = WorkingMemory()
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_pagination_bootstrap"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+
+    config = {
+        "working_memory": wm,
+        "episodic_memory": em,
+        "max_tokens": 50
+    }
+
+    await plugin.bootstrap(config)
+
+    assert plugin.working_memory == wm
+    assert plugin.episodic_memory == em
+    assert plugin.max_tokens == 50
+
+@pytest.mark.asyncio
+async def test_virtual_context_pagination_plugin_before_retrieval_no_pagination() -> None:
+    plugin = VirtualContextPaginationPlugin(max_tokens=50)
+    wm = WorkingMemory()
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_pagination_no"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+
+    config = {
+        "working_memory": wm,
+        "episodic_memory": em,
+    }
+    await plugin.bootstrap(config)
+
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("short context", 0.5, state, user_id=1)
+    await wm.add(e1)
+
+    assert len(wm.get_entries(user_id=1)) == 1
+
+    query = "test query"
+    result = plugin.before_retrieval(query, user_id=1)
+
+    assert result == query
+    assert len(wm.get_entries(user_id=1)) == 1
+    assert len(em.get_all_events(user_id=1)) == 0
+
+@pytest.mark.asyncio
+async def test_virtual_context_pagination_plugin_before_retrieval_with_pagination() -> None:
+    plugin = VirtualContextPaginationPlugin(max_tokens=15)
+    wm = WorkingMemory(limit=10)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_episodic_memory_pagination_yes"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+
+    config = {
+        "working_memory": wm,
+        "episodic_memory": em,
+    }
+    await plugin.bootstrap(config)
+
+    state = PADState(0, 0, 0)
+
+    # Each entry is 4 words -> ~5 tokens. Total 4 entries = ~20 tokens.
+    e1 = MemoryEntry("word1 word2 word3 word4", 0.5, state, user_id=1)
+    e2 = MemoryEntry("word5 word6 word7 word8", 0.6, state, user_id=1)
+    e3 = MemoryEntry("word9 word10 word11 word12", 0.7, state, user_id=1)
+    e4 = MemoryEntry("word13 word14 word15 word16", 0.8, state, user_id=1)
+
+    await wm.add(e1)
+    await wm.add(e2)
+    await wm.add(e3)
+    await wm.add(e4)
+
+    assert len(wm.get_entries(user_id=1)) == 4
+    # Check that initial token size is greater than max_tokens
+    assert plugin.get_token_length(wm.get_entries(user_id=1)) > 15
+
+    query = "trigger pagination"
+    result = plugin.before_retrieval(query, user_id=1)
+
+    assert result == query
+
+    # After pagination, the size should be within limit (15 tokens -> ~3 entries max)
+    entries = wm.get_entries(user_id=1)
+    # The plugin removes half of entries per loop. It had 4, half is 2.
+    # It removes e1, e2. Remaining e3, e4 (which is ~10 tokens). It stops.
+    assert len(entries) == 2
+    assert entries[0].content == "word9 word10 word11 word12"
+    assert entries[1].content == "word13 word14 word15 word16"
+
+    # Check episodic memory
+    events = em.get_all_events(user_id=1)
+    assert len(events) == 2
+    paged_contents = [event["text"] for event in events]
+    assert "word1 word2 word3 word4" in paged_contents
+    assert "word5 word6 word7 word8" in paged_contents
+    assert events[0]["metadata"]["paged_out_explicitly"] == True


### PR DESCRIPTION
Inspired by OpenClaw: Implement a Virtual Context component inside Context Engine to handle long conversational memory pagination by splitting it into pages of working memory and episodic memory.

Acceptance criteria met:
- Virtual context automatically paginates memory.
- Context Plugin Hooks handle before_retrieval pagination checks.
- Tests confirm contexts are sized within token limits.

---
*PR created automatically by Jules for task [2159276194899372074](https://jules.google.com/task/2159276194899372074) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `VirtualContextPaginationPlugin` to page out oldest working memory entries to episodic memory
> - Adds [virtual_context_pagination.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/583/files#diff-fb38d2279223e4cdb44d0e0c5f8bc31be8ceadae652846938a9fc1d95f9bb8bf), a new `ContextPlugin` that enforces a token budget on working memory before each retrieval.
> - The `before_retrieval` hook estimates token length using a 1.3× word-count heuristic and iteratively pages out the oldest half of working memory entries until under `max_tokens`.
> - Paged-out entries are written to episodic memory with metadata including importance, PAD values, and tags, then removed from working memory.
> - Adds tests covering bootstrap, no-op below the token limit, and pagination behavior above the limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e482813.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->