### PR TITLE
feat: OpenClaw Canvas streaming for working memory

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9604,7 +9604,7 @@
     },
     {
       "id": "openclaw-live-canvas-streaming-ee940fcb",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw Canvas streaming for working memory",
@@ -21702,6 +21702,60 @@
       "risk": "medium",
       "area": "integration",
       "status": "todo"
+    },
+    {
+      "id": "openclaw-canvas-state-sync-patching-v5-abc",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas State Sync Patching V5",
+      "description": "Inspired by OpenClaw Live Visualization trend: Create a Canvas state patch manager using standard JSON patch format to optimize websocket state synchronization between the backend brain and UI canvas.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_patching_v5.py",
+        "tests/test_canvas_patching_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Patch manager correctly generates and applies JSON state patches.",
+        "Tests verify that bandwidth is significantly reduced compared to full-state streaming."
+      ]
+    },
+    {
+      "id": "mcp-server-side-streaming-v3-def",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tool Server Server-Side Streaming Support v3",
+      "description": "Inspired by June 2026 OpenAI and Anthropic streaming trends: Implement server-side streaming output capabilities for exported MCP tools in Magda, enabling external clients to stream token chunks directly from LLM-driven skills instead of waiting for full execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_streaming_v3.py",
+        "tests/test_mcp_streaming_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP server supports exporting tool schemas with streaming response metadata.",
+        "The server correctly emits streaming chunks over JSON-RPC when a tool is executed in streaming mode.",
+        "Tests verify chunked output generation and transmission."
+      ]
+    },
+    {
+      "id": "openai-agents-sdk-handover-routing-v14-ghi",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "OpenAI Agents SDK Dynamic Handover and Routing Module v14",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a specialized handover router that allows subagents to yield control back to the parent coordinator or delegate to another specialized subagent dynamically via structured handover tool execution.",
+      "allowed_paths": [
+        "magda_agent/skills/handover_router_v14.py",
+        "tests/test_handover_router_v14.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "HandoverRouter allows registering agents and defining handover tool signatures.",
+        "Dynamically routes control flow between agents upon handover execution.",
+        "Tests verify state preservation and successful routing across different handoffs.",
+        "No external APIs are called, everything is mock-tested."
+      ]
     }
   ]
 }

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -6,6 +6,8 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from magda_agent.visualization.server import CanvasServer
+from magda_agent.visualization.canvas_streamer import CanvasMemoryStreamer
+
 from magda_agent.architecture.gateway import LocalFirstGateway
 from magda_agent.visualization.canvas_api_v2 import get_canvas_v2_router
 from pydantic import BaseModel
@@ -239,6 +241,7 @@ autonomous_executor = AutonomousExecutor(
 )
 
 
+canvas_memory_streamer = CanvasMemoryStreamer(working_memory=memory_system.working_memory)
 canvas_server = CanvasServer(consciousness=consciousness)
 a2a_server = A2AServer(planner=planner, security_context=a2a_security)
 rpc_manager = SubAgentRPCManager(llm=llm_client)
@@ -258,6 +261,7 @@ async def lifespan(app: FastAPI):
     asyncio.create_task(daily_report_scheduler.start())
     asyncio.create_task(operations_scheduler.start())
     await autonomous_executor.start()
+    asyncio.create_task(canvas_memory_streamer.start_streaming())
     asyncio.create_task(canvas_server.start_streaming())
     asyncio.create_task(discord_bridge.start())
     yield
@@ -266,6 +270,7 @@ async def lifespan(app: FastAPI):
     await daily_report_scheduler.stop()
     await operations_scheduler.stop()
     await autonomous_executor.stop()
+    await canvas_memory_streamer.stop_streaming()
     await canvas_server.stop_streaming()
     await discord_bridge.stop()
     memory_system.close()
@@ -413,3 +418,16 @@ async def websocket_canvas(websocket: WebSocket):
             data = await websocket.receive_text()
     except WebSocketDisconnect:
         canvas_server.disconnect(websocket)
+
+@app.websocket("/ws/canvas/memory")
+async def websocket_canvas_memory(websocket: WebSocket):
+    token = websocket.query_params.get("token")
+    if not _configured_api_token() or not hmac.compare_digest(token or "", _configured_api_token() or ""):
+        await websocket.close(code=1008)
+        return
+    await canvas_memory_streamer.connect(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+    except WebSocketDisconnect:
+        canvas_memory_streamer.disconnect(websocket)

--- a/magda_agent/visualization/canvas_streamer.py
+++ b/magda_agent/visualization/canvas_streamer.py
@@ -1,0 +1,121 @@
+import asyncio
+import json
+import logging
+from typing import List, Dict, Any, Optional
+from fastapi import WebSocket, WebSocketDisconnect
+from magda_agent.memory.working import WorkingMemory
+
+logger = logging.getLogger(__name__)
+
+class CanvasMemoryStreamer:
+    """
+    WebSocket server for streaming live working memory changes (diffs).
+    """
+    def __init__(self, working_memory: WorkingMemory, interval: float = 1.0):
+        self.working_memory = working_memory
+        self.interval = interval
+        self.active_connections: List[WebSocket] = []
+        self._running = False
+        self._last_state: Dict[int, List[Dict[str, Any]]] = {}
+
+    async def connect(self, websocket: WebSocket):
+        """Accept a websocket connection and add it to the active pool."""
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info(f"Canvas client connected. Total clients: {len(self.active_connections)}")
+
+    def disconnect(self, websocket: WebSocket):
+        """Remove a websocket connection from the pool."""
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+            logger.info(f"Canvas client disconnected. Total clients: {len(self.active_connections)}")
+
+    async def broadcast(self, message: str):
+        """Broadcast a message to all active websocket connections."""
+        disconnected = []
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(message)
+            except Exception as e:
+                logger.error(f"Failed to send message to canvas client: {e}")
+                disconnected.append(connection)
+
+        for conn in disconnected:
+            self.disconnect(conn)
+
+    def _get_current_state(self) -> Dict[int, List[Dict[str, Any]]]:
+        """Extract the current state of working memory."""
+        state = {}
+        for user_id, entries in self.working_memory._entries_by_user.items():
+            state[user_id] = [
+                {
+                    "id": e.id,
+                    "content": e.content,
+                    "timestamp": e.timestamp,
+                    "importance": e.importance,
+                    "tags": e.tags
+                } for e in entries
+            ]
+        return state
+
+    def _calculate_diff(self, current_state: Dict[int, List[Dict[str, Any]]]) -> Dict[str, Any]:
+        """Calculate diffs between the last state and current state."""
+        diffs = {"added": {}, "removed": {}, "updated": {}}
+
+        # For simplicity, we diff on entry ID
+        all_last_users = set(self._last_state.keys())
+        all_current_users = set(current_state.keys())
+
+        for user_id in all_last_users.union(all_current_users):
+            last_entries = self._last_state.get(user_id, [])
+            current_entries = current_state.get(user_id, [])
+
+            last_dict = {e["id"]: e for e in last_entries}
+            current_dict = {e["id"]: e for e in current_entries}
+
+            added = []
+            removed = []
+            updated = []
+
+            for eid, entry in current_dict.items():
+                if eid not in last_dict:
+                    added.append(entry)
+                elif last_dict[eid] != entry:
+                    updated.append(entry)
+
+            for eid, entry in last_dict.items():
+                if eid not in current_dict:
+                    removed.append(entry)
+
+            if added:
+                diffs["added"][user_id] = added
+            if removed:
+                diffs["removed"][user_id] = removed
+            if updated:
+                diffs["updated"][user_id] = updated
+
+        return diffs
+
+    async def start_streaming(self):
+        """Start the background task that periodically broadcasts the cognitive state."""
+        self._running = True
+        logger.info("Canvas memory streaming started.")
+        self._last_state = self._get_current_state()
+
+        while self._running:
+            try:
+                if self.active_connections:
+                    current_state = self._get_current_state()
+                    diffs = self._calculate_diff(current_state)
+
+                    if diffs["added"] or diffs["removed"] or diffs["updated"]:
+                        await self.broadcast(json.dumps({"type": "memory_diff", "diffs": diffs}))
+                        self._last_state = current_state
+            except Exception as e:
+                logger.error(f"Error while streaming canvas memory state: {e}")
+            await asyncio.sleep(self.interval)
+
+    async def stop_streaming(self):
+        """Stop the background streaming task."""
+        self._running = False
+        logger.info("Canvas memory streaming stopped.")

--- a/tests/test_canvas_streamer.py
+++ b/tests/test_canvas_streamer.py
@@ -1,0 +1,90 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import MagicMock, AsyncMock
+from magda_agent.visualization.canvas_streamer import CanvasMemoryStreamer
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+
+def test_canvas_streamer_connect_disconnect():
+    async def run_test():
+        working_memory = WorkingMemory()
+        streamer = CanvasMemoryStreamer(working_memory)
+
+        websocket = AsyncMock()
+        await streamer.connect(websocket)
+        websocket.accept.assert_called_once()
+        assert websocket in streamer.active_connections
+
+        streamer.disconnect(websocket)
+        assert websocket not in streamer.active_connections
+
+    asyncio.run(run_test())
+
+def test_canvas_streamer_diff_calculation():
+    working_memory = WorkingMemory()
+    streamer = CanvasMemoryStreamer(working_memory)
+
+    # State 1: Add memory entry
+    entry1 = MemoryEntry("Hello", 0.8, None, user_id=1)
+    working_memory._entries_by_user[1] = [entry1]
+
+    state1 = streamer._get_current_state()
+    diffs1 = streamer._calculate_diff(state1)
+    assert 1 in diffs1["added"]
+    assert len(diffs1["added"][1]) == 1
+    assert diffs1["added"][1][0]["content"] == "Hello"
+
+    streamer._last_state = state1
+
+    # State 2: Update entry and add a new one
+    entry1.content = "Hello World"
+    entry2 = MemoryEntry("Hi", 0.5, None, user_id=1)
+    working_memory._entries_by_user[1] = [entry1, entry2]
+
+    state2 = streamer._get_current_state()
+    diffs2 = streamer._calculate_diff(state2)
+    assert 1 in diffs2["added"]
+    assert len(diffs2["added"][1]) == 1
+    assert diffs2["added"][1][0]["content"] == "Hi"
+
+    assert 1 in diffs2["updated"]
+    assert len(diffs2["updated"][1]) == 1
+    assert diffs2["updated"][1][0]["content"] == "Hello World"
+
+    streamer._last_state = state2
+
+    # State 3: Remove entry 1
+    working_memory._entries_by_user[1] = [entry2]
+
+    state3 = streamer._get_current_state()
+    diffs3 = streamer._calculate_diff(state3)
+    assert 1 in diffs3["removed"]
+    assert len(diffs3["removed"][1]) == 1
+    assert diffs3["removed"][1][0]["id"] == entry1.id
+
+def test_canvas_streamer_broadcast():
+    async def run_test():
+        working_memory = WorkingMemory()
+        streamer = CanvasMemoryStreamer(working_memory)
+
+        ws1 = AsyncMock()
+        ws2 = AsyncMock()
+        ws3 = AsyncMock() # This one will fail
+
+        ws3.send_text.side_effect = Exception("Connection closed")
+
+        await streamer.connect(ws1)
+        await streamer.connect(ws2)
+        await streamer.connect(ws3)
+
+        await streamer.broadcast("test message")
+
+        ws1.send_text.assert_called_once_with("test message")
+        ws2.send_text.assert_called_once_with("test message")
+        ws3.send_text.assert_called_once_with("test message")
+
+        assert ws1 in streamer.active_connections
+        assert ws2 in streamer.active_connections
+        assert ws3 not in streamer.active_connections # Should be disconnected on error
+
+    asyncio.run(run_test())


### PR DESCRIPTION
Resolves the `openclaw-live-canvas-streaming-ee940fcb` task.

Introduces a WebSocket endpoint in `magda_agent/api.py` dedicated to broadcasting working memory state differences to Canvas UI clients. The diffs logic reduces overhead from sending massive contextual tokens directly via full snapshots. Tests are mocked securely avoiding external system dependencies. Also appends 3 related AI-agent trend tasks.

---
*PR created automatically by Jules for task [9045748530327681747](https://jules.google.com/task/9045748530327681747) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WebSocket streaming of working memory diffs to the Canvas API
> - Adds `CanvasMemoryStreamer` in [`canvas_streamer.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/601/files#diff-f06356bcae43177f3600490cd9ab59d638031580022aaa0c3ad21d509b306cc9) that polls `WorkingMemory` on a configurable interval, computes per-user diffs (added/removed/updated entries), and broadcasts `{type: "memory_diff", diffs}` JSON messages to all connected clients.
> - Adds a `/ws/canvas/memory` WebSocket endpoint in [`api.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/601/files#diff-acf5b1edb87fda54aad97ee5eb3857c9f1042d25a5c905eed0cb49f8e4d57b6d) secured with `hmac.compare_digest` token validation; the streamer starts and stops with the FastAPI app lifecycle.
> - Failed client connections are pruned automatically during broadcast.
> - Tests covering connection management, diff scenarios, and broadcast pruning are added in [`tests/test_canvas_streamer.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/601/files#diff-6530635bd86f4803f14adbbd0f503b76c557a9d6b09eeb254e32cfde8a953e43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0453f58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->