### PR TITLE
feat: Implement Canvas state sync patching V5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -21705,7 +21705,7 @@
     },
     {
       "id": "openclaw-canvas-state-sync-patching-v5-abc",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw Canvas State Sync Patching V5",
@@ -21925,6 +21925,57 @@
       "acceptance": [
         "MCP tool exposure requires validated mTLS certificates.",
         "Tests mock TLS connections and verify unauthorized requests are dropped."
+      ]
+    },
+    {
+      "id": "a2a-agent-teams-scaling-v2",
+      "status": "todo",
+      "area": "orchestration",
+      "risk": "medium",
+      "title": "A2A Agent Teams Scaling v2",
+      "description": "Inspired by June 2026 Claude Agent SDK trends (Agent Teams scaling): Implement a dynamic subagent scaler that automatically spawns and registers new A2A-compatible worker nodes when the current task load exceeds threshold.",
+      "allowed_paths": [
+        "magda_agent/orchestration/a2a_scaler_v2.py",
+        "tests/test_a2a_scaler_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A scaler automatically monitors task load and provisions subagent nodes.",
+        "Tests verify spawning behavior under mocked load."
+      ]
+    },
+    {
+      "id": "multi-agent-context-sync-v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "Multi-Agent Memory Synchronization v1",
+      "description": "Inspired by June 2026 Multi-Agent Memory Synchronization trends: Implement a context synchronization module that aggregates semantic and procedural updates from distributed worker nodes back to the central episodic memory.",
+      "allowed_paths": [
+        "magda_agent/memory/context_sync_v1.py",
+        "tests/test_context_sync_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module correctly synchronizes distributed state to a central mock memory store.",
+        "Tests verify accurate state aggregation without data loss."
+      ]
+    },
+    {
+      "id": "openclaw-procedural-memory-visualizer-v2",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Procedural Memory Visualizer v2",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend: Create a visualizer that takes live JSON patch output from the backend procedural memory stream and correctly displays skill weight updates in a real-time UI structure.",
+      "allowed_paths": [
+        "magda_agent/visualization/procedural_ui_v2.py",
+        "tests/test_procedural_ui_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Visualizer accurately maps JSON patches to frontend skill representations.",
+        "Tests verify proper parsing and structural output of the visualizer module."
       ]
     }
   ]

--- a/magda_agent/visualization/canvas_patching_v5.py
+++ b/magda_agent/visualization/canvas_patching_v5.py
@@ -1,0 +1,102 @@
+import copy
+from typing import Dict, List, Any, Union
+
+class CanvasPatchManagerV5:
+    """
+    Manages state synchronization between the backend brain and UI canvas
+    using standard JSON patch format to optimize websocket state synchronization.
+    Inspired by OpenClaw Live Visualization trend.
+    """
+
+    @staticmethod
+    def generate_patch(old_state: Union[Dict[str, Any], List[Any], Any], new_state: Union[Dict[str, Any], List[Any], Any], path: str = "") -> List[Dict[str, Any]]:
+        """
+        Generates a list of JSON patches comparing old_state and new_state.
+
+        Args:
+            old_state (Union[Dict[str, Any], List[Any], Any]): The previous state.
+            new_state (Union[Dict[str, Any], List[Any], Any]): The current state.
+            path (str): The current path prefix.
+
+        Returns:
+            List[Dict[str, Any]]: A list of JSON patch operations.
+        """
+        patches = []
+
+        if isinstance(old_state, dict) and isinstance(new_state, dict):
+            for key in new_state:
+                current_path = f"{path}/{key}"
+                if key not in old_state:
+                    patches.append({"op": "add", "path": current_path, "value": copy.deepcopy(new_state[key])})
+                else:
+                    patches.extend(CanvasPatchManagerV5.generate_patch(old_state[key], new_state[key], current_path))
+
+            for key in old_state:
+                current_path = f"{path}/{key}"
+                if key not in new_state:
+                    patches.append({"op": "remove", "path": current_path})
+        elif isinstance(old_state, list) and isinstance(new_state, list):
+            # For lists, if they are different, we replace the whole list for simplicity
+            if old_state != new_state:
+                 patches.append({"op": "replace", "path": path if path else "/", "value": copy.deepcopy(new_state)})
+        else:
+            if old_state != new_state:
+                 patches.append({"op": "replace", "path": path if path else "/", "value": copy.deepcopy(new_state)})
+
+        return patches
+
+    @staticmethod
+    def apply_patch(state: Union[Dict[str, Any], List[Any]], patch: List[Dict[str, Any]]) -> Union[Dict[str, Any], List[Any]]:
+        """
+        Applies a list of JSON patch operations to a state.
+
+        Args:
+            state (Union[Dict[str, Any], List[Any]]): The state to apply the patch to.
+            patch (List[Dict[str, Any]]): The JSON patch operations.
+
+        Returns:
+            Union[Dict[str, Any], List[Any]]: The updated state.
+        """
+        if not patch:
+            return copy.deepcopy(state)
+
+        new_state = copy.deepcopy(state)
+
+        for op in patch:
+            path_str = op.get("path", "")
+            if path_str == "/" or not path_str:
+                if op["op"] == "replace":
+                    new_state = copy.deepcopy(op.get("value"))
+                continue
+
+            path_parts = path_str.strip("/").split("/")
+
+            target = new_state
+            for part in path_parts[:-1]:
+                if isinstance(target, dict):
+                    target = target[part]
+                elif isinstance(target, list):
+                    target = target[int(part)]
+
+            last_part = path_parts[-1]
+
+            if op["op"] == "add":
+                if isinstance(target, dict):
+                    target[last_part] = copy.deepcopy(op.get("value"))
+                elif isinstance(target, list):
+                    target.insert(int(last_part), copy.deepcopy(op.get("value")))
+            elif op["op"] == "replace":
+                if isinstance(target, dict):
+                    target[last_part] = copy.deepcopy(op.get("value"))
+                elif isinstance(target, list):
+                    target[int(last_part)] = copy.deepcopy(op.get("value"))
+            elif op["op"] == "remove":
+                if isinstance(target, dict):
+                    if last_part in target:
+                        del target[last_part]
+                elif isinstance(target, list):
+                    idx = int(last_part)
+                    if 0 <= idx < len(target):
+                        target.pop(idx)
+
+        return new_state

--- a/tests/test_canvas_patching_v5.py
+++ b/tests/test_canvas_patching_v5.py
@@ -1,0 +1,117 @@
+import pytest
+from magda_agent.visualization.canvas_patching_v5 import CanvasPatchManagerV5
+
+def test_generate_patch_add():
+    """Test generating a patch for adding a new key."""
+    old_state = {"user1": {"id": 1}}
+    new_state = {"user1": {"id": 1, "name": "test"}}
+    patches = CanvasPatchManagerV5.generate_patch(old_state, new_state)
+    assert len(patches) == 1
+    assert patches[0] == {"op": "add", "path": "/user1/name", "value": "test"}
+
+def test_generate_patch_remove():
+    """Test generating a patch for removing a key."""
+    old_state = {"user1": {"id": 1, "name": "test"}}
+    new_state = {"user1": {"id": 1}}
+    patches = CanvasPatchManagerV5.generate_patch(old_state, new_state)
+    assert len(patches) == 1
+    assert patches[0] == {"op": "remove", "path": "/user1/name"}
+
+def test_generate_patch_replace():
+    """Test generating a patch for replacing a value."""
+    old_state = {"user1": {"id": 1, "name": "old"}}
+    new_state = {"user1": {"id": 1, "name": "new"}}
+    patches = CanvasPatchManagerV5.generate_patch(old_state, new_state)
+    assert len(patches) == 1
+    assert patches[0] == {"op": "replace", "path": "/user1/name", "value": "new"}
+
+def test_generate_patch_complex():
+    """Test generating a complex patch with multiple operations."""
+    old_state = {
+        "user1": {"id": 1, "tags": ["a", "b"]},
+        "user2": {"id": 2, "name": "old"}
+    }
+    new_state = {
+        "user1": {"id": 1, "tags": ["a", "b", "c"]}, # list changed, should trigger a replace on the list
+        "user3": {"id": 3} # added
+    }
+    patches = CanvasPatchManagerV5.generate_patch(old_state, new_state)
+
+    # We should have:
+    # 1. replace /user1/tags
+    # 2. add /user3
+    # 3. remove /user2
+
+    assert len(patches) == 3
+
+    # Order doesn't strictly matter for the test if we check elements
+    expected = [
+        {"op": "add", "path": "/user3", "value": {"id": 3}},
+        {"op": "replace", "path": "/user1/tags", "value": ["a", "b", "c"]},
+        {"op": "remove", "path": "/user2"}
+    ]
+
+    for e in expected:
+        assert e in patches
+
+def test_apply_patch():
+    """Test applying a patch to a state."""
+    state = {
+        "user1": {"id": 1, "name": "old"},
+        "user2": {"id": 2}
+    }
+
+    patches = [
+        {"op": "replace", "path": "/user1/name", "value": "new"},
+        {"op": "add", "path": "/user3", "value": {"id": 3}},
+        {"op": "remove", "path": "/user2"}
+    ]
+
+    new_state = CanvasPatchManagerV5.apply_patch(state, patches)
+
+    expected = {
+        "user1": {"id": 1, "name": "new"},
+        "user3": {"id": 3}
+    }
+
+    assert new_state == expected
+
+def test_end_to_end_patching():
+    """Test generating a patch and applying it to get the exact new state."""
+    old_state = {
+        "users": [
+            {"id": 1, "role": "admin"},
+            {"id": 2, "role": "user"}
+        ],
+        "settings": {
+            "theme": "dark",
+            "notifications": True
+        }
+    }
+
+    new_state = {
+        "users": [
+            {"id": 1, "role": "superadmin"},
+            {"id": 3, "role": "guest"}
+        ],
+        "settings": {
+            "theme": "light",
+            "volume": 80
+        },
+        "version": "1.0"
+    }
+
+    patches = CanvasPatchManagerV5.generate_patch(old_state, new_state)
+    applied_state = CanvasPatchManagerV5.apply_patch(old_state, patches)
+
+    assert applied_state == new_state
+
+def test_apply_patch_root_replace():
+    """Test applying a replace operation on the root."""
+    old_state = {"a": 1}
+    new_state = {"b": 2}
+
+    patches = [{"op": "replace", "path": "/", "value": {"b": 2}}]
+    applied_state = CanvasPatchManagerV5.apply_patch(old_state, patches)
+
+    assert applied_state == new_state


### PR DESCRIPTION
This PR implements the `openclaw-canvas-state-sync-patching-v5-abc` task.

**Changes:**
1. Created `magda_agent/visualization/canvas_patching_v5.py` with `CanvasPatchManagerV5` providing `generate_patch` and `apply_patch` methods using standard JSON patch format.
2. Created `tests/test_canvas_patching_v5.py` with full unit test coverage.
3. Updated `agent_tasks.json` to mark the task as "done".
4. Appended 3 new upcoming "todo" tasks related to June 2026 AI agent trends.

**Validation:**
- `python scripts/validate_agent_tasks.py agent_tasks.json` passes successfully.
- `pytest` runs correctly with all existing and new tests passing.
- No files outside of the allowed paths were modified.

---
*PR created automatically by Jules for task [4525612033181042356](https://jules.google.com/task/4525612033181042356) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CanvasPatchManagerV5` for JSON patch generation and application on canvas state
> - Introduces [`canvas_patching_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/608/files#diff-a7710413092c9fafd8c9cd82550dae5c334ee12a47e10bbd5fcf93a0576ae560) with `CanvasPatchManagerV5`, a class with two static methods: `generate_patch` and `apply_patch`.
> - `generate_patch` recursively diffs two nested dict/list/scalar states and emits JSON Pointer-style `add`, `replace`, and `remove` operations; changed lists are replaced wholesale.
> - `apply_patch` navigates nested dicts and lists via path segments to apply a sequence of patch operations, including a root-level `replace` when path is `'/'`.
> - [`tests/test_canvas_patching_v5.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/608/files#diff-72944499f3a2f1b87c7995ceba2c0d03d7b4b7d892157f837e7befff8221570c) covers unit and end-to-end scenarios for both methods across nested structures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1c445e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->