### PR TITLE
Enhance ConcurrentSkillExecutor for MCP Tool Concurrency

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9812,7 +9812,7 @@
     },
     {
       "id": "openai-mcp-tool-concurrency-3ce889ad-9455-4502-9a20-88ba0f70038f",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "OpenAI Agents SDK MCP Tool Concurrency",

--- a/magda_agent/skills/mcp_concurrency.py
+++ b/magda_agent/skills/mcp_concurrency.py
@@ -39,8 +39,14 @@ class MCPConcurrentSkillExecutor:
             name = call.get("name", "")
             kwargs = call.get("kwargs", {})
 
-            # Extract server prefix (e.g. 'math_server-add' -> 'math_server')
-            server_prefix = name.split("-")[0] if "-" in name else name
+            # Extract server prefix (supports '__', ':', '-')
+            # Specific delimiters like '__' and ':' must be checked before '-'
+            # to handle server names with hyphens (e.g. google-search:web_search)
+            server_prefix = name
+            for sep in ["__", ":", "-"]:
+                if sep in name:
+                    server_prefix = name.split(sep)[0]
+                    break
 
             if server_prefix not in batches:
                 batches[server_prefix] = []
@@ -139,3 +145,7 @@ class MCPConcurrentSkillExecutor:
                         break
 
         return final_results
+
+
+# Alias for compatibility with trend specifications referring to ConcurrentSkillExecutor
+ConcurrentSkillExecutor = MCPConcurrentSkillExecutor

--- a/tests/test_mcp_concurrency.py
+++ b/tests/test_mcp_concurrency.py
@@ -323,3 +323,106 @@ async def test_mcp_manager_backpressure(mcp_manager):
 
     backpressure_errors = [r for r in results if isinstance(r, str) and "BackpressureError" in r]
     assert len(backpressure_errors) > 0
+
+
+# --- New tests verifying ConcurrentSkillExecutor enhancements ---
+from magda_agent.skills.mcp_concurrency import ConcurrentSkillExecutor
+
+@pytest.mark.asyncio
+async def test_concurrent_skill_executor_alias():
+    """
+    Ensure the ConcurrentSkillExecutor alias works identically.
+    """
+    class MockClient:
+        async def execute(self, name, kwargs):
+            return f"ok_{name}"
+
+    mock_client = MockClient()
+    executor = ConcurrentSkillExecutor(mock_client)
+    tool_calls = [{"name": "test-tool", "kwargs": {}}]
+    results = await executor.execute_mcp_tools_concurrently(tool_calls)
+    assert results == ["ok_test-tool"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_prefix_separators():
+    """
+    Ensure different prefix separators (__, -, :) are handled correctly, especially
+    when server names themselves contain a hyphen (e.g. google-search:web_search).
+    """
+    batches_recorded = []
+
+    class MockClient:
+        async def execute_batch(self, server, calls):
+            batches_recorded.append((server, len(calls)))
+            return [f"{c['name']}_done" for c in calls]
+
+    mock_client = MockClient()
+    executor = MCPConcurrentSkillExecutor(mock_client)
+
+    tool_calls = [
+        {"name": "math_server__add", "kwargs": {}},
+        {"name": "math_server-subtract", "kwargs": {}},
+        {"name": "math_server:multiply", "kwargs": {}},
+        {"name": "other_server__foo", "kwargs": {}},
+        {"name": "google-search:web_search", "kwargs": {}}
+    ]
+
+    results = await executor.execute_mcp_tools_concurrently(tool_calls)
+    assert len(batches_recorded) == 3
+    # "math_server", "other_server", and "google-search" (not "google") should be identified
+    servers_batched = {b[0] for b in batches_recorded}
+    assert "math_server" in servers_batched
+    assert "other_server" in servers_batched
+    assert "google-search" in servers_batched
+    assert "google" not in servers_batched
+    assert results == [
+        "math_server__add_done",
+        "math_server-subtract_done",
+        "math_server:multiply_done",
+        "other_server__foo_done",
+        "google-search:web_search_done"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_performance_concurrency_vs_sequential():
+    """
+    Performance test: verify that executing MCP tools concurrently demonstrates
+    substantial time savings versus sequential execution.
+    """
+    class MockSlowClient:
+        async def execute(self, name, kwargs):
+            await asyncio.sleep(0.05)
+            return f"{name}_done"
+
+    mock_client = MockSlowClient()
+    executor = MCPConcurrentSkillExecutor(mock_client)
+
+    tool_calls = [
+        {"name": "server1-tool_a", "kwargs": {}},
+        {"name": "server2-tool_b", "kwargs": {}},
+        {"name": "server3-tool_c", "kwargs": {}}
+    ]
+
+    # Measure concurrent execution time
+    start_concurrent = asyncio.get_event_loop().time()
+    concurrent_results = await executor.execute_mcp_tools_concurrently(tool_calls)
+    end_concurrent = asyncio.get_event_loop().time()
+    concurrent_duration = end_concurrent - start_concurrent
+
+    # Measure sequential execution time (manually calling mock client sequentially)
+    start_sequential = asyncio.get_event_loop().time()
+    sequential_results = []
+    for call in tool_calls:
+        res = await mock_client.execute(call["name"], call["kwargs"])
+        sequential_results.append(res)
+    end_sequential = asyncio.get_event_loop().time()
+    sequential_duration = end_sequential - start_sequential
+
+    # Assert correctness
+    assert concurrent_results == sequential_results
+
+    # Assert performance: concurrent should be significantly faster than sequential.
+    # 3 calls executed sequentially take ~0.15s, while concurrently they take ~0.05s.
+    assert concurrent_duration < sequential_duration * 0.7


### PR DESCRIPTION
This change enhances MCPConcurrentSkillExecutor to support multiple separators when parsing server prefixes from MCP tool names, resolves the separator precedence bug (e.g. server names with hyphens), defines ConcurrentSkillExecutor as an alias, and adds comprehensive tests.

---
*PR created automatically by Jules for task [13645283913055812689](https://jules.google.com/task/13645283913055812689) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix server prefix extraction in `MCPConcurrentSkillExecutor` to support hyphenated server names
> - Updates the prefix-splitting logic in [`mcp_concurrency.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/615/files#diff-b77c907af979815f1f6cc222bd188c6f2dbf0abf2f19b68318c6ab103af1c5bf) to check separators in priority order `['__', ':', '-']`, so tool names like `google-search:web_search` batch under `google-search` rather than `google`.
> - Adds a module-level alias `ConcurrentSkillExecutor = MCPConcurrentSkillExecutor` for backward compatibility with existing imports.
> - New tests cover separator precedence, the alias, and a performance check confirming concurrent execution is faster than sequential.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c5f5c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->