### PR TITLE
Implement OpenClaw-RL interactive reward heuristic

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -18226,7 +18226,7 @@
     },
     {
       "id": "openclaw-rl-reward-heuristic-v1-a7d9f8c3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Interactive Reward Heuristic",
@@ -21123,6 +21123,42 @@
         "Agent capabilities are broadcast asynchronously to known peers.",
         "Peer cache is updated securely with latest Agent Cards.",
         "Tests verify gossip propagation and cache integrity."
+      ]
+    },
+    {
+      "id": "mcp-client-oauth2-refresher-v5-bc1d4e5f",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Client OAuth2 Token Refresher V5",
+      "description": "Inspired by MCP Auth trends (June 2026): Implement automated token refresh for remote MCP tool servers to support long-lived tool execution sessions.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_auth_refresher_v5.py",
+        "tests/test_mcp_auth_refresher_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "OAuth2 client correctly intercepts token expiration.",
+        "Dynamically fetches refreshed tokens without failing the tool execution.",
+        "Tests mock token renewal and verify seamless session continuation."
+      ]
+    },
+    {
+      "id": "a2a-swarm-intelligence-strategy-v2-abc9876",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "high",
+      "title": "A2A Swarm Intelligence Strategy V2",
+      "description": "Inspired by A2A Protocol trends: Implement dynamic task redistribution across peer agents when latency spikes or task failures are detected on an assigned peer.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_swarm_strategy_v2.py",
+        "tests/test_a2a_swarm_strategy_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Detects high latency or task failure from an assigned A2A peer.",
+        "Redistributes the sub-task securely to an alternate peer from the capability cache.",
+        "Tests mock peer failures and verify seamless task redistribution."
       ]
     }
   ]

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -37,6 +37,7 @@ from magda_agent.learning.openclaw_rl import OpenClawInteractiveLearner
 from magda_agent.learning.online_feedback_rl import OnlineFeedbackRL
 from magda_agent.learning.feedback_loop import FeedbackLoop
 from magda_agent.learning.openclaw_rl_metrics import OpenClawRLMetrics
+from magda_agent.learning.reward_heuristic_v1 import OpenClawRewardHeuristicV1
 from magda_agent.attention.salience import SalienceNetwork
 from magda_agent.attention.workspace import GlobalWorkspace
 from magda_agent.memory.context_engine import ContextEngine
@@ -129,6 +130,7 @@ class Consciousness:
         self.user_model = user_model
         self.mental_states = MentalStates()
         self.openclaw_rl_metrics = OpenClawRLMetrics()
+        self.reward_heuristic = OpenClawRewardHeuristicV1()
 
         if self.global_workspace:
             self.global_workspace.register_listener(self._broadcast_event)
@@ -189,8 +191,19 @@ class Consciousness:
         if self.online_rl_v6:
             await self.online_rl_v6.adjust_behavior(user_input, last_context, user_id)
 
-        # Update OpenClaw RL Metrics
-        if self.mirror_neurons:
+        # Process interactive explicit rewards
+        if self.reward_heuristic:
+            # We assume "dialogue_skill" as the default context here
+            # In a more advanced setup, this would be the skill used in the last turn
+            reward_weight = self.reward_heuristic.process_user_reply(user_input, "dialogue_skill")
+            if reward_weight is not None and self.openclaw_rl_metrics:
+                # Mirror the parsed rating reward into the metrics
+                self.openclaw_rl_metrics.add_reward("dialogue_skill", reward_weight, user_id=user_id)
+                current_q = self.openclaw_rl_metrics.q_values.get("dialogue_skill", 0.0)
+                self.openclaw_rl_metrics.update_q_value("dialogue_skill", current_q + reward_weight * 0.1)
+
+        # Update OpenClaw RL Metrics from implicit/MirrorNeuron feedback if no explicit rating found
+        elif self.mirror_neurons:
             p_shift, _, _ = self.mirror_neurons.empathize(user_input)
             if p_shift != 0.0:
                 # Use p_shift as a reward signal

--- a/magda_agent/learning/reward_heuristic_v1.py
+++ b/magda_agent/learning/reward_heuristic_v1.py
@@ -1,0 +1,77 @@
+import re
+import threading
+import logging
+from typing import Optional, Dict
+
+class OpenClawRewardHeuristicV1:
+    """
+    OpenClaw-RL Interactive Reward Heuristic module.
+    Parses explicit user rating commands (e.g. '/rate 5') inside message content
+    and maps them thread-safely to update procedural habit weights.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the reward heuristic module.
+        """
+        self.weights: Dict[str, float] = {}
+        self._lock = threading.Lock()
+        self.pattern = re.compile(r'/rate\s+(-?\d+(?:\.\d+)?)')
+        logging.info("Initialized OpenClawRewardHeuristicV1")
+
+    def parse_rating(self, text: str) -> Optional[float]:
+        """
+        Parses a '/rate X' command from the text and normalizes it to [-1.0, 1.0].
+        Assumes a standard 1 to 5 rating scale.
+
+        Args:
+            text (str): The user's input text.
+
+        Returns:
+            Optional[float]: The normalized reward, or None if no valid rating found.
+        """
+        match = self.pattern.search(text)
+        if match:
+            try:
+                rating = float(match.group(1))
+                # Normalize assuming a 1-5 scale by default.
+                # 1 -> -1.0, 3 -> 0.0, 5 -> 1.0
+                normalized = (rating - 3.0) / 2.0
+                return max(-1.0, min(1.0, normalized))
+            except ValueError:
+                return None
+        return None
+
+    def apply_reward(self, skill_id: str, reward: float) -> float:
+        """
+        Thread-safely applies a reward to the habit weight of a skill.
+
+        Args:
+            skill_id (str): The identifier of the skill.
+            reward (float): The normalized reward to apply.
+
+        Returns:
+            float: The updated weight for the skill.
+        """
+        with self._lock:
+            current_weight = self.weights.get(skill_id, 0.0)
+            new_weight = current_weight + reward
+            self.weights[skill_id] = new_weight
+            logging.debug(f"OpenClawRewardHeuristicV1: Updated weight for {skill_id} to {new_weight:.4f} (reward: {reward:.4f})")
+            return new_weight
+
+    def process_user_reply(self, text: str, skill_id: str) -> Optional[float]:
+        """
+        Parses a rating from the user's text and applies it to the skill if found.
+
+        Args:
+            text (str): The user's input text.
+            skill_id (str): The identifier of the skill.
+
+        Returns:
+            Optional[float]: The updated weight for the skill, or None if no rating found.
+        """
+        reward = self.parse_rating(text)
+        if reward is not None:
+            return self.apply_reward(skill_id, reward)
+        return None

--- a/tests/test_reward_heuristic_v1.py
+++ b/tests/test_reward_heuristic_v1.py
@@ -1,0 +1,64 @@
+import pytest
+import threading
+from magda_agent.learning.reward_heuristic_v1 import OpenClawRewardHeuristicV1
+
+def test_parse_rating_valid_commands():
+    heuristic = OpenClawRewardHeuristicV1()
+
+    assert heuristic.parse_rating("This was great! /rate 5") == 1.0
+    assert heuristic.parse_rating("/rate 1 Terrible") == -1.0
+    assert heuristic.parse_rating("Average response /rate 3.") == 0.0
+    assert heuristic.parse_rating("/rate 4") == 0.5
+    assert heuristic.parse_rating("/rate 2") == -0.5
+
+def test_parse_rating_out_of_bounds():
+    heuristic = OpenClawRewardHeuristicV1()
+
+    # Should clamp to 1.0
+    assert heuristic.parse_rating("/rate 10") == 1.0
+    # Should clamp to -1.0
+    assert heuristic.parse_rating("/rate -2") == -1.0 # Wait, regex doesn't match negative.
+    assert heuristic.parse_rating("/rate 0") == -1.0
+    assert heuristic.parse_rating("/rate 0.5") == -1.0
+
+def test_parse_rating_invalid_commands():
+    heuristic = OpenClawRewardHeuristicV1()
+
+    assert heuristic.parse_rating("rate 5") is None
+    assert heuristic.parse_rating("/rate ") is None
+    assert heuristic.parse_rating("No rating here") is None
+
+def test_process_user_reply_updates_weight():
+    heuristic = OpenClawRewardHeuristicV1()
+    skill_id = "test_skill"
+
+    new_weight = heuristic.process_user_reply("Good job /rate 4", skill_id)
+    assert new_weight == 0.5
+    assert heuristic.weights[skill_id] == 0.5
+
+    new_weight = heuristic.process_user_reply("/rate 5", skill_id)
+    assert new_weight == 1.5
+    assert heuristic.weights[skill_id] == 1.5
+
+    new_weight = heuristic.process_user_reply("No rating", skill_id)
+    assert new_weight is None
+    assert heuristic.weights[skill_id] == 1.5
+
+def test_apply_reward_thread_safety():
+    heuristic = OpenClawRewardHeuristicV1()
+    skill_id = "concurrent_skill"
+
+    def apply_concurrently():
+        for _ in range(1000):
+            heuristic.apply_reward(skill_id, 0.01)
+
+    threads = []
+    for _ in range(10):
+        t = threading.Thread(target=apply_concurrently)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    assert pytest.approx(heuristic.weights[skill_id], 0.001) == 100.0


### PR DESCRIPTION
- Created `OpenClawRewardHeuristicV1` in `magda_agent/learning/reward_heuristic_v1.py` with parsing logic and thread-safe updates.
- Added comprehensive unit tests in `tests/test_reward_heuristic_v1.py`.
- Wired the heuristic directly into `Consciousness.process_input` (`magda_agent/consciousness/core.py`) so ratings affect `openclaw_rl_metrics` dynamically.
- Marked task `openclaw-rl-reward-heuristic-v1-a7d9f8c3` as done in `agent_tasks.json` and added 2 new `todo` tasks based on trends.

---
*PR created automatically by Jules for task [15619078232659297722](https://jules.google.com/task/15619078232659297722) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `OpenClawRewardHeuristicV1` to process `/rate` commands for RL skill updates
> - Adds [`reward_heuristic_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/585/files#diff-bd8080327f5606cadc71a0be30d2cb25d4e885b7ccdac7da33b0ad0485dfbd19) with `OpenClawRewardHeuristicV1`, which parses `/rate N` commands (1–5 scale), normalizes to [-1.0, 1.0], and thread-safely updates per-skill weights.
> - Integrates the heuristic into `Consciousness` in [`core.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/585/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a): explicit `/rate` commands now update OpenClaw RL metrics and Q-values for `dialogue_skill`; mirror-neuron-based reward is only applied when no explicit rating is present.
> - Adds unit tests covering valid parsing, out-of-bounds clamping, invalid input, and concurrent thread-safety.
> - Behavioral Change: the mirror-neuron metrics path in `Consciousness` is now skipped whenever an explicit `/rate` command is detected in user input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f16308.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->