### PR TITLE
A2A Discovery V2 Extensions

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -28,7 +28,7 @@
       "low",
       "medium"
     ],
-    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks — never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
+    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks \u2014 never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
     "max_todo_tasks": 5000
   },
   "autonomous_loop_policy": {
@@ -832,7 +832,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from user replies (next-state signal)",
-      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed — use simple reward heuristics.",
+      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed \u2014 use simple reward heuristics.",
       "allowed_paths": [
         "magda_agent/learning/**",
         "magda_agent/metacognition/**",
@@ -1050,7 +1050,7 @@
       "area": "attention",
       "risk": "medium",
       "title": "Global Workspace broadcast mechanism",
-      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic — workspace should mediate.",
+      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic \u2014 workspace should mediate.",
       "allowed_paths": [
         "magda_agent/attention/**",
         "magda_agent/consciousness/**",
@@ -1109,7 +1109,7 @@
       "status": "done",
       "area": "memory",
       "risk": "low",
-      "title": "Periodic consolidation of episodic → semantic memory",
+      "title": "Periodic consolidation of episodic \u2192 semantic memory",
       "description": "Subconsciousness periodically reviews episodic memories, extracts stable facts, and promotes them to semantic memory. Decay irrelevant episodes. Inspired by sleep consolidation in neuroscience.",
       "allowed_paths": [
         "magda_agent/subconsciousness/**",
@@ -1150,7 +1150,7 @@
       "area": "metacognition",
       "risk": "low",
       "title": "Confidence calibration for responses",
-      "description": "Agent should estimate confidence in its responses. Low confidence → add caveats, suggest verification. High confidence → direct answer. Track calibration accuracy over time.",
+      "description": "Agent should estimate confidence in its responses. Low confidence \u2192 add caveats, suggest verification. High confidence \u2192 direct answer. Track calibration accuracy over time.",
       "allowed_paths": [
         "magda_agent/metacognition/**",
         "magda_agent/consciousness/**",
@@ -1851,7 +1851,7 @@
       "area": "UI",
       "risk": "low",
       "title": "Context Engine Canvas Visualization",
-      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent’s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
+      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent\u2019s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
       "allowed_paths": [
         "magda_agent/memory/canvas.py",
         "tests/test_canvas*.py",
@@ -2996,7 +2996,7 @@
       "area": "operations",
       "risk": "medium",
       "title": "Scheduled operations cron-like tasks",
-      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement cron-like scheduled tasks that the agent can run autonomously.",
+      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement cron-like scheduled tasks that the agent can run autonomously.",
       "allowed_paths": [
         "magda_agent/operations/cron.py",
         "tests/test_cron.py",
@@ -3015,7 +3015,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Skill marketplace compatibility",
-      "description": "Inspired by trend: Skill marketplace — совместимость с agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
+      "description": "Inspired by trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
       "allowed_paths": [
         "magda_agent/integration/skill_marketplace.py",
         "tests/test_skill_marketplace_integration.py",
@@ -3070,7 +3070,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine plugin architecture",
-      "description": "Inspired by trend 'Context Engine — plugin-архитектура для управления контекстом': Implement a plugin interface with lifecycle hooks for managing working memory context.",
+      "description": "Inspired by trend 'Context Engine \u2014 plugin-\u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 \u0434\u043b\u044f \u0443\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u044f \u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442\u043e\u043c': Implement a plugin interface with lifecycle hooks for managing working memory context.",
       "allowed_paths": [
         "magda_agent/memory/context_engine.py",
         "tests/test_context_engine*.py",
@@ -3088,7 +3088,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams sub-agents spawning",
-      "description": "Inspired by trend 'Agent Teams — порождение sub-agents для параллельных задач': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
+      "description": "Inspired by trend 'Agent Teams \u2014 \u043f\u043e\u0440\u043e\u0436\u0434\u0435\u043d\u0438\u0435 sub-agents \u0434\u043b\u044f \u043f\u0430\u0440\u0430\u043b\u043b\u0435\u043b\u044c\u043d\u044b\u0445 \u0437\u0430\u0434\u0430\u0447': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
       "allowed_paths": [
         "magda_agent/agents/teams.py",
         "tests/test_agent_teams*.py",
@@ -3106,7 +3106,7 @@
       "area": "gateway",
       "risk": "low",
       "title": "Cross-platform reach across channels",
-      "description": "Inspired by trend 'Cross-platform reach — один агент, много каналов': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
+      "description": "Inspired by trend 'Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
       "allowed_paths": [
         "magda_agent/gateway/channels.py",
         "tests/test_gateway_channels*.py",
@@ -3141,7 +3141,7 @@
       "area": "gateway",
       "risk": "medium",
       "title": "Canvas live visualization support",
-      "description": "Inspired by trend: OpenClaw - Canvas для live визуализации. Add visualization capabilities and state streaming to the context engine.",
+      "description": "Inspired by trend: OpenClaw - Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Add visualization capabilities and state streaming to the context engine.",
       "allowed_paths": [
         "magda_agent/gateway/canvas.py",
         "tests/test_canvas*.py",
@@ -3292,7 +3292,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Hermes agentskills.io export compatibility",
-      "description": "Inspired by Hermes Agent trend: Skill marketplace — совместимость с agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
+      "description": "Inspired by Hermes Agent trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
       "allowed_paths": [
         "magda_agent/skills/agentskills_export.py",
         "tests/test_agentskills_export.py",
@@ -3397,7 +3397,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Hermes Persistent Memory",
-      "description": "Inspired by Hermes Agent trend: Persistent memory: чем дольше работает, тем лучше знает пользователя. Implement a persistent user profile memory.",
+      "description": "Inspired by Hermes Agent trend: Persistent memory: \u0447\u0435\u043c \u0434\u043e\u043b\u044c\u0448\u0435 \u0440\u0430\u0431\u043e\u0442\u0430\u0435\u0442, \u0442\u0435\u043c \u043b\u0443\u0447\u0448\u0435 \u0437\u043d\u0430\u0435\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement a persistent user profile memory.",
       "allowed_paths": [
         "magda_agent/memory/hermes_persistent.py",
         "tests/test_hermes_persistent.py",
@@ -3414,7 +3414,7 @@
       "area": "architecture",
       "risk": "high",
       "title": "OpenClaw Context Engine Lifecycle Hooks",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Implement lifecycle hooks for plugins.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Implement lifecycle hooks for plugins.",
       "allowed_paths": [
         "magda_agent/architecture/context_hooks.py",
         "tests/test_context_hooks.py",
@@ -3432,7 +3432,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "A2A Discovery via Agent Cards",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
       "allowed_paths": [
         "magda_agent/architecture/a2a_discovery.py",
         "tests/test_a2a_discovery*.py",
@@ -3468,7 +3468,7 @@
       "area": "ui",
       "risk": "medium",
       "title": "OpenClaw Canvas Live Visualization",
-      "description": "Inspired by trend: OpenClaw Canvas для live визуализации. Implement an interface for live visualization of the agent's internal state and working memory.",
+      "description": "Inspired by trend: OpenClaw Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement an interface for live visualization of the agent's internal state and working memory.",
       "allowed_paths": [
         "magda_agent/ui/canvas.py",
         "tests/test_canvas*.py",
@@ -3486,7 +3486,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams Subagent Spawning",
-      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
+      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
       "allowed_paths": [
         "magda_agent/multi_agent/team_spawner.py",
         "tests/test_team_spawner*.py",
@@ -3521,7 +3521,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Lifecycle Plugins",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
       "allowed_paths": [
         "magda_agent/memory/context_engine_lifecycle.py",
         "tests/test_context_engine_lifecycle.py",
@@ -3555,7 +3555,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach implementation",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
       "allowed_paths": [
         "magda_agent/integration/cross_platform.py",
         "tests/test_cross_platform.py",
@@ -3572,7 +3572,7 @@
       "area": "evaluation",
       "risk": "low",
       "title": "Quality metrics longitudinal tracking",
-      "description": "Inspired by trend: Quality metrics — longitudinal tracking, не одноразовый pytest. Implement longitudinal tracking of code quality metrics.",
+      "description": "Inspired by trend: Quality metrics \u2014 longitudinal tracking, \u043d\u0435 \u043e\u0434\u043d\u043e\u0440\u0430\u0437\u043e\u0432\u044b\u0439 pytest. Implement longitudinal tracking of code quality metrics.",
       "allowed_paths": [
         "magda_agent/evaluation/longitudinal_metrics.py",
         "tests/test_longitudinal_metrics.py",
@@ -3589,7 +3589,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Exporter v6",
-      "description": "Inspired by the MCP-совместимость trend: Magda должна уметь экспортировать skills как MCP tools.",
+      "description": "Inspired by the MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c trend: Magda \u0434\u043e\u043b\u0436\u043d\u0430 \u0443\u043c\u0435\u0442\u044c \u044d\u043a\u0441\u043f\u043e\u0440\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c skills \u043a\u0430\u043a MCP tools.",
       "allowed_paths": [
         "magda_agent/integration/mcp_exporter.py",
         "tests/test_mcp_exporter*.py",
@@ -3606,7 +3606,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A delegation v6",
-      "description": "Inspired by trend: A2A поддержка — возможность делегировать задачи другим агентам.",
+      "description": "Inspired by trend: A2A \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0430 \u2014 \u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e\u0441\u0442\u044c \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0437\u0430\u0434\u0430\u0447\u0438 \u0434\u0440\u0443\u0433\u0438\u043c \u0430\u0433\u0435\u043d\u0442\u0430\u043c.",
       "allowed_paths": [
         "magda_agent/multi_agent/a2a_delegator.py",
         "tests/test_a2a_delegator*.py",
@@ -3623,7 +3623,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning v6",
-      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections).",
+      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections).",
       "allowed_paths": [
         "magda_agent/learning/online_learning.py",
         "tests/test_online_learning*.py",
@@ -3691,7 +3691,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Creation from Experience",
-      "description": "Inspired by Hermes Agent trend: Self-improving agent с built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
+      "description": "Inspired by Hermes Agent trend: Self-improving agent \u0441 built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
       "allowed_paths": [
         "magda_agent/skills/skill_generator.py",
         "tests/test_skill_generator*.py",
@@ -3709,7 +3709,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Triad Architecture",
-      "description": "Inspired by Claude Agent SDK trend: Трёхагентная архитектура Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
+      "description": "Inspired by Claude Agent SDK trend: \u0422\u0440\u0451\u0445\u0430\u0433\u0435\u043d\u0442\u043d\u0430\u044f \u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
       "allowed_paths": [
         "magda_agent/agents/triad_coordinator.py",
         "tests/test_triad_coordinator*.py",
@@ -4055,7 +4055,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "MCP JSON-RPC Interface",
-      "description": "Inspired by trend: MCP-совместимость (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
+      "description": "Inspired by trend: MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
       "allowed_paths": [
         "magda_agent/integration/mcp_server.py",
         "tests/test_mcp_server*.py",
@@ -4072,7 +4072,7 @@
       "area": "evaluation",
       "risk": "medium",
       "title": "AgentBench Multi-Domain Evaluation",
-      "description": "Inspired by trend: Evaluation (бенчмарки) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
+      "description": "Inspired by trend: Evaluation (\u0431\u0435\u043d\u0447\u043c\u0430\u0440\u043a\u0438) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
       "allowed_paths": [
         "magda_agent/evaluation/agentbench.py",
         "tests/test_agentbench*.py",
@@ -4105,7 +4105,7 @@
       "area": "visualization",
       "risk": "low",
       "title": "Canvas Live Visualization API v2",
-      "description": "Inspired by OpenClaw trend: Canvas для live визуализации. Implement API endpoints for the canvas streaming.",
+      "description": "Inspired by OpenClaw trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement API endpoints for the canvas streaming.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_api_v2.py",
         "tests/test_canvas_api_v2.py",
@@ -4137,7 +4137,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "Scheduled operations: daily reports",
-      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement scheduled daily reports capability.",
+      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement scheduled daily reports capability.",
       "allowed_paths": [
         "magda_agent/scheduler/cron.py",
         "tests/test_cron*.py",
@@ -4154,7 +4154,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach: Telegram channel v2",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Add improved Telegram messenger integration.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Add improved Telegram messenger integration.",
       "allowed_paths": [
         "magda_agent/channels/telegram.py",
         "tests/test_telegram*.py",
@@ -4288,7 +4288,7 @@
       "area": "execution",
       "risk": "high",
       "title": "Agent Teams Worktree Isolation",
-      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
+      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
       "allowed_paths": [
         "magda_agent/agents/subagent.py",
         "magda_agent/isolation/git_worktree.py",
@@ -4307,7 +4307,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Control Checkpoints Interface",
-      "description": "Inspired by trend: ACS (Agent Control Specification) — 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
+      "description": "Inspired by trend: ACS (Agent Control Specification) \u2014 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
       "allowed_paths": [
         "magda_agent/safety/acs_guard.py",
         "tests/test_acs_guard.py",
@@ -4379,7 +4379,7 @@
       "area": "channels",
       "risk": "medium",
       "title": "Cross-platform reach channels",
-      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Expand channel adapters for more platforms.",
+      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Expand channel adapters for more platforms.",
       "allowed_paths": [
         "magda_agent/channels/reach_v2.py",
         "tests/test_reach_v2.py",
@@ -4396,7 +4396,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from dialogue v3",
-      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections). Implement immediate context integration.",
+      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections). Implement immediate context integration.",
       "allowed_paths": [
         "magda_agent/learning/dialogue_v3.py",
         "tests/test_dialogue_v3.py",
@@ -4532,7 +4532,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Agent Discovery via Cards v2",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Add discovery components to the network layer.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Add discovery components to the network layer.",
       "allowed_paths": [
         "magda_agent/integration/a2a_discovery_v2.py",
         "tests/test_a2a_discovery_v2.py",
@@ -5542,7 +5542,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT Virtual Context Management v1",
-      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> стандарт)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
+      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
       "allowed_paths": [
         "magda_agent/memory/virtual_context.py",
         "tests/test_virtual_context.py",
@@ -5560,7 +5560,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Agent Control Specification Checkpoints v3",
-      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) — 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
+      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) \u2014 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
       "allowed_paths": [
         "magda_agent/safety/acs_checkpoints_v3.py",
         "tests/test_acs_checkpoints_v3.py",
@@ -8693,7 +8693,7 @@
       "area": "planning",
       "risk": "medium",
       "title": "Claude Agent Teams Dependency Graph",
-      "description": "Inspired by Claude Agent SDK trend: Task system с dependency graphs. Update planning to utilize dependency graphs.",
+      "description": "Inspired by Claude Agent SDK trend: Task system \u0441 dependency graphs. Update planning to utilize dependency graphs.",
       "allowed_paths": [
         "magda_agent/planning/dependency_graph.py",
         "tests/test_dependency_graph.py",
@@ -8846,7 +8846,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging",
-      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
+      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger.py",
         "tests/test_canvas_logger.py",
@@ -8985,7 +8985,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging V3",
-      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
+      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger_v3.py",
         "tests/test_canvas_logger_v3.py",
@@ -9379,7 +9379,7 @@
     },
     {
       "id": "a2a-discovery-enhancement-1195dd93-bfaf-469e-a684-dbda3648a34c",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Discovery Extensions",
@@ -11865,7 +11865,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery Agent Cards v4",
-      "description": "Inspired by trend: Agent discovery через Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
+      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -12117,7 +12117,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Protocol Discovery Mesh",
-      "description": "Inspired by trend: Agent discovery через Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
+      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -19329,7 +19329,7 @@
     {
       "id": "agentskills-io-export-v1",
       "title": "Hermes agentskills.io Format Exporter v1",
-      "description": "Inspired by Hermes Agent trend 'Открытый стандарт skills: agentskills.io', implement an exporter to convert internal magda skills to the agentskills.io open standard.",
+      "description": "Inspired by Hermes Agent trend '\u041e\u0442\u043a\u0440\u044b\u0442\u044b\u0439 \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442 skills: agentskills.io', implement an exporter to convert internal magda skills to the agentskills.io open standard.",
       "status": "todo",
       "area": "skills",
       "risk": "medium",
@@ -19346,7 +19346,7 @@
     {
       "id": "claude-agent-teams-subagent-spawner-v1",
       "title": "Claude Agent Teams Subagent Spawner",
-      "description": "Inspired by Claude Agent SDK trend 'Agent Teams: multi-agent с git worktree isolation', implement a subagent spawner for parallel tasks.",
+      "description": "Inspired by Claude Agent SDK trend 'Agent Teams: multi-agent \u0441 git worktree isolation', implement a subagent spawner for parallel tasks.",
       "status": "todo",
       "area": "agents",
       "risk": "medium",

--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -28,7 +28,7 @@
       "low",
       "medium"
     ],
-    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks \u2014 never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
+    "instruction": "Add new todo tasks ONLY when the pool falls below minimum_todo_tasks. Before adding, scan existing done and blocked tasks — never recreate implemented features. Prefer stabilization, wiring, and test coverage over new trend modules. Read docs/trends.md for inspiration when replenishment is needed.",
     "max_todo_tasks": 5000
   },
   "autonomous_loop_policy": {
@@ -832,7 +832,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from user replies (next-state signal)",
-      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed \u2014 use simple reward heuristics.",
+      "description": "Inspired by OpenClaw-RL: treat each user reply as a next-state signal. Positive signals reinforce approach, negative signals trigger reflection and adjustment. No external RL infra needed — use simple reward heuristics.",
       "allowed_paths": [
         "magda_agent/learning/**",
         "magda_agent/metacognition/**",
@@ -1050,7 +1050,7 @@
       "area": "attention",
       "risk": "medium",
       "title": "Global Workspace broadcast mechanism",
-      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic \u2014 workspace should mediate.",
+      "description": "When workspace selects a focused event, broadcast context to all subsystems (memory, planner, emotions). Currently process_input is monolithic — workspace should mediate.",
       "allowed_paths": [
         "magda_agent/attention/**",
         "magda_agent/consciousness/**",
@@ -1109,7 +1109,7 @@
       "status": "done",
       "area": "memory",
       "risk": "low",
-      "title": "Periodic consolidation of episodic \u2192 semantic memory",
+      "title": "Periodic consolidation of episodic → semantic memory",
       "description": "Subconsciousness periodically reviews episodic memories, extracts stable facts, and promotes them to semantic memory. Decay irrelevant episodes. Inspired by sleep consolidation in neuroscience.",
       "allowed_paths": [
         "magda_agent/subconsciousness/**",
@@ -1150,7 +1150,7 @@
       "area": "metacognition",
       "risk": "low",
       "title": "Confidence calibration for responses",
-      "description": "Agent should estimate confidence in its responses. Low confidence \u2192 add caveats, suggest verification. High confidence \u2192 direct answer. Track calibration accuracy over time.",
+      "description": "Agent should estimate confidence in its responses. Low confidence → add caveats, suggest verification. High confidence → direct answer. Track calibration accuracy over time.",
       "allowed_paths": [
         "magda_agent/metacognition/**",
         "magda_agent/consciousness/**",
@@ -1851,7 +1851,7 @@
       "area": "UI",
       "risk": "low",
       "title": "Context Engine Canvas Visualization",
-      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent\u2019s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
+      "description": "Inspired by OpenClaw Canvas trend. Create a live visualization adapter for the Context Engine to broadcast the agent’s working memory and current focused tasks to an external Canvas client via websocket. [blocked: duplicate of done task 'context-engine-plugin']",
       "allowed_paths": [
         "magda_agent/memory/canvas.py",
         "tests/test_canvas*.py",
@@ -2996,7 +2996,7 @@
       "area": "operations",
       "risk": "medium",
       "title": "Scheduled operations cron-like tasks",
-      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement cron-like scheduled tasks that the agent can run autonomously.",
+      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement cron-like scheduled tasks that the agent can run autonomously.",
       "allowed_paths": [
         "magda_agent/operations/cron.py",
         "tests/test_cron.py",
@@ -3015,7 +3015,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Skill marketplace compatibility",
-      "description": "Inspired by trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
+      "description": "Inspired by trend: Skill marketplace — совместимость с agentskills.io. Ensure skills are compatible with standard skill marketplace formats.",
       "allowed_paths": [
         "magda_agent/integration/skill_marketplace.py",
         "tests/test_skill_marketplace_integration.py",
@@ -3070,7 +3070,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine plugin architecture",
-      "description": "Inspired by trend 'Context Engine \u2014 plugin-\u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 \u0434\u043b\u044f \u0443\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u044f \u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442\u043e\u043c': Implement a plugin interface with lifecycle hooks for managing working memory context.",
+      "description": "Inspired by trend 'Context Engine — plugin-архитектура для управления контекстом': Implement a plugin interface with lifecycle hooks for managing working memory context.",
       "allowed_paths": [
         "magda_agent/memory/context_engine.py",
         "tests/test_context_engine*.py",
@@ -3088,7 +3088,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams sub-agents spawning",
-      "description": "Inspired by trend 'Agent Teams \u2014 \u043f\u043e\u0440\u043e\u0436\u0434\u0435\u043d\u0438\u0435 sub-agents \u0434\u043b\u044f \u043f\u0430\u0440\u0430\u043b\u043b\u0435\u043b\u044c\u043d\u044b\u0445 \u0437\u0430\u0434\u0430\u0447': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
+      "description": "Inspired by trend 'Agent Teams — порождение sub-agents для параллельных задач': Enable the Planner/Manager to spawn isolated sub-agents for parallel task execution.",
       "allowed_paths": [
         "magda_agent/agents/teams.py",
         "tests/test_agent_teams*.py",
@@ -3106,7 +3106,7 @@
       "area": "gateway",
       "risk": "low",
       "title": "Cross-platform reach across channels",
-      "description": "Inspired by trend 'Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
+      "description": "Inspired by trend 'Cross-platform reach — один агент, много каналов': Expand the Multi-channel Gateway to support more platforms beyond Telegram.",
       "allowed_paths": [
         "magda_agent/gateway/channels.py",
         "tests/test_gateway_channels*.py",
@@ -3141,7 +3141,7 @@
       "area": "gateway",
       "risk": "medium",
       "title": "Canvas live visualization support",
-      "description": "Inspired by trend: OpenClaw - Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Add visualization capabilities and state streaming to the context engine.",
+      "description": "Inspired by trend: OpenClaw - Canvas для live визуализации. Add visualization capabilities and state streaming to the context engine.",
       "allowed_paths": [
         "magda_agent/gateway/canvas.py",
         "tests/test_canvas*.py",
@@ -3292,7 +3292,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Hermes agentskills.io export compatibility",
-      "description": "Inspired by Hermes Agent trend: Skill marketplace \u2014 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c \u0441 agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
+      "description": "Inspired by Hermes Agent trend: Skill marketplace — совместимость с agentskills.io. Ensure magda can export skills using the open agentskills.io standard.",
       "allowed_paths": [
         "magda_agent/skills/agentskills_export.py",
         "tests/test_agentskills_export.py",
@@ -3397,7 +3397,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "Hermes Persistent Memory",
-      "description": "Inspired by Hermes Agent trend: Persistent memory: \u0447\u0435\u043c \u0434\u043e\u043b\u044c\u0448\u0435 \u0440\u0430\u0431\u043e\u0442\u0430\u0435\u0442, \u0442\u0435\u043c \u043b\u0443\u0447\u0448\u0435 \u0437\u043d\u0430\u0435\u0442 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement a persistent user profile memory.",
+      "description": "Inspired by Hermes Agent trend: Persistent memory: чем дольше работает, тем лучше знает пользователя. Implement a persistent user profile memory.",
       "allowed_paths": [
         "magda_agent/memory/hermes_persistent.py",
         "tests/test_hermes_persistent.py",
@@ -3414,7 +3414,7 @@
       "area": "architecture",
       "risk": "high",
       "title": "OpenClaw Context Engine Lifecycle Hooks",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Implement lifecycle hooks for plugins.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Implement lifecycle hooks for plugins.",
       "allowed_paths": [
         "magda_agent/architecture/context_hooks.py",
         "tests/test_context_hooks.py",
@@ -3432,7 +3432,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "A2A Discovery via Agent Cards",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Implement a discovery service that locates and connects to other agents using standard Agent Cards.",
       "allowed_paths": [
         "magda_agent/architecture/a2a_discovery.py",
         "tests/test_a2a_discovery*.py",
@@ -3468,7 +3468,7 @@
       "area": "ui",
       "risk": "medium",
       "title": "OpenClaw Canvas Live Visualization",
-      "description": "Inspired by trend: OpenClaw Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement an interface for live visualization of the agent's internal state and working memory.",
+      "description": "Inspired by trend: OpenClaw Canvas для live визуализации. Implement an interface for live visualization of the agent's internal state and working memory.",
       "allowed_paths": [
         "magda_agent/ui/canvas.py",
         "tests/test_canvas*.py",
@@ -3486,7 +3486,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Agent Teams Subagent Spawning",
-      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
+      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation / Subagent spawning. Implement a dedicated service to dynamically spawn, monitor, and clean up task-specific subagents.",
       "allowed_paths": [
         "magda_agent/multi_agent/team_spawner.py",
         "tests/test_team_spawner*.py",
@@ -3521,7 +3521,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "OpenClaw Context Engine Lifecycle Plugins",
-      "description": "Inspired by OpenClaw trend: Context Engine plugin interface \u0441 lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
+      "description": "Inspired by OpenClaw trend: Context Engine plugin interface с lifecycle hooks. Enhance Context Engine with pre_retrieval and post_retrieval hooks.",
       "allowed_paths": [
         "magda_agent/memory/context_engine_lifecycle.py",
         "tests/test_context_engine_lifecycle.py",
@@ -3555,7 +3555,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach implementation",
-      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Implement cross-platform capabilities to reach across multiple chat platforms simultaneously.",
       "allowed_paths": [
         "magda_agent/integration/cross_platform.py",
         "tests/test_cross_platform.py",
@@ -3572,7 +3572,7 @@
       "area": "evaluation",
       "risk": "low",
       "title": "Quality metrics longitudinal tracking",
-      "description": "Inspired by trend: Quality metrics \u2014 longitudinal tracking, \u043d\u0435 \u043e\u0434\u043d\u043e\u0440\u0430\u0437\u043e\u0432\u044b\u0439 pytest. Implement longitudinal tracking of code quality metrics.",
+      "description": "Inspired by trend: Quality metrics — longitudinal tracking, не одноразовый pytest. Implement longitudinal tracking of code quality metrics.",
       "allowed_paths": [
         "magda_agent/evaluation/longitudinal_metrics.py",
         "tests/test_longitudinal_metrics.py",
@@ -3589,7 +3589,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Exporter v6",
-      "description": "Inspired by the MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c trend: Magda \u0434\u043e\u043b\u0436\u043d\u0430 \u0443\u043c\u0435\u0442\u044c \u044d\u043a\u0441\u043f\u043e\u0440\u0442\u0438\u0440\u043e\u0432\u0430\u0442\u044c skills \u043a\u0430\u043a MCP tools.",
+      "description": "Inspired by the MCP-совместимость trend: Magda должна уметь экспортировать skills как MCP tools.",
       "allowed_paths": [
         "magda_agent/integration/mcp_exporter.py",
         "tests/test_mcp_exporter*.py",
@@ -3606,7 +3606,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A delegation v6",
-      "description": "Inspired by trend: A2A \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0430 \u2014 \u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e\u0441\u0442\u044c \u0434\u0435\u043b\u0435\u0433\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0437\u0430\u0434\u0430\u0447\u0438 \u0434\u0440\u0443\u0433\u0438\u043c \u0430\u0433\u0435\u043d\u0442\u0430\u043c.",
+      "description": "Inspired by trend: A2A поддержка — возможность делегировать задачи другим агентам.",
       "allowed_paths": [
         "magda_agent/multi_agent/a2a_delegator.py",
         "tests/test_a2a_delegator*.py",
@@ -3623,7 +3623,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning v6",
-      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections).",
+      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections).",
       "allowed_paths": [
         "magda_agent/learning/online_learning.py",
         "tests/test_online_learning*.py",
@@ -3691,7 +3691,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "Hermes Skill Creation from Experience",
-      "description": "Inspired by Hermes Agent trend: Self-improving agent \u0441 built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
+      "description": "Inspired by Hermes Agent trend: Self-improving agent с built-in learning loop that creates skills from experience. Implement a service that dynamically synthesizes executable python scripts for new agent skills based on repeated user queries.",
       "allowed_paths": [
         "magda_agent/skills/skill_generator.py",
         "tests/test_skill_generator*.py",
@@ -3709,7 +3709,7 @@
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude Triad Architecture",
-      "description": "Inspired by Claude Agent SDK trend: \u0422\u0440\u0451\u0445\u0430\u0433\u0435\u043d\u0442\u043d\u0430\u044f \u0430\u0440\u0445\u0438\u0442\u0435\u043a\u0442\u0443\u0440\u0430 Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
+      "description": "Inspired by Claude Agent SDK trend: Трёхагентная архитектура Planner, Generator, Evaluator. Refactor the main autonomous loop to instantiate a distinct PlannerAgent, GeneratorAgent, and EvaluatorAgent working in sequence.",
       "allowed_paths": [
         "magda_agent/agents/triad_coordinator.py",
         "tests/test_triad_coordinator*.py",
@@ -4055,7 +4055,7 @@
       "area": "skills",
       "risk": "medium",
       "title": "MCP JSON-RPC Interface",
-      "description": "Inspired by trend: MCP-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u043e\u0441\u0442\u044c (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
+      "description": "Inspired by trend: MCP-совместимость (JSON-RPC client-server interface). Implement an MCP JSON-RPC protocol server interface.",
       "allowed_paths": [
         "magda_agent/integration/mcp_server.py",
         "tests/test_mcp_server*.py",
@@ -4072,7 +4072,7 @@
       "area": "evaluation",
       "risk": "medium",
       "title": "AgentBench Multi-Domain Evaluation",
-      "description": "Inspired by trend: Evaluation (\u0431\u0435\u043d\u0447\u043c\u0430\u0440\u043a\u0438) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
+      "description": "Inspired by trend: Evaluation (бенчмарки) - AgentBench: multi-domain. Integrate AgentBench framework to test Magda's performance.",
       "allowed_paths": [
         "magda_agent/evaluation/agentbench.py",
         "tests/test_agentbench*.py",
@@ -4105,7 +4105,7 @@
       "area": "visualization",
       "risk": "low",
       "title": "Canvas Live Visualization API v2",
-      "description": "Inspired by OpenClaw trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Implement API endpoints for the canvas streaming.",
+      "description": "Inspired by OpenClaw trend: Canvas для live визуализации. Implement API endpoints for the canvas streaming.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_api_v2.py",
         "tests/test_canvas_api_v2.py",
@@ -4137,7 +4137,7 @@
       "area": "architecture",
       "risk": "medium",
       "title": "Scheduled operations: daily reports",
-      "description": "Inspired by trend: Scheduled operations \u2014 cron-\u043f\u043e\u0434\u043e\u0431\u043d\u044b\u0435 \u0437\u0430\u0434\u0430\u0447\u0438 \u0431\u0435\u0437 \u0443\u0447\u0430\u0441\u0442\u0438\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f. Implement scheduled daily reports capability.",
+      "description": "Inspired by trend: Scheduled operations — cron-подобные задачи без участия пользователя. Implement scheduled daily reports capability.",
       "allowed_paths": [
         "magda_agent/scheduler/cron.py",
         "tests/test_cron*.py",
@@ -4154,7 +4154,7 @@
       "area": "integration",
       "risk": "medium",
       "title": "Cross-platform reach: Telegram channel v2",
-      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Add improved Telegram messenger integration.",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Add improved Telegram messenger integration.",
       "allowed_paths": [
         "magda_agent/channels/telegram.py",
         "tests/test_telegram*.py",
@@ -4288,7 +4288,7 @@
       "area": "execution",
       "risk": "high",
       "title": "Agent Teams Worktree Isolation",
-      "description": "Inspired by trend: Agent Teams: multi-agent \u0441 git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
+      "description": "Inspired by trend: Agent Teams: multi-agent с git worktree isolation (Claude Agent SDK). Implement SubAgent isolation.",
       "allowed_paths": [
         "magda_agent/agents/subagent.py",
         "magda_agent/isolation/git_worktree.py",
@@ -4307,7 +4307,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Control Checkpoints Interface",
-      "description": "Inspired by trend: ACS (Agent Control Specification) \u2014 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
+      "description": "Inspired by trend: ACS (Agent Control Specification) — 5 validation checkpoints. Implement formal interface for ACS checkpoints.",
       "allowed_paths": [
         "magda_agent/safety/acs_guard.py",
         "tests/test_acs_guard.py",
@@ -4379,7 +4379,7 @@
       "area": "channels",
       "risk": "medium",
       "title": "Cross-platform reach channels",
-      "description": "Inspired by trend: Cross-platform reach \u2014 \u043e\u0434\u0438\u043d \u0430\u0433\u0435\u043d\u0442, \u043c\u043d\u043e\u0433\u043e \u043a\u0430\u043d\u0430\u043b\u043e\u0432. Expand channel adapters for more platforms.",
+      "description": "Inspired by trend: Cross-platform reach — один агент, много каналов. Expand channel adapters for more platforms.",
       "allowed_paths": [
         "magda_agent/channels/reach_v2.py",
         "tests/test_reach_v2.py",
@@ -4396,7 +4396,7 @@
       "area": "learning",
       "risk": "medium",
       "title": "Online learning from dialogue v3",
-      "description": "Inspired by trend: Online learning \u2014 \u0443\u0447\u0438\u0442\u044c\u0441\u044f \u043d\u0430 \u043a\u0430\u0436\u0434\u043e\u043c \u0434\u0438\u0430\u043b\u043e\u0433\u0435 (\u043d\u0435 \u0442\u043e\u043b\u044c\u043a\u043e reflections). Implement immediate context integration.",
+      "description": "Inspired by trend: Online learning — учиться на каждом диалоге (не только reflections). Implement immediate context integration.",
       "allowed_paths": [
         "magda_agent/learning/dialogue_v3.py",
         "tests/test_dialogue_v3.py",
@@ -4532,7 +4532,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Agent Discovery via Cards v2",
-      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Add discovery components to the network layer.",
+      "description": "Inspired by trend: A2A (Agent-to-Agent Protocol) Agent discovery через Agent Cards. Add discovery components to the network layer.",
       "allowed_paths": [
         "magda_agent/integration/a2a_discovery_v2.py",
         "tests/test_a2a_discovery_v2.py",
@@ -5542,7 +5542,7 @@
       "area": "memory",
       "risk": "medium",
       "title": "MemGPT Virtual Context Management v1",
-      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
+      "description": "Inspired by the trend: 'Virtual context management (MemGPT/Letta pattern -> стандарт)'. Implement a virtual context window manager that pages episodic memory in and out of the LLM context automatically.",
       "allowed_paths": [
         "magda_agent/memory/virtual_context.py",
         "tests/test_virtual_context.py",
@@ -5560,7 +5560,7 @@
       "area": "safety",
       "risk": "high",
       "title": "ACS Agent Control Specification Checkpoints v3",
-      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) \u2014 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
+      "description": "Inspired by the June 2026 standard: 'ACS (Agent Control Specification) — 5 validation checkpoints in agentic workflows'. Implement the 5 explicit validation checkpoints for tool execution.",
       "allowed_paths": [
         "magda_agent/safety/acs_checkpoints_v3.py",
         "tests/test_acs_checkpoints_v3.py",
@@ -8693,7 +8693,7 @@
       "area": "planning",
       "risk": "medium",
       "title": "Claude Agent Teams Dependency Graph",
-      "description": "Inspired by Claude Agent SDK trend: Task system \u0441 dependency graphs. Update planning to utilize dependency graphs.",
+      "description": "Inspired by Claude Agent SDK trend: Task system с dependency graphs. Update planning to utilize dependency graphs.",
       "allowed_paths": [
         "magda_agent/planning/dependency_graph.py",
         "tests/test_dependency_graph.py",
@@ -8846,7 +8846,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging",
-      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
+      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to intercept specific Context Engine lifecycle hooks (before_retrieval, after_retrieval).",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger.py",
         "tests/test_canvas_logger.py",
@@ -8985,7 +8985,7 @@
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Detailed Logging V3",
-      "description": "Inspired by trend: Canvas \u0434\u043b\u044f live \u0432\u0438\u0437\u0443\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
+      "description": "Inspired by trend: Canvas для live визуализации. Expand OpenClaw Canvas to provide real-time agent thought process visualization.",
       "allowed_paths": [
         "magda_agent/visualization/canvas_logger_v3.py",
         "tests/test_canvas_logger_v3.py",
@@ -11865,7 +11865,7 @@
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery Agent Cards v4",
-      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
+      "description": "Inspired by trend: Agent discovery через Agent Cards (A2A protocol). Implement an updated agent discovery mechanism for peer-to-peer network discovery using the new Agent Cards v4 standard.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -12117,7 +12117,7 @@
       "area": "integration",
       "risk": "high",
       "title": "A2A Protocol Discovery Mesh",
-      "description": "Inspired by trend: Agent discovery \u0447\u0435\u0440\u0435\u0437 Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
+      "description": "Inspired by trend: Agent discovery через Agent Cards. Implement a peer-to-peer discovery mesh to actively broadcast Agent Cards to neighboring nodes over A2A.",
       "allowed_paths": [
         "magda_agent/integration/a2a_cards.py",
         "tests/test_a2a_cards.py",
@@ -19329,7 +19329,7 @@
     {
       "id": "agentskills-io-export-v1",
       "title": "Hermes agentskills.io Format Exporter v1",
-      "description": "Inspired by Hermes Agent trend '\u041e\u0442\u043a\u0440\u044b\u0442\u044b\u0439 \u0441\u0442\u0430\u043d\u0434\u0430\u0440\u0442 skills: agentskills.io', implement an exporter to convert internal magda skills to the agentskills.io open standard.",
+      "description": "Inspired by Hermes Agent trend 'Открытый стандарт skills: agentskills.io', implement an exporter to convert internal magda skills to the agentskills.io open standard.",
       "status": "todo",
       "area": "skills",
       "risk": "medium",
@@ -19346,7 +19346,7 @@
     {
       "id": "claude-agent-teams-subagent-spawner-v1",
       "title": "Claude Agent Teams Subagent Spawner",
-      "description": "Inspired by Claude Agent SDK trend 'Agent Teams: multi-agent \u0441 git worktree isolation', implement a subagent spawner for parallel tasks.",
+      "description": "Inspired by Claude Agent SDK trend 'Agent Teams: multi-agent с git worktree isolation', implement a subagent spawner for parallel tasks.",
       "status": "todo",
       "area": "agents",
       "risk": "medium",

--- a/magda_agent/integration/a2a_discovery_v2.py
+++ b/magda_agent/integration/a2a_discovery_v2.py
@@ -111,3 +111,74 @@ class A2ADiscoveryV2:
         """
         agent_ids = self._capability_index.get(capability, [])
         return [self._discovered_agents[aid] for aid in agent_ids]
+
+    def find_agents_by_capabilities(self, capabilities: List[str], match_all: bool = True) -> List[AgentCardV2]:
+        """
+        Returns a list of Agent Cards that support the given list of capabilities.
+        If match_all is True, the agent must support all specified capabilities.
+        If match_all is False, the agent must support at least one of the specified capabilities.
+        """
+        if not capabilities:
+            return list(self._discovered_agents.values())
+
+        matching_agents = []
+        for card in self._discovered_agents.values():
+            card_caps = set(card.capabilities)
+            req_caps = set(capabilities)
+            if match_all:
+                if req_caps.issubset(card_caps):
+                    matching_agents.append(card)
+            else:
+                if req_caps.intersection(card_caps):
+                    matching_agents.append(card)
+        return matching_agents
+
+    async def register_with_registry(self, registry_url: str, auth_token: Optional[str] = None) -> bool:
+        """
+        Registers the local Agent Card V2 with a central discovery registry.
+        """
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+
+        try:
+            import httpx
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{registry_url}/register",
+                    json=asdict(self.local_card),
+                    headers=headers
+                )
+                response.raise_for_status()
+                logging.info(f"Successfully registered with {registry_url} (v2)")
+                return True
+        except Exception as e:
+            logging.error(f"Failed to register with registry {registry_url}: {e}")
+            return False
+
+    async def discover_from_registry(self, registry_url: str, auth_token: Optional[str] = None) -> List[AgentCardV2]:
+        """
+        Fetches all available Agent Cards from a central discovery registry.
+        """
+        headers = {}
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
+
+        try:
+            import httpx
+            async with httpx.AsyncClient() as client:
+                response = await client.get(f"{registry_url}/cards", headers=headers)
+                response.raise_for_status()
+                cards_data = response.json()
+
+                discovered = []
+                for card_data in cards_data:
+                    card = AgentCardV2(**card_data)
+                    self._register_agent(card)
+                    discovered.append(card)
+
+                logging.info(f"Discovered {len(discovered)} agents from {registry_url} (v2)")
+                return discovered
+        except Exception as e:
+            logging.error(f"Failed to discover from registry {registry_url}: {e}")
+            return []

--- a/tests/test_a2a_discovery_v2.py
+++ b/tests/test_a2a_discovery_v2.py
@@ -1,5 +1,8 @@
 import pytest
 import json
+import respx
+import httpx
+from dataclasses import asdict
 from magda_agent.integration.a2a_discovery_v2 import AgentCardV2, A2ADiscoveryV2
 
 @pytest.fixture
@@ -93,3 +96,86 @@ async def test_fetch_invalid_card_json_v2(local_card_v2: AgentCardV2) -> None:
 
     # No agents should be discovered
     assert len(discovery._discovered_agents) == 0
+
+@pytest.mark.asyncio
+async def test_find_agents_by_capabilities_filtering(local_card_v2: AgentCardV2, remote_card_1_v2: AgentCardV2, remote_card_2_v2: AgentCardV2) -> None:
+    discovery = A2ADiscoveryV2(local_card=local_card_v2)
+
+    network_envelopes = [
+        json.dumps({"type": "a2a_discovery_broadcast", "version": "2.0", "payload": remote_card_1_v2.to_json()}),
+        json.dumps({"type": "a2a_discovery_broadcast", "version": "2.0", "payload": remote_card_2_v2.to_json()})
+    ]
+
+    await discovery.fetch_cards(network_envelopes=network_envelopes)
+
+    # Remote 1: "image_generation", "chat"
+    # Remote 2: "code_execution", "linting"
+
+    # Match all (intersection check)
+    match_both = discovery.find_agents_by_capabilities(["chat", "image_generation"], match_all=True)
+    assert len(match_both) == 1
+    assert match_both[0].agent_id == remote_card_1_v2.agent_id
+
+    match_non_existent = discovery.find_agents_by_capabilities(["chat", "code_execution"], match_all=True)
+    assert len(match_non_existent) == 0
+
+    # Match any (union check)
+    match_any = discovery.find_agents_by_capabilities(["chat", "code_execution"], match_all=False)
+    assert len(match_any) == 2
+    agent_ids = {a.agent_id for a in match_any}
+    assert remote_card_1_v2.agent_id in agent_ids
+    assert remote_card_2_v2.agent_id in agent_ids
+
+    # Empty capabilities input should return all discovered agents
+    match_empty = discovery.find_agents_by_capabilities([])
+    assert len(match_empty) == 2
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_register_with_registry_v2(local_card_v2: AgentCardV2) -> None:
+    discovery = A2ADiscoveryV2(local_card=local_card_v2)
+    registry_url = "http://discovery-registry-v2.local"
+
+    # Mock the registration endpoint
+    route = respx.post(f"{registry_url}/register").mock(return_value=httpx.Response(201))
+
+    success = await discovery.register_with_registry(registry_url, auth_token="test-token-v2")
+
+    assert success is True
+    assert route.called
+    assert route.calls.last.request.headers["Authorization"] == "Bearer test-token-v2"
+
+    # Verify the payload
+    sent_data = json.loads(route.calls.last.request.content)
+    assert sent_data["agent_id"] == local_card_v2.agent_id
+    assert sent_data["protocol_version"] == "v2"
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_discover_from_registry_v2(local_card_v2: AgentCardV2, remote_card_1_v2: AgentCardV2, remote_card_2_v2: AgentCardV2) -> None:
+    discovery = A2ADiscoveryV2(local_card=local_card_v2)
+    registry_url = "http://discovery-registry-v2.local"
+
+    # Mock the discovery endpoint
+    cards_data = [asdict(remote_card_1_v2), asdict(remote_card_2_v2)]
+    route = respx.get(f"{registry_url}/cards").mock(return_value=httpx.Response(200, json=cards_data))
+
+    discovered = await discovery.discover_from_registry(registry_url)
+
+    assert len(discovered) == 2
+    assert route.called
+    assert discovery.get_agent_by_id(remote_card_1_v2.agent_id).name == remote_card_1_v2.name
+    assert discovery.get_agent_by_id(remote_card_2_v2.agent_id).name == remote_card_2_v2.name
+    assert remote_card_1_v2.name in [c.name for c in discovery.find_agents_by_capabilities(["chat"])]
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_register_with_registry_failure_v2(local_card_v2: AgentCardV2) -> None:
+    discovery = A2ADiscoveryV2(local_card=local_card_v2)
+    registry_url = "http://discovery-registry-v2.local"
+
+    # Mock a failure
+    respx.post(f"{registry_url}/register").mock(return_value=httpx.Response(500))
+
+    success = await discovery.register_with_registry(registry_url)
+    assert success is False


### PR DESCRIPTION
Extended AgentCardV2 and A2ADiscoveryV2 to support matching multiple agent capabilities simultaneously (using find_agents_by_capabilities with match_all) and HTTP-based registration and discovery with central registries (using register_with_registry and discover_from_registry). Also added comprehensive unit tests for these new features in tests/test_a2a_discovery_v2.py and updated agent_tasks.json status to done.

---
*PR created automatically by Jules for task [15492561297041476823](https://jules.google.com/task/15492561297041476823) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add capability filtering and registry registration/discovery to `A2ADiscoveryV2`
> - Adds `find_agents_by_capabilities` to filter discovered `AgentCardV2` instances by capability list, supporting both AND (`match_all=True`) and OR semantics.
> - Adds `register_with_registry` to POST the local agent card to a central registry endpoint, returning a boolean success indicator.
> - Adds `discover_from_registry` to GET agent cards from a registry, parse them into `AgentCardV2` instances, and populate internal indexes.
> - Adds async tests in [test_a2a_discovery_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/587/files#diff-400cde35e08362e4334ac419a063ed3e6033a13bfcdec0d447c5b0d517a797e4) covering filtering, successful/failed registration, and registry discovery using `respx` mocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 496555a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->