### PR TITLE
Implement Dynamic Skill Weight Decay

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9621,7 +9621,7 @@
     },
     {
       "id": "51f91ae6-38f6-46c9-8710-6a8bda48741a",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw Dynamic Skill Weight Decay",

--- a/magda_agent/learning/decay.py
+++ b/magda_agent/learning/decay.py
@@ -1,0 +1,142 @@
+import math
+import logging
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def decay_weight_exponential(
+    weight: float,
+    elapsed_time: float,
+    decay_rate: float,
+    baseline: float = 1.0
+) -> float:
+    """
+    Decays a single weight towards a baseline value using exponential decay over time.
+
+    Formula:
+        new_weight = baseline + (weight - baseline) * exp(-decay_rate * elapsed_time)
+
+    Args:
+        weight (float): The current weight.
+        elapsed_time (float): Time elapsed (in seconds, turns, or other units).
+                              Must be non-negative. If negative, returns original weight.
+        decay_rate (float): The rate of decay. Must be non-negative.
+        baseline (float): The target baseline value that weights decay towards. Defaults to 1.0.
+
+    Returns:
+        float: The decayed weight.
+    """
+    if elapsed_time <= 0.0 or decay_rate <= 0.0:
+        return weight
+
+    diff = weight - baseline
+    decay_factor = math.exp(-decay_rate * elapsed_time)
+    return baseline + diff * decay_factor
+
+
+def decay_weight_step(
+    weight: float,
+    steps: int,
+    decay_rate: float,
+    baseline: float = 1.0
+) -> float:
+    """
+    Decays a single weight towards a baseline value using discrete steps.
+
+    Formula:
+        new_weight = baseline + (weight - baseline) * (1 - decay_rate) ** steps
+
+    Args:
+        weight (float): The current weight.
+        steps (int): The number of steps elapsed. Must be non-negative.
+        decay_rate (float): The decay rate per step (between 0.0 and 1.0).
+        baseline (float): The target baseline value that weights decay towards. Defaults to 1.0.
+
+    Returns:
+        float: The decayed weight.
+    """
+    if steps <= 0 or decay_rate <= 0.0:
+        return weight
+
+    # Clamp decay_rate to [0, 1]
+    clamped_rate = max(0.0, min(1.0, decay_rate))
+    diff = weight - baseline
+    decay_factor = (1.0 - clamped_rate) ** steps
+    return baseline + diff * decay_factor
+
+
+def decay_skill_weights(
+    skill_weights: Dict[str, float],
+    last_updated: Dict[str, float],
+    current_time: float,
+    decay_rate: float,
+    baseline: float = 1.0
+) -> Dict[str, float]:
+    """
+    Decays a dictionary of skill weights based on individual last updated timestamps.
+
+    Args:
+        skill_weights (Dict[str, float]): Map of skill names to current weights.
+        last_updated (Dict[str, float]): Map of skill names to their last updated timestamps.
+        current_time (float): The current timestamp.
+        decay_rate (float): The exponential decay rate.
+        baseline (float): Target baseline value. Defaults to 1.0.
+
+    Returns:
+        Dict[str, float]: A new dictionary containing the decayed skill weights.
+    """
+    decayed_weights = {}
+    for skill, weight in skill_weights.items():
+        last_time = last_updated.get(skill)
+        if last_time is not None:
+            elapsed = current_time - last_time
+            decayed_weights[skill] = decay_weight_exponential(
+                weight, elapsed, decay_rate, baseline
+            )
+        else:
+            decayed_weights[skill] = weight
+    return decayed_weights
+
+
+class SkillWeightDecayer:
+    """
+    A helper class to manage and apply time-based or step-based skill weight decay.
+    """
+
+    def __init__(self, decay_rate: float = 0.05, baseline: float = 1.0) -> None:
+        """
+        Initializes the SkillWeightDecayer.
+
+        Args:
+            decay_rate (float): The decay rate used for step or time-based decay.
+            baseline (float): The baseline value towards which weights decay. Defaults to 1.0.
+        """
+        self.decay_rate = decay_rate
+        self.baseline = baseline
+
+    def decay_by_time(
+        self,
+        skill_weights: Dict[str, float],
+        last_updated: Dict[str, float],
+        current_time: float
+    ) -> Dict[str, float]:
+        """
+        Applies time-based exponential decay to a set of skill weights.
+        """
+        return decay_skill_weights(
+            skill_weights, last_updated, current_time, self.decay_rate, self.baseline
+        )
+
+    def decay_by_steps(
+        self,
+        skill_weights: Dict[str, float],
+        steps: int = 1
+    ) -> Dict[str, float]:
+        """
+        Applies step-based decay to all skill weights uniformly.
+        """
+        return {
+            skill: decay_weight_step(weight, steps, self.decay_rate, self.baseline)
+            for skill, weight in skill_weights.items()
+        }

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -1,0 +1,129 @@
+import pytest
+import math
+from magda_agent.learning.decay import (
+    decay_weight_exponential,
+    decay_weight_step,
+    decay_skill_weights,
+    SkillWeightDecayer,
+)
+
+
+def test_decay_weight_exponential_above_baseline():
+    # Weight starts at 2.0, decays towards 1.0 with rate 0.5 over 2.0 seconds
+    # Expected: 1.0 + (2.0 - 1.0) * exp(-0.5 * 2.0) = 1.0 + 1.0 * exp(-1) = 1.0 + 1.0 / e
+    weight = 2.0
+    elapsed_time = 2.0
+    decay_rate = 0.5
+    baseline = 1.0
+
+    result = decay_weight_exponential(weight, elapsed_time, decay_rate, baseline)
+    expected = baseline + (weight - baseline) * math.exp(-decay_rate * elapsed_time)
+    assert pytest.approx(result) == expected
+    assert result > 1.0
+    assert result < 2.0
+
+
+def test_decay_weight_exponential_below_baseline():
+    # Weight starts at 0.5, decays towards 1.0 with rate 0.5 over 2.0 seconds
+    # Expected: 1.0 + (0.5 - 1.0) * exp(-1) = 1.0 - 0.5 / e
+    weight = 0.5
+    elapsed_time = 2.0
+    decay_rate = 0.5
+    baseline = 1.0
+
+    result = decay_weight_exponential(weight, elapsed_time, decay_rate, baseline)
+    expected = baseline + (weight - baseline) * math.exp(-decay_rate * elapsed_time)
+    assert pytest.approx(result) == expected
+    assert result > 0.5
+    assert result < 1.0
+
+
+def test_decay_weight_exponential_edge_cases():
+    # Negative elapsed time -> should return original weight
+    assert decay_weight_exponential(2.0, -1.0, 0.5, 1.0) == 2.0
+    # Zero elapsed time -> should return original weight
+    assert decay_weight_exponential(2.0, 0.0, 0.5, 1.0) == 2.0
+    # Zero decay rate -> should return original weight
+    assert decay_weight_exponential(2.0, 5.0, 0.0, 1.0) == 2.0
+    # Weight already at baseline -> should return baseline
+    assert decay_weight_exponential(1.0, 5.0, 0.5, 1.0) == 1.0
+
+
+def test_decay_weight_step_above_baseline():
+    # Weight starts at 2.0, decays towards 1.0 with step rate 0.1 over 3 steps
+    # Expected: 1.0 + (2.0 - 1.0) * (1 - 0.1) ** 3 = 1.0 + 1.0 * 0.9 ** 3 = 1.0 + 0.729 = 1.729
+    weight = 2.0
+    steps = 3
+    decay_rate = 0.1
+    baseline = 1.0
+
+    result = decay_weight_step(weight, steps, decay_rate, baseline)
+    assert pytest.approx(result) == 1.729
+
+
+def test_decay_weight_step_below_baseline():
+    # Weight starts at 0.2, decays towards 1.0 with step rate 0.2 over 2 steps
+    # Expected: 1.0 + (0.2 - 1.0) * (1 - 0.2) ** 2 = 1.0 - 0.8 * 0.64 = 1.0 - 0.512 = 0.488
+    weight = 0.2
+    steps = 2
+    decay_rate = 0.2
+    baseline = 1.0
+
+    result = decay_weight_step(weight, steps, decay_rate, baseline)
+    assert pytest.approx(result) == 0.488
+
+
+def test_decay_weight_step_edge_cases():
+    # Negative steps -> should return original weight
+    assert decay_weight_step(2.0, -5, 0.1, 1.0) == 2.0
+    # Zero steps -> should return original weight
+    assert decay_weight_step(2.0, 0, 0.1, 1.0) == 2.0
+    # Zero decay rate -> should return original weight
+    assert decay_weight_step(2.0, 3, 0.0, 1.0) == 2.0
+
+
+def test_decay_skill_weights():
+    skill_weights = {"skill_a": 1.8, "skill_b": 0.4, "skill_c": 1.0}
+    last_updated = {"skill_a": 1000.0, "skill_b": 1050.0}  # skill_c has no last updated timestamp
+    current_time = 1100.0
+    decay_rate = 0.01
+    baseline = 1.0
+
+    result = decay_skill_weights(
+        skill_weights, last_updated, current_time, decay_rate, baseline
+    )
+
+    # For skill_a: elapsed = 100.0, expected = 1.0 + 0.8 * exp(-0.01 * 100) = 1.0 + 0.8 / e
+    expected_a = 1.0 + 0.8 * math.exp(-1.0)
+    assert pytest.approx(result["skill_a"]) == expected_a
+
+    # For skill_b: elapsed = 50.0, expected = 1.0 + (-0.6) * exp(-0.01 * 50) = 1.0 - 0.6 * exp(-0.5)
+    expected_b = 1.0 - 0.6 * math.exp(-0.5)
+    assert pytest.approx(result["skill_b"]) == expected_b
+
+    # For skill_c: no timestamp, should return original weight
+    assert result["skill_c"] == 1.0
+
+
+def test_skill_weight_decayer_class_time():
+    decayer = SkillWeightDecayer(decay_rate=0.02, baseline=1.0)
+    skill_weights = {"skill_a": 1.5}
+    last_updated = {"skill_a": 100.0}
+    current_time = 150.0
+
+    # Elapsed = 50.0. Expected: 1.0 + 0.5 * exp(-0.02 * 50) = 1.0 + 0.5 * exp(-1.0) = 1.0 + 0.5 / e
+    result = decayer.decay_by_time(skill_weights, last_updated, current_time)
+    expected = 1.0 + 0.5 * math.exp(-1.0)
+    assert pytest.approx(result["skill_a"]) == expected
+
+
+def test_skill_weight_decayer_class_steps():
+    decayer = SkillWeightDecayer(decay_rate=0.1, baseline=1.0)
+    skill_weights = {"skill_a": 1.5, "skill_b": 0.5}
+
+    result = decayer.decay_by_steps(skill_weights, steps=2)
+
+    # For skill_a: 1.0 + 0.5 * (0.9) ** 2 = 1.0 + 0.5 * 0.81 = 1.405
+    assert pytest.approx(result["skill_a"]) == 1.405
+    # For skill_b: 1.0 - 0.5 * (0.9) ** 2 = 1.0 - 0.5 * 0.81 = 0.595
+    assert pytest.approx(result["skill_b"]) == 0.595


### PR DESCRIPTION
Implemented the dynamic skill weight decay feature inspired by OpenClaw trends. Added a robust decay module with exponential and step-based formulas and comprehensive test coverage.

---
*PR created automatically by Jules for task [7571586773747868271](https://jules.google.com/task/7571586773747868271) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement dynamic skill weight decay with exponential and step-based strategies
> Adds [decay.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/602/files#diff-4f5f22d43d062dfac243b7a0d8868fcfa81d7426070734316f768d22a7ce30ee) with two decay strategies for skill weights: exponential time-based decay and discrete step-based decay, both targeting a configurable baseline.
>
> - `decay_weight_exponential` computes `baseline + (weight - baseline) * exp(-rate * elapsed_time)`; guards against non-positive time or rate.
> - `decay_weight_step` computes `baseline + (weight - baseline) * (1 - rate) ** steps`; clamps rate to `[0, 1]`.
> - `decay_skill_weights` applies exponential decay across a dict of skill weights using per-skill `last_updated` timestamps.
> - `SkillWeightDecayer` wraps both strategies as instance methods, encapsulating `decay_rate` and `baseline` configuration.
> - Unit tests in [tests/test_decay.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/602/files#diff-9c699fb372f6272f48767ae25fffc35400b0fac2c280494267b5821d52408477) cover above/below-baseline cases, edge cases, dict-based decay, and the class API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4a252a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->