### PR TITLE
feat: A2A Workflow Orchestrator v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10196,7 +10196,7 @@
     },
     {
       "id": "1f3e194c-cddb-4c65-9782-1ba9b98fdc8e",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Workflow Orchestrator v2",
@@ -23165,6 +23165,40 @@
         "Dependency graph correctly orders tasks for A2A delegation.",
         "Tasks wait for prerequisites before delegation.",
         "Tests verify graph resolution and delegation sequencing."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-isolation-v5",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Agent Teams Git Worktree Isolation V5",
+      "description": "Inspired by Claude Agent SDK: Implement deep Git worktree isolation for specialized agent teams to avoid context bleeding when modifying dependencies concurrently.",
+      "allowed_paths": [
+        "magda_agent/teams/git_worktree_v5.py",
+        "tests/test_git_worktree_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Git worktree isolation applies strict namespace constraints.",
+        "Tests verify clean execution and cleanup."
+      ]
+    },
+    {
+      "id": "openclaw-rl-tool-ranking-system-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Tool Ranking System V2",
+      "description": "Inspired by OpenClaw RL trend: Implement an advanced ranking system for tools that updates their expected utility scores in real-time based on success rates and multi-turn user satisfaction.",
+      "allowed_paths": [
+        "magda_agent/learning/tool_ranking_v2.py",
+        "tests/test_tool_ranking_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ToolRankingSystem calculates utility scores based on success feedback.",
+        "Tests verify score adjustment and tool selection bias."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_orchestrator_v2.py
+++ b/magda_agent/integration/a2a_orchestrator_v2.py
@@ -1,0 +1,41 @@
+from typing import Dict, Any
+import logging
+from magda_agent.integration.a2a_discovery import A2ADiscovery
+from magda_agent.integration.a2a_delegation import A2ADelegator
+
+
+class A2AOrchestratorV2:
+    """
+    Coordinates dispatching tasks to multiple A2A sub-agents using A2ADelegator natively via Agent Cards.
+    """
+    def __init__(self, discovery: A2ADiscovery, delegator: A2ADelegator):
+        """
+        Initializes the orchestrator with discovery and delegator components.
+        """
+        self.discovery = discovery
+        self.delegator = delegator
+
+    async def route_task(self, task_context: Dict[str, Any], required_capability: str) -> str:
+        """
+        Discovers an available agent with the required capability and delegates the task to it.
+
+        Args:
+            task_context: The task context or sub-plan to delegate.
+            required_capability: The capability required to execute the task.
+
+        Returns:
+            A result string describing the outcome.
+        """
+        agents = self.discovery.find_agents_by_capability(required_capability)
+
+        if not agents:
+            logging.warning(f"No agents found for capability: {required_capability}")
+            return f"No agent found with capability: {required_capability}"
+
+        target_agent = agents[0]
+
+        logging.info(f"Routing task to Agent: {target_agent.name} (ID: {target_agent.agent_id}) for capability: {required_capability}")
+
+        result = await self.delegator.delegate_to_peer(target_agent, task_context)
+
+        return result

--- a/tests/test_a2a_orchestrator_v2.py
+++ b/tests/test_a2a_orchestrator_v2.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+import asyncio
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_delegation import A2ADelegator
+from magda_agent.integration.a2a_orchestrator_v2 import A2AOrchestratorV2
+
+@pytest.fixture
+def mock_agent_card():
+    return AgentCard(
+        agent_id="test-agent-123",
+        name="TestAgent",
+        description="A test agent",
+        capabilities=["coding", "analysis"],
+        endpoints={"mcp": "http://localhost:9000"}
+    )
+
+@pytest.fixture
+def a2a_discovery(mock_agent_card):
+    local_card = AgentCard("local", "local", "local", [], {})
+    discovery = A2ADiscovery(local_card)
+    discovery._discovered_agents[mock_agent_card.agent_id] = mock_agent_card
+    discovery._capability_index["coding"] = [mock_agent_card.agent_id]
+    discovery._capability_index["analysis"] = [mock_agent_card.agent_id]
+    return discovery
+
+@pytest.fixture
+def a2a_delegator(a2a_discovery):
+    return A2ADelegator(a2a_discovery)
+
+@pytest.fixture
+def a2a_orchestrator_v2(a2a_discovery, a2a_delegator):
+    return A2AOrchestratorV2(a2a_discovery, a2a_delegator)
+
+@pytest.mark.asyncio
+async def test_route_task_success(a2a_orchestrator_v2, mock_agent_card):
+    task_context = {"task": "Write hello world"}
+    required_capability = "coding"
+
+    a2a_orchestrator_v2.delegator.delegate_to_peer = AsyncMock(return_value="Delegated to Peer Agent TestAgent: Success")
+
+    result = await a2a_orchestrator_v2.route_task(task_context, required_capability)
+
+    assert result == "Delegated to Peer Agent TestAgent: Success"
+    a2a_orchestrator_v2.delegator.delegate_to_peer.assert_called_once_with(mock_agent_card, task_context)
+
+@pytest.mark.asyncio
+async def test_route_task_no_agents_found(a2a_orchestrator_v2):
+    task_context = {"task": "Draw a cat"}
+    required_capability = "drawing"
+
+    a2a_orchestrator_v2.delegator.delegate_to_peer = AsyncMock()
+
+    result = await a2a_orchestrator_v2.route_task(task_context, required_capability)
+
+    assert result == "No agent found with capability: drawing"
+    a2a_orchestrator_v2.delegator.delegate_to_peer.assert_not_called()


### PR DESCRIPTION
Implements the A2A Workflow Orchestrator v2 as specified in task 1f3e194c-cddb-4c65-9782-1ba9b98fdc8e.

- Added `A2AOrchestratorV2` in `magda_agent/integration/a2a_orchestrator_v2.py`.
- Added tests in `tests/test_a2a_orchestrator_v2.py` with mock discovery and delegation calls.
- Marked task as `done` in `agent_tasks.json`.
- Added 2 new AI trend-inspired tasks to `agent_tasks.json`.
- Validated task structure using `scripts/validate_agent_tasks.py`.

---
*PR created automatically by Jules for task [5406843630166414795](https://jules.google.com/task/5406843630166414795) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A workflow orchestrator v2 with capability-based agent routing
> - Adds [`A2AOrchestratorV2`](https://github.com/kazah4359-lgtm/Magda-agent/pull/640/files#diff-4793107b09729c628c5c0d3365318e5ab454f4327346b952b376f84e5cf7afd0) which wraps `A2ADiscovery` and `A2ADelegator` to route tasks to agents by capability.
> - `route_task` queries discovery for a matching agent and delegates via `delegator.delegate_to_peer`; returns a `'No agent found with capability: <cap>'` string if no match exists.
> - Adds pytest coverage in [`tests/test_a2a_orchestrator_v2.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/640/files#diff-045aa08623a4b78fe68dce9b494a3bc717930a267b8ca4ca2b09d7c3c46f29e7) for both the happy path and the no-agent fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43c61f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->