### PR TITLE
feat: Skill Execution Experience Extraction

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9743,7 +9743,7 @@
     },
     {
       "id": "f6d81948-9139-4c7e-931b-be57b6b56f28",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "low",
       "title": "Skill Execution Experience Extraction",
@@ -22027,6 +22027,59 @@
       "acceptance": [
         "Reward tracker infers positive weights from implicit metrics.",
         "Tests verify weight adjustments based on mocked engagement data."
+      ]
+    },
+    {
+      "id": "mcp-advanced-routing-strategy-2026-abc",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Advanced Routing Strategy",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a specialized handover router strategy for routing external MCP tool invocations efficiently to sub-agents based on their capabilities.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_advanced_routing.py",
+        "tests/test_mcp_advanced_routing.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Router correctly directs MCP tool requests to sub-agents with appropriate capabilities.",
+        "Tests mock sub-agent capability mapping and tool routing correctly."
+      ]
+    },
+    {
+      "id": "openclaw-rl-tool-ranking-system-xyz",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Tool Ranking System",
+      "description": "Inspired by OpenClaw RL trend: Implement a ranking system for tools and skills that updates their expected utility scores in real-time based on success rates and user satisfaction.",
+      "allowed_paths": [
+        "magda_agent/learning/tool_ranking.py",
+        "tests/test_tool_ranking.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ToolRankingSystem calculates utility scores based on success feedback.",
+        "Planner/Basal Ganglia uses updated rankings to select tools.",
+        "Tests verify score adjustment and tool selection bias."
+      ]
+    },
+    {
+      "id": "a2a-service-health-monitor-v2-123",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "low",
+      "title": "A2A Service Health Monitor v2",
+      "description": "Inspired by A2A Protocol trend: Enhance A2A discovery with active health checking. The monitor pings discovered peers and ejects unresponsive agents from the known cluster.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_health_monitor_v2.py",
+        "tests/test_a2a_health_monitor_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Health monitor actively pings peers.",
+        "Unresponsive peers are removed from the capability mesh.",
+        "Tests mock network timeouts and verify removal behavior."
       ]
     }
   ]

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -2,6 +2,8 @@ from magda_agent.agents.planner_agent import PlannerAgent
 from magda_agent.agents.generator_agent import GeneratorAgent
 from magda_agent.agents.evaluator_agent import EvaluatorAgent
 import logging
+from magda_agent.learning.skill_hints import SkillHintsExtractor
+
 from typing import List, Dict, Any, Optional
 from magda_agent.llm_client import LLMClient
 from magda_agent.emotions.engine import EmotionalEngine
@@ -476,6 +478,26 @@ class Consciousness:
         if getattr(self, 'dialogue_online_learner_v4', None):
             self.dialogue_online_learner_v4.capture_state_action(user_input, response)
 
+
+        if getattr(self, 'skill_hints_extractor', None) and self.tracer:
+            try:
+                steps = self.tracer.get_trace()
+                tool_logs = []
+                for step in steps:
+                    if step['step_type'] == 'tool_execution':
+                        tool_logs.append({
+                            'tool_name': step['data'].get('tool_name'),
+                            'arguments': step['data'].get('arguments', {}),
+                            'success': step['data'].get('success', False)
+                        })
+                if tool_logs:
+                    hints = self.skill_hints_extractor.extract_hints(tool_logs)
+                    for tool, hint in hints.items():
+                        logging.info(f"Generated Skill Hint for {tool}: {hint}")
+                        if self.procedural_memory:
+                            self.procedural_memory.store_procedure(name=f"{tool}_hint", procedure=hint)
+            except Exception as e:
+                logging.error(f"Error extracting skill hints: {e}")
         if self.online_rl_integrator:
             await self.online_rl_integrator.process_feedback(user_input, "last_action_context", user_id)
 

--- a/magda_agent/learning/skill_hints.py
+++ b/magda_agent/learning/skill_hints.py
@@ -1,0 +1,82 @@
+"""
+Skill Execution Experience Extraction module.
+
+This module provides the SkillHintsExtractor class, which analyzes recent
+successful external skill execution logs and synthesizes reusable "hints"
+to optimize and speed up subsequent invocations of those same tools.
+"""
+
+from typing import List, Dict, Any
+
+class SkillHintsExtractor:
+    """
+    Extracts reusable hints from successful tool execution logs.
+    """
+
+    def __init__(self, llm_client: Any = None):
+        """
+        Initialize the extractor.
+
+        Args:
+            llm_client: Optional LLM client to use for synthesizing hints.
+        """
+        self.llm_client = llm_client
+
+    def extract_hints(self, tool_execution_logs: List[Dict[str, Any]]) -> Dict[str, str]:
+        """
+        Extract hints from a list of tool execution logs.
+
+        Args:
+            tool_execution_logs (List[Dict[str, Any]]): A list of dictionaries representing
+                tool executions. Each dictionary should contain at least 'tool_name',
+                'arguments', and 'success' keys.
+
+        Returns:
+            Dict[str, str]: A dictionary mapping tool names to synthesized hint strings.
+        """
+        successful_executions: Dict[str, List[Dict[str, Any]]] = {}
+
+        for log in tool_execution_logs:
+            tool_name = log.get("tool_name")
+            success = log.get("success", False)
+            arguments = log.get("arguments", {})
+
+            if success and tool_name:
+                if tool_name not in successful_executions:
+                    successful_executions[tool_name] = []
+                successful_executions[tool_name].append(arguments)
+
+        hints = {}
+        for tool_name, executions in successful_executions.items():
+            hints[tool_name] = self._synthesize_hint(tool_name, executions)
+
+        return hints
+
+    def _synthesize_hint(self, tool_name: str, executions: List[Dict[str, Any]]) -> str:
+        """
+        Synthesize a hint for a specific tool based on its successful executions.
+
+        Args:
+            tool_name (str): The name of the tool.
+            executions (List[Dict[str, Any]]): A list of arguments from successful executions.
+
+        Returns:
+            str: The synthesized hint.
+        """
+        if self.llm_client:
+            # Simulate an LLM call to synthesize the hint
+            prompt = f"Synthesize a usage hint for the tool '{tool_name}' based on these successful arguments: {executions}"
+            # In a real implementation, this would call self.llm_client.generate(prompt)
+            # We assume the mock returns a string directly
+            return self.llm_client.generate(prompt)
+
+        # Fallback to a simple heuristic if no LLM client is provided
+        num_executions = len(executions)
+        common_keys = set()
+        if executions:
+            common_keys = set(executions[0].keys())
+            for exec_args in executions[1:]:
+                common_keys.intersection_update(exec_args.keys())
+
+        keys_str = ", ".join(common_keys) if common_keys else "no common arguments"
+        return f"Tool '{tool_name}' successfully used {num_executions} times. Common arguments: {keys_str}."

--- a/tests/test_skill_hints.py
+++ b/tests/test_skill_hints.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.skill_hints import SkillHintsExtractor
+
+def test_extract_hints_no_logs():
+    """Test extracting hints with an empty log list."""
+    extractor = SkillHintsExtractor()
+    hints = extractor.extract_hints([])
+    assert hints == {}
+
+def test_extract_hints_only_failed_executions():
+    """Test that failed executions are ignored."""
+    extractor = SkillHintsExtractor()
+    logs = [
+        {"tool_name": "search", "arguments": {"query": "python"}, "success": False},
+        {"tool_name": "read_file", "arguments": {"path": "main.py"}, "success": False},
+    ]
+    hints = extractor.extract_hints(logs)
+    assert hints == {}
+
+def test_extract_hints_heuristic_fallback():
+    """Test the fallback heuristic when no LLM client is provided."""
+    extractor = SkillHintsExtractor()
+    logs = [
+        {"tool_name": "search", "arguments": {"query": "python", "limit": 10}, "success": True},
+        {"tool_name": "search", "arguments": {"query": "pytest", "limit": 5}, "success": True},
+        {"tool_name": "search", "arguments": {"query": "mypy"}, "success": True},
+        {"tool_name": "read_file", "arguments": {"path": "main.py"}, "success": True},
+    ]
+    hints = extractor.extract_hints(logs)
+
+    assert "search" in hints
+    assert "read_file" in hints
+
+    # "query" is common to all successful 'search' executions
+    assert "query" in hints["search"]
+    assert "successfully used 3 times" in hints["search"]
+
+    assert "path" in hints["read_file"]
+    assert "successfully used 1 times" in hints["read_file"]
+
+def test_extract_hints_with_mocked_llm():
+    """Test extracting hints using a mocked LLM client."""
+    mock_llm_client = MagicMock()
+    mock_llm_client.generate.return_value = "Mocked LLM hint for tool."
+
+    extractor = SkillHintsExtractor(llm_client=mock_llm_client)
+    logs = [
+        {"tool_name": "calculator", "arguments": {"expression": "2+2"}, "success": True},
+        {"tool_name": "calculator", "arguments": {"expression": "3*4"}, "success": False}, # should be ignored
+    ]
+
+    hints = extractor.extract_hints(logs)
+
+    assert "calculator" in hints
+    assert hints["calculator"] == "Mocked LLM hint for tool."
+
+    # Verify the LLM was called with the correct prompt format
+    mock_llm_client.generate.assert_called_once()
+    call_args = mock_llm_client.generate.call_args[0][0]
+    assert "calculator" in call_args
+    assert "{'expression': '2+2'}" in call_args
+    assert "3*4" not in call_args


### PR DESCRIPTION
This PR addresses task `f6d81948-9139-4c7e-931b-be57b6b56f28` regarding extracting experience from skill executions.
It implements the `SkillHintsExtractor` which parses tool execution logs generated by the `Tracer` within `core.py` and synthesizes hints to be stored in procedural memory, enabling future performance enhancements. The PR also updates the task manifest with new AI agent trend items.

---
*PR created automatically by Jules for task [8253940633650708828](https://jules.google.com/task/8253940633650708828) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add skill execution experience extraction to the cognitive loop
> - Adds [`SkillHintsExtractor`](https://github.com/kazah4359-lgtm/Magda-agent/pull/610/files#diff-35fada143175df98d10a425698ac650407491a180fdeabe9f8ccc3f54c951713) in a new `learning` module that groups successful tool execution logs by tool name and synthesizes per-tool hint strings, using an injected LLM client or a heuristic fallback based on common argument keys.
> - Integrates hint extraction into [`consciousness.Consciousness`](https://github.com/kazah4359-lgtm/Magda-agent/pull/610/files#diff-10f3d90cbd671753c15902548435794f822a2add14a1004e3fba815032cfe39a): after each response, successful `tool_execution` steps are read from the tracer, hints are synthesized, and stored in `procedural_memory` under keys like `<tool>_hint`.
> - Extraction errors are caught and logged without interrupting the cognitive loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21bc096.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->