### PR TITLE
feat: Multi-Platform Request Routing

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9777,7 +9777,7 @@
     },
     {
       "id": "hermes-multi-platform-routing-a20c6a3e-06c3-471c-8a96-a9b52d552c4f",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "Hermes Multi-Platform Request Routing",
@@ -22080,6 +22080,57 @@
         "Health monitor actively pings peers.",
         "Unresponsive peers are removed from the capability mesh.",
         "Tests mock network timeouts and verify removal behavior."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backup-v2-abc",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "Hermes Cron Nightly Backup v2",
+      "description": "Inspired by June 2026 Hermes Agent trends (Cron Scheduler): Implement a cron-scheduled nightly backup routine that securely snapshots working and episodic memory without blocking the agent.",
+      "allowed_paths": [
+        "magda_agent/operations/cron_backup_v2.py",
+        "tests/test_cron_backup_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Backup process schedules successfully within cron framework.",
+        "Tests verify mock snapshots are created and async non-blocking execution works."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-multi-agent-ui-v2-xyz",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas Multi-Agent UI Streamer v2",
+      "description": "Inspired by June 2026 OpenClaw Canvas Live Visualization trends: Expand canvas streamer to push aggregated state patches containing subagent topology and multi-agent workflow statuses to external UI clients.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_multiagent_v2.py",
+        "tests/test_canvas_multiagent_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module processes subagent topology updates into valid UI state patches.",
+        "Tests verify structural integrity and formatting of multi-agent UI patches."
+      ]
+    },
+    {
+      "id": "claude-evaluator-semantic-diff-v2-def",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Claude Evaluator Semantic Diff Check v2",
+      "description": "Inspired by June 2026 Claude Agent SDK trends: Add a semantic diff evaluation module for the Critic/Evaluator sub-agent to compare and score the generated PR diffs structurally against natural language acceptance criteria.",
+      "allowed_paths": [
+        "magda_agent/evaluation/semantic_diff_v2.py",
+        "tests/test_semantic_diff_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Semantic diff evaluator extracts functional changes and scores them against mock criteria.",
+        "Tests use mock LLM responses to verify the semantic grading behavior."
       ]
     }
   ]

--- a/magda_agent/integration/routing.py
+++ b/magda_agent/integration/routing.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+from typing import Dict, Any, Optional
+
+@dataclass
+class NormalizedEvent:
+    """
+    Represents a standard event format normalized from various platforms.
+    """
+    platform: str
+    user_id: str
+    text: str
+    raw_payload: Dict[str, Any]
+    metadata: Optional[Dict[str, Any]] = None
+
+class MultiPlatformRouter:
+    """
+    Routing layer for handling and normalizing requests from various platforms
+    (Telegram, Discord, CLI) into a unified internal format.
+    """
+
+    def normalize_event(self, platform: str, payload: Dict[str, Any]) -> NormalizedEvent:
+        """
+        Normalizes an incoming platform-specific payload into a standard NormalizedEvent.
+
+        Args:
+            platform (str): The platform origin (e.g., "telegram", "discord", "cli").
+            payload (Dict[str, Any]): The raw payload from the platform.
+
+        Returns:
+            NormalizedEvent: The parsed and normalized event.
+
+        Raises:
+            ValueError: If the platform is unsupported or the payload is invalid.
+        """
+        platform = platform.lower()
+        if platform == "telegram":
+            return self._parse_telegram(payload)
+        elif platform == "discord":
+            return self._parse_discord(payload)
+        elif platform == "cli":
+            return self._parse_cli(payload)
+        else:
+            raise ValueError(f"Unsupported platform: {platform}")
+
+    def _parse_telegram(self, payload: Dict[str, Any]) -> NormalizedEvent:
+        """Parses a Telegram payload."""
+        message = payload.get("message", {})
+        from_user = message.get("from", {})
+        user_id = str(from_user.get("id", ""))
+        text = message.get("text", "")
+
+        if not user_id:
+            raise ValueError("Invalid Telegram payload: missing user id")
+
+        return NormalizedEvent(
+            platform="telegram",
+            user_id=user_id,
+            text=text,
+            raw_payload=payload,
+            metadata={"chat_id": message.get("chat", {}).get("id")}
+        )
+
+    def _parse_discord(self, payload: Dict[str, Any]) -> NormalizedEvent:
+        """Parses a Discord payload."""
+        author = payload.get("author", {})
+        user_id = str(author.get("id", ""))
+        text = payload.get("content", "")
+
+        if not user_id:
+            raise ValueError("Invalid Discord payload: missing author id")
+
+        return NormalizedEvent(
+            platform="discord",
+            user_id=user_id,
+            text=text,
+            raw_payload=payload,
+            metadata={"channel_id": payload.get("channel_id")}
+        )
+
+    def _parse_cli(self, payload: Dict[str, Any]) -> NormalizedEvent:
+        """Parses a CLI payload."""
+        user_id = payload.get("user", "local_user")
+        text = payload.get("input", "")
+
+        if "input" not in payload:
+            raise ValueError("Invalid CLI payload: missing input text")
+
+        return NormalizedEvent(
+            platform="cli",
+            user_id=user_id,
+            text=text,
+            raw_payload=payload,
+            metadata={}
+        )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,73 @@
+import pytest
+from magda_agent.integration.routing import MultiPlatformRouter, NormalizedEvent
+
+def test_telegram_routing():
+    router = MultiPlatformRouter()
+    payload = {
+        "message": {
+            "from": {"id": 12345},
+            "chat": {"id": 67890},
+            "text": "/start"
+        }
+    }
+
+    event = router.normalize_event("telegram", payload)
+
+    assert isinstance(event, NormalizedEvent)
+    assert event.platform == "telegram"
+    assert event.user_id == "12345"
+    assert event.text == "/start"
+    assert event.metadata["chat_id"] == 67890
+    assert event.raw_payload == payload
+
+def test_discord_routing():
+    router = MultiPlatformRouter()
+    payload = {
+        "author": {"id": "987654321"},
+        "channel_id": "112233",
+        "content": "!ping"
+    }
+
+    event = router.normalize_event("discord", payload)
+
+    assert event.platform == "discord"
+    assert event.user_id == "987654321"
+    assert event.text == "!ping"
+    assert event.metadata["channel_id"] == "112233"
+
+def test_cli_routing():
+    router = MultiPlatformRouter()
+    payload = {
+        "user": "test_user",
+        "input": "hello world"
+    }
+
+    event = router.normalize_event("cli", payload)
+
+    assert event.platform == "cli"
+    assert event.user_id == "test_user"
+    assert event.text == "hello world"
+
+def test_unsupported_platform():
+    router = MultiPlatformRouter()
+
+    with pytest.raises(ValueError, match="Unsupported platform: slack"):
+        router.normalize_event("slack", {"text": "hello"})
+
+def test_invalid_telegram_payload():
+    router = MultiPlatformRouter()
+
+    with pytest.raises(ValueError, match="Invalid Telegram payload: missing user id"):
+        router.normalize_event("telegram", {"message": {"text": "hello"}})
+
+def test_invalid_discord_payload():
+    router = MultiPlatformRouter()
+
+    with pytest.raises(ValueError, match="Invalid Discord payload: missing author id"):
+        router.normalize_event("discord", {"content": "hello"})
+
+def test_invalid_cli_payload():
+    router = MultiPlatformRouter()
+
+    with pytest.raises(ValueError, match="Invalid CLI payload: missing input text"):
+        router.normalize_event("cli", {"user": "bob"})


### PR DESCRIPTION
Implement multi-platform request routing layer to handle requests from Telegram, Discord, and CLI through a unified normalized event interface. Includes standard format validation. This task was inspired by Hermes Agent trend.

---
*PR created automatically by Jules for task [13085374707736531511](https://jules.google.com/task/13085374707736531511) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **New features:**
    - Added `MultiPlatformRouter` and `NormalizedEvent` in `magda_agent/integration/routing.py` for Telegram, Discord, and CLI support
    - Added comprehensive unit tests in `tests/test_routing.py` covering successful and invalid payload scenarios
- **Backlog updates:**
    - Marked routing task as done and added 3 new AI trend-inspired tasks to `agent_tasks.json`

<sub>This will update automatically on new commits.</sub>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MultiPlatformRouter` to normalize Telegram, Discord, and CLI payloads
> Introduces [`routing.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/612/files#diff-36dac68362e6bccaf1e5fd03c9f23f8cf3d659b3e6451347543620fd700db6a9) with a `NormalizedEvent` dataclass and `MultiPlatformRouter` class that parse platform-specific payloads into a unified structure. Each parser extracts `user_id`, `text`, and platform metadata (e.g. `chat_id`, `channel_id`), and raises `ValueError` for missing required fields or unsupported platforms. Full unit test coverage is added in [`tests/test_routing.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/612/files#diff-d161c06bc3b5d600a6118ab40b4194a81d226f5f3fdbe17022dc501d823a4f95).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5322ee3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->