### PR TITLE
feat: implement RLMetricsSystemV5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9917,7 +9917,7 @@
     },
     {
       "id": "openclaw-rl-metrics-v5-f60b1d89",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL Metrics System v5",
@@ -22482,6 +22482,58 @@
       "acceptance": [
         "MCP action tools execute in isolated subprocesses.",
         "Tests mock execution and verify secure, isolated execution output."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-auto-refinement-v10-2026",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Agent Skills Auto-Refinement v10",
+      "description": "Inspired by Hermes trends (June 2026): Implement an enhanced auto-refinement module that uses an LLM evaluator to score code quality and readability of procedurally generated skills, automatically proposing refactors if the score is low.",
+      "allowed_paths": [
+        "magda_agent/skills/auto_refinement_v10.py",
+        "tests/test_auto_refinement_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Auto-refinement module can evaluate skill code quality.",
+        "Module generates proposed refactors using an LLM evaluator.",
+        "Tests verify that mock skill data triggers correct refactor proposals."
+      ]
+    },
+    {
+      "id": "claude-evaluator-subagent-isolation-v4",
+      "title": "Claude Evaluator Subagent Isolation V4",
+      "description": "Inspired by Claude Agent SDK (June 2026): Implement deep Git worktree isolation for spawned evaluator subagents, applying cgroups and namespace constraints to strictly limit CPU and memory usage.",
+      "area": "agents",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/agents/evaluator_subagent_isolation_v4.py",
+        "tests/test_evaluator_subagent_isolation_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagents run inside isolated Git worktrees with resource constraints.",
+        "Tests verify clean execution and resource restriction handling."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-vision-feedback-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Vision Feedback Alignment v2",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Extend OpenClaw reinforcement learning to parse visual feedback from user-uploaded images/screens, classifying user emotion (positive/negative) to act as next-state reward signals.",
+      "allowed_paths": [
+        "magda_agent/learning/vision_sentiment_v2.py",
+        "tests/test_vision_sentiment_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Vision sentiment signals successfully update habit weights.",
+        "Tests verify weight adjustments using mock image sentiment signals."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -334,3 +334,4 @@
 * [ ] FEATURE: OpenClaw RL Multi-agent Feedback Exchange V2 (openclaw-rl-multiagent-feedback-v2)
 * [x] FEATURE: MCP Tool Taint Tracking Sandbox v5 (mcp-action-tool-taint-tracking-v5-6c2393a2)
 * [x] FEATURE: A2A Task Delegation Streaming Interface v3
+* [x] FEATURE: OpenClaw RL Metrics System v5 (openclaw-rl-metrics-v5-f60b1d89)

--- a/magda_agent/learning/metrics_v5.py
+++ b/magda_agent/learning/metrics_v5.py
@@ -1,0 +1,36 @@
+"""
+Metrics V5 for OpenClaw RL
+Time-series database adapter for the online reinforcement learning metrics system.
+"""
+from typing import Dict, Any, List
+
+class RLMetricsSystemV5:
+    """
+    Time-series database adapter for the online reinforcement learning metrics system
+    to capture longitudinal quality updates more efficiently.
+    """
+    from typing import Optional
+
+    def __init__(self, backend_store: Optional[List[Dict[str, Any]]] = None) -> None:
+        """
+        Initializes the metrics system.
+        """
+        self.store = [] if backend_store is None else backend_store
+
+    def log_signal(self, agent_id: str, timestamp: float, reward: float, metadata: Dict[str, Any]) -> None:
+        """
+        Pushes next-state signals to a time-series store format.
+        """
+        entry = {
+            "agent_id": agent_id,
+            "timestamp": timestamp,
+            "reward": reward,
+            "metadata": metadata
+        }
+        self.store.append(entry)
+
+    def get_metrics(self) -> List[Dict[str, Any]]:
+        """
+        Retrieves the logged metrics.
+        """
+        return self.store

--- a/tests/test_rl_metrics_v5.py
+++ b/tests/test_rl_metrics_v5.py
@@ -1,0 +1,19 @@
+"""
+Tests for RL Metrics System V5
+"""
+import pytest
+from magda_agent.learning.metrics_v5 import RLMetricsSystemV5
+
+def test_log_signal() -> None:
+    """
+    Test logging a signal correctly pushes it to the store.
+    """
+    system = RLMetricsSystemV5()
+    system.log_signal("agent_1", 12345.6, 0.95, {"action": "test"})
+    metrics = system.get_metrics()
+
+    assert len(metrics) == 1
+    assert metrics[0]["agent_id"] == "agent_1"
+    assert metrics[0]["timestamp"] == 12345.6
+    assert metrics[0]["reward"] == 0.95
+    assert metrics[0]["metadata"] == {"action": "test"}


### PR DESCRIPTION
Resolves task `openclaw-rl-metrics-v5-f60b1d89` by implementing a time-series backend adapter for OpenClaw-RL. Added type hints and passing unit tests. Appended 3 new trend-inspired tasks to the manifest and synchronized the backlog.

---
*PR created automatically by Jules for task [7836148264777308296](https://jules.google.com/task/7836148264777308296) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLMetricsSystemV5` class for in-memory RL signal logging
> Adds [metrics_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/622/files#diff-c577192da03a76b839f4fac6cd3ce9e79b93a01336a02aab8ea7084e6b652c38) with `RLMetricsSystemV5`, a simple class that stores RL metrics (agent_id, timestamp, reward, metadata) in an in-memory list. Provides `log_signal` to append entries and `get_metrics` to retrieve them. A basic test in [test_rl_metrics_v5.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/622/files#diff-2f1168a7b9473831405a29dd4e5d19afc5dc0a53a51184927ca84520847203b1) verifies that logged signals are stored correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7441509.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->