### PR TITLE
feat: Implement A2A Discovery Enhancements v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9951,7 +9951,7 @@
     },
     {
       "id": "a2a-discovery-enhancements-v4-b68bc3d3",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Discovery Enhancements v4",
@@ -22587,6 +22587,60 @@
       "acceptance": [
         "PreflightPolicyValidator intercepts and validates MCP action parameters.",
         "Tests mock execution and verify secure, isolated execution output or block action."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-lifecycle-hooks-v1",
+      "title": "OpenClaw Context Engine Lifecycle Hooks V1",
+      "description": "Inspired by OpenClaw trends: Implement context engine lifecycle hooks to allow external plugins to dynamically modify working memory during the before_retrieval and after_retrieval phases.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/context_lifecycle_v1.py",
+        "tests/test_context_lifecycle_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine supports registering lifecycle hooks.",
+        "Hooks successfully execute and modify working memory context strings.",
+        "Tests mock plugin behavior and verify context modification."
+      ]
+    },
+    {
+      "id": "claude-agent-hierarchical-delegation-v1",
+      "title": "Claude Agent Hierarchical Delegation V1",
+      "description": "Inspired by Claude Agent multi-agent orchestration trends: Implement a hierarchical delegation module where a lead Planner agent can spawn Sub-planners with constrained scopes and isolated Git worktrees.",
+      "area": "agents",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/agents/hierarchical_planner_v1.py",
+        "tests/test_hierarchical_planner_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lead planner can dynamically spawn isolated sub-planners.",
+        "Sub-planners run with restricted scopes.",
+        "Tests verify successful delegation and scope containment."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-v6",
+      "title": "Hermes Cron Scheduler V6",
+      "description": "Inspired by Hermes scheduled operations trends: Enhance CronScheduler to support declarative YAML definitions for nightly consolidation and automated report generation tasks.",
+      "area": "scheduler",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/scheduler/cron_v6.py",
+        "tests/test_cron_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "CronScheduler dynamically parses scheduling intervals from YAML.",
+        "Automated tasks correctly trigger bound functions.",
+        "Tests verify parsing logic and task triggering with mocked time."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_discovery_v4_ext.py
+++ b/magda_agent/integration/a2a_discovery_v4_ext.py
@@ -1,0 +1,57 @@
+from typing import List, Optional, Set
+import logging
+from magda_agent.integration.a2a_discovery_v4 import A2ADiscoveryRegistryV4, AgentCardV4
+
+class A2ADiscoveryRegistryV4Ext(A2ADiscoveryRegistryV4):
+    """
+    Extended A2A discovery registry that supports advanced capability matching and querying.
+    Inspired by A2A Protocol capability-based delegation trends.
+    """
+
+    def filter_by_capabilities(self, required_capabilities: List[str]) -> List[AgentCardV4]:
+        """
+        Filters all registered agents and returns only those that support
+        all of the specified capabilities.
+
+        Args:
+            required_capabilities: A list of capabilities strings to match against.
+
+        Returns:
+            A list of AgentCardV4 instances that possess the required capabilities.
+        """
+        if not required_capabilities:
+            return self.get_all_agents()
+
+        required_set = set(required_capabilities)
+        matched_agents = []
+        for agent in self.get_all_agents():
+            agent_caps_set = set(agent.capabilities)
+            if required_set.issubset(agent_caps_set):
+                matched_agents.append(agent)
+
+        return matched_agents
+
+    def find_agent_for_delegation(self, required_capabilities: List[str], exclude_agent_id: Optional[str] = None) -> Optional[AgentCardV4]:
+        """
+        Finds an optimal agent for delegating a task that requires specific capabilities.
+
+        Args:
+            required_capabilities: A list of capabilities the agent must support.
+            exclude_agent_id: Optional agent ID to exclude (typically the caller's own ID).
+
+        Returns:
+            An AgentCardV4 if a suitable agent is found, otherwise None.
+        """
+        matched_agents = self.filter_by_capabilities(required_capabilities)
+
+        if exclude_agent_id:
+            matched_agents = [agent for agent in matched_agents if agent.agent_id != exclude_agent_id]
+
+        if matched_agents:
+            # We can implement a more complex routing strategy here (e.g. least loaded, lowest latency)
+            # For now, simply return the first match.
+            logging.info(f"Found suitable agent {matched_agents[0].agent_id} for capabilities {required_capabilities}")
+            return matched_agents[0]
+
+        logging.warning(f"No suitable agent found for capabilities {required_capabilities}")
+        return None

--- a/tests/test_a2a_discovery_v4_ext.py
+++ b/tests/test_a2a_discovery_v4_ext.py
@@ -1,0 +1,90 @@
+import pytest
+from typing import List, Optional
+from magda_agent.integration.a2a_discovery_v4 import AgentCardV4
+from magda_agent.integration.a2a_discovery_v4_ext import A2ADiscoveryRegistryV4Ext
+
+@pytest.fixture
+def registry() -> A2ADiscoveryRegistryV4Ext:
+    """Provides a fresh instance of A2ADiscoveryRegistryV4Ext."""
+    return A2ADiscoveryRegistryV4Ext()
+
+@pytest.fixture
+def mock_cards() -> List[str]:
+    """Provides mock JSON string representations of Agent Cards."""
+    return [
+        AgentCardV4(
+            agent_id="agent-1",
+            name="Planner Agent",
+            description="Specializes in generating plans",
+            capabilities=["planning", "research", "summarization"],
+            endpoints={"rpc": "http://agent-1/rpc"}
+        ).to_json(),
+        AgentCardV4(
+            agent_id="agent-2",
+            name="Coder Agent",
+            description="Writes and reviews code",
+            capabilities=["coding", "review", "git"],
+            endpoints={"rpc": "http://agent-2/rpc"}
+        ).to_json(),
+        AgentCardV4(
+            agent_id="agent-3",
+            name="DevOps Agent",
+            description="Handles deployments",
+            capabilities=["deployment", "docker", "git"],
+            endpoints={"rpc": "http://agent-3/rpc"}
+        ).to_json()
+    ]
+
+def test_filter_by_capabilities_matches_exact(registry: A2ADiscoveryRegistryV4Ext, mock_cards: List[str]) -> None:
+    """Verifies that filter_by_capabilities returns the exact match for required capabilities."""
+    registry.parse_and_register_cards(mock_cards)
+
+    results = registry.filter_by_capabilities(["coding", "review"])
+    assert len(results) == 1
+    assert results[0].agent_id == "agent-2"
+
+def test_filter_by_capabilities_matches_multiple(registry: A2ADiscoveryRegistryV4Ext, mock_cards: List[str]) -> None:
+    """Verifies that filter_by_capabilities returns multiple agents if they possess the capability."""
+    registry.parse_and_register_cards(mock_cards)
+
+    results = registry.filter_by_capabilities(["git"])
+    assert len(results) == 2
+    agent_ids = {agent.agent_id for agent in results}
+    assert agent_ids == {"agent-2", "agent-3"}
+
+def test_filter_by_capabilities_no_match(registry: A2ADiscoveryRegistryV4Ext, mock_cards: List[str]) -> None:
+    """Verifies that filter_by_capabilities returns empty list when no agent has the capability."""
+    registry.parse_and_register_cards(mock_cards)
+
+    results = registry.filter_by_capabilities(["machine-learning"])
+    assert len(results) == 0
+
+def test_filter_by_capabilities_empty_requirements(registry: A2ADiscoveryRegistryV4Ext, mock_cards: List[str]) -> None:
+    """Verifies that filter_by_capabilities returns all agents when empty capabilities are provided."""
+    registry.parse_and_register_cards(mock_cards)
+
+    results = registry.filter_by_capabilities([])
+    assert len(results) == 3
+
+def test_find_agent_for_delegation(registry: A2ADiscoveryRegistryV4Ext, mock_cards: List[str]) -> None:
+    """Verifies find_agent_for_delegation successfully returns a matching agent."""
+    registry.parse_and_register_cards(mock_cards)
+
+    agent = registry.find_agent_for_delegation(["planning", "summarization"])
+    assert agent is not None
+    assert agent.agent_id == "agent-1"
+
+def test_find_agent_for_delegation_with_exclude(registry: A2ADiscoveryRegistryV4Ext, mock_cards: List[str]) -> None:
+    """Verifies find_agent_for_delegation respects the exclude_agent_id parameter."""
+    registry.parse_and_register_cards(mock_cards)
+
+    agent = registry.find_agent_for_delegation(["git"], exclude_agent_id="agent-3")
+    assert agent is not None
+    assert agent.agent_id == "agent-2"
+
+def test_find_agent_for_delegation_no_match(registry: A2ADiscoveryRegistryV4Ext, mock_cards: List[str]) -> None:
+    """Verifies find_agent_for_delegation returns None if no single agent satisfies all capabilities."""
+    registry.parse_and_register_cards(mock_cards)
+
+    agent = registry.find_agent_for_delegation(["planning", "coding"])
+    assert agent is None

--- a/update_backlog.py
+++ b/update_backlog.py
@@ -1,5 +1,0 @@
-with open('backlog.md', 'a') as f:
-    f.write("\n* [x] FEATURE: OpenClaw Online RL Loop v6 (openclaw-online-rl-dialogue-v6-e9301cfc)\n")
-    f.write("* [ ] FEATURE: Claude Agent Teams Subagent Spawner V2 (claude-agent-teams-subagent-spawner-v2)\n")
-    f.write("* [ ] FEATURE: OpenClaw Context Engine Hooks V6 (openclaw-context-engine-hooks-v6)\n")
-    f.write("* [ ] FEATURE: MCP Dynamic Capability Negotiation V7 (mcp-dynamic-capability-negotiation-v7)\n")


### PR DESCRIPTION
Inspired by A2A Protocol trends: Extended A2ADiscovery to support capability matching and advanced Agent Card querying for cross-agent delegation. Updated agent tasks appropriately according to June 2026 AI Agent trends.

---
*PR created automatically by Jules for task [12469425224528911787](https://jules.google.com/task/12469425224528911787) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add capability-based filtering and delegation selection to A2A discovery registry
> - Introduces [`A2ADiscoveryRegistryV4Ext`](https://github.com/kazah4359-lgtm/Magda-agent/pull/624/files#diff-15df2c2c20a1bc19ef2df2e46e030abb69e5ecae913d4952c30cc0fa8d54f51f), a subclass of `A2ADiscoveryRegistryV4`, with two new methods: `filter_by_capabilities` and `find_agent_for_delegation`.
> - `filter_by_capabilities` returns agents whose capability set is a superset of the required capabilities, or all agents when no capabilities are specified.
> - `find_agent_for_delegation` wraps `filter_by_capabilities` with optional agent exclusion, returning the first matching `AgentCardV4` or `None` if no match exists.
> - Adds [tests](https://github.com/kazah4359-lgtm/Magda-agent/pull/624/files#diff-c18cc0542a47844810df0189eb8aff136039164e847d20cd69600d8a3e385b27) covering exact matches, multi-agent matches, empty requirements, exclusion, and no-match cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89e97bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->