### PR TITLE
feat: Implement A2A Delegation Circuit Breaker V6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9500,7 +9500,7 @@
     },
     {
       "id": "a2a-delegation-circuit-breaker-v6-unique-62a89989",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Delegation Circuit Breaker V6",
@@ -21387,6 +21387,59 @@
         "Sub-agents initialize in isolated worktrees.",
         "Worktree state changes do not affect main branch until merged.",
         "Tests verify worktree lifecycle hooks (create, execute, cleanup)."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-visualizer-v2-d668530a",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Canvas Visualizer Update V2",
+      "description": "Inspired by OpenClaw trends: Implement a Canvas module with structured websocket diffing for the ContextEngine, streaming only modified working memory fragments instead of full state updates.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_diff_v2.py",
+        "tests/test_canvas_diff_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Canvas visualizer correctly calculates JSON diffs.",
+        "Diffs are broadcast to clients over websocket.",
+        "Tests verify payload correctly reflects memory changes using mocks."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v7-102c3849",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V7",
+      "description": "Inspired by June 2026 AI Trends: Expand MCP capabilities negotiation to support complex fallback strategies and multi-turn schema matching.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v7.py",
+        "tests/test_mcp_negotiation_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Negotiation handles fallback routes smoothly.",
+        "Tests mock negotiation timeouts and mismatch handling."
+      ]
+    },
+    {
+      "id": "a2a-agent-capabilities-health-checker-v1-c4bd1a6c",
+      "status": "todo",
+      "area": "multi_agent",
+      "risk": "low",
+      "title": "A2A Capabilities Health Checker",
+      "description": "Inspired by A2A Protocol trends: Implement a periodic cron job to ping discovered A2A peers from the capability cache, removing unresponsive agents from the known registry.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_health_checker_v1.py",
+        "tests/test_a2a_health_checker_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron job periodically iterates through discovered peers.",
+        "Unresponsive peers are purged from the cache.",
+        "Tests mock network timeouts and verify removal."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -312,3 +312,7 @@
 * [ ] FEATURE: Claude Evaluator Subagent Isolation V3 (claude-evaluator-subagent-isolation-v3)
 * [ ] FEATURE: MCP Dynamic Tool Permissions v2 (mcp-dynamic-tool-permissions-v2-unique)
 * [x] FEATURE: OpenClaw Context Engine Virtual Context (openclaw-context-engine-virtual-context-ce0c6f0b)
+
+* [ ] FEATURE: OpenClaw Canvas Visualizer Update V2 (openclaw-canvas-visualizer-v2-d668530a)
+* [ ] FEATURE: MCP Dynamic Capability Negotiation V7 (mcp-dynamic-capability-negotiation-v7-102c3849)
+* [ ] FEATURE: A2A Capabilities Health Checker (a2a-agent-capabilities-health-checker-v1-c4bd1a6c)

--- a/magda_agent/integration/a2a_circuit_breaker_v6.py
+++ b/magda_agent/integration/a2a_circuit_breaker_v6.py
@@ -1,0 +1,192 @@
+from enum import Enum
+import time
+import logging
+from typing import Any, Dict, Callable, Optional, Coroutine
+
+logger = logging.getLogger(__name__)
+
+class CircuitState(Enum):
+    """
+    Represents the states of the circuit breaker.
+    """
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+class CircuitBreakerOpenException(Exception):
+    """
+    Exception raised when a request is blocked because the circuit breaker is OPEN.
+    """
+    pass
+
+class PeerState:
+    """
+    Represents the state of a single peer agent.
+    """
+    def __init__(self) -> None:
+        """
+        Initializes the state for a single peer agent.
+        """
+        self.state: CircuitState = CircuitState.CLOSED
+        self.consecutive_failures: int = 0
+        self.consecutive_successes: int = 0
+        self.last_state_change: float = time.time()
+
+class A2ADelegationCircuitBreakerV6:
+    """
+    A circuit breaker implementation for A2A (Agent-to-Agent) task delegation.
+    Prevents continuous task delegation failures to unresponsive peer agents
+    by tripping the circuit and gracefully degrading.
+    """
+    def __init__(
+        self,
+        failure_threshold: int = 3,
+        recovery_timeout: float = 5.0,
+        success_threshold: int = 2
+    ) -> None:
+        """
+        Initializes the circuit breaker with custom thresholds.
+
+        Args:
+            failure_threshold (int): Number of consecutive failures to trip the circuit.
+            recovery_timeout (float): Time in seconds to wait before checking if peer recovered.
+            success_threshold (int): Number of consecutive successes in HALF_OPEN to close the circuit.
+        """
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.success_threshold = success_threshold
+        self.peer_states: Dict[str, PeerState] = {}
+
+    def _get_or_create_peer_state(self, peer_id: str) -> PeerState:
+        """
+        Retrieves or initializes the state tracker for a given peer agent ID.
+        """
+        if peer_id not in self.peer_states:
+            self.peer_states[peer_id] = PeerState()
+        return self.peer_states[peer_id]
+
+    def get_peer_state(self, peer_id: str) -> CircuitState:
+        """
+        Gets the current state of the circuit breaker for a peer agent.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+
+        Returns:
+            CircuitState: The current circuit state (CLOSED, OPEN, HALF_OPEN).
+        """
+        peer_state = self._get_or_create_peer_state(peer_id)
+        if peer_state.state == CircuitState.OPEN:
+            now = time.time()
+            if now - peer_state.last_state_change >= self.recovery_timeout:
+                # Transition to HALF_OPEN
+                logger.info(f"Circuit breaker for peer {peer_id} transitioning from OPEN to HALF_OPEN due to timeout.")
+                peer_state.state = CircuitState.HALF_OPEN
+                peer_state.consecutive_successes = 0
+                peer_state.last_state_change = now
+        return peer_state.state
+
+    def is_execution_allowed(self, peer_id: str) -> bool:
+        """
+        Determines whether execution is allowed for a peer agent.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+
+        Returns:
+            bool: True if execution is allowed, False otherwise.
+        """
+        state = self.get_peer_state(peer_id)
+        return state in (CircuitState.CLOSED, CircuitState.HALF_OPEN)
+
+    def record_success(self, peer_id: str) -> None:
+        """
+        Records a successful execution, updating the peer's state.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+        """
+        peer_state = self._get_or_create_peer_state(peer_id)
+        if peer_state.state == CircuitState.HALF_OPEN:
+            peer_state.consecutive_successes += 1
+            if peer_state.consecutive_successes >= self.success_threshold:
+                logger.info(f"Circuit breaker for peer {peer_id} reset to CLOSED after {peer_state.consecutive_successes} successes.")
+                peer_state.state = CircuitState.CLOSED
+                peer_state.consecutive_failures = 0
+                peer_state.consecutive_successes = 0
+                peer_state.last_state_change = time.time()
+        elif peer_state.state == CircuitState.CLOSED:
+            peer_state.consecutive_failures = 0
+
+    def record_failure(self, peer_id: str) -> None:
+        """
+        Records a failed execution, possibly tripping the circuit.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+        """
+        peer_state = self._get_or_create_peer_state(peer_id)
+        now = time.time()
+        if peer_state.state == CircuitState.CLOSED:
+            peer_state.consecutive_failures += 1
+            if peer_state.consecutive_failures >= self.failure_threshold:
+                logger.warning(f"Circuit breaker for peer {peer_id} tripped to OPEN after {peer_state.consecutive_failures} failures.")
+                peer_state.state = CircuitState.OPEN
+                peer_state.last_state_change = now
+        elif peer_state.state == CircuitState.HALF_OPEN:
+            logger.warning(f"Circuit breaker for peer {peer_id} tripped back to OPEN after failure in HALF_OPEN.")
+            peer_state.state = CircuitState.OPEN
+            peer_state.consecutive_failures = self.failure_threshold
+            peer_state.consecutive_successes = 0
+            peer_state.last_state_change = now
+
+    async def execute(
+        self,
+        peer_id: str,
+        func: Callable[..., Coroutine[Any, Any, Any]],
+        *args: Any,
+        fallback_func: Optional[Callable[..., Any]] = None,
+        **kwargs: Any
+    ) -> Any:
+        """
+        Executes an asynchronous function with circuit breaker protection.
+
+        Args:
+            peer_id (str): The identifier of the peer agent.
+            func (Callable): The asynchronous function/coroutine to execute.
+            args (Any): Variable positional arguments to pass to the function.
+            fallback_func (Optional[Callable]): Optional sync or async function to call on failure/block.
+            kwargs (Any): Variable keyword arguments to pass to the function.
+
+        Returns:
+            Any: The result of the function execution, or fallback.
+
+        Raises:
+            CircuitBreakerOpenException: If the circuit is OPEN and no fallback_func is provided.
+        """
+        if not self.is_execution_allowed(peer_id):
+            logger.warning(f"Execution blocked by circuit breaker for peer {peer_id}.")
+            if fallback_func is not None:
+                return await self._execute_fallback(fallback_func, *args, **kwargs)
+            raise CircuitBreakerOpenException(f"Circuit breaker for peer {peer_id} is OPEN.")
+
+        try:
+            result = await func(*args, **kwargs)
+            self.record_success(peer_id)
+            return result
+        except Exception as e:
+            logger.exception(f"Exception during execution under circuit breaker for peer {peer_id}: {e}")
+            self.record_failure(peer_id)
+            if fallback_func is not None:
+                return await self._execute_fallback(fallback_func, *args, **kwargs)
+            raise
+
+    async def _execute_fallback(self, fallback_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """
+        Helper to execute sync or async fallbacks.
+        """
+        import inspect
+        if inspect.iscoroutinefunction(fallback_func):
+            return await fallback_func(*args, **kwargs)
+        else:
+            return fallback_func(*args, **kwargs)

--- a/tests/test_a2a_circuit_breaker_v6.py
+++ b/tests/test_a2a_circuit_breaker_v6.py
@@ -1,0 +1,182 @@
+import pytest
+import asyncio
+import time
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.integration.a2a_circuit_breaker_v6 import (
+    A2ADelegationCircuitBreakerV6,
+    CircuitState,
+    CircuitBreakerOpenException,
+)
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_normal_execution() -> None:
+    """
+    Verifies that the circuit breaker allows execution when CLOSED and tracks state.
+    """
+    breaker = A2ADelegationCircuitBreakerV6(failure_threshold=2, recovery_timeout=0.1, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def mock_delegate() -> Dict[str, Any]:
+        return {"status": "success"}
+
+    result = await breaker.execute(peer_id, mock_delegate)
+    assert result == {"status": "success"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_trips_on_failures() -> None:
+    """
+    Verifies that the circuit breaker trips to OPEN after consecutive failures exceed threshold.
+    """
+    breaker = A2ADelegationCircuitBreakerV6(failure_threshold=2, recovery_timeout=1.0, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Peer unresponsive")
+
+    # First failure
+    with pytest.raises(ValueError, match="Peer unresponsive"):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.CLOSED
+
+    # Second failure - should trip to OPEN
+    with pytest.raises(ValueError, match="Peer unresponsive"):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Execution is now blocked and raises CircuitBreakerOpenException
+    with pytest.raises(CircuitBreakerOpenException):
+        await breaker.execute(peer_id, failing_delegate)
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_recovery_to_half_open_and_close() -> None:
+    """
+    Verifies that the circuit breaker recovers to HALF_OPEN after timeout and closes on successes.
+    """
+    breaker = A2ADelegationCircuitBreakerV6(failure_threshold=1, recovery_timeout=0.1, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Peer unresponsive")
+
+    # Trip the circuit
+    with pytest.raises(ValueError):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Wait for recovery timeout
+    await asyncio.sleep(0.12)
+
+    # Check state should become HALF_OPEN
+    assert breaker.get_peer_state(peer_id) == CircuitState.HALF_OPEN
+
+    # Successful execution trial 1
+    async def successful_delegate() -> Dict[str, Any]:
+        return {"result": "ok"}
+
+    res = await breaker.execute(peer_id, successful_delegate)
+    assert res == {"result": "ok"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.HALF_OPEN
+
+    # Successful execution trial 2 - should close the circuit
+    res2 = await breaker.execute(peer_id, successful_delegate)
+    assert res2 == {"result": "ok"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_half_open_fails_fast() -> None:
+    """
+    Verifies that if an execution fails in HALF_OPEN, the circuit trips back to OPEN immediately.
+    """
+    breaker = A2ADelegationCircuitBreakerV6(failure_threshold=1, recovery_timeout=0.1, success_threshold=2)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Peer unresponsive")
+
+    # Trip the circuit
+    with pytest.raises(ValueError):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Wait for recovery timeout
+    await asyncio.sleep(0.12)
+    assert breaker.get_peer_state(peer_id) == CircuitState.HALF_OPEN
+
+    # Failure in HALF_OPEN should trip back to OPEN immediately
+    with pytest.raises(ValueError, match="Peer unresponsive"):
+        await breaker.execute(peer_id, failing_delegate)
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_peer_isolation() -> None:
+    """
+    Verifies that circuit breaker state is isolated per peer.
+    """
+    breaker = A2ADelegationCircuitBreakerV6(failure_threshold=1, recovery_timeout=1.0)
+    peer_a = "peer-A"
+    peer_b = "peer-B"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Failed")
+
+    async def successful_delegate() -> str:
+        return "success"
+
+    # Trip Peer A
+    with pytest.raises(ValueError):
+        await breaker.execute(peer_a, failing_delegate)
+    assert breaker.get_peer_state(peer_a) == CircuitState.OPEN
+
+    # Peer B should still be CLOSED and functional
+    assert breaker.get_peer_state(peer_b) == CircuitState.CLOSED
+    res = await breaker.execute(peer_b, successful_delegate)
+    assert res == "success"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_synchronous_fallback() -> None:
+    """
+    Verifies that synchronous fallback functions degrade execution gracefully.
+    """
+    breaker = A2ADelegationCircuitBreakerV6(failure_threshold=1, recovery_timeout=1.0)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Failed")
+
+    def sync_fallback() -> Dict[str, Any]:
+        return {"status": "fallback_local", "reason": "service_unavailable"}
+
+    # Fails and triggers fallback
+    res = await breaker.execute(peer_id, failing_delegate, fallback_func=sync_fallback)
+    assert res == {"status": "fallback_local", "reason": "service_unavailable"}
+    assert breaker.get_peer_state(peer_id) == CircuitState.OPEN
+
+    # Blocked execution calls fallback directly
+    res2 = await breaker.execute(peer_id, failing_delegate, fallback_func=sync_fallback)
+    assert res2 == {"status": "fallback_local", "reason": "service_unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_asynchronous_fallback() -> None:
+    """
+    Verifies that asynchronous fallback functions degrade execution gracefully.
+    """
+    breaker = A2ADelegationCircuitBreakerV6(failure_threshold=1, recovery_timeout=1.0)
+    peer_id = "peer-1"
+
+    async def failing_delegate() -> Any:
+        raise ValueError("Failed")
+
+    async def async_fallback() -> Dict[str, Any]:
+        return {"status": "fallback_async_local"}
+
+    res = await breaker.execute(peer_id, failing_delegate, fallback_func=async_fallback)
+    assert res == {"status": "fallback_async_local"}


### PR DESCRIPTION
This PR implements the `A2ADelegationCircuitBreakerV6` module as per the `a2a-delegation-circuit-breaker-v6-unique-62a89989` task. 

**Changes:**
- Created `magda_agent/integration/a2a_circuit_breaker_v6.py` with fully typed and docstring-documented code.
- Created `tests/test_a2a_circuit_breaker_v6.py` and ensured tests pass successfully.
- Marked task as `done` in `agent_tasks.json`.
- Appended 3 new "todo" tasks inspired by 2026 AI agent trends (MCP negotiation, OpenClaw Canvas, and A2A capabilities) to `agent_tasks.json` and `backlog.md`.
- Maintained strict allowed path boundaries and passed pre-commit checks.

---
*PR created automatically by Jules for task [12872541679893778453](https://jules.google.com/task/12872541679893778453) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A delegation circuit breaker with per-peer state tracking and fallback support
> - Implements [`A2ADelegationCircuitBreakerV6`](https://github.com/kazah4359-lgtm/Magda-agent/pull/594/files#diff-42ecadde896ace6f5204f2e52b7d45a388ca9a4c5f46883d2d292227d1091c0c) with CLOSED/OPEN/HALF_OPEN states tracked independently per peer ID.
> - Trips to OPEN after configurable consecutive failures; transitions to HALF_OPEN after a recovery timeout, then closes after a configurable number of successful trial executions.
> - The `execute` async method supports optional sync or async fallbacks; raises `CircuitBreakerOpenException` when blocked with no fallback.
> - Adds 7 unit tests in [`tests/test_a2a_circuit_breaker_v6.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/594/files#diff-b9befc0e99eb101b91de0976d21405ef34ef2aa3c180eb845610a3cb32106cad) covering normal flow, tripping, recovery, half-open failure, peer isolation, and both fallback types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f8b2c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->