### PR TITLE
feat(execution): implement MCPConcurrentExecutor

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9570,7 +9570,7 @@
     },
     {
       "id": "mcp-server-tool-concurrency-5ec68904-3f7f-4a2e-81c2-14dc184faf34",
-      "status": "todo",
+      "status": "done",
       "area": "execution",
       "risk": "medium",
       "title": "MCP Server-Prefixed Tool Concurrency",
@@ -21650,6 +21650,57 @@
       ],
       "risk": "medium",
       "area": "multi-agent",
+      "status": "todo"
+    },
+    {
+      "id": "a2a-distributed-telemetry-exporter-v1",
+      "title": "A2A Distributed Telemetry Exporter v1",
+      "description": "Inspired by A2A Protocol trend (June 2026): Implement an exporter that broadcasts agent execution metrics and telemetry to an A2A observability mesh for decentralized monitoring.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_exporter_v1.py",
+        "tests/test_a2a_exporter_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter pushes structured telemetry via A2A protocol.",
+        "Tests verify format and mocked broadcast execution."
+      ],
+      "risk": "low",
+      "area": "telemetry",
+      "status": "todo"
+    },
+    {
+      "id": "openclaw-rl-multimodal-audio-feedback-v1",
+      "title": "OpenClaw RL Audio Feedback Alignment v1",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Extend OpenClaw reinforcement learning to parse user audio tone/inflection shifts from voice inputs as next-state reward signals.",
+      "allowed_paths": [
+        "magda_agent/learning/audio_sentiment_v1.py",
+        "tests/test_audio_sentiment_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audio sentiment signals successfully update habit weights.",
+        "Tests verify weight adjustments using mock audio signals."
+      ],
+      "risk": "medium",
+      "area": "learning",
+      "status": "todo"
+    },
+    {
+      "id": "mcp-websocket-streaming-v2-unique",
+      "title": "MCP Server WebSocket Transport v2",
+      "description": "Inspired by MCP trend (June 2026): Implement a WebSocket transport for the MCP server to support real-time full-duplex communication with external agents.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_websocket_v2_unique.py",
+        "tests/test_mcp_websocket_v2_unique.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket transport successfully handles JSON-RPC messages.",
+        "Tests mock WebSocket connections and message parsing."
+      ],
+      "risk": "medium",
+      "area": "integration",
       "status": "todo"
     }
   ]

--- a/magda_agent/execution/mcp_concurrent.py
+++ b/magda_agent/execution/mcp_concurrent.py
@@ -1,0 +1,38 @@
+import asyncio
+import logging
+from typing import Any, Callable, Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+class MCPConcurrentExecutor:
+    """
+    A specialized concurrency module designed for running multiple
+    MCP action tools in parallel without blocking the event loop.
+    """
+
+    def __init__(self) -> None:
+        """Initializes the MCPConcurrentExecutor."""
+        pass
+
+    async def execute_tools_concurrently(self, tasks: List[Tuple[Callable[..., Any], Dict[str, Any]]]) -> List[Any]:
+        """
+        Executes a list of asynchronous tool functions concurrently.
+
+        Args:
+            tasks: A list of tuples, where each tuple contains an async callable
+                   and a dictionary of kwargs to pass to that callable.
+
+        Returns:
+            A list containing the results of the tool executions in the same order
+            as the input tasks. Exceptions raised by individual tools will be
+            returned as Exception objects in the list rather than crashing the loop.
+        """
+        coroutines = []
+        for func, kwargs in tasks:
+            coroutines.append(func(**kwargs))
+
+        logger.info(f"Executing {len(coroutines)} MCP tools concurrently.")
+
+        # Use return_exceptions=True so one failing tool doesn't abort the others
+        results = await asyncio.gather(*coroutines, return_exceptions=True)
+        return list(results)

--- a/tests/test_mcp_concurrent.py
+++ b/tests/test_mcp_concurrent.py
@@ -1,0 +1,53 @@
+import asyncio
+import time
+import pytest
+from unittest.mock import AsyncMock
+from magda_agent.execution.mcp_concurrent import MCPConcurrentExecutor
+
+async def mock_tool_success(delay: float = 0.1, result: str = "success") -> str:
+    """A mock asynchronous tool that succeeds after a delay."""
+    await asyncio.sleep(delay)
+    return result
+
+async def mock_tool_failure(delay: float = 0.1, error_msg: str = "error") -> str:
+    """A mock asynchronous tool that fails after a delay."""
+    await asyncio.sleep(delay)
+    raise ValueError(error_msg)
+
+def test_execute_tools_concurrently_success():
+    """Test that multiple successful tools run concurrently."""
+    executor = MCPConcurrentExecutor()
+
+    tasks = [
+        (mock_tool_success, {"delay": 0.2, "result": "res1"}),
+        (mock_tool_success, {"delay": 0.2, "result": "res2"}),
+        (mock_tool_success, {"delay": 0.2, "result": "res3"}),
+    ]
+
+    start_time = time.time()
+    results = asyncio.run(executor.execute_tools_concurrently(tasks))
+    end_time = time.time()
+
+    duration = end_time - start_time
+
+    assert results == ["res1", "res2", "res3"]
+    # If sequential, it would take > 0.6 seconds. Concurrently, it should take ~0.2 seconds.
+    assert duration < 0.4, f"Execution took too long ({duration}s), possibly not concurrent."
+
+def test_execute_tools_concurrently_with_exceptions():
+    """Test that exceptions do not crash the gather and are returned as results."""
+    executor = MCPConcurrentExecutor()
+
+    tasks = [
+        (mock_tool_success, {"delay": 0.1, "result": "ok"}),
+        (mock_tool_failure, {"delay": 0.1, "error_msg": "failed"}),
+        (mock_tool_success, {"delay": 0.1, "result": "ok2"}),
+    ]
+
+    results = asyncio.run(executor.execute_tools_concurrently(tasks))
+
+    assert len(results) == 3
+    assert results[0] == "ok"
+    assert isinstance(results[1], ValueError)
+    assert str(results[1]) == "failed"
+    assert results[2] == "ok2"


### PR DESCRIPTION
This PR addresses the task "mcp-server-tool-concurrency" (ID: mcp-server-tool-concurrency-5ec68904-3f7f-4a2e-81c2-14dc184faf34).

It includes:
- `MCPConcurrentExecutor` module to run MCP action tools in parallel without event loop blocking.
- Associated tests validating concurrent execution speeds and exception handling.
- `agent_tasks.json` update marking the task as done.
- 3 new 'todo' tasks inspired by modern AI agent trends appended to `agent_tasks.json`.

---
*PR created automatically by Jules for task [9641259974280588080](https://jules.google.com/task/9641259974280588080) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPConcurrentExecutor` to run MCP tools in parallel
> - Adds [`MCPConcurrentExecutor`](https://github.com/kazah4359-lgtm/Magda-agent/pull/599/files#diff-828c8171f2ccacea961efa5d9a0613f8b88a209d13627ea39d16b6e1e8337856) with an `execute_tools_concurrently` async method that accepts a list of `(callable, kwargs)` tuples and runs them via `asyncio.gather` with `return_exceptions=True`.
> - Failures are returned as `Exception` instances in-place rather than aborting the batch, preserving result order.
> - Two tests in [`tests/test_mcp_concurrent.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/599/files#diff-d750cb8af23e6acab07fc99c9278cc9208f3dd70a66e44b0c1e062229dbe0da5) validate concurrent timing and exception-capture semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 345a132.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->