### PR TITLE
Implement A2A Delegator Status Reconciliation Worker

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -19801,7 +19801,7 @@
     },
     {
       "id": "a2a-delegator-status-reconciliation",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Delegator Status Reconciliation Worker",
@@ -22757,6 +22757,57 @@
       "allowed_paths": [
         "magda_agent/memory/daily_reflection_cron_v4.py",
         "tests/test_daily_reflection_cron_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron job aggregates daily logs.",
+        "Episodic memory is condensed correctly."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-audio-feedback-v3-new",
+      "title": "OpenClaw RL Audio Feedback Alignment v3",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Extend OpenClaw reinforcement learning to parse user audio tone/inflection shifts from voice inputs as next-state reward signals.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/learning/audio_sentiment_v3.py",
+        "tests/test_audio_sentiment_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audio sentiment signals successfully update habit weights.",
+        "Tests verify weight adjustments using mock audio signals."
+      ]
+    },
+    {
+      "id": "mcp-websocket-streaming-v6-new",
+      "title": "MCP Server WebSocket Transport v6",
+      "description": "Inspired by MCP trend (June 2026): Implement a WebSocket transport for the MCP server to support real-time full-duplex communication with external agents.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_websocket_v6.py",
+        "tests/test_mcp_websocket_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket transport successfully handles JSON-RPC messages.",
+        "Tests mock WebSocket connections and message parsing."
+      ]
+    },
+    {
+      "id": "hermes-cron-daily-reflection-v5-new",
+      "title": "Hermes Cron Daily Reflection Background Job v5",
+      "description": "Inspired by Hermes Agent trend: Create a persistent background cron job that aggregates daily episodic memories, condenses them into semantic rules, and saves them to procedural memory.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/memory/daily_reflection_cron_v5.py",
+        "tests/test_daily_reflection_cron_v5.py",
         "agent_tasks.json"
       ],
       "acceptance": [

--- a/magda_agent/integration/a2a_status_reconciliation.py
+++ b/magda_agent/integration/a2a_status_reconciliation.py
@@ -1,0 +1,167 @@
+import asyncio
+import logging
+from typing import Dict, Any, List, Optional
+import httpx
+
+from magda_agent.integration.a2a_discovery_v3_unique import A2ADiscoveryServiceV3Unique
+
+logger = logging.getLogger(__name__)
+
+class A2AStatusReconciliationWorker:
+    """
+    An asynchronous background worker that uses A2ADiscoveryServiceV3Unique
+    to query known active peer agents and reconcile the local delegator task status
+    with peer remote states, handling orphaned tasks.
+    """
+
+    def __init__(
+        self,
+        discovery_service: Optional[A2ADiscoveryServiceV3Unique] = None,
+        poll_interval: float = 60.0,
+        timeout: float = 10.0
+    ):
+        """
+        Initializes the A2AStatusReconciliationWorker.
+
+        Args:
+            discovery_service: Instance of A2ADiscoveryServiceV3Unique.
+            poll_interval: Interval in seconds between reconciliation passes.
+            timeout: HTTP request timeout in seconds.
+        """
+        self.discovery_service = discovery_service or A2ADiscoveryServiceV3Unique()
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+        self._running = False
+        self._task = None
+        # Format: { "task_id": {"peer_id": "...", "status": "pending", "payload": {...}} }
+        self.local_tasks: Dict[str, Dict[str, Any]] = {}
+
+    def add_task(self, task_id: str, peer_id: str, payload: Dict[str, Any]) -> None:
+        """
+        Registers a task to be tracked by the reconciliation worker.
+        """
+        self.local_tasks[task_id] = {
+            "peer_id": peer_id,
+            "status": "pending",
+            "payload": payload,
+            "retry_count": 0
+        }
+        logger.info(f"Task {task_id} added to reconciliation worker for peer {peer_id}.")
+
+    async def start(self) -> None:
+        """
+        Starts the background reconciliation loop.
+        """
+        if not self._running:
+            self._running = True
+            self._task = asyncio.create_task(self._reconciliation_loop())
+            logger.info("A2AStatusReconciliationWorker started.")
+
+    async def stop(self) -> None:
+        """
+        Stops the background reconciliation loop.
+        """
+        if self._running:
+            self._running = False
+            if self._task:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+            logger.info("A2AStatusReconciliationWorker stopped.")
+
+    async def _reconciliation_loop(self) -> None:
+        """
+        The main loop that periodically queries peer agents for task statuses.
+        """
+        while self._running:
+            try:
+                await self.reconcile_tasks()
+            except Exception as e:
+                logger.error(f"Error during A2A status reconciliation: {e}")
+
+            await asyncio.sleep(self.poll_interval)
+
+    async def reconcile_tasks(self) -> None:
+        """
+        Iterates through active tasks, queries peer agents for their remote status,
+        and updates local state or handles orphaned tasks.
+        """
+        # Create a snapshot of tasks to reconcile
+        tasks_to_check = {
+            tid: info for tid, info in self.local_tasks.items()
+            if info["status"] in ("pending", "processing")
+        }
+
+        if not tasks_to_check:
+            return
+
+        for task_id, task_info in tasks_to_check.items():
+            peer_id = task_info["peer_id"]
+            agent_card = self.discovery_service.get_agent_card(peer_id)
+
+            if not agent_card:
+                logger.warning(f"Peer {peer_id} not found for task {task_id}. Marking as orphaned.")
+                self._handle_orphaned_task(task_id)
+                continue
+
+            rpc_endpoint = agent_card.endpoints.get("rpc")
+            if not rpc_endpoint:
+                logger.warning(f"Peer {peer_id} has no RPC endpoint. Marking task {task_id} as orphaned.")
+                self._handle_orphaned_task(task_id)
+                continue
+
+            status_endpoint = f"{rpc_endpoint}/status/{task_id}"
+
+            try:
+                async with httpx.AsyncClient() as client:
+                    response = await client.get(status_endpoint, timeout=self.timeout)
+
+                    if response.status_code == 404:
+                        logger.warning(f"Task {task_id} not found on peer {peer_id}. Marking as orphaned.")
+                        self._handle_orphaned_task(task_id)
+                        continue
+
+                    response.raise_for_status()
+                    data = response.json()
+
+                    remote_status = data.get("status")
+                    if remote_status:
+                        self._update_task_status(task_id, remote_status)
+            except httpx.RequestError as e:
+                logger.warning(f"Network error querying task {task_id} from {peer_id}: {e}")
+                self._handle_network_failure(task_id)
+            except httpx.HTTPStatusError as e:
+                logger.warning(f"HTTP error {e.response.status_code} querying task {task_id} from {peer_id}")
+                self._handle_network_failure(task_id)
+
+    def _update_task_status(self, task_id: str, new_status: str) -> None:
+        """
+        Updates the status of a tracked task.
+        """
+        if task_id in self.local_tasks:
+            old_status = self.local_tasks[task_id]["status"]
+            if old_status != new_status:
+                self.local_tasks[task_id]["status"] = new_status
+                logger.info(f"Task {task_id} status updated: {old_status} -> {new_status}")
+
+    def _handle_orphaned_task(self, task_id: str) -> None:
+        """
+        Handles a task that is deemed orphaned (e.g., peer agent disappeared or lost the task).
+        Currently marks it as failed/orphaned. In a robust system, this might trigger a re-queue.
+        """
+        if task_id in self.local_tasks:
+            self.local_tasks[task_id]["status"] = "orphaned"
+            logger.info(f"Task {task_id} has been marked as orphaned and requires re-queuing.")
+
+    def _handle_network_failure(self, task_id: str) -> None:
+        """
+        Handles transient network failures when querying a task status.
+        Increments retry count and marks as orphaned if it exceeds a threshold.
+        """
+        if task_id in self.local_tasks:
+            self.local_tasks[task_id]["retry_count"] += 1
+            if self.local_tasks[task_id]["retry_count"] >= 3:
+                logger.warning(f"Task {task_id} exceeded max retries for status check. Marking as orphaned.")
+                self._handle_orphaned_task(task_id)

--- a/tests/test_a2a_status_reconciliation.py
+++ b/tests/test_a2a_status_reconciliation.py
@@ -1,0 +1,111 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+import httpx
+
+from magda_agent.integration.a2a_status_reconciliation import A2AStatusReconciliationWorker
+from magda_agent.integration.a2a_discovery_v3_unique import A2ADiscoveryServiceV3Unique
+from magda_agent.integration.a2a_cards import AgentCardV3
+
+@pytest.fixture
+def mock_discovery_service():
+    service = MagicMock(spec=A2ADiscoveryServiceV3Unique)
+    # Mock an agent card
+    card = AgentCardV3(
+        agent_id="peer-123",
+        name="TestPeer",
+        description="A test peer",
+        capabilities=["test"],
+        endpoints={"rpc": "http://peer-123.local"}
+    )
+    service.get_agent_card.return_value = card
+    return service
+
+@pytest.fixture
+def worker(mock_discovery_service):
+    return A2AStatusReconciliationWorker(
+        discovery_service=mock_discovery_service,
+        poll_interval=0.1, # fast for tests
+        timeout=1.0
+    )
+
+def test_add_task(worker):
+    worker.add_task("task-1", "peer-123", {"data": "test"})
+    assert "task-1" in worker.local_tasks
+    assert worker.local_tasks["task-1"]["status"] == "pending"
+    assert worker.local_tasks["task-1"]["peer_id"] == "peer-123"
+    assert worker.local_tasks["task-1"]["retry_count"] == 0
+
+@pytest.mark.asyncio
+async def test_reconcile_tasks_successful_update(worker):
+    worker.add_task("task-1", "peer-123", {"data": "test"})
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "completed"}
+    mock_response.raise_for_status.return_value = None
+
+    with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response
+
+        await worker.reconcile_tasks()
+
+        mock_get.assert_called_once_with("http://peer-123.local/status/task-1", timeout=1.0)
+        assert worker.local_tasks["task-1"]["status"] == "completed"
+
+@pytest.mark.asyncio
+async def test_reconcile_tasks_missing_peer(worker):
+    worker.add_task("task-2", "unknown-peer", {"data": "test"})
+
+    # Make get_agent_card return None for unknown peer
+    worker.discovery_service.get_agent_card.return_value = None
+
+    await worker.reconcile_tasks()
+
+    assert worker.local_tasks["task-2"]["status"] == "orphaned"
+
+@pytest.mark.asyncio
+async def test_reconcile_tasks_404_not_found(worker):
+    worker.add_task("task-3", "peer-123", {"data": "test"})
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+
+    with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response
+
+        await worker.reconcile_tasks()
+
+        assert worker.local_tasks["task-3"]["status"] == "orphaned"
+
+@pytest.mark.asyncio
+async def test_reconcile_tasks_network_failure_retries(worker):
+    worker.add_task("task-4", "peer-123", {"data": "test"})
+
+    with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = httpx.RequestError("Network error", request=MagicMock())
+
+        # 1st attempt
+        await worker.reconcile_tasks()
+        assert worker.local_tasks["task-4"]["status"] == "pending"
+        assert worker.local_tasks["task-4"]["retry_count"] == 1
+
+        # 2nd attempt
+        await worker.reconcile_tasks()
+        assert worker.local_tasks["task-4"]["status"] == "pending"
+        assert worker.local_tasks["task-4"]["retry_count"] == 2
+
+        # 3rd attempt (exceeds max retries)
+        await worker.reconcile_tasks()
+        assert worker.local_tasks["task-4"]["status"] == "orphaned"
+        assert worker.local_tasks["task-4"]["retry_count"] == 3
+
+@pytest.mark.asyncio
+async def test_start_stop_worker(worker):
+    # Just to ensure start and stop don't block or raise errors
+    await worker.start()
+    assert worker._running is True
+    assert worker._task is not None
+
+    await worker.stop()
+    assert worker._running is False


### PR DESCRIPTION
Fixes the `#a2a-delegator-status-reconciliation` backlog item by adding a background worker capable of maintaining and syncing delegated task states with active peer agents via HTTP RPC endpoints. Also injects 3 new relevant AI Agent tasks.

---
*PR created automatically by Jules for task [2944813514901622102](https://jules.google.com/task/2944813514901622102) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `A2AStatusReconciliationWorker` to reconcile delegator task statuses with peer agents
> - Introduces [`A2AStatusReconciliationWorker`](https://github.com/kazah4359-lgtm/Magda-agent/pull/630/files#diff-ab389c45222dc6ca8277d362853b2eefb86e6fdaca62c326e3bcfd72cfecc404) that periodically polls peer agents over HTTP (`GET {rpc}/status/{task_id}`) to sync local task statuses.
> - Tasks are registered via `add_task` with initial `pending` status; the worker updates status from peer responses or marks tasks `orphaned` on 404 or after 3 consecutive request failures.
> - Peer discovery uses `A2ADiscoveryServiceV3Unique` to resolve RPC endpoints by `peer_id`; missing endpoints immediately orphan the task.
> - Adds a [test suite](https://github.com/kazah4359-lgtm/Magda-agent/pull/630/files#diff-691c7ac680cab3d0b7310ae7b25868df3b9dc1963b3a47a4d38f2003cd609daf) covering status updates, missing peers, 404 handling, retry exhaustion, and start/stop lifecycle.
> - Risk: orphaned tasks require external re-queuing logic; the worker only marks them and logs — no automatic requeue is implemented.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c43157a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->