### PR TITLE
feat: MCP Tool Taint Tracking Sandbox v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9882,7 +9882,7 @@
     },
     {
       "id": "mcp-action-tool-taint-tracking-v5-6c2393a2",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "MCP Tool Taint Tracking Sandbox v5",
@@ -22395,6 +22395,42 @@
         "Pruner module iterates over episodic memories.",
         "Scores memory quality and evicts data below a configured threshold.",
         "Tests use mocked ChromaDB interactions to verify eviction logic."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-marketplace-v1-new-f3b1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Agent Skills Marketplace Publisher V1",
+      "description": "Inspired by Hermes trends (June 2026): Implement a MarketplacePublisher module to export and publish local Magda skills directly to the agentskills.io standard registry via a REST API.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_publisher_v1.py",
+        "tests/test_marketplace_publisher_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MarketplacePublisher formats local skills to agentskills.io JSON structure.",
+        "Module pushes formatted skills to external endpoint via HTTP POST.",
+        "Tests pass with mocked HTTP client."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-ui-streamer-v2-new-a1c2",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw RL Canvas Multi-Agent UI Streamer v2",
+      "description": "Inspired by OpenClaw Canvas UI trends: Extend Canvas UI to support Multi-Agent streams by multiplexing state diffs from multiple sub-agents into a single WebSocket connection.",
+      "allowed_paths": [
+        "magda_agent/visualization/multi_agent_canvas_streamer_v2.py",
+        "tests/test_multi_agent_canvas_streamer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Streamer interleaves messages from multiple sub-agent states correctly.",
+        "Each streamed JSON patch identifies the origin agent UUID.",
+        "Tests verify correct multiplexing using mock asyncio streams."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -332,3 +332,4 @@
 * [ ] FEATURE: A2A Swarm Intelligence Strategy V4 (a2a-swarm-intelligence-strategy-v4)
 * [ ] FEATURE: Claude Worktree Pruning and Resource Optimizer V2 (claude-worktree-pruning-optimizer-v2)
 * [ ] FEATURE: OpenClaw RL Multi-agent Feedback Exchange V2 (openclaw-rl-multiagent-feedback-v2)
+* [x] FEATURE: MCP Tool Taint Tracking Sandbox v5 (mcp-action-tool-taint-tracking-v5-6c2393a2)

--- a/magda_agent/security/mcp_taint.py
+++ b/magda_agent/security/mcp_taint.py
@@ -1,4 +1,4 @@
-"""MCP Tool Taint Tracking Sandbox v4."""
+"""MCP Tool Taint Tracking Sandbox v5."""
 import inspect
 import functools
 from typing import Any, Callable, List, Optional
@@ -8,12 +8,27 @@ class TaintSandboxError(PolicyViolationError):
     """Raised when tainted data violates policy during MCP tool execution."""
     pass
 
+def _check_taint_by_path(value: Any, path: List[str]) -> bool:
+    """Helper to check if a nested dictionary path is tainted."""
+    if not path:
+        return is_tainted(value)
+
+    current = value
+    for key in path:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return False
+    return is_tainted(current)
+
+
 def mcp_action_taint_sandbox(critical_params: Optional[List[str]] = None) -> Callable[..., Any]:
     """
     Decorator for MCP action tools to track taint and block unsafe calls.
+    Supports dot-notation in critical_params to check nested dictionary fields.
 
     Args:
-        critical_params: List of parameter names that must not receive tainted data.
+        critical_params: List of parameter names (or dot-paths) that must not receive tainted data.
 
     Returns:
         A decorator for taint tracking.
@@ -30,11 +45,15 @@ def mcp_action_taint_sandbox(critical_params: Optional[List[str]] = None) -> Cal
             bound_args.apply_defaults()
 
             # Block if any critical parameter receives tainted data
-            for param_name, param_value in bound_args.arguments.items():
-                if param_name in critical_params and is_tainted(param_value):
-                    raise TaintSandboxError(
-                        f"Critical parameter '{param_name}' in '{func.__name__}' received tainted data."
-                    )
+            for crit_param in critical_params:
+                parts = crit_param.split(".")
+                param_name = parts[0]
+                if param_name in bound_args.arguments:
+                    param_value = bound_args.arguments[param_name]
+                    if _check_taint_by_path(param_value, parts[1:]):
+                        raise TaintSandboxError(
+                            f"Critical parameter '{crit_param}' in '{func.__name__}' received tainted data."
+                        )
 
             # Execute the function
             result: Any = func(*args, **kwargs)

--- a/tests/test_mcp_taint.py
+++ b/tests/test_mcp_taint.py
@@ -94,3 +94,39 @@ def test_advanced_mcp_taint_tracker_clean_inputs() -> None:
     result = process(clean_data)
     assert is_tainted(result) is False
     assert result == "Processed public"
+
+def test_mcp_action_taint_sandbox_blocks_nested_dict() -> None:
+    """Tests that the sandbox blocks a critical parameter if a nested dict value is tainted."""
+    @mcp_action_taint_sandbox(critical_params=["config"])
+    def execute(config: dict) -> str:
+        return "ok"
+
+    with pytest.raises(TaintSandboxError, match="Critical parameter 'config' in 'execute' received tainted data."):
+        execute({"cmd": {"run": mark_tainted("rm -rf")}})
+
+def test_mcp_action_taint_sandbox_allows_clean_nested_dict() -> None:
+    """Tests that the sandbox allows a clean nested dict."""
+    @mcp_action_taint_sandbox(critical_params=["config"])
+    def execute(config: dict) -> str:
+        return "ok"
+
+    result = execute({"cmd": {"run": "ls"}})
+    assert result == "ok"
+
+def test_mcp_action_taint_sandbox_dot_notation() -> None:
+    """Tests that the sandbox checks specific dot-notation paths."""
+    @mcp_action_taint_sandbox(critical_params=["config.cmd.run"])
+    def execute(config: dict) -> str:
+        return "ok"
+
+    # Should block if the specific path is tainted
+    with pytest.raises(TaintSandboxError, match="Critical parameter 'config.cmd.run' in 'execute' received tainted data."):
+        execute({"cmd": {"run": mark_tainted("rm -rf")}})
+
+    # Should allow if a different path is tainted
+    result = execute({"cmd": {"run": "ls"}, "other": mark_tainted("bad")})
+    assert result == "ok"
+
+    # Should allow if the path doesn't exist
+    result2 = execute({"other": "safe"})
+    assert result2 == "ok"


### PR DESCRIPTION
Implemented the MCP Tool Taint Tracking Sandbox v5 as requested by the task `mcp-action-tool-taint-tracking-v5-6c2393a2`. The update enhances the existing `mcp_action_taint_sandbox` decorator to parse dot-notation strings, enabling precise taint tracking inside deeply nested configuration dictionaries. Relevant tests were created, the task json was appropriately managed, and 2 new trend-inspired tasks were appended.

---
*PR created automatically by Jules for task [9555973824585235833](https://jules.google.com/task/9555973824585235833) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dot-notation nested taint path support to `mcp_action_taint_sandbox`
> - Adds `_check_taint_by_path` helper in [`mcp_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/620/files#diff-02c3b4d8419a3de8bacbec4684b3ec1f39eac400f5af247489cf37a5d82de7c9) to traverse nested dicts by a list of path segments and check taint at the resolved value.
> - Extends `mcp_action_taint_sandbox` to accept dot-notation in `critical_params` (e.g. `'config.cmd.run'`), raising `TaintSandboxError` with the full path when the specified nested value is tainted.
> - Adds tests in [`test_mcp_taint.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/620/files#diff-11766a2a2fda0a2a3c7fe2e355fecc91a476ab29ec0329863ec60e3373975cf7) covering blocked nested dicts, clean nested dicts, and dot-notation path matching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fca90fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->