### PR TITLE
feat: implement MCP Dynamic Tool Auto-Discovery V1

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -18262,7 +18262,7 @@
     },
     {
       "id": "mcp-dynamic-auto-discovery-v1-98a2f",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Tool Auto-Discovery V1",
@@ -21159,6 +21159,42 @@
         "Detects high latency or task failure from an assigned A2A peer.",
         "Redistributes the sub-task securely to an alternate peer from the capability cache.",
         "Tests mock peer failures and verify seamless task redistribution."
+      ]
+    },
+    {
+      "id": "openclaw-live-canvas-visualizer-v2-1a2b3c",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Visualizer Update V2",
+      "description": "Inspired by OpenClaw trends: Implement a Canvas module with structured websocket diffing for the ContextEngine, streaming only modified working memory fragments instead of full state updates.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_diff_v2.py",
+        "tests/test_canvas_diff_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas visualizer correctly calculates JSON diffs.",
+        "Diffs are broadcast to clients over websocket.",
+        "Tests verify payload correctly reflects memory changes using mocks."
+      ]
+    },
+    {
+      "id": "a2a-agent-capabilities-health-checker-v1-4d5e6f",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "low",
+      "title": "A2A Capabilities Health Checker",
+      "description": "Inspired by A2A Protocol trends: Implement a periodic cron job to ping discovered A2A peers from the capability cache, removing unresponsive agents from the known registry.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_health_checker_v1.py",
+        "tests/test_a2a_health_checker_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron job periodically iterates through discovered peers.",
+        "Unresponsive peers are purged from the cache.",
+        "Tests mock network timeouts and verify removal."
       ]
     }
   ]

--- a/magda_agent/skills/__init__.py
+++ b/magda_agent/skills/__init__.py
@@ -169,6 +169,23 @@ def initialize_skills(policy_layer: Optional["PolicyLayer"] = None) -> SkillRegi
     )
 
 
+    # Register MCP Auto-Discovery V1
+    from magda_agent.skills.mcp_auto_discovery_v1 import MCPAutoDiscoveryV1
+    from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+    mcp_registry_v7 = MCPRegistryV7()
+    mcp_discoverer = MCPAutoDiscoveryV1(registry=mcp_registry_v7)
+
+    def run_mcp_auto_discovery(directory: str) -> str:
+        """Runs the auto discovery and returns the list of registered tools."""
+        mcp_discoverer.discover_and_register(directory)
+        return f"Discovered and registered: {mcp_registry_v7.list_tools()}"
+
+    registry.register_skill(
+        name="mcp_auto_discovery_v1",
+        func=run_mcp_auto_discovery,
+        description="Scans a specified directory to dynamically discover and register MCP tool schemas from Python files. Input: 'directory' string."
+    )
+
     # Register Marketplace Sync Routine
     from magda_agent.skills.marketplace_sync import MarketplaceSyncRoutine
     def sync_marketplace_sync() -> int:

--- a/magda_agent/skills/mcp_auto_discovery_v1.py
+++ b/magda_agent/skills/mcp_auto_discovery_v1.py
@@ -1,0 +1,133 @@
+import ast
+import os
+import glob
+from typing import Dict, Any, List, Optional
+import logging
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+
+class MCPAutoDiscoveryV1:
+    """
+    Auto-discovery mechanism that scans a directory for Python modules,
+    extracts function definitions using AST, converts them to MCP tool schemas,
+    and registers them dynamically in the MCPRegistryV7.
+    """
+
+    def __init__(self, registry: MCPRegistryV7):
+        """
+        Initialize the discovery module with a target registry.
+
+        Args:
+            registry (MCPRegistryV7): The registry to update.
+        """
+        self.registry = registry
+
+    def discover_and_register(self, directory: str) -> None:
+        """
+        Scans a directory for .py files, parses them, and registers tools.
+
+        Args:
+            directory (str): The directory path to scan.
+        """
+        if not os.path.isdir(directory):
+            logging.error(f"Discovery directory not found: {directory}")
+            return
+
+        for filepath in glob.glob(os.path.join(directory, "**/*.py"), recursive=True):
+            self._process_file(filepath)
+
+    def _process_file(self, filepath: str) -> None:
+        """
+        Parses a single Python file using AST and registers extracted tools.
+
+        Args:
+            filepath (str): The path to the Python file.
+        """
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                source = f.read()
+            tree = ast.parse(source, filename=filepath)
+        except Exception as e:
+            logging.error(f"Failed to parse file {filepath}: {e}")
+            return
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                schema = self._extract_schema_from_function(node)
+                if schema:
+                    self.registry.register_tool(schema)
+
+    def _extract_schema_from_function(self, node: ast.FunctionDef) -> Optional[Dict[str, Any]]:
+        """
+        Converts an AST FunctionDef node to an MCP tool schema.
+        Only considers functions that start with 'mcp_tool_' or have a docstring.
+        We require a docstring for the description.
+
+        Args:
+            node (ast.FunctionDef): The function definition node.
+
+        Returns:
+            Optional[Dict[str, Any]]: The generated schema or None if invalid.
+        """
+        # Exclude private/magic functions unless explicitly an MCP tool
+        if node.name.startswith("_"):
+            return None
+
+        # Extract docstring
+        docstring = ast.get_docstring(node)
+        if not docstring:
+            # We require a description for MCP tools
+            return None
+
+        # Build schema
+        schema: Dict[str, Any] = {
+            "name": node.name,
+            "description": docstring.strip(),
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }
+
+        properties = schema["inputSchema"]["properties"]
+        required = schema["inputSchema"]["required"]
+
+        # Parse arguments
+        args = node.args.args
+        defaults = node.args.defaults
+
+        # Number of arguments without defaults
+        num_required = len(args) - len(defaults)
+
+        for i, arg in enumerate(args):
+            # Skip self/cls
+            if arg.arg in ("self", "cls") and i == 0:
+                continue
+
+            arg_name = arg.arg
+
+            # Map type hints to JSON schema types (basic mapping)
+            arg_type = "string" # Default
+            if arg.annotation:
+                if isinstance(arg.annotation, ast.Name):
+                    if arg.annotation.id == "int":
+                        arg_type = "integer"
+                    elif arg.annotation.id == "float":
+                        arg_type = "number"
+                    elif arg.annotation.id == "bool":
+                        arg_type = "boolean"
+                    elif arg.annotation.id in ("list", "List"):
+                        arg_type = "array"
+                    elif arg.annotation.id in ("dict", "Dict"):
+                        arg_type = "object"
+
+            properties[arg_name] = {
+                "type": arg_type,
+                "description": f"Parameter {arg_name}"
+            }
+
+            # Check if required (no default value)
+            if i < num_required:
+                required.append(arg_name)
+
+        return schema

--- a/tests/test_mcp_auto_discovery_v1.py
+++ b/tests/test_mcp_auto_discovery_v1.py
@@ -1,0 +1,73 @@
+import os
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.skills.mcp_auto_discovery_v1 import MCPAutoDiscoveryV1
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+
+@pytest.fixture
+def dummy_directory(tmp_path):
+    """Creates a dummy directory with a valid and an invalid Python file."""
+    # Create valid python file
+    valid_py = tmp_path / "valid_tool.py"
+    valid_py.write_text(
+        "def mcp_tool_test(param1: int, param2: str = 'default'):\n"
+        "    \"\"\"This is a test tool.\"\"\"\n"
+        "    pass\n"
+        "\n"
+        "def helper_func():\n"
+        "    pass\n" # no docstring, should be ignored
+        "\n"
+        "def _private_func():\n"
+        "    \"\"\"This should be ignored.\"\"\"\n"
+        "    pass\n",
+        encoding="utf-8"
+    )
+
+    # Create invalid python file
+    invalid_py = tmp_path / "invalid.py"
+    invalid_py.write_text(
+        "def syntax_error(:\n"
+        "    pass",
+        encoding="utf-8"
+    )
+
+    return tmp_path
+
+def test_mcp_auto_discovery(dummy_directory):
+    """Test discovering and registering tools from a directory."""
+    mock_registry = MagicMock(spec=MCPRegistryV7)
+
+    discovery = MCPAutoDiscoveryV1(registry=mock_registry)
+    discovery.discover_and_register(str(dummy_directory))
+
+    # Expect one call to register_tool for mcp_tool_test
+    # helper_func should be ignored because it lacks a docstring
+    # _private_func should be ignored because it's private
+    assert mock_registry.register_tool.call_count == 1
+
+    args, kwargs = mock_registry.register_tool.call_args
+    schema = args[0]
+
+    assert schema["name"] == "mcp_tool_test"
+    assert schema["description"] == "This is a test tool."
+    assert "inputSchema" in schema
+    assert "properties" in schema["inputSchema"]
+
+    properties = schema["inputSchema"]["properties"]
+    assert "param1" in properties
+    assert properties["param1"]["type"] == "integer"
+    assert "param2" in properties
+    assert properties["param2"]["type"] == "string"
+
+    required = schema["inputSchema"]["required"]
+    assert "param1" in required
+    assert "param2" not in required
+
+def test_mcp_auto_discovery_invalid_dir():
+    """Test discovery on an invalid directory."""
+    mock_registry = MagicMock(spec=MCPRegistryV7)
+
+    discovery = MCPAutoDiscoveryV1(registry=mock_registry)
+    discovery.discover_and_register("/nonexistent_directory/path")
+
+    assert mock_registry.register_tool.call_count == 0


### PR DESCRIPTION
Implements `MCPAutoDiscoveryV1` for dynamically scanning Python files and registering MCP tools based on AST parsing. Also updates `agent_tasks.json` with new AI agent trend tasks.

---
*PR created automatically by Jules for task [16530912777897695121](https://jules.google.com/task/16530912777897695121) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP dynamic tool auto-discovery skill via AST-based Python file scanning
> - Adds a new `mcp_auto_discovery_v1` skill in [`magda_agent/skills/__init__.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/589/files#diff-bfa99a5f255fc1d222418cb8c21dfa1cce609468589a12c95c937cd2b77bd315) that accepts a directory path and scans it for Python files to register MCP tools.
> - Implements [`MCPAutoDiscoveryV1`](https://github.com/kazah4359-lgtm/Magda-agent/pull/589/files#diff-b9b64d7b58aa44053900f6b1f1af0c32881aa4f5f2a201e37f6fcaa3a45a07f6) which uses Python's `ast` module to parse function definitions, infer parameter types from type hints, and build MCP-compatible JSON schemas from docstrings and signatures.
> - Private/magic functions and functions without docstrings are skipped; parse errors are logged and skipped without halting discovery.
> - Tests in [`tests/test_mcp_auto_discovery_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/589/files#diff-df350ebbaeb5177a2869a4ce29480f2ce054cac0ed6709be57dee35c6ac438b9) verify correct schema extraction from valid files and graceful handling of invalid directories and syntax errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1f0641.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->