### PR TITLE
feat: implement OpenClaw Live Canvas Telemetry Streaming

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10162,7 +10162,7 @@
     },
     {
       "id": "openclaw-live-canvas-telemetry-927071b0",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw Live Canvas Telemetry Streaming",
@@ -23075,6 +23075,60 @@
       "acceptance": [
         "Cron job aggregates daily logs.",
         "Episodic memory is condensed correctly."
+      ]
+    },
+    {
+      "id": "openclaw-rl-self-reflection-v1",
+      "title": "OpenClaw RL Self-Reflection Loop V1",
+      "description": "Inspired by OpenClaw trends: Implement a self-reflection loop that analyzes past RL trajectories and generates synthetic experience to update policy weights during idle time.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/self_reflection_v1.py",
+        "tests/test_self_reflection_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Self-reflection loop analyzes past trajectories.",
+        "Updates policy weights based on synthetic insights.",
+        "Tests mock trajectory parsing and weight updates."
+      ]
+    },
+    {
+      "id": "claude-code-auto-documentation-v1",
+      "title": "Claude Code Auto-Documentation V1",
+      "description": "Inspired by Claude Code trends: Implement a background agent that automatically generates and updates docstrings and module documentation as code is changed.",
+      "area": "agents",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/agents/auto_doc_v1.py",
+        "tests/test_auto_doc_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "AutoDoc agent identifies undocumented code.",
+        "Generates and inserts appropriate documentation.",
+        "Tests mock code changes and verify doc generation."
+      ]
+    },
+    {
+      "id": "mcp-tool-health-monitor-v1",
+      "title": "MCP Tool Health Monitor V1",
+      "description": "Inspired by MCP trends: Implement a background monitor that periodically pings registered MCP tools to ensure availability and disables tools that fail repeatedly.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_health_monitor_v1.py",
+        "tests/test_mcp_health_monitor_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Monitor pings MCP tools at regular intervals.",
+        "Failing tools are flagged and temporarily disabled.",
+        "Tests mock ping responses and verify tool status changes."
       ]
     }
   ]

--- a/magda_agent/telemetry/canvas_stream.py
+++ b/magda_agent/telemetry/canvas_stream.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional
+
+
+class CanvasTelemetryStreamer:
+    """
+    A websocket telemetry streamer that broadcasts agent memory state
+    and planner steps in real-time to an external Canvas client.
+    """
+
+    def __init__(self, websocket: Optional[Any] = None) -> None:
+        """
+        Initialize the CanvasTelemetryStreamer.
+
+        Args:
+            websocket (Optional[Any]): An open asynchronous websocket connection.
+        """
+        self.websocket = websocket
+        self.logger = logging.getLogger(__name__)
+
+    async def broadcast_memory_state(self, memory_state: Dict[str, Any]) -> None:
+        """
+        Broadcast the agent's memory state to the connected Canvas client.
+
+        Args:
+            memory_state (Dict[str, Any]): The memory state to broadcast.
+        """
+        await self._broadcast_event("memory_state_update", memory_state)
+
+    async def broadcast_planner_step(self, planner_step: Dict[str, Any]) -> None:
+        """
+        Broadcast a planner step to the connected Canvas client.
+
+        Args:
+            planner_step (Dict[str, Any]): The planner step to broadcast.
+        """
+        await self._broadcast_event("planner_step_update", planner_step)
+
+    async def _broadcast_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        """
+        Helper method to format and send events over the websocket.
+
+        Args:
+            event_type (str): The type of the event.
+            data (Dict[str, Any]): The payload of the event.
+        """
+        if self.websocket is None:
+            self.logger.debug(f"Skipping broadcast for {event_type} - no websocket connected.")
+            return
+
+        payload = {
+            "type": event_type,
+            "data": data
+        }
+
+        try:
+            message = json.dumps(payload)
+            await self.websocket.send_text(message)
+            self.logger.debug(f"Successfully broadcasted {event_type} event.")
+        except Exception as e:
+            self.logger.error(f"Failed to broadcast {event_type} event: {e}")

--- a/tests/test_canvas_stream.py
+++ b/tests/test_canvas_stream.py
@@ -1,0 +1,73 @@
+import asyncio
+import json
+from typing import Any
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.telemetry.canvas_stream import CanvasTelemetryStreamer
+
+
+class MockWebsocket:
+    def __init__(self):
+        self.send_text = AsyncMock()
+
+
+def test_initialization():
+    """Test streamer initialization with and without websocket."""
+    streamer_no_ws = CanvasTelemetryStreamer()
+    assert streamer_no_ws.websocket is None
+
+    mock_ws = MockWebsocket()
+    streamer_with_ws = CanvasTelemetryStreamer(mock_ws)
+    assert streamer_with_ws.websocket == mock_ws
+
+
+def test_broadcast_memory_state():
+    """Test broadcasting memory state."""
+    mock_ws = MockWebsocket()
+    streamer = CanvasTelemetryStreamer(mock_ws)
+
+    memory_state = {"working_memory": ["item1", "item2"]}
+    expected_payload = {
+        "type": "memory_state_update",
+        "data": memory_state
+    }
+
+    asyncio.run(streamer.broadcast_memory_state(memory_state))
+
+    mock_ws.send_text.assert_called_once_with(json.dumps(expected_payload))
+
+
+def test_broadcast_planner_step():
+    """Test broadcasting planner step."""
+    mock_ws = MockWebsocket()
+    streamer = CanvasTelemetryStreamer(mock_ws)
+
+    planner_step = {"step": 1, "action": "think"}
+    expected_payload = {
+        "type": "planner_step_update",
+        "data": planner_step
+    }
+
+    asyncio.run(streamer.broadcast_planner_step(planner_step))
+
+    mock_ws.send_text.assert_called_once_with(json.dumps(expected_payload))
+
+
+def test_broadcast_no_websocket():
+    """Test broadcast behavior when no websocket is connected."""
+    streamer = CanvasTelemetryStreamer()
+    # This should not raise an exception
+    asyncio.run(streamer.broadcast_memory_state({"data": "test"}))
+
+
+def test_broadcast_exception_handling():
+    """Test handling of exceptions during broadcast."""
+    mock_ws = MockWebsocket()
+    mock_ws.send_text.side_effect = Exception("Connection closed")
+
+    streamer = CanvasTelemetryStreamer(mock_ws)
+
+    # This should catch the exception and not raise it
+    asyncio.run(streamer.broadcast_planner_step({"data": "test"}))
+    assert mock_ws.send_text.called


### PR DESCRIPTION
This PR implements the OpenClaw Live Canvas Telemetry Streaming task (`openclaw-live-canvas-telemetry-927071b0`).

It introduces the `CanvasTelemetryStreamer` class to broadcast agent memory states and planner steps in real-time to an external Canvas client using websockets.
The PR also includes extensive unit tests with mocked websockets.
Additionally, it updates `agent_tasks.json` to mark the task as "done" and appends 3 new AI trend-inspired tasks as requested.

---
*PR created automatically by Jules for task [437033680088624767](https://jules.google.com/task/437033680088624767) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `CanvasTelemetryStreamer` to broadcast agent memory and planner events over WebSocket
> Introduces a new `magda_agent.telemetry` package with a `CanvasTelemetryStreamer` class that sends JSON-encoded events over an async WebSocket connection.
>
> - `broadcast_memory_state` and `broadcast_planner_step` emit typed payloads (`memory_state_update`, `planner_step_update`) via `websocket.send_text`
> - When no WebSocket is provided, broadcasts are silently skipped with a debug log; send errors are caught and logged without propagating
> - Full unit test coverage added in [test_canvas_stream.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/638/files#diff-28b01f2552e72ef765658b458aba491bb06e73141b84da4055396e0c7c0cb304) covering init, payloads, no-op behavior, and exception handling
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc041a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->