### PR TITLE
feat: Implement Claude SDK Sub-agent Spawning Factory

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9708,7 +9708,7 @@
     },
     {
       "id": "claude-subagent-spawning-cc8646b1-345e-4f9b-8283-4d9b7ac86e43",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "Claude SDK Sub-agent Spawning",
@@ -21892,6 +21892,40 @@
       "risk": "medium",
       "area": "integration",
       "status": "todo"
+    },
+    {
+      "id": "openclaw-rl-multimodal-vision-feedback-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Vision Feedback Alignment v1",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Extend OpenClaw reinforcement learning to parse visual feedback from user-uploaded images and screens as next-state reward signals.",
+      "allowed_paths": [
+        "magda_agent/learning/vision_sentiment_v1.py",
+        "tests/test_vision_sentiment_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Vision sentiment signals successfully update habit weights.",
+        "Tests verify weight adjustments using mock image sentiment signals."
+      ]
+    },
+    {
+      "id": "mcp-server-auth-tls-v1",
+      "status": "todo",
+      "area": "security",
+      "risk": "high",
+      "title": "MCP Server TLS Auth Enforcement",
+      "description": "Inspired by MCP standardization: Enforce strictly mutual TLS authentication when exposing Magda's internal skills as MCP tools to prevent unauthorized executions.",
+      "allowed_paths": [
+        "magda_agent/mcp/tls_auth.py",
+        "tests/test_tls_auth.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP tool exposure requires validated mTLS certificates.",
+        "Tests mock TLS connections and verify unauthorized requests are dropped."
+      ]
     }
   ]
 }

--- a/magda_agent/agents/subagent_factory.py
+++ b/magda_agent/agents/subagent_factory.py
@@ -1,0 +1,51 @@
+import logging
+from typing import Optional
+from magda_agent.llm_client import LLMClient
+from magda_agent.agents.sub_agent import SubAgent
+
+class SubagentFactory:
+    """
+    Factory class that dynamically spawns isolated sub-agents with dedicated virtual contexts
+    and runtime boundaries, inspired by the Claude Agent SDK pattern.
+    """
+
+    @staticmethod
+    def spawn_subagent(
+        role: str,
+        llm: LLMClient,
+        system_prompt: Optional[str] = None,
+        use_isolation: bool = True
+    ) -> SubAgent:
+        """
+        Spawns a new SubAgent pre-configured for a specific role (e.g., Planner, Evaluator).
+
+        Args:
+            role: The role of the subagent, such as 'Planner' or 'Evaluator'.
+            llm: The LLM client for the subagent to use.
+            system_prompt: An optional custom system prompt. If None, a role-specific default is used.
+            use_isolation: Whether to use git worktree isolation (defaults to True for boundary isolation).
+
+        Returns:
+            A configured SubAgent instance.
+        """
+        logging.info(f"Spawning isolated sub-agent for role: {role}")
+
+        if system_prompt is None:
+            if role.lower() == "planner":
+                system_prompt = (
+                    "You are an isolated Planner Sub-Agent. Your task is to analyze the given context "
+                    "and generate a step-by-step execution plan without performing the actions yourself."
+                )
+            elif role.lower() == "evaluator":
+                system_prompt = (
+                    "You are an isolated Evaluator Sub-Agent. Your task is to review the given context "
+                    "and outputs, critically evaluating their correctness, safety, and alignment with the goal."
+                )
+            else:
+                system_prompt = f"You are an isolated Sub-Agent dedicated to the role of: {role}."
+
+        return SubAgent(
+            llm=llm,
+            system_prompt=system_prompt,
+            use_isolation=use_isolation
+        )

--- a/tests/test_subagent_factory.py
+++ b/tests/test_subagent_factory.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.agents.subagent_factory import SubagentFactory
+from magda_agent.agents.sub_agent import SubAgent
+from magda_agent.llm_client import LLMClient
+
+def test_spawn_planner_isolated():
+    """
+    Test spawning a Planner subagent with isolated context properly configured.
+    """
+    mock_llm = MagicMock(spec=LLMClient)
+
+    agent = SubagentFactory.spawn_subagent(
+        role="Planner",
+        llm=mock_llm
+    )
+
+    assert isinstance(agent, SubAgent)
+    assert agent.llm == mock_llm
+    assert agent.use_isolation is True
+    assert "Planner Sub-Agent" in agent.system_prompt
+    assert agent.worktree_manager is not None
+
+def test_spawn_evaluator_isolated():
+    """
+    Test spawning an Evaluator subagent with isolated context properly configured.
+    """
+    mock_llm = MagicMock(spec=LLMClient)
+
+    agent = SubagentFactory.spawn_subagent(
+        role="Evaluator",
+        llm=mock_llm
+    )
+
+    assert isinstance(agent, SubAgent)
+    assert agent.llm == mock_llm
+    assert agent.use_isolation is True
+    assert "Evaluator Sub-Agent" in agent.system_prompt
+    assert agent.worktree_manager is not None
+
+def test_spawn_custom_role():
+    """
+    Test spawning a subagent with a custom role and custom system prompt.
+    """
+    mock_llm = MagicMock(spec=LLMClient)
+    custom_prompt = "You are a custom CodeReviewer Sub-Agent."
+
+    agent = SubagentFactory.spawn_subagent(
+        role="CodeReviewer",
+        llm=mock_llm,
+        system_prompt=custom_prompt,
+        use_isolation=False
+    )
+
+    assert isinstance(agent, SubAgent)
+    assert agent.system_prompt == custom_prompt
+    assert agent.use_isolation is False
+    assert agent.worktree_manager is None


### PR DESCRIPTION
Resolves the task to implement a Claude SDK-inspired `SubagentFactory` that dynamically spawns isolated sub-agents (e.g. Planner, Evaluator) with their own dedicated virtual context boundaries. The PR includes:
- The factory implementation (`magda_agent/agents/subagent_factory.py`)
- Full test coverage (`tests/test_subagent_factory.py`) with mocked components.
- Agent task tracker updates (1 completed task, 2 new generated tasks).

---
*PR created automatically by Jules for task [13181238289257283716](https://jules.google.com/task/13181238289257283716) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SubagentFactory` class to spawn role-specific sub-agents via Claude SDK
> - Introduces [`SubagentFactory`](https://github.com/kazah4359-lgtm/Magda-agent/pull/607/files#diff-302c9531cf90e57757f905f5f5f0d18ebc5f818c343925b5990b8f76a5788577) with a `spawn_subagent` static method that creates `SubAgent` instances with role-specific default system prompts for Planner and Evaluator roles, falling back to a generic prompt for other roles.
> - Isolation (`use_isolation`) is passed through to the `SubAgent` constructor, which controls whether a `worktree_manager` is attached.
> - Adds three tests in [`tests/test_subagent_factory.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/607/files#diff-d552392a54e4d0aec25f54b64ed2655732ec0cb2bbe73e6c6419d0650aa2df18) covering Planner, Evaluator, and custom-role spawning with a mocked `LLMClient`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8abf96f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->