### PR TITLE
Implement OpenClaw Canvas Live Event Emitter

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10266,7 +10266,7 @@
     },
     {
       "id": "0d904de7-29ce-4f8d-8baf-d7d3c6300df1",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw Canvas Live Event Emitter",

--- a/magda_agent/telemetry/live_event_emitter.py
+++ b/magda_agent/telemetry/live_event_emitter.py
@@ -1,0 +1,67 @@
+import logging
+import json
+import time
+from typing import Any, Dict, Optional
+
+class LiveEventEmitter:
+    """
+    A unified event emitter that aggregates agent state changes
+    (planner, memory, execution) and streams them via WebSocket.
+    """
+    def __init__(self, websocket: Optional[Any] = None) -> None:
+        """
+        Initialize the LiveEventEmitter with an optional websocket.
+        """
+        self.websocket = websocket
+        self.logger = logging.getLogger(__name__)
+
+    def set_websocket(self, websocket: Any) -> None:
+        """
+        Dynamically update or set the websocket connection.
+        """
+        self.websocket = websocket
+
+    async def emit_planner_change(self, data: Dict[str, Any]) -> None:
+        """
+        Emit a planner-related state change.
+        """
+        await self.emit_state_change("planner", data)
+
+    async def emit_memory_change(self, data: Dict[str, Any]) -> None:
+        """
+        Emit a memory-related state change.
+        """
+        await self.emit_state_change("memory", data)
+
+    async def emit_execution_change(self, data: Dict[str, Any]) -> None:
+        """
+        Emit an execution-related state change.
+        """
+        await self.emit_state_change("execution", data)
+
+    async def emit_state_change(self, category: str, data: Dict[str, Any]) -> None:
+        """
+        Emit a state change event for the given category with timestamp.
+        """
+        if self.websocket is None:
+            self.logger.debug(f"Skipping emit for {category} - no websocket connected.")
+            return
+
+        payload = {
+            "type": f"{category}_change",
+            "category": category,
+            "timestamp": time.time(),
+            "data": data
+        }
+
+        try:
+            message = json.dumps(payload)
+            # Support send_text (standard FastAPI style used in tests)
+            if hasattr(self.websocket, "send_text"):
+                await self.websocket.send_text(message)
+            else:
+                # Fallback to standard send if send_text is not present
+                await self.websocket.send(message)
+            self.logger.debug(f"Successfully emitted {category} event.")
+        except Exception as e:
+            self.logger.error(f"Failed to emit {category} event: {e}")

--- a/tests/test_live_event_emitter.py
+++ b/tests/test_live_event_emitter.py
@@ -1,0 +1,134 @@
+import asyncio
+import json
+import time
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.telemetry.live_event_emitter import LiveEventEmitter
+
+
+class MockWebsocket:
+    def __init__(self):
+        self.send_text = AsyncMock()
+
+
+class MockWebsocketFallback:
+    def __init__(self):
+        self.send = AsyncMock()
+
+
+def test_initialization():
+    """Test streamer initialization with and without websocket."""
+    emitter_no_ws = LiveEventEmitter()
+    assert emitter_no_ws.websocket is None
+
+    mock_ws = MockWebsocket()
+    emitter_with_ws = LiveEventEmitter(mock_ws)
+    assert emitter_with_ws.websocket == mock_ws
+
+
+def test_set_websocket():
+    """Test updating the websocket connection dynamically."""
+    emitter = LiveEventEmitter()
+    assert emitter.websocket is None
+
+    mock_ws = MockWebsocket()
+    emitter.set_websocket(mock_ws)
+    assert emitter.websocket == mock_ws
+
+
+def test_emit_planner_change():
+    """Test emitting planner change."""
+    mock_ws = MockWebsocket()
+    emitter = LiveEventEmitter(mock_ws)
+
+    planner_state = {"current_step": "research_topic", "status": "active"}
+
+    # Run the emitter
+    asyncio.run(emitter.emit_planner_change(planner_state))
+
+    assert mock_ws.send_text.called
+    sent_payload_str = mock_ws.send_text.call_args[0][0]
+    payload = json.loads(sent_payload_str)
+
+    assert payload["type"] == "planner_change"
+    assert payload["category"] == "planner"
+    assert "timestamp" in payload
+    assert isinstance(payload["timestamp"], (int, float))
+    assert payload["data"] == planner_state
+
+
+def test_emit_memory_change():
+    """Test emitting memory change."""
+    mock_ws = MockWebsocket()
+    emitter = LiveEventEmitter(mock_ws)
+
+    memory_state = {"episodic_count": 42}
+
+    # Run the emitter
+    asyncio.run(emitter.emit_memory_change(memory_state))
+
+    assert mock_ws.send_text.called
+    sent_payload_str = mock_ws.send_text.call_args[0][0]
+    payload = json.loads(sent_payload_str)
+
+    assert payload["type"] == "memory_change"
+    assert payload["category"] == "memory"
+    assert "timestamp" in payload
+    assert payload["data"] == memory_state
+
+
+def test_emit_execution_change():
+    """Test emitting execution change."""
+    mock_ws = MockWebsocket()
+    emitter = LiveEventEmitter(mock_ws)
+
+    execution_state = {"tool_name": "search", "args": {"query": "pytest"}}
+
+    # Run the emitter
+    asyncio.run(emitter.emit_execution_change(execution_state))
+
+    assert mock_ws.send_text.called
+    sent_payload_str = mock_ws.send_text.call_args[0][0]
+    payload = json.loads(sent_payload_str)
+
+    assert payload["type"] == "execution_change"
+    assert payload["category"] == "execution"
+    assert "timestamp" in payload
+    assert payload["data"] == execution_state
+
+
+def test_emit_fallback_send():
+    """Test that standard send is used if send_text is absent on websocket."""
+    mock_ws = MockWebsocketFallback()
+    emitter = LiveEventEmitter(mock_ws)
+
+    data = {"msg": "hello"}
+    asyncio.run(emitter.emit_state_change("custom", data))
+
+    assert mock_ws.send.called
+    sent_payload_str = mock_ws.send.call_args[0][0]
+    payload = json.loads(sent_payload_str)
+
+    assert payload["type"] == "custom_change"
+    assert payload["category"] == "custom"
+    assert payload["data"] == data
+
+
+def test_emit_no_websocket():
+    """Test that emitting works gracefully without websocket connected."""
+    emitter = LiveEventEmitter()
+    # Should run fine without exceptions
+    asyncio.run(emitter.emit_planner_change({"key": "val"}))
+
+
+def test_emit_exception_handling():
+    """Test that exceptions raised by websocket are handled gracefully."""
+    mock_ws = MockWebsocket()
+    mock_ws.send_text.side_effect = Exception("Websocket connection closed unexpectedly")
+
+    emitter = LiveEventEmitter(mock_ws)
+
+    # Should run fine without rising exceptions
+    asyncio.run(emitter.emit_planner_change({"key": "val"}))
+    assert mock_ws.send_text.called


### PR DESCRIPTION
Implemented the OpenClaw Canvas Live Event Emitter feature, including LiveEventEmitter class under magda_agent/telemetry/live_event_emitter.py, a comprehensive test suite under tests/test_live_event_emitter.py, and updated agent_tasks.json status to done.

---
*PR created automatically by Jules for task [10684144255189394594](https://jules.google.com/task/10684144255189394594) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `LiveEventEmitter` class to stream agent state changes over WebSocket
> - Adds [`live_event_emitter.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/644/files#diff-fb6f8d21a51e5a1022af9b767643e4b3ac9e49930137d4a3d7729608c1033c90) with a `LiveEventEmitter` class that sends timestamped JSON events for planner, memory, and execution state changes over a WebSocket connection.
> - The emitter supports `send_text` (FastAPI/Starlette style) with a fallback to `send`, and skips emission with a debug log when no WebSocket is attached.
> - Includes a `set_websocket` method to attach or replace the WebSocket at runtime without recreating the emitter.
> - Adds async tests in [`tests/test_live_event_emitter.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/644/files#diff-c8d6a9484703d97301081e1af46e58095a003507310a0c2256ae355b723e441d) covering all emit paths, fallback behavior, no-socket graceful handling, and exception logging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edf298a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->