### PR TITLE
feat: A2A workflow handshake verification

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9726,7 +9726,7 @@
     },
     {
       "id": "9e919a81-f62d-429c-a775-97c065058d4b",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "A2A Workflow Handshake Verification",
@@ -21976,6 +21976,57 @@
       "acceptance": [
         "Visualizer accurately maps JSON patches to frontend skill representations.",
         "Tests verify proper parsing and structural output of the visualizer module."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-auth-v5-uuid",
+      "status": "todo",
+      "area": "security",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Auth v5",
+      "description": "Inspired by MCP June 2026 trends (Tool execution permissions): Implement a granular capability authorization layer for MCP tools that validates request tokens before passing execution context to the underlying capability.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_cap_auth_v5.py",
+        "tests/test_mcp_cap_auth_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Capability auth layer correctly validates or rejects execution based on tokens.",
+        "Tests verify mocked token validation logic."
+      ]
+    },
+    {
+      "id": "a2a-capability-gossiping-v5-uuid",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Capability Gossip Protocol v5",
+      "description": "Inspired by A2A standard trend (June 2026): Implement an asynchronous gossip protocol for A2A capabilities mesh, allowing distributed agents to propagate capability updates across a network.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_gossip_v5.py",
+        "tests/test_a2a_gossip_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Gossip protocol diffuses capability updates.",
+        "Tests verify gossip diffusion mechanics using mocked network endpoints."
+      ]
+    },
+    {
+      "id": "openclaw-rl-implicit-reward-v5-uuid",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "title": "OpenClaw RL Implicit Reward Tracking v5",
+      "description": "Inspired by OpenClaw online RL trend (June 2026): Create a reward tracker that infers implicit positive rewards from user engagement metrics (e.g., response latency and follow-up depth) rather than explicit ratings.",
+      "allowed_paths": [
+        "magda_agent/learning/implicit_reward_v5.py",
+        "tests/test_implicit_reward_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Reward tracker infers positive weights from implicit metrics.",
+        "Tests verify weight adjustments based on mocked engagement data."
       ]
     }
   ]

--- a/magda_agent/architecture/a2a_handshake.py
+++ b/magda_agent/architecture/a2a_handshake.py
@@ -1,0 +1,103 @@
+import hmac
+import hashlib
+import json
+import time
+from typing import Dict, Any, Optional
+
+class A2AHandshakeProtocol:
+    """
+    Implements a cryptographically signed handshake protocol between interacting sub-agents
+    to verify their identities before delegating sub-tasks, minimizing risks of context injection spoofing.
+    """
+
+    def __init__(self, secret_key: str, expiration_seconds: int = 300) -> None:
+        """
+        Initializes the A2AHandshakeProtocol.
+
+        Args:
+            secret_key: The secret key used for HMAC signing.
+            expiration_seconds: The maximum age (in seconds) of a valid handshake signature.
+        """
+        self.secret_key = secret_key.encode('utf-8')
+        self.expiration_seconds = expiration_seconds
+
+    def generate_signature(self, payload: Dict[str, Any], timestamp: Optional[float] = None) -> str:
+        """
+        Generates an HMAC signature for the given payload and timestamp.
+
+        Args:
+            payload: The dictionary payload to sign.
+            timestamp: Optional timestamp to use. If not provided, current time is used.
+
+        Returns:
+            The generated hexadecimal signature string.
+        """
+        if timestamp is None:
+            timestamp = time.time()
+
+        # Serialize the payload securely
+        serialized_payload = json.dumps(payload, sort_keys=True)
+        message = f"{timestamp}:{serialized_payload}".encode('utf-8')
+
+        return hmac.new(self.secret_key, message, hashlib.sha256).hexdigest()
+
+    def create_handshake(self, source_agent_id: str, target_agent_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Creates a signed handshake payload for delegating a task to another agent.
+
+        Args:
+            source_agent_id: The ID of the agent initiating the delegation.
+            target_agent_id: The ID of the agent receiving the delegation.
+            context: Additional context or task data being passed.
+
+        Returns:
+            A dictionary containing the handshake payload, timestamp, and signature.
+        """
+        timestamp = time.time()
+        payload = {
+            "source": source_agent_id,
+            "target": target_agent_id,
+            "context": context
+        }
+        signature = self.generate_signature(payload, timestamp)
+
+        return {
+            "payload": payload,
+            "timestamp": timestamp,
+            "signature": signature
+        }
+
+    def verify_handshake(self, handshake_data: Dict[str, Any], expected_target_id: str) -> bool:
+        """
+        Verifies a signed handshake from another agent.
+
+        Args:
+            handshake_data: The handshake dictionary received from the source agent.
+            expected_target_id: The ID of the agent verifying the handshake (should match target).
+
+        Returns:
+            True if the handshake is valid, not expired, and securely signed. False otherwise.
+        """
+        try:
+            payload = handshake_data.get("payload")
+            timestamp = handshake_data.get("timestamp")
+            signature = handshake_data.get("signature")
+
+            if payload is None or timestamp is None or signature is None:
+                return False
+
+            # Check expiration
+            current_time = time.time()
+            if current_time - timestamp > self.expiration_seconds:
+                return False
+
+            # Verify target ID matches
+            if payload.get("target") != expected_target_id:
+                return False
+
+            # Verify signature
+            expected_signature = self.generate_signature(payload, timestamp)
+            return hmac.compare_digest(signature, expected_signature)
+
+        except (ValueError, TypeError, KeyError):
+            return False

--- a/magda_agent/integration/a2a.py
+++ b/magda_agent/integration/a2a.py
@@ -1,5 +1,7 @@
 from typing import Dict, Any, List, Optional, Union
 import logging
+import os
+from magda_agent.architecture.a2a_handshake import A2AHandshakeProtocol
 from magda_agent.integration.a2a_discovery import AgentCard, A2ADiscovery
 from magda_agent.integration.a2a_discovery_v2 import AgentCardV2, A2ADiscoveryV2
 from magda_agent.integration.a2a_cards import AgentCardV3, A2ADiscoveryV3
@@ -13,13 +15,14 @@ class A2AManager:
     of sub-plans/tasks to capable peers in a peer-to-peer network.
     Inspired by A2A Protocol trends.
     """
-    def __init__(self, local_card: Union[AgentCard, AgentCardV2, AgentCardV3, AgentCardV4]) -> None:
+    def __init__(self, local_card: Union[AgentCard, AgentCardV2, AgentCardV3, AgentCardV4], secret_key: Optional[str] = None) -> None:
         """
         Initializes the manager with the local agent's identity and capabilities.
 
         Args:
             local_card: The AgentCard, AgentCardV2, AgentCardV3, or AgentCardV4 representing this agent.
         """
+        self.handshake_protocol = A2AHandshakeProtocol(secret_key or os.getenv('A2A_SECRET_KEY', 'dev_default_key'))
         self.local_card_version = 1
         if isinstance(local_card, AgentCardV4):
             self.discovery = A2ADiscoveryRegistryV4()
@@ -84,25 +87,46 @@ class A2AManager:
     async def delegate_task(self, capability: str, task_context: Dict[str, Any]) -> str:
         """
         Delegates a task to a discovered peer that supports the required capability.
-
-        Args:
-            capability: The required capability (e.g., 'code_execution').
-            task_context: The context or sub-plan of the task to delegate.
-
-        Returns:
-            A string indicating the outcome of the delegation.
         """
         logging.info(f"A2AManager attempting to delegate task requiring capability: {capability}")
+
+        # We find a target agent to use for the handshake
+        target_agent_id = None
+
         if self.local_card_version == 4:
-            # Simple matching for V4
             for agent in self.discovery.get_all_agents():
                 if capability in agent.capabilities and agent.agent_id != self.local_card.agent_id:
-                    return f"Delegated to Agent {agent.name}"
+                    target_agent_id = agent.agent_id
+                    break
+        else:
+            local_id = getattr(self.discovery, 'local_card', None)
+            local_agent_id = local_id.agent_id if local_id else "unknown_local"
+            # Avoid private _discovered_agents if possible, but for v1-v3 this is the pattern used in original code
+            # In original code get_known_peers returns list(self.discovery._discovered_agents.values())
+            for agent in self.get_known_peers():
+                if capability in agent.capabilities and agent.agent_id != local_agent_id:
+                    target_agent_id = agent.agent_id
+                    break
+
+        # If we found a target, we attach the handshake to the context before proceeding
+        if target_agent_id:
+            local_id = self.local_card.agent_id if self.local_card_version == 4 else getattr(getattr(self.discovery, 'local_card', None), 'agent_id', "unknown_local")
+
+            # Create a shallow copy of the context for the payload to avoid circular reference
+            # when we assign the handshake back to task_context
+            context_copy = dict(task_context)
+            handshake_payload = self.handshake_protocol.create_handshake(local_id, target_agent_id, context_copy)
+            # Use a new dict instead of mutating input
+            task_context = dict(task_context)
+            task_context["_a2a_handshake"] = handshake_payload
+
+        if self.local_card_version == 4:
+            if target_agent_id:
+                agent_name = next((a.name for a in self.discovery.get_all_agents() if a.agent_id == target_agent_id), target_agent_id)
+                return f"Delegated to Agent {agent_name}"
             return "No agent found"
 
         return await self.delegator.delegate_subplan(capability, task_context)
-
-
     async def broadcast_status(self, is_available: bool, active_tasks: int) -> bool:
         """
         Broadcasts the current agent status using the A2AStatusBroadcaster.

--- a/magda_agent/integration/a2a_delegation.py
+++ b/magda_agent/integration/a2a_delegation.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 import logging
+from magda_agent.architecture.a2a_handshake import A2AHandshakeProtocol
 from magda_agent.integration.a2a_discovery import A2ADiscovery
 from magda_agent.integration.a2a_tracing import A2ATracer
 from magda_agent.integration.a2a_security import A2ASecurityContext
@@ -15,6 +16,8 @@ class A2ADelegator:
         """
         self.discovery = discovery
         self.security_context = getattr(discovery, 'security_context', None) or A2ASecurityContext()
+        import os
+        self.handshake_protocol = A2AHandshakeProtocol(os.getenv('A2A_SECRET_KEY', 'dev_default_key'))
 
 
 
@@ -81,11 +84,15 @@ class A2ADelegator:
         if not endpoint:
             return f"Agent {target_agent.name} missing MCP endpoint"
 
+        local_id = getattr(getattr(self.discovery, 'local_card', None), 'agent_id', "unknown_local")
+        context_copy = dict(plan_context)
+        handshake_payload = self.handshake_protocol.create_handshake(local_id, target_agent.agent_id, context_copy)
+
         payload = {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "execute_subplan",
-            "params": {"context": plan_context}
+            "params": {"context": plan_context, "_a2a_handshake": handshake_payload}
         }
 
         headers = {}
@@ -160,11 +167,17 @@ class A2ADelegator:
         if not endpoint:
             return f"Agent {target_agent.name} missing MCP endpoint"
 
+        # GENERATE HANDSHAKE
+        local_id = getattr(getattr(self.discovery, 'local_card', None), 'agent_id', "unknown_local")
+        context_copy = dict(plan_context)
+        handshake_payload = self.handshake_protocol.create_handshake(local_id, target_agent.agent_id, context_copy)
+
+        # We attach it directly to the payload's params
         payload = {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "execute_subplan",
-            "params": {"capability": capability, "context": plan_context}
+            "params": {"capability": capability, "context": plan_context, "_a2a_handshake": handshake_payload}
         }
 
         headers = {}

--- a/magda_agent/integration/a2a_server.py
+++ b/magda_agent/integration/a2a_server.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from magda_agent.architecture.a2a_handshake import A2AHandshakeProtocol
 from typing import Any, Dict, Optional, List
 from fastapi import FastAPI, Request, Response
 from magda_agent.planning.planner import Planner
@@ -11,9 +12,11 @@ class A2AServer:
     A JSON-RPC 2.0 Server interface for the A2A (Agent-to-Agent) Protocol.
     Receives and parses A2A task delegation requests and routes them to the Planner.
     """
-    def __init__(self, planner: Planner, security_context: Optional[A2ASecurityContext] = None) -> None:
+    def __init__(self, planner: Planner, security_context: Optional[A2ASecurityContext] = None, handshake_protocol: Optional[A2AHandshakeProtocol] = None, agent_id: str = 'default_target') -> None:
         """Initializes the A2AServer with a planner module and optional security context."""
         self.planner = planner
+        self.handshake_protocol = handshake_protocol
+        self.agent_id = agent_id
         self.security_context = security_context
         self.app = FastAPI(title="A2A JSON-RPC Server")
 
@@ -87,6 +90,49 @@ class A2AServer:
             }), media_type="application/json", status_code=400)
 
         if method in ["delegate_task", "execute_subplan"]:
+            if not isinstance(params, dict):
+                if is_notification:
+                    return Response(status_code=204)
+                return Response(content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32602, "message": "Invalid params"},
+                    "id": req_id
+                }), media_type="application/json", status_code=400)
+
+            if self.handshake_protocol and "_a2a_handshake" in params:
+                handshake_data = params.pop("_a2a_handshake")
+
+                # Verify the signature and target ID
+                if not self.handshake_protocol.verify_handshake(handshake_data, expected_target_id=self.agent_id):
+                    if is_notification:
+                        return Response(status_code=204)
+                    return Response(content=json.dumps({
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32002, "message": "Unauthorized: Invalid or expired handshake"},
+                        "id": req_id
+                    }), media_type="application/json", status_code=401)
+
+                # VULNERABILITY FIX: Ensure the signed context matches the actual params being executed!
+                signed_context = handshake_data.get("payload", {}).get("context", {})
+                if signed_context != params:
+                    if is_notification:
+                        return Response(status_code=204)
+                    return Response(content=json.dumps({
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32002, "message": "Unauthorized: Payload mismatch detected"},
+                        "id": req_id
+                    }), media_type="application/json", status_code=401)
+
+            elif self.handshake_protocol:
+                if is_notification:
+                    return Response(status_code=204)
+                return Response(content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32002, "message": "Unauthorized: Missing handshake"},
+                    "id": req_id
+                }), media_type="application/json", status_code=401)
+
+
             if not isinstance(params, dict):
                 if is_notification:
                     return Response(status_code=204)

--- a/tests/test_a2a_handshake.py
+++ b/tests/test_a2a_handshake.py
@@ -1,0 +1,86 @@
+import pytest
+import time
+from magda_agent.architecture.a2a_handshake import A2AHandshakeProtocol
+
+@pytest.fixture
+def handshake_protocol():
+    return A2AHandshakeProtocol(secret_key="test_super_secret_key", expiration_seconds=300)
+
+def test_generate_signature(handshake_protocol):
+    payload = {"source": "agentA", "target": "agentB", "context": {"task": "do_something"}}
+    timestamp = 1672531200.0
+
+    sig1 = handshake_protocol.generate_signature(payload, timestamp)
+    sig2 = handshake_protocol.generate_signature(payload, timestamp)
+
+    assert sig1 == sig2
+    assert isinstance(sig1, str)
+    assert len(sig1) > 0
+
+def test_create_and_verify_handshake(handshake_protocol):
+    source_id = "agentA"
+    target_id = "agentB"
+    context = {"task": "evaluate_model"}
+
+    handshake_data = handshake_protocol.create_handshake(source_id, target_id, context)
+
+    assert "payload" in handshake_data
+    assert "timestamp" in handshake_data
+    assert "signature" in handshake_data
+
+    is_valid = handshake_protocol.verify_handshake(handshake_data, expected_target_id=target_id)
+    assert is_valid is True
+
+def test_verify_handshake_rejects_wrong_target(handshake_protocol):
+    source_id = "agentA"
+    target_id = "agentB"
+    context = {"task": "evaluate_model"}
+
+    handshake_data = handshake_protocol.create_handshake(source_id, target_id, context)
+
+    # Target expects agentC, but handshake was for agentB
+    is_valid = handshake_protocol.verify_handshake(handshake_data, expected_target_id="agentC")
+    assert is_valid is False
+
+def test_verify_handshake_rejects_spoofed_context(handshake_protocol):
+    source_id = "agentA"
+    target_id = "agentB"
+    context = {"task": "evaluate_model"}
+
+    handshake_data = handshake_protocol.create_handshake(source_id, target_id, context)
+
+    # Spoof context payload
+    handshake_data["payload"]["context"]["task"] = "malicious_task"
+
+    is_valid = handshake_protocol.verify_handshake(handshake_data, expected_target_id=target_id)
+    assert is_valid is False
+
+def test_verify_handshake_rejects_expired_timestamp(handshake_protocol, monkeypatch):
+    source_id = "agentA"
+    target_id = "agentB"
+    context = {"task": "evaluate_model"}
+
+    # Mock current time to be far in the past to generate expired handshake
+    past_time = time.time() - 400 # Default expiration is 300
+
+    def mock_time():
+        return past_time
+
+    monkeypatch.setattr(time, "time", mock_time)
+
+    handshake_data = handshake_protocol.create_handshake(source_id, target_id, context)
+
+    # Now restore time and check verification
+    monkeypatch.undo()
+
+    is_valid = handshake_protocol.verify_handshake(handshake_data, expected_target_id=target_id)
+    assert is_valid is False
+
+def test_verify_handshake_rejects_malformed_data(handshake_protocol):
+    # Missing signature
+    data1 = {"payload": {}, "timestamp": time.time()}
+    assert handshake_protocol.verify_handshake(data1, "agentB") is False
+
+    # Completely empty
+    data2 = {}
+    assert handshake_protocol.verify_handshake(data2, "agentB") is False


### PR DESCRIPTION
Implemented cryptographically signed handshake protocol between interacting sub-agents to verify their identities before delegating sub-tasks, minimizing risks of context injection spoofing.

---
*PR created automatically by Jules for task [10720712318425718866](https://jules.google.com/task/10720712318425718866) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add HMAC-SHA256 handshake verification to A2A delegation and server
> - Adds [`A2AHandshakeProtocol`](https://github.com/kazah4359-lgtm/Magda-agent/pull/609/files#diff-741dcc3a098522b6ca4d061216139a186854b87885cb769a94cc4ddb57a54d2e) implementing HMAC-SHA256 signing with expiration and target-ID validation for agent-to-agent requests.
> - [`A2ADelegator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/609/files#diff-63653ef42d92af90747a5f5e269f1df0011e8545b185e8e30afd28662f2c1eb1) now attaches a signed `_a2a_handshake` field to outbound delegation params for both peer and capability paths.
> - [`A2AServer.handle_request`](https://github.com/kazah4359-lgtm/Magda-agent/pull/609/files#diff-3e26ca5cfd4aa46513f90fc76ee061b94aa0b93e6b9430e71f4df273c80d672b) enforces handshake presence and validity for `delegate_task` and `execute_subplan`, including a strict check that the signed context matches the actual request params.
> - [`A2AManager`](https://github.com/kazah4359-lgtm/Magda-agent/pull/609/files#diff-f768b47687f1afa793af21f4300b58413cfe22bdea05247a2224dc1372f33d9e) instantiates the handshake protocol from an explicit secret or the `A2A_SECRET_KEY` env var, falling back to `dev_default_key`.
> - Risk: existing `A2AServer` deployments without a `handshake_protocol` skip validation; servers configured with one will reject all unsigned or mismatched requests with HTTP 401.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 994af66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->