### PR TITLE
feat(security): Implement MCPKernelFS for sandbox isolation enhancements

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9655,7 +9655,7 @@
     },
     {
       "id": "f8acf4d1-72cb-44bf-bb54-97f8b5f7f6cf",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "Claude Code Sandbox Isolation Enhancements",
@@ -21807,6 +21807,57 @@
         "WebSocket streamer correctly sends Q-value updates.",
         "Tests mock RL updates and verify the WebSocket payload format."
       ]
+    },
+    {
+      "id": "mcp-context-compression-v1",
+      "title": "MCP Context Compression v1",
+      "description": "Inspired by Claude Agent SDK context compression trend (June 2026): Implement an MCP context compression middleware that automatically summarizes older conversation turns when the tool payload exceeds a threshold token limit.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_context_compression.py",
+        "tests/test_mcp_context_compression.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Middleware compresses context payload.",
+        "Tests verify compression execution using a mock LLM."
+      ],
+      "risk": "medium",
+      "area": "integration",
+      "status": "todo"
+    },
+    {
+      "id": "a2a-agent-capability-mesh-v1",
+      "title": "A2A Agent Capability Mesh v1",
+      "description": "Inspired by A2A Protocol trend (June 2026): Develop a dynamic registry that maintains peer agent capabilities across the network, resolving Agent Cards continuously to keep a mesh routing table updated.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_capability_mesh.py",
+        "tests/test_a2a_capability_mesh.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Mesh registry resolves and caches capabilities.",
+        "Tests mock network discovery and verify caching behavior."
+      ],
+      "risk": "low",
+      "area": "integration",
+      "status": "todo"
+    },
+    {
+      "id": "canvas-procedural-memory-stream-v1",
+      "title": "Canvas Procedural Memory Stream v1",
+      "description": "Inspired by OpenClaw Canvas live visualization trend (June 2026): Create a WebSocket streamer for the Canvas UI that specifically visualizes updates to procedural memory weights and skill acquisition in real-time.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_procedural_stream.py",
+        "tests/test_canvas_procedural_stream.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket endpoint correctly streams procedural memory state diffs.",
+        "Tests mock procedural memory updates and verify stream format."
+      ],
+      "risk": "low",
+      "area": "visualization",
+      "status": "todo"
     }
   ]
 }

--- a/magda_agent/security/mcp_kernel.py
+++ b/magda_agent/security/mcp_kernel.py
@@ -1,5 +1,6 @@
 import ast
 from magda_agent.security.mcp_kernel_taint import is_tainted
+from magda_agent.security.mcp_kernel_fs import MCPKernelFS
 
 import builtins
 from typing import Any, Dict, Optional, Set
@@ -17,7 +18,8 @@ class MCPKernel:
     generator/comprehension frame tricks, and reassignment of allowed builtins.
     """
 
-    def __init__(self, allowed_builtins: Optional[Set[str]] = None):
+    def __init__(self, allowed_builtins: Optional[Set[str]] = None, allowed_fs: Optional[MCPKernelFS] = None):
+        self.allowed_fs = allowed_fs
         self.allowed_builtins = allowed_builtins or {
             "print", "len", "range", "int", "str", "float", "list", "dict",
             "set", "tuple", "bool",
@@ -48,7 +50,21 @@ class MCPKernel:
         if not self.is_safe(code):
             raise SecurityError("Code contains unsafe operations and was blocked by MCPKernel taint tracking.")
 
+
         safe_builtins = {name: getattr(builtins, name) for name in self.allowed_builtins if hasattr(builtins, name)}
+
+        # Support file operations if sandboxed FS is provided
+        if self.allowed_fs:
+            safe_builtins["open"] = self.allowed_fs.open
+            if "open" in self._unsafe_names:
+                self._unsafe_names.remove("open")
+            self.allowed_builtins.add("open")
+        else:
+            if "open" not in self._unsafe_names:
+                self._unsafe_names.add("open")
+            if "open" in self.allowed_builtins:
+                self.allowed_builtins.remove("open")
+
         execution_globals: Dict[str, Any] = {}
         if globals_dict:
             execution_globals.update({k: v for k, v in globals_dict.items() if k != "__builtins__"})

--- a/magda_agent/security/mcp_kernel_fs.py
+++ b/magda_agent/security/mcp_kernel_fs.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+from typing import Any, IO, List, Optional, Union
+
+
+
+
+class MCPKernelFS:
+    """
+    MCPKernelFS provides a sandboxed interface for file system operations.
+    It restricts file access to explicitly allowed directories during tool execution.
+    """
+
+    def __init__(self, allowed_directories: List[Union[str, Path]]):
+        """
+        Initialize the MCPKernelFS with a list of allowed directories.
+
+        Args:
+            allowed_directories: A list of paths representing allowed directories.
+        """
+        self.allowed_directories: List[Path] = [Path(d).resolve() for d in allowed_directories]
+
+
+    def _raise_security_error(self, message: str) -> None:
+        from magda_agent.security.mcp_kernel import SecurityError
+        raise SecurityError(message)
+
+    def _get_resolved_allowed_path(self, target_path: Path) -> Path:
+        """
+        Check if the resolved target path falls within any of the allowed directories.
+
+        Args:
+            target_path: The path to check.
+
+        Returns:
+            Path: The resolved path if allowed.
+
+        Raises:
+            SecurityError: If the path is outside allowed directories.
+        """
+        resolved_path = target_path.resolve()
+        for allowed_dir in self.allowed_directories:
+            try:
+                # Check if resolved_path is relative to allowed_dir (i.e., inside it)
+                resolved_path.relative_to(allowed_dir)
+                return resolved_path
+            except ValueError:
+                continue
+        self._raise_security_error(f"Access to path '{target_path}' is denied by MCPKernelFS.")
+
+    def open(self, file_path: Union[str, Path], mode: str = "r", **kwargs: Any) -> IO[Any]:
+        """
+        Open a file if it falls within the allowed directories.
+
+        Args:
+            file_path: The path of the file to open.
+            mode: The mode to open the file in.
+            **kwargs: Additional keyword arguments for open().
+
+        Returns:
+            A file object.
+
+        Raises:
+            SecurityError: If the path is outside allowed directories.
+        """
+        path = Path(file_path)
+        resolved_path = self._get_resolved_allowed_path(path)
+        return open(resolved_path, mode=mode, **kwargs)
+
+    def read_text(self, file_path: Union[str, Path], encoding: str = "utf-8") -> str:
+        """
+        Read text from a file if it falls within the allowed directories.
+
+        Args:
+            file_path: The path of the file to read.
+            encoding: The encoding to use.
+
+        Returns:
+            str: The contents of the file.
+
+        Raises:
+            SecurityError: If the path is outside allowed directories.
+        """
+        path = Path(file_path)
+        resolved_path = self._get_resolved_allowed_path(path)
+        return resolved_path.read_text(encoding=encoding)
+
+    def write_text(self, file_path: Union[str, Path], data: str, encoding: str = "utf-8") -> int:
+        """
+        Write text to a file if it falls within the allowed directories.
+
+        Args:
+            file_path: The path of the file to write to.
+            data: The text to write.
+            encoding: The encoding to use.
+
+        Returns:
+            int: The number of characters written.
+
+        Raises:
+            SecurityError: If the path is outside allowed directories.
+        """
+        path = Path(file_path)
+        resolved_path = self._get_resolved_allowed_path(path)
+        return resolved_path.write_text(data, encoding=encoding)

--- a/tests/test_mcp_kernel_fs.py
+++ b/tests/test_mcp_kernel_fs.py
@@ -1,0 +1,88 @@
+import pytest
+from pathlib import Path
+
+from magda_agent.security.mcp_kernel import SecurityError
+from magda_agent.security.mcp_kernel_fs import MCPKernelFS
+
+
+def test_mcp_kernel_fs_allowed_read_write(tmp_path: Path) -> None:
+    """Test that allowed paths can be read and written to."""
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    fs = MCPKernelFS([allowed_dir])
+
+    target_file = allowed_dir / "test.txt"
+    fs.write_text(target_file, "hello sandbox")
+    content = fs.read_text(target_file)
+
+    assert content == "hello sandbox"
+
+
+def test_mcp_kernel_fs_disallowed_read_write(tmp_path: Path) -> None:
+    """Test that reading/writing outside allowed paths raises a SecurityError."""
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    disallowed_dir = tmp_path / "disallowed"
+    disallowed_dir.mkdir()
+
+    fs = MCPKernelFS([allowed_dir])
+    target_file = disallowed_dir / "secret.txt"
+
+    # Should raise error when writing
+    with pytest.raises(SecurityError, match="is denied by MCPKernelFS"):
+        fs.write_text(target_file, "secret data")
+
+    # Write manually to test reading
+    target_file.write_text("secret data")
+
+    # Should raise error when reading
+    with pytest.raises(SecurityError, match="is denied by MCPKernelFS"):
+        fs.read_text(target_file)
+
+
+def test_mcp_kernel_fs_open_allowed(tmp_path: Path) -> None:
+    """Test that opening a file in allowed directory works."""
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    fs = MCPKernelFS([allowed_dir])
+
+    target_file = allowed_dir / "test_open.txt"
+
+    with fs.open(target_file, "w") as f:
+        f.write("open test")
+
+    with fs.open(target_file, "r") as f:
+        content = f.read()
+
+    assert content == "open test"
+
+
+def test_mcp_kernel_fs_open_disallowed(tmp_path: Path) -> None:
+    """Test that opening a file outside allowed directory raises SecurityError."""
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    disallowed_dir = tmp_path / "disallowed"
+    disallowed_dir.mkdir()
+
+    fs = MCPKernelFS([allowed_dir])
+    target_file = disallowed_dir / "secret_open.txt"
+    target_file.write_text("secret data")
+
+    with pytest.raises(SecurityError, match="is denied by MCPKernelFS"):
+        fs.open(target_file, "r")
+
+
+def test_mcp_kernel_fs_relative_path_escape(tmp_path: Path) -> None:
+    """Test that path traversal attempts using .. are caught."""
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    disallowed_dir = tmp_path / "disallowed"
+    disallowed_dir.mkdir()
+
+    fs = MCPKernelFS([allowed_dir])
+
+    # Path inside allowed dir pointing outside using ..
+    target_file = allowed_dir / ".." / "disallowed" / "secret.txt"
+
+    with pytest.raises(SecurityError, match="is denied by MCPKernelFS"):
+        fs.write_text(target_file, "escape attempt")


### PR DESCRIPTION
Implemented `MCPKernelFS` to provide a sandboxed environment for the `MCPKernel` to safely operate on file paths. Restricted operations to explicitly allowed directories. 

Added testing and updated `agent_tasks.json` with three new trends from June 2026 AI Agent paradigms (Context compression, Capability mesh, Procedural memory visualizer).

---
*PR created automatically by Jules for task [18164609140705951223](https://jules.google.com/task/18164609140705951223) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPKernelFS` sandbox to restrict filesystem access in `MCPKernel` code execution
> - Introduces [`mcp_kernel_fs.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/604/files#diff-6627ab45f036612b7acba24dfdfaffb0bed87de330a0cbb9eb5f7dc9d5fc7cfe) with a new `MCPKernelFS` class that restricts file I/O (`open`, `read_text`, `write_text`) to an allowlist of directories, raising `SecurityError` on violations including path traversal attempts.
> - Extends [`MCPKernel`](https://github.com/kazah4359-lgtm/Magda-agent/pull/604/files#diff-c9496d67499c3235484d0d78f150458a586927e05d02488038ddb89504aafd84) with an optional `allowed_fs` parameter; when set, replaces the blocked `open` builtin in the execution environment with the sandboxed `MCPKernelFS.open`.
> - Adds [`tests/test_mcp_kernel_fs.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/604/files#diff-0e23c6431b3810c2b95a8753fa3ca62840492d5419455d665c06e509bdea83f4) covering allowed access, disallowed access, and `..` traversal prevention.
> - Risk: `open` is blocked by `is_safe()` on the *first* `execute()` call even when `allowed_fs` is set, because the safety policy mutation happens after the safety check; subsequent calls permit it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 166ab4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->