### PR TITLE
feat: Realtime Guardrail Action Interceptor

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10213,7 +10213,7 @@
     },
     {
       "id": "6561db15-0289-4c6a-9a85-b1b43d7f28ca",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "high",
       "title": "Realtime Guardrail Action Interceptor",
@@ -23199,6 +23199,41 @@
       "acceptance": [
         "ToolRankingSystem calculates utility scores based on success feedback.",
         "Tests verify score adjustment and tool selection bias."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v1-f1c7052b",
+      "title": "MCP Action Tool Exporter V1",
+      "description": "Inspired by the MCP standard trend (June 2026): Implement an exporter that converts Magda local skills into a standard JSON-RPC 2.0 MCP manifest, exposing them as standard action tools.",
+      "area": "integration",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter.py",
+        "tests/test_mcp_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter successfully reads local skills and generates a valid MCP manifest.",
+        "Tests verify the manifest structure and correct formatting of JSON-RPC definitions."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugin-v1-9c6520a4",
+      "title": "OpenClaw Context Engine Plugin V1",
+      "description": "Inspired by OpenClaw Context Engine trends (June 2026): Implement a Context Engine plugin interface with lifecycle hooks (e.g., pre-prompt, post-response) to dynamically modify the virtual context window before generation.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/context_plugin_v1.py",
+        "tests/test_context_plugin_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context Engine allows registration of plugins via lifecycle hooks.",
+        "Plugins can safely intercept and modify the context buffer before sending to LLM.",
+        "Tests verify hook execution and context modifications."
       ]
     }
   ]

--- a/magda_agent/safety/realtime_interceptor.py
+++ b/magda_agent/safety/realtime_interceptor.py
@@ -1,0 +1,79 @@
+import asyncio
+import logging
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from magda_agent.safety.policy import PolicyLayer
+
+
+class PolicyViolationError(Exception):
+    """Exception raised by tools when a policy violation is detected mid-execution."""
+    pass
+
+
+class RealtimeGuardrailInterceptor:
+    """
+    Interceptor that triggers a safe fallback state when external API tool calls detect policy violations mid-execution.
+    """
+
+    def __init__(self, policy_layer: Optional[PolicyLayer] = None) -> None:
+        """
+        Initializes the RealtimeGuardrailInterceptor.
+
+        Args:
+            policy_layer (Optional[PolicyLayer]): The policy evaluator to verify safety before execution.
+        """
+        self.policy_layer = policy_layer or PolicyLayer()
+
+    async def intercept_and_execute(
+        self,
+        tool_func: Callable[..., Any],
+        tool_name: str,
+        kwargs: Dict[str, Any]
+    ) -> Tuple[bool, Any]:
+        """
+        Executes the tool function with mid-execution guardrails. If a PolicyViolationError or generic execution
+        error is detected, it intercepts the issue and returns a structured tuple containing False and a fallback prompt.
+
+        Args:
+            tool_func (Callable[..., Any]): The synchronous or asynchronous function representing the tool call.
+            tool_name (str): Name of the tool.
+            kwargs (Dict[str, Any]): Arguments passed to the tool.
+
+        Returns:
+            Tuple[bool, Any]: (Success, Result or Fallback prompt).
+        """
+        # 1. Pre-execution policy check
+        allow, explanation = self.policy_layer.evaluate(tool_name, **kwargs)
+        if not allow:
+            logging.warning(f"RealtimeInterceptor: Pre-execution policy violation for '{tool_name}'.")
+            fallback_prompt = (
+                f"SAFETY ALERT: Pre-execution of tool '{tool_name}' with arguments {kwargs} "
+                f"was blocked due to a policy violation: {explanation}. "
+                f"Please analyze the violation, dynamically revise your execution plan, and try a "
+                f"different approach."
+            )
+            return False, fallback_prompt
+
+        # 2. Execute the tool and intercept exceptions
+        try:
+            if asyncio.iscoroutinefunction(tool_func):
+                result = await tool_func(**kwargs)
+            else:
+                # Run synchronous tool in a thread to avoid blocking the asyncio event loop
+                result = await asyncio.to_thread(tool_func, **kwargs)
+            return True, result
+        except PolicyViolationError as e:
+            logging.error(f"RealtimeInterceptor: Mid-execution policy violation detected for '{tool_name}'. Error: {e}")
+            fallback_prompt = (
+                f"MID-EXECUTION SAFETY ALERT: Tool '{tool_name}' detected a policy violation mid-execution: {str(e)}. "
+                f"The action was aborted to maintain safety. Please handle this dynamically and adjust your plan."
+            )
+            return False, fallback_prompt
+        except Exception as e:
+            logging.error(f"RealtimeInterceptor: Execution failure for '{tool_name}'. Error: {e}")
+            fallback_prompt = (
+                f"EXECUTION FAILURE: Failed to execute tool '{tool_name}'. "
+                f"Error: {str(e)}. "
+                f"Please adjust your strategy, handle this error dynamically, and generate an alternative plan."
+            )
+            return False, fallback_prompt

--- a/magda_agent/skills/registry.py
+++ b/magda_agent/skills/registry.py
@@ -1,4 +1,4 @@
-from typing import Dict, Callable, Any, Optional, TYPE_CHECKING
+from typing import Dict, Callable, Any, Optional, Tuple, TYPE_CHECKING
 import logging
 
 if TYPE_CHECKING:
@@ -23,6 +23,11 @@ class SkillRegistry:
         # Initialize RealtimeGuardrail
         from magda_agent.safety.guardrails import RealtimeGuardrail
         self.realtime_guardrail = RealtimeGuardrail(policy_layer) if policy_layer else None        # Initialize ACSMemoryPolicy and chain with existing policy layer
+
+        # Initialize RealtimeGuardrailInterceptor
+        from magda_agent.safety.realtime_interceptor import RealtimeGuardrailInterceptor
+        self.realtime_interceptor = RealtimeGuardrailInterceptor(policy_layer) if policy_layer else None
+
         from magda_agent.safety.acs_memory import ACSMemoryPolicy
         self.acs_memory_policy = ACSMemoryPolicy()
 
@@ -75,9 +80,32 @@ class SkillRegistry:
 
             # 3. Execute with appropriate guard
             import time
+            import asyncio
             start_time = time.time()
             try:
-                if self.realtime_guardrail is not None:
+                if getattr(self, 'realtime_interceptor', None) is not None:
+                    # We can't use asyncio.run if there is a running event loop, and run_until_complete
+                    # cannot be called from a running event loop either.
+                    # We will invoke a synchronous version or use a separate thread
+                    import threading
+
+                    def run_async_in_thread(coro: Any) -> Tuple[bool, Any]:
+                        """Runs an async coroutine in a separate thread and returns the result."""
+                        res = []
+                        def _thread_target() -> None:
+                            try:
+                                res.append(asyncio.run(coro))
+                            except Exception as e:
+                                res.append((False, f"Thread execution error: {e}"))
+                        t = threading.Thread(target=_thread_target)
+                        t.start()
+                        t.join()
+                        return res[0] if res else (False, "Thread execution failed")
+
+                    success, result = run_async_in_thread(
+                        self.realtime_interceptor.intercept_and_execute(self.skills[name], name, kwargs)
+                    )
+                elif self.realtime_guardrail is not None:
                     result = self.realtime_guardrail.execute_with_guardrails(self.skills[name], name, **kwargs)
                 elif self.runtime_governance is not None:
                     result = self.runtime_governance.execute_tool(self.skills[name], name, **kwargs)

--- a/tests/test_realtime_interceptor.py
+++ b/tests/test_realtime_interceptor.py
@@ -1,0 +1,76 @@
+import asyncio
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.safety.realtime_interceptor import RealtimeGuardrailInterceptor, PolicyViolationError
+
+
+class MockPolicyLayer:
+    def __init__(self, allow=True, explanation="Allowed"):
+        self.allow = allow
+        self.explanation = explanation
+
+    def evaluate(self, tool_name, **kwargs):
+        return self.allow, self.explanation
+
+
+def test_interceptor_pre_execution_block():
+    mock_policy = MockPolicyLayer(allow=False, explanation="Denied due to test.")
+    interceptor = RealtimeGuardrailInterceptor(policy_layer=mock_policy)
+
+    async def mock_tool():
+        return "Success"
+
+    result, message = asyncio.run(interceptor.intercept_and_execute(mock_tool, "test_tool", {}))
+    assert result is False
+    assert "SAFETY ALERT" in message
+    assert "Denied due to test" in message
+
+
+def test_interceptor_mid_execution_policy_violation():
+    mock_policy = MockPolicyLayer(allow=True)
+    interceptor = RealtimeGuardrailInterceptor(policy_layer=mock_policy)
+
+    async def mock_tool():
+        raise PolicyViolationError("Detected unsafe output generated mid-execution")
+
+    result, message = asyncio.run(interceptor.intercept_and_execute(mock_tool, "test_tool", {}))
+    assert result is False
+    assert "MID-EXECUTION SAFETY ALERT" in message
+    assert "Detected unsafe output generated mid-execution" in message
+
+
+def test_interceptor_execution_failure():
+    mock_policy = MockPolicyLayer(allow=True)
+    interceptor = RealtimeGuardrailInterceptor(policy_layer=mock_policy)
+
+    def sync_mock_tool():
+        raise ValueError("Generic error")
+
+    result, message = asyncio.run(interceptor.intercept_and_execute(sync_mock_tool, "sync_tool", {}))
+    assert result is False
+    assert "EXECUTION FAILURE" in message
+    assert "Generic error" in message
+
+
+def test_interceptor_success_async():
+    mock_policy = MockPolicyLayer(allow=True)
+    interceptor = RealtimeGuardrailInterceptor(policy_layer=mock_policy)
+
+    async def async_mock_tool(arg1):
+        return f"Async Success: {arg1}"
+
+    result, message = asyncio.run(interceptor.intercept_and_execute(async_mock_tool, "async_tool", {"arg1": "test"}))
+    assert result is True
+    assert message == "Async Success: test"
+
+
+def test_interceptor_success_sync():
+    mock_policy = MockPolicyLayer(allow=True)
+    interceptor = RealtimeGuardrailInterceptor(policy_layer=mock_policy)
+
+    def sync_mock_tool(arg1):
+        return f"Sync Success: {arg1}"
+
+    result, message = asyncio.run(interceptor.intercept_and_execute(sync_mock_tool, "sync_tool", {"arg1": "test"}))
+    assert result is True
+    assert message == "Sync Success: test"


### PR DESCRIPTION
Implements the "Realtime Guardrail Action Interceptor" feature for Magda's agentic framework.

This PR introduces:
- A new `RealtimeGuardrailInterceptor` in `magda_agent/safety/realtime_interceptor.py` that handles mid-execution errors (specifically `PolicyViolationError`) by catching them and generating structured fallback prompts. This prevents the primary event loop and workflow from crashing and allows dynamic reprompts.
- Integration in `magda_agent/skills/registry.py`. Because `SkillRegistry` exposes a synchronous API that may be called while an `asyncio` loop is running (e.g., from `aiogram`), it bridges the async execution of the interceptor safely by spawning an ephemeral background thread.
- Comprehensive tests using `unittest.mock` for the interceptor, validating successful execution, pre-execution blocks, and mid-execution `PolicyViolationError` exceptions.
- Updated `agent_tasks.json` marking the completed task as `done` and adding two new AI trend-inspired tasks (MCP Manifest Exporter and OpenClaw Context Engine Plugin).

---
*PR created automatically by Jules for task [6707790893577614785](https://jules.google.com/task/6707790893577614785) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RealtimeGuardrailInterceptor` to wrap tool execution with pre- and mid-execution policy checks
> - Introduces [`realtime_interceptor.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/641/files#diff-2d980f58e246fb2ffeef081177ef27999a727de82828c474454d7dad6fd87e04) with `RealtimeGuardrailInterceptor`, which runs a pre-execution policy check before invoking a tool and catches `PolicyViolationError` raised mid-execution, returning a `(success: bool, payload)` tuple with structured alert messages on failure.
> - Adds `PolicyViolationError` so tool implementations can signal policy violations that the interceptor will handle gracefully instead of propagating exceptions.
> - Integrates the interceptor into [`skills/registry.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/641/files#diff-86e5584dfd92efbf66a1e0600c1ab5a5e678bc67b8a389d2501997611f7f2ffa): when a `policy_layer` is provided, `SkillRegistry` instantiates the interceptor and routes tool calls through it in a separate thread via `asyncio.run`.
> - Risk: tool execution now runs in a new thread when the interceptor is active, which may interact unexpectedly with thread-local state or non-thread-safe tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc33f17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->