### PR TITLE
feat(security): implement A2A message taint sandbox integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10076,7 +10076,7 @@
     },
     {
       "id": "48b4da15-5d63-4af2-83a0-f0ed55cfeda4",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "A2A Message Taint Sandbox Integration",
@@ -22884,6 +22884,58 @@
         "Worktree Garbage Collector identifies stale worktrees.",
         "Removes them safely without affecting active agents.",
         "Tests mock file system operations to verify cleanup logic."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-distillation-v2-unique",
+      "title": "OpenClaw RL Trajectory Distillation v2",
+      "description": "Inspired by OpenClaw RL online learning trend: Distill long episodic memory trajectories containing multiple tool interactions into reusable macro-skills stored in procedural memory, updating behavior weights upon successful deployment. Adds multi-modal support.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_distillation_v2.py",
+        "tests/test_trajectory_distillation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Macro-skills are extracted from trajectory logs, including multi-modal interactions.",
+        "Tests verify macro-skill generation and RL weight adjustments."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-auth-v3-unique",
+      "title": "MCP Dynamic Capability Auth v3",
+      "description": "Inspired by MCP standardization: Dynamically parse and enforce authentication schema constraints from external MCP server capabilities before attempting to route actions to them, using external OAuth2 token sources.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_auth_v3.py",
+        "tests/test_mcp_auth_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Auth requirements from MCP servers are correctly parsed and validated with OAuth2 flows.",
+        "Tests verify tool routing fails safely when auth is missing or expired."
+      ]
+    },
+    {
+      "id": "a2a-capability-gossiping-v3-unique",
+      "title": "A2A Capability Gossip Protocol v3",
+      "description": "Inspired by A2A standard trend: Implement a decentralized gossip protocol module for the A2A Discovery Service, enabling agents to periodically broadcast and cache neighboring agent capabilities, including peer health checks.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_gossip_protocol_v3.py",
+        "tests/test_a2a_gossip_protocol_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent capabilities and health are broadcast asynchronously to known peers.",
+        "Peer cache is updated securely with latest Agent Cards.",
+        "Tests verify gossip propagation, health check, and cache integrity."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_server.py
+++ b/magda_agent/integration/a2a_server.py
@@ -6,6 +6,8 @@ from fastapi import FastAPI, Request, Response
 from magda_agent.planning.planner import Planner
 from magda_agent.integration.a2a_tracing import A2ATracer
 from magda_agent.integration.a2a_security import A2ASecurityContext
+from magda_agent.security.a2a_taint import process_a2a_message, validate_a2a_execution, A2ATaintError
+from magda_agent.security.a2a_taint import process_a2a_message, validate_a2a_execution, A2ATaintError
 
 class A2AServer:
     """
@@ -90,6 +92,30 @@ class A2AServer:
             }), media_type="application/json", status_code=400)
 
         if method in ["delegate_task", "execute_subplan"]:
+
+            try:
+                tainted_params = process_a2a_message(params)
+                params = validate_a2a_execution(tainted_params)
+            except A2ATaintError as e:
+                if is_notification:
+                    return Response(status_code=204)
+                return Response(content=json.dumps({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32002, "message": str(e)},
+                    "id": req_id
+                }), media_type="application/json", status_code=403)
+                try:
+                    # Sanitize inputs to avoid prompt injections and taint attacks
+                    tainted_params = process_a2a_message(params)
+                    params = validate_a2a_execution(tainted_params)
+                except A2ATaintError as e:
+                    if is_notification:
+                        return Response(status_code=204)
+                    return Response(content=json.dumps({
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32002, "message": str(e)},
+                        "id": req_id
+                    }), media_type="application/json", status_code=403)
             if not isinstance(params, dict):
                 if is_notification:
                     return Response(status_code=204)

--- a/magda_agent/security/a2a_taint.py
+++ b/magda_agent/security/a2a_taint.py
@@ -1,0 +1,34 @@
+"""A2A Message Taint Sandbox Integration."""
+
+from typing import Any, Dict
+from magda_agent.security.mcp_kernel_taint import mark_tainted, is_tainted, sanitize, PolicyViolationError
+
+class A2ATaintError(PolicyViolationError):
+    """Raised when an A2A message contains unsafe or tainted data."""
+    pass
+
+def process_a2a_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Processes an incoming A2A delegate message.
+    Taints the message to prevent it from executing unsafe operations directly.
+    """
+    return mark_tainted(message)
+
+def _has_injection(payload: Any) -> bool:
+    """Checks for prompt injections or malicious commands."""
+    s = str(payload).lower()
+    dangerous_patterns = ["rm -rf", "system(", "exec(", "eval(", "drop table", "ignore previous instructions"]
+    for pattern in dangerous_patterns:
+        if pattern in s:
+            return True
+    return False
+
+def validate_a2a_execution(payload: Any) -> Any:
+    """
+    Validates a payload before local execution.
+    If the payload is tainted AND contains dangerous patterns, it raises an A2ATaintError.
+    Otherwise, returns the sanitized payload.
+    """
+    if is_tainted(payload) and _has_injection(payload):
+        raise A2ATaintError("A2A payload is tainted and contains dangerous patterns.")
+    return sanitize(payload)

--- a/tests/test_a2a_taint.py
+++ b/tests/test_a2a_taint.py
@@ -1,0 +1,22 @@
+import pytest
+from magda_agent.security.a2a_taint import process_a2a_message, validate_a2a_execution, A2ATaintError
+from magda_agent.security.mcp_kernel_taint import is_tainted
+
+def test_process_a2a_message_taints_data():
+    message = {"action": "execute", "command": "rm -rf /"}
+    tainted_message = process_a2a_message(message)
+    assert is_tainted(tainted_message)
+
+def test_validate_a2a_execution_raises_error_on_tainted_data():
+    message = {"action": "execute", "command": "rm -rf /"}
+    tainted_message = process_a2a_message(message)
+
+    with pytest.raises(A2ATaintError):
+        validate_a2a_execution(tainted_message)
+
+def test_validate_a2a_execution_passes_clean_data():
+    message = {"action": "execute", "command": "echo 'hello'"}
+    # Even if we process it (which taints it), if it's not dangerous, it should pass
+    tainted_message = process_a2a_message(message)
+    clean_payload = validate_a2a_execution(tainted_message)
+    assert clean_payload == message


### PR DESCRIPTION
Implements the A2A Message Taint Sandbox Integration as specified in agent_tasks.json (task `48b4da15-5d63-4af2-83a0-f0ed55cfeda4`). This intercepts A2A delegate messages, applies taint tracking, and validates the payloads before local execution, effectively mitigating remote injection attacks. Also adds 3 new trend-inspired tasks to the backlog.

---
*PR created automatically by Jules for task [14872876415052488295](https://jules.google.com/task/14872876415052488295) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement A2A message taint sandbox in `A2AServer` to block injection attacks
> - Adds [a2a_taint.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/633/files#diff-af9f548c2da3307f1a4b6c52320f57039983efa5277a782fd47ac15ddf761756) with `process_a2a_message`, `validate_a2a_execution`, and `_has_injection` to detect dangerous patterns (e.g. `rm -rf`, `eval(`, `ignore previous instructions`) in A2A payloads.
> - `A2AServer.handle_request` in [a2a_server.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/633/files#diff-3e26ca5cfd4aa46513f90fc76ee061b94aa0b93e6b9430e71f4df273c80d672b) now runs taint processing and validation for `delegate_task` and `execute_subplan` before invoking planner logic, returning HTTP 403 with JSON-RPC error `-32002` on violations (or 204 for notifications).
> - Introduces `A2ATaintError` (subclass of `PolicyViolationError`) for callers to catch taint-specific policy violations.
> - Risk: The import block and the taint-validation code block in `a2a_server.py` appear duplicated, which may cause unexpected behavior at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d3edd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->