### PR TITLE
feat(visualization): add OpenClaw-RL canvas metrics v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9466,7 +9466,7 @@
     },
     {
       "id": "openclaw-rl-canvas-metrics-v4-unique-d77f4f61",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw-RL Canvas Metrics V4",
@@ -21282,6 +21282,57 @@
       "acceptance": [
         "Automated pruning runs correctly on older memory entries.",
         "Tests verify memory retention limits."
+      ]
+    },
+    {
+      "id": "claude-evaluator-git-worktree-v16",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Claude Evaluator Git Worktree V16",
+      "description": "Inspired by Claude Agent Teams multi-agent architectures: Run the evaluator subagent inside an isolated git worktree.",
+      "allowed_paths": [
+        "magda_agent/evaluation/evaluator_worktree_v16.py",
+        "tests/test_evaluator_worktree_v16.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagent utilizes Git Worktree isolation.",
+        "Tests verify isolated execution."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-swapper-v16",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Context Swapper V16",
+      "description": "Inspired by OpenClaw memory virtualization trends: Implement a context swapper that efficiently pages semantic facts to local file storage when context exceeds the token limit.",
+      "allowed_paths": [
+        "magda_agent/memory/context_swapper_v16.py",
+        "tests/test_context_swapper_v16.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ContextSwapper pages context effectively based on token limits.",
+        "Tests mock LLM tokens and verify swapper action."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-permissions-v16",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Dynamic Tool Permissions V16",
+      "description": "Inspired by MCP standardization: Dynamically parse and enforce authentication schema constraints from external MCP server capabilities before routing actions.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_permissions_v16.py",
+        "tests/test_mcp_permissions_v16.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Auth requirements from MCP servers are correctly validated.",
+        "Tests verify tool execution blocks securely."
       ]
     }
   ]

--- a/magda_agent/visualization/rl_metrics_canvas_v4.py
+++ b/magda_agent/visualization/rl_metrics_canvas_v4.py
@@ -1,0 +1,39 @@
+import json
+from typing import Dict, Any
+
+from magda_agent.learning.canvas_metrics import RLCanvasMetricsExporter
+
+
+class RLMetricsCanvasV4:
+    """
+    OpenClaw-RL Canvas Metrics V4 visualizer.
+    This class wraps the RLCanvasMetricsExporter to provide a JSON stream
+    of Q-value updates and reinforcement learning metrics for the Canvas UI.
+    """
+
+    def __init__(self, exporter: RLCanvasMetricsExporter) -> None:
+        """
+        Initializes the RLMetricsCanvasV4 with an exporter.
+
+        Args:
+            exporter (RLCanvasMetricsExporter): The exporter used to retrieve formatted RL metrics.
+        """
+        self.exporter = exporter
+
+    def get_metrics_payload(self) -> Dict[str, Any]:
+        """
+        Retrieves the structured RL metrics payload.
+
+        Returns:
+            Dict[str, Any]: The structured UI visualization state for RL metrics.
+        """
+        return self.exporter.export_canvas_payload()
+
+    def get_metrics_json(self) -> str:
+        """
+        Retrieves the structured RL metrics payload as a JSON string.
+
+        Returns:
+            str: JSON-encoded string of the RL metrics state.
+        """
+        return json.dumps(self.get_metrics_payload())

--- a/tests/test_rl_metrics_canvas_v4.py
+++ b/tests/test_rl_metrics_canvas_v4.py
@@ -1,0 +1,52 @@
+import json
+from unittest.mock import MagicMock
+from magda_agent.visualization.rl_metrics_canvas_v4 import RLMetricsCanvasV4
+from magda_agent.learning.canvas_metrics import RLCanvasMetricsExporter
+
+
+def test_get_metrics_payload() -> None:
+    """
+    Tests that get_metrics_payload correctly delegates to the exporter.
+    """
+    mock_exporter = MagicMock(spec=RLCanvasMetricsExporter)
+
+    mock_payload = {
+        "status": "active",
+        "total_rewards_received": 10,
+        "global_average_q": 0.5,
+        "moving_average_reward_5": 0.8,
+        "trajectory_trend": "improving",
+        "skill_distribution_entropy": 0.1,
+        "skills_coverage": {},
+        "raw_rewards_trajectory": []
+    }
+
+    mock_exporter.export_canvas_payload.return_value = mock_payload
+
+    visualizer = RLMetricsCanvasV4(exporter=mock_exporter)
+
+    payload = visualizer.get_metrics_payload()
+
+    assert payload == mock_payload
+    mock_exporter.export_canvas_payload.assert_called_once()
+
+
+def test_get_metrics_json() -> None:
+    """
+    Tests that get_metrics_json correctly formats the payload as a JSON string.
+    """
+    mock_exporter = MagicMock(spec=RLCanvasMetricsExporter)
+
+    mock_payload = {
+        "status": "active",
+        "total_rewards_received": 5
+    }
+
+    mock_exporter.export_canvas_payload.return_value = mock_payload
+
+    visualizer = RLMetricsCanvasV4(exporter=mock_exporter)
+
+    json_string = visualizer.get_metrics_json()
+
+    assert json_string == json.dumps(mock_payload)
+    mock_exporter.export_canvas_payload.assert_called_once()


### PR DESCRIPTION
Implemented `RLMetricsCanvasV4` that wraps `RLCanvasMetricsExporter` to provide a JSON stream of Q-value updates and reinforcement learning metrics for the Canvas UI. Included tests to verify its correctness. Updated `agent_tasks.json` with status="done" for `openclaw-rl-canvas-metrics-v4-unique-d77f4f61` and generated three new trend-inspired tasks based on `docs/trends.md`.

---
*PR created automatically by Jules for task [3266691416911582741](https://jules.google.com/task/3266691416911582741) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLMetricsCanvasV4` class to expose RL canvas metrics as dict or JSON
> Adds [`rl_metrics_canvas_v4.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/592/files#diff-15d901063a19a1fa9e1ef3062bfec2482e3202d6d58483305d7f476b58e8e419) with `RLMetricsCanvasV4`, a thin wrapper around `RLCanvasMetricsExporter` that provides `get_metrics_payload()` (structured dict) and `get_metrics_json()` (JSON string). Two unit tests cover both methods using a mocked exporter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32fbc01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->