### PR TITLE
feat: implement MCP dynamic integration v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9968,7 +9968,7 @@
     },
     {
       "id": "mcp-tools-integration-dynamic-v2-c96eac36",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Tools Dynamic Integration v2",
@@ -22692,6 +22692,42 @@
       "acceptance": [
         "Cron job aggregates daily logs.",
         "Episodic memory is condensed correctly."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugins-v1-new",
+      "title": "OpenClaw Context Engine External Plugins V1",
+      "description": "Inspired by OpenClaw trends: Implement a context engine plugin registry that allows external developers to load Python modules dynamically and hook into working memory updates.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/context_plugins_v1.py",
+        "tests/test_context_plugins_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine allows dynamic registration of python modules as plugins.",
+        "Plugins can intercept memory updates safely.",
+        "Tests mock plugin behavior."
+      ]
+    },
+    {
+      "id": "claude-teams-git-subagent-isolation-v2-new",
+      "title": "Claude Teams Git Worktree Subagent Isolation V2",
+      "description": "Inspired by Claude Teams Agent trend: Extend Git worktree isolation with cgroup resource constraints for multi-agent processes to limit subagent memory/CPU directly inside the spawner.",
+      "area": "agents",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/agents/worktree_cgroups_v2.py",
+        "tests/test_worktree_cgroups_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Git worktree isolation applies cgroup constraints.",
+        "Subagents execute within confined resource bounds.",
+        "Tests mock resource limits."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_dynamic_integration_v2.py
+++ b/magda_agent/integration/mcp_dynamic_integration_v2.py
@@ -1,0 +1,85 @@
+import logging
+from typing import Dict, Any, Callable, Optional
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+
+class MCPDynamicIntegrationV2:
+    """
+    A dynamic module to seamlessly import and execute external MCP tools at runtime.
+    Wraps MCP tools dynamically and registers them into the skill registry.
+    """
+
+    def __init__(self, registry: MCPRegistryV7):
+        """
+        Initialize the MCP Dynamic Integration module.
+
+        Args:
+            registry (MCPRegistryV7): The skill registry to use for registering tools.
+        """
+        self.registry = registry
+        # Map of tool_name to its executable wrapper
+        self._executors: Dict[str, Callable[..., Any]] = {}
+
+    def register_and_wrap(self, tool_schema: Dict[str, Any], executor: Callable[..., Any]) -> bool:
+        """
+        Dynamically reads an MCP standard tool definition, wraps it into the skill registry,
+        and associates it with an execution callable.
+
+        Args:
+            tool_schema (Dict[str, Any]): The MCP tool schema.
+            executor (Callable[..., Any]): The callable that executes the tool logic.
+
+        Returns:
+            bool: True if registration was successful, False otherwise.
+        """
+        if not isinstance(tool_schema, dict) or "name" not in tool_schema:
+            logging.error("Failed to register tool: Invalid schema missing 'name'.")
+            return False
+
+        tool_name = tool_schema["name"]
+
+        # Register the schema into the registry
+        if self.registry.register_tool(tool_schema):
+            self._executors[tool_name] = executor
+            logging.info(f"Dynamically registered and wrapped MCP tool: {tool_name}")
+            return True
+        else:
+            logging.error(f"Registry failed to register MCP tool schema: {tool_name}")
+            return False
+
+    def execute_tool(self, tool_name: str, **kwargs: Any) -> Any:
+        """
+        Dynamically executes a registered external MCP tool.
+
+        Args:
+            tool_name (str): The name of the MCP tool to execute.
+            **kwargs (Any): The arguments to pass to the tool's executor.
+
+        Returns:
+            Any: The result from the executor, or None if tool not found or failed.
+        """
+        if tool_name not in self._executors:
+            logging.error(f"Execution failed: MCP tool '{tool_name}' not found or not wrapped.")
+            return None
+
+        executor = self._executors[tool_name]
+        try:
+            result = executor(**kwargs)
+            return result
+        except Exception as e:
+            logging.error(f"Execution failed for MCP tool '{tool_name}': {e}")
+            return None
+
+    def unregister_tool(self, tool_name: str) -> bool:
+        """
+        Unregisters the tool from both the integration module and the underlying registry.
+
+        Args:
+            tool_name (str): The name of the MCP tool to unregister.
+
+        Returns:
+            bool: True if successfully unregistered, False otherwise.
+        """
+        if tool_name in self._executors:
+            del self._executors[tool_name]
+            return self.registry.unregister_tool(tool_name)
+        return False

--- a/tests/test_mcp_dynamic_integration_v2.py
+++ b/tests/test_mcp_dynamic_integration_v2.py
@@ -1,0 +1,95 @@
+import pytest
+from typing import Any, Dict
+from unittest.mock import MagicMock
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+from magda_agent.integration.mcp_dynamic_integration_v2 import MCPDynamicIntegrationV2
+
+@pytest.fixture
+def registry() -> MCPRegistryV7:
+    """Provides a fresh instance of MCPRegistryV7."""
+    return MCPRegistryV7()
+
+@pytest.fixture
+def mcp_integration(registry: MCPRegistryV7) -> MCPDynamicIntegrationV2:
+    """Provides a fresh instance of MCPDynamicIntegrationV2."""
+    return MCPDynamicIntegrationV2(registry=registry)
+
+def test_register_and_wrap_success(mcp_integration: MCPDynamicIntegrationV2) -> None:
+    """Test successfully wrapping and registering a valid MCP tool schema."""
+    schema: Dict[str, Any] = {
+        "name": "mock_tool",
+        "description": "A mock tool for testing.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "arg1": {"type": "string"}
+            }
+        }
+    }
+    mock_executor = MagicMock(return_value="success")
+
+    result = mcp_integration.register_and_wrap(schema, mock_executor)
+    assert result is True
+    assert "mock_tool" in mcp_integration.registry.list_tools()
+    assert mcp_integration._executors["mock_tool"] == mock_executor
+
+def test_register_and_wrap_invalid_schema(mcp_integration: MCPDynamicIntegrationV2) -> None:
+    """Test wrapping an invalid schema fails appropriately."""
+    schema: Dict[str, Any] = {
+        "description": "Missing name field."
+    }
+    mock_executor = MagicMock()
+
+    result = mcp_integration.register_and_wrap(schema, mock_executor)
+    assert result is False
+    assert len(mcp_integration._executors) == 0
+
+def test_execute_tool_success(mcp_integration: MCPDynamicIntegrationV2) -> None:
+    """Test dynamically executing a registered tool."""
+    schema: Dict[str, Any] = {
+        "name": "mock_tool_exec",
+        "description": "Mock executor."
+    }
+
+    def executor_func(arg1: str) -> str:
+        return f"Executed with {arg1}"
+
+    mcp_integration.register_and_wrap(schema, executor_func)
+
+    result = mcp_integration.execute_tool("mock_tool_exec", arg1="test_value")
+    assert result == "Executed with test_value"
+
+def test_execute_tool_not_found(mcp_integration: MCPDynamicIntegrationV2) -> None:
+    """Test executing a tool that doesn't exist returns None."""
+    result = mcp_integration.execute_tool("nonexistent_tool")
+    assert result is None
+
+def test_execute_tool_exception_handling(mcp_integration: MCPDynamicIntegrationV2) -> None:
+    """Test execution failure is handled gracefully."""
+    schema: Dict[str, Any] = {
+        "name": "mock_tool_fail",
+        "description": "Mock failure."
+    }
+
+    mock_executor = MagicMock(side_effect=ValueError("Execution error"))
+    mcp_integration.register_and_wrap(schema, mock_executor)
+
+    result = mcp_integration.execute_tool("mock_tool_fail")
+    assert result is None
+    mock_executor.assert_called_once()
+
+def test_unregister_tool(mcp_integration: MCPDynamicIntegrationV2) -> None:
+    """Test unregistering an MCP tool."""
+    schema: Dict[str, Any] = {
+        "name": "mock_tool_unreg",
+        "description": "Mock unregister."
+    }
+    mock_executor = MagicMock()
+
+    mcp_integration.register_and_wrap(schema, mock_executor)
+    assert "mock_tool_unreg" in mcp_integration._executors
+
+    result = mcp_integration.unregister_tool("mock_tool_unreg")
+    assert result is True
+    assert "mock_tool_unreg" not in mcp_integration._executors
+    assert "mock_tool_unreg" not in mcp_integration.registry.list_tools()


### PR DESCRIPTION
Implements `MCPDynamicIntegrationV2` in `magda_agent/integration/mcp_dynamic_integration_v2.py` as required by task `mcp-tools-integration-dynamic-v2-c96eac36`. Adds comprehensive mock test coverage in `tests/test_mcp_dynamic_integration_v2.py`. Also sets the task's status to done in `agent_tasks.json` and appends two new tasks inspired by trends.

---
*PR created automatically by Jules for task [11291954638257349895](https://jules.google.com/task/11291954638257349895) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MCPDynamicIntegrationV2` for runtime MCP tool registration and execution
> - Introduces [`MCPDynamicIntegrationV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/626/files#diff-86be2f4ec7ee896dbb507fc7f1da350c39cc0182eed98371e8013fb046faa0e3), a new class that wraps `MCPRegistryV7` to support dynamic registration, execution, and unregistration of MCP tools at runtime.
> - `register_and_wrap` validates a tool schema, registers it with the registry, and stores an executor callable keyed by tool name.
> - `execute_tool` looks up the executor by name and forwards kwargs, returning `None` on missing tool or execution failure.
> - `unregister_tool` removes the executor from internal state and calls the registry's own unregister method.
> - Adds [tests/test_mcp_dynamic_integration_v2.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/626/files#diff-e9aebc65fee0e17b40294d078c3612e3879047a92a1a7f2797fd44a36014b63b) covering registration, invalid schema, execution, missing tool, exception handling, and unregister behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5cbb2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->