### PR TITLE
feat: Claude Planner Evaluation v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -9986,7 +9986,7 @@
     },
     {
       "id": "claude-planner-evaluation-v2-aaff5526",
-      "status": "todo",
+      "status": "done",
       "area": "planning",
       "risk": "medium",
       "title": "Claude Planner Evaluation v2",
@@ -22728,6 +22728,40 @@
         "Git worktree isolation applies cgroup constraints.",
         "Subagents execute within confined resource bounds.",
         "Tests mock resource limits."
+      ]
+    },
+    {
+      "id": "mcp-websocket-streaming-v5-new",
+      "title": "MCP Server WebSocket Transport v5",
+      "description": "Inspired by MCP trend (June 2026): Implement a WebSocket transport for the MCP server to support real-time full-duplex communication with external agents.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_websocket_v5.py",
+        "tests/test_mcp_websocket_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket transport successfully handles JSON-RPC messages.",
+        "Tests mock WebSocket connections and message parsing."
+      ]
+    },
+    {
+      "id": "hermes-cron-daily-reflection-v4-new",
+      "title": "Hermes Cron Daily Reflection Background Job v4",
+      "description": "Inspired by Hermes Agent trend: Create a persistent background cron job that aggregates daily episodic memories, condenses them into semantic rules, and saves them to procedural memory.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/memory/daily_reflection_cron_v4.py",
+        "tests/test_daily_reflection_cron_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron job aggregates daily logs.",
+        "Episodic memory is condensed correctly."
       ]
     }
   ]

--- a/magda_agent/planning/evaluator.py
+++ b/magda_agent/planning/evaluator.py
@@ -1,0 +1,68 @@
+import json
+import logging
+from typing import List, Dict, Any
+
+from magda_agent.llm_client import LLMClient
+
+
+class PlannerEvaluator:
+    """
+    Evaluator for critique of generated plans before execution starts.
+    Inspired by Claude Agent SDK.
+    """
+
+    def __init__(self, llm: LLMClient):
+        self.llm = llm
+
+    async def evaluate_plan(self, plan: List[Dict[str, Any]], user_input: str) -> Dict[str, Any]:
+        """
+        Evaluates a generated plan against the user input.
+
+        Args:
+            plan (List[Dict[str, Any]]): The generated plan steps.
+            user_input (str): The original user request.
+
+        Returns:
+            Dict[str, Any]: Evaluation result, e.g. {"approved": True, "feedback": ""}
+        """
+        logging.info("Evaluating generated plan.")
+
+        system_prompt = (
+            "You are the Evaluator Sub-agent of an AI system.\n"
+            "Your job is to critique a generated execution plan before it starts.\n"
+            "Check for logic errors, missing dependencies, unnecessary complexity, and alignment with the user's goal.\n"
+            "Return a JSON object with the following keys:\n"
+            "- 'approved': boolean, whether the plan is safe and logical to execute\n"
+            "- 'feedback': string, explanation or suggestions for improvement if rejected, or empty if approved.\n"
+            "Respond ONLY with valid JSON."
+        )
+
+        plan_str = json.dumps(plan, indent=2, ensure_ascii=False)
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": f"User Input:\n{user_input}\n\nGenerated Plan:\n{plan_str}"}
+        ]
+
+        try:
+            response_text = await self.llm.chat_completion(messages)
+
+            if response_text.startswith("```json"):
+                response_text = response_text[7:]
+            if response_text.startswith("```"):
+                response_text = response_text[3:]
+            if response_text.endswith("```"):
+                response_text = response_text[:-3]
+
+            result = json.loads(response_text.strip())
+
+            if "approved" not in result or "feedback" not in result:
+                logging.warning("Evaluator response missing required keys, defaulting to approved.")
+                return {"approved": True, "feedback": "Fallback: missing keys in evaluation."}
+
+            return result
+        except json.JSONDecodeError as e:
+            logging.error(f"Failed to decode evaluator JSON: {e}")
+            return {"approved": True, "feedback": "Fallback: evaluation parsing failed."}
+        except Exception as e:
+            logging.error(f"Error during plan evaluation: {e}")
+            return {"approved": True, "feedback": f"Fallback: evaluation error {e}"}

--- a/tests/test_planner_evaluator.py
+++ b/tests/test_planner_evaluator.py
@@ -1,0 +1,76 @@
+import json
+import asyncio
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.planning.evaluator import PlannerEvaluator
+
+
+def test_evaluate_plan_approved():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat_completion = AsyncMock(return_value='{"approved": true, "feedback": ""}')
+
+    evaluator = PlannerEvaluator(llm=mock_llm)
+
+    plan = [{"id": "step_0", "description": "do something"}]
+    result = asyncio.run(evaluator.evaluate_plan(plan, "test user input"))
+
+    assert result["approved"] is True
+    assert result["feedback"] == ""
+    mock_llm.chat_completion.assert_called_once()
+
+
+def test_evaluate_plan_rejected():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat_completion = AsyncMock(return_value='{"approved": false, "feedback": "Missing validation step."}')
+
+    evaluator = PlannerEvaluator(llm=mock_llm)
+
+    plan = [{"id": "step_0", "description": "do something"}]
+    result = asyncio.run(evaluator.evaluate_plan(plan, "test user input"))
+
+    assert result["approved"] is False
+    assert "Missing validation step." in result["feedback"]
+
+
+def test_evaluate_plan_json_decode_error():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat_completion = AsyncMock(return_value='invalid json output')
+
+    evaluator = PlannerEvaluator(llm=mock_llm)
+
+    plan = [{"id": "step_0", "description": "do something"}]
+    result = asyncio.run(evaluator.evaluate_plan(plan, "test user input"))
+
+    # Fallback behavior
+    assert result["approved"] is True
+    assert "parsing failed" in result["feedback"]
+
+
+def test_evaluate_plan_missing_keys():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat_completion = AsyncMock(return_value='{"status": "ok"}')
+
+    evaluator = PlannerEvaluator(llm=mock_llm)
+
+    plan = [{"id": "step_0", "description": "do something"}]
+    result = asyncio.run(evaluator.evaluate_plan(plan, "test user input"))
+
+    # Fallback behavior
+    assert result["approved"] is True
+    assert "missing keys" in result["feedback"]
+
+
+def test_evaluate_plan_llm_exception():
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat_completion = AsyncMock(side_effect=Exception("API error"))
+
+    evaluator = PlannerEvaluator(llm=mock_llm)
+
+    plan = [{"id": "step_0", "description": "do something"}]
+    result = asyncio.run(evaluator.evaluate_plan(plan, "test user input"))
+
+    # Fallback behavior
+    assert result["approved"] is True
+    assert "evaluation error" in result["feedback"]


### PR DESCRIPTION
Implemented `PlannerEvaluator` to critique generated execution plans before they start as described in the `claude-planner-evaluation-v2-aaff5526` task. Tests are implemented using pure standard library mock capabilities. The task was marked as done and new trend tasks have been added.

---
*PR created automatically by Jules for task [4757220310828398199](https://jules.google.com/task/4757220310828398199) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PlannerEvaluator` sub-agent to critique and approve generated plans
> - Adds [`PlannerEvaluator`](https://github.com/kazah4359-lgtm/Magda-agent/pull/627/files#diff-fde557fbc044ed2484b75f9db09c69162e94c6f7322dcfd7932912f0b96930d7) which sends a generated plan to an LLM and returns a `{'approved': bool, 'feedback': str}` dict.
> - The evaluator strips Markdown code fences from LLM responses before JSON parsing, and falls back to `{'approved': True, 'feedback': <message>}` on parse errors, missing keys, or LLM exceptions.
> - Five unit tests in [`tests/test_planner_evaluator.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/627/files#diff-2f60c6b4ab4a32129fb480afe00b02c9350a6979cd957ca8c15c3e69aa31e192) cover the approved, rejected, JSON error, missing keys, and exception paths.
> - Two new agent task definitions are appended to [`agent_tasks.json`](https://github.com/kazah4359-lgtm/Magda-agent/pull/627/files#diff-5a19389f12e32b28eb5803fc0c24f5ddadd21a122ce1f25a114d074a59244205).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fdba5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->