### PR TITLE
feat(learning): OpenClaw Online Learning Module v8

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10128,7 +10128,7 @@
     },
     {
       "id": "openclaw-online-learning-v8-ff098179",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw Online Learning Module v8",

--- a/magda_agent/learning/online_learning_v8.py
+++ b/magda_agent/learning/online_learning_v8.py
@@ -1,0 +1,170 @@
+import logging
+from typing import Any, Dict, List, Optional
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+logger = logging.getLogger(__name__)
+
+class OpenClawOnlineLearningV8:
+    """
+    OpenClaw Online Learning Module v8.
+    Implements continuous online reinforcement learning from user feedback during dialogue interactions.
+    Updates skill weights based on explicit/implicit feedback, leveraging MirrorNeurons for sentiment extraction.
+    """
+
+    def __init__(
+        self,
+        initial_weights: Optional[Dict[str, float]] = None,
+        mirror_neurons: Optional[MirrorNeurons] = None,
+        learning_rate: float = 0.1,
+        min_weight: float = 0.1,
+        max_weight: float = 2.0
+    ) -> None:
+        """
+        Initializes the OpenClawOnlineLearningV8 module.
+
+        Args:
+            initial_weights (Optional[Dict[str, float]]): Initial weights for skills.
+            mirror_neurons (Optional[MirrorNeurons]): MirrorNeurons instance for emotional shift detection.
+            learning_rate (float): The step size (alpha) for updating weights.
+            min_weight (float): Minimum allowable weight for any skill.
+            max_weight (float): Maximum allowable weight for any skill.
+        """
+        self.skill_weights: Dict[str, float] = initial_weights or {}
+        self.mirror_neurons = mirror_neurons or MirrorNeurons()
+        self.learning_rate = learning_rate
+        self.min_weight = min_weight
+        self.max_weight = max_weight
+        self.trajectory_history: List[Dict[str, Any]] = []
+        logger.info("OpenClawOnlineLearningV8 initialized successfully.")
+
+    def extract_reward(self, user_reply: str, tool_output: Optional[str] = None) -> float:
+        """
+        Extracts a reward signal (-1.0 to 1.0) from conversational next-state signals.
+        Combines MirrorNeurons' empathy shift with explicit keyword matching.
+
+        Args:
+            user_reply (str): The text of the user's response.
+            tool_output (Optional[str]): Optional output from the tool execution.
+
+        Returns:
+            float: A reward score between -1.0 and 1.0.
+        """
+        if not user_reply:
+            return 0.0
+
+        # Combine dialogue context
+        full_text = user_reply
+        if tool_output:
+            full_text += f" {tool_output}"
+
+        # 1. Get sentiment shift from MirrorNeurons
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(full_text)
+
+        # 2. Heuristic word-based overrides to complement MirrorNeurons
+        words = full_text.lower().replace(".", "").replace(",", "").replace("!", "").replace("?", "").split()
+
+        # Positive indicators
+        pos_words = {"good", "great", "excellent", "thanks", "thank", "awesome", "perfect", "correct", "yes", "success"}
+        # Negative indicators
+        neg_words = {"bad", "wrong", "terrible", "fail", "failure", "error", "no", "incorrect", "bug", "stop"}
+
+        pos_matches = sum(1 for w in words if w in pos_words)
+        neg_matches = sum(1 for w in words if w in neg_words)
+
+        # Basic sentiment heuristic combined with MirrorNeurons
+        reward = p_shift
+
+        if pos_matches > neg_matches:
+            reward = max(reward, 0.5)
+            if "excellent" in words or "perfect" in words:
+                reward = 1.0
+        elif neg_matches > pos_matches:
+            reward = min(reward, -0.5)
+            if "terrible" in words or "fail" in words or "bug" in words:
+                reward = -1.0
+
+        # Clamp reward to safe range
+        return max(-1.0, min(1.0, reward))
+
+    def update_weight(self, skill_id: str, reward: float) -> float:
+        """
+        Updates the weight of a skill using the reinforcement update rule:
+        W_new = W_old + learning_rate * (reward)
+        and clamps the weight between min_weight and max_weight.
+
+        Args:
+            skill_id (str): The identifier of the skill.
+            reward (float): The reward signal (-1.0 to 1.0).
+
+        Returns:
+            float: The updated weight of the skill.
+        """
+        current_weight = self.skill_weights.get(skill_id, 1.0)
+
+        # Update rule: adjust weight based on the reward received
+        new_weight = current_weight + self.learning_rate * reward
+        new_weight = max(self.min_weight, min(self.max_weight, new_weight))
+
+        self.skill_weights[skill_id] = new_weight
+        logger.info(f"Updated skill weight for '{skill_id}': {current_weight:.2f} -> {new_weight:.2f} (Reward: {reward})")
+        return new_weight
+
+    def process_feedback(self, skill_id: str, user_reply: str, tool_output: Optional[str] = None) -> float:
+        """
+        Processes conversational feedback synchronously, extracting the reward and updating the skill weight.
+
+        Args:
+            skill_id (str): The skill being evaluated.
+            user_reply (str): The text of the user's reply.
+            tool_output (Optional[str]): The optional output of the tool.
+
+        Returns:
+            float: The updated weight of the skill.
+        """
+        reward = self.extract_reward(user_reply, tool_output)
+
+        # Log trajectory step
+        self.trajectory_history.append({
+            "skill_id": skill_id,
+            "user_reply": user_reply,
+            "tool_output": tool_output,
+            "reward": reward
+        })
+
+        return self.update_weight(skill_id, reward)
+
+    async def process_feedback_async(self, skill_id: str, user_reply: str, tool_output: Optional[str] = None) -> float:
+        """
+        Processes conversational feedback asynchronously. Useful for integration with async pipelines.
+
+        Args:
+            skill_id (str): The skill being evaluated.
+            user_reply (str): The text of the user's reply.
+            tool_output (Optional[str]): The optional output of the tool.
+
+        Returns:
+            float: The updated weight of the skill.
+        """
+        # In this base v8 implementation, we perform the same logic asynchronously
+        return self.process_feedback(skill_id, user_reply, tool_output)
+
+    def get_skill_weight(self, skill_id: str) -> float:
+        """
+        Retrieves the weight of a skill, defaulting to 1.0 if not yet set.
+
+        Args:
+            skill_id (str): The skill identifier.
+
+        Returns:
+            float: The skill's current weight.
+        """
+        return self.skill_weights.get(skill_id, 1.0)
+
+    def get_all_weights(self) -> Dict[str, float]:
+        """
+        Retrieves a copy of all current skill weights.
+
+        Returns:
+            Dict[str, float]: All skill weights.
+        """
+        return self.skill_weights.copy()

--- a/tests/test_online_learning_v8.py
+++ b/tests/test_online_learning_v8.py
@@ -1,0 +1,102 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.online_learning_v8 import OpenClawOnlineLearningV8
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+@pytest.fixture
+def mock_mirror_neurons():
+    return MagicMock(spec=MirrorNeurons)
+
+def test_initialization():
+    learner = OpenClawOnlineLearningV8(initial_weights={"skill_a": 1.2})
+    assert learner.get_skill_weight("skill_a") == 1.2
+    assert learner.get_skill_weight("skill_b") == 1.0  # default
+    assert learner.get_all_weights() == {"skill_a": 1.2}
+
+def test_extract_reward_empty_and_neutral(mock_mirror_neurons):
+    learner = OpenClawOnlineLearningV8(mirror_neurons=mock_mirror_neurons)
+
+    # Test empty user reply
+    assert learner.extract_reward("") == 0.0
+
+    # Test neutral
+    mock_mirror_neurons.empathize.return_value = (0.0, 0.0, 0.0)
+    assert learner.extract_reward("hello world") == 0.0
+
+def test_extract_reward_positive_and_negative(mock_mirror_neurons):
+    learner = OpenClawOnlineLearningV8(mirror_neurons=mock_mirror_neurons)
+
+    # Positive emotion shift
+    mock_mirror_neurons.empathize.return_value = (0.3, 0.1, 0.0)
+    reward = learner.extract_reward("I am happy")
+    assert reward == 0.3
+
+    # Negative override matching word
+    mock_mirror_neurons.empathize.return_value = (0.0, 0.0, 0.0)
+    reward = learner.extract_reward("That is wrong and terrible")
+    assert reward == -1.0
+
+    # Positive override matching word
+    mock_mirror_neurons.empathize.return_value = (0.0, 0.0, 0.0)
+    reward = learner.extract_reward("thanks, this is perfect")
+    assert reward == 1.0
+
+def test_process_feedback_positive(mock_mirror_neurons):
+    learner = OpenClawOnlineLearningV8(mirror_neurons=mock_mirror_neurons, learning_rate=0.2)
+    mock_mirror_neurons.empathize.return_value = (0.4, 0.0, 0.0)
+
+    new_weight = learner.process_feedback("skill_1", "Yes, thank you")
+
+    # reward extracted is max(p_shift, 0.5) due to positive word 'yes' or 'thank' -> 0.5
+    # new_weight = 1.0 + 0.2 * 0.5 = 1.1
+    assert new_weight == 1.1
+    assert learner.get_skill_weight("skill_1") == 1.1
+    assert len(learner.trajectory_history) == 1
+    assert learner.trajectory_history[0]["skill_id"] == "skill_1"
+    assert learner.trajectory_history[0]["reward"] == 0.5
+
+def test_process_feedback_negative(mock_mirror_neurons):
+    learner = OpenClawOnlineLearningV8(mirror_neurons=mock_mirror_neurons, learning_rate=0.1)
+    mock_mirror_neurons.empathize.return_value = (-0.3, 0.0, 0.0)
+
+    new_weight = learner.process_feedback("skill_2", "no, it is broken")
+
+    # reward is min(p_shift, -0.5) due to 'no' -> -0.5
+    # new_weight = 1.0 + 0.1 * -0.5 = 0.95
+    assert abs(new_weight - 0.95) < 1e-6
+    assert abs(learner.get_skill_weight("skill_2") - 0.95) < 1e-6
+
+def test_weight_clamping(mock_mirror_neurons):
+    learner = OpenClawOnlineLearningV8(
+        mirror_neurons=mock_mirror_neurons,
+        learning_rate=0.5,
+        min_weight=0.5,
+        max_weight=1.5
+    )
+
+    # Push weight above max
+    mock_mirror_neurons.empathize.return_value = (0.9, 0.0, 0.0)
+    # perfect word -> reward 1.0
+    learner.process_feedback("skill_x", "perfect!")
+    learner.process_feedback("skill_x", "perfect!")
+    assert learner.get_skill_weight("skill_x") == 1.5
+
+    # Push weight below min
+    mock_mirror_neurons.empathize.return_value = (-0.9, 0.0, 0.0)
+    # terrible word -> reward -1.0
+    learner.process_feedback("skill_x", "terrible")
+    learner.process_feedback("skill_x", "terrible")
+    learner.process_feedback("skill_x", "terrible")
+    assert learner.get_skill_weight("skill_x") == 0.5
+
+@pytest.mark.asyncio
+async def test_process_feedback_async(mock_mirror_neurons):
+    learner = OpenClawOnlineLearningV8(mirror_neurons=mock_mirror_neurons, learning_rate=0.1)
+    mock_mirror_neurons.empathize.return_value = (0.2, 0.0, 0.0)
+
+    new_weight = await learner.process_feedback_async("skill_3", "it is good")
+
+    # good word -> reward is 0.5
+    # weight = 1.0 + 0.1 * 0.5 = 1.05
+    assert abs(new_weight - 1.05) < 1e-6
+    assert abs(learner.get_skill_weight("skill_3") - 1.05) < 1e-6


### PR DESCRIPTION
We have successfully implemented OpenClaw Online Learning Module v8 under `magda_agent/learning/online_learning_v8.py` and written comprehensive tests under `tests/test_online_learning_v8.py`. Both the task verification tests and our specific unit tests pass perfectly.

---
*PR created automatically by Jules for task [8461858800489253198](https://jules.google.com/task/8461858800489253198) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `OpenClawOnlineLearningV8` online reinforcement learning module
> - Introduces [`online_learning_v8.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/636/files#diff-740f1cedf96e705ac1e5d8ddfd2c7f7b0c3c5eaa763688055e06bbab60b95046) with the `OpenClawOnlineLearningV8` class, which maintains per-skill weights updated via user feedback.
> - Reward extraction combines `MirrorNeurons` empathy polarity shifts with keyword heuristics, clamping the result to `[-1.0, 1.0]` with hard overrides for terms like 'excellent'/'perfect' (+1.0) and 'terrible'/'fail'/'bug' (-1.0).
> - Weight updates follow `W_new = W_old + learning_rate * reward`, clamped to configured min/max bounds, with missing skills defaulting to `1.0`.
> - Both sync (`process_feedback`) and async (`process_feedback_async`) paths are provided; the async path currently delegates to the sync implementation.
> - Full test coverage is added in [`tests/test_online_learning_v8.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/636/files#diff-29f0d653b985843db6e600a6026a28b9b1f0feb6b3f4ebf05201e6a859c35548), covering initialization, reward extraction, weight clamping, and async feedback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a23bd80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->