### PR TITLE
feat: Implement A2A Enterprise Auth Handshake V1

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -20394,7 +20394,7 @@
     },
     {
       "id": "a2a-enterprise-auth-handshake-v1-4ffcb75b",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Enterprise Auth Handshake V1",
@@ -23341,6 +23341,57 @@
         "The DependencyOptimizer subagent creates optimal DAGs from linear planner output.",
         "The DAG structure isolates parallelizable tasks successfully.",
         "Tests mock the planner output and verify the generated DAG dependencies."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-handshake-revocation-v2-bb4b53da",
+      "title": "A2A Enterprise Auth Handshake Revocation System",
+      "description": "Inspired by A2A standard trends: Build upon the token exchange handshake to implement a robust revocation system where a compromised peer can be instantly blacklisted and its tokens invalidated across the A2A sub-agent mesh.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth_revocation.py",
+        "tests/test_a2a_auth_revocation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A token revocation registry is implemented.",
+        "Tests verify tokens are successfully revoked and denied upon subsequent handshake requests."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-caching-invalidation-v2-bf330743",
+      "title": "MCP Tool Action Result Caching Invalidation V2",
+      "description": "Inspired by MCP kernel trends: Implement an explicit caching invalidation strategy for MCP read-only tools, clearing cached results intelligently based on configurable TTLs to ensure agents do not act on stale data.",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_caching_invalidation.py",
+        "tests/test_mcp_caching_invalidation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP cache TTL invalidation is implemented.",
+        "Tests mock time and verify cache correctly evicts expired data."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-failure-recovery-v1-2770fd0c",
+      "title": "OpenClaw Trajectory Failure Recovery Analysis V1",
+      "description": "Inspired by OpenClaw Trajectory Quality Evaluation trends: Build a failure recovery analyzer that parses failed multi-turn RL trajectories to identify the exact step where context loss occurred, generating a lesson for procedural memory.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_failure_recovery_v1.py",
+        "tests/test_trajectory_failure_recovery_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Failure recovery analyzer processes failed trajectories and extracts structural lessons.",
+        "Tests mock failed traces and verify lesson generation."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_auth_handshake_v1.py
+++ b/magda_agent/integration/a2a_auth_handshake_v1.py
@@ -1,0 +1,84 @@
+import uuid
+import logging
+from typing import Dict, Optional
+
+class A2AAuthHandshake:
+    """
+    Implements a secure token exchange handshake between peer agents
+    to ensure enterprise-grade authorization before task delegation.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the A2AAuthHandshake with an empty registry of authorized peers
+        and an empty set of active handshake tokens.
+        """
+        self._authorized_peers: Dict[str, str] = {}
+        self._active_tokens: Dict[str, str] = {}
+
+    def generate_handshake_token(self, agent_id: str) -> str:
+        """
+        Generates a secure token for an agent to initiate a handshake.
+
+        Args:
+            agent_id (str): The ID of the agent requesting the token.
+
+        Returns:
+            str: The generated handshake token.
+        """
+        token = f"a2a_hs_{uuid.uuid4().hex}"
+        self._active_tokens[token] = agent_id
+        logging.info(f"Generated handshake token for agent {agent_id}.")
+        return token
+
+    def verify_handshake(self, agent_id: str, token: str) -> bool:
+        """
+        Verifies a handshake token and authorizes the agent if valid.
+
+        Args:
+            agent_id (str): The ID of the agent attempting the handshake.
+            token (str): The token provided by the agent.
+
+        Returns:
+            bool: True if the handshake is successful, False otherwise.
+        """
+        if token in self._active_tokens and self._active_tokens[token] == agent_id:
+            self._authorized_peers[agent_id] = token
+            # In a real scenario, we might want to expire or single-use the token,
+            # but for this basic handshake, keeping it in active_tokens is fine,
+            # or we remove it to make it single use for the initial handshake.
+            # Let's make it single-use for the handshake process itself.
+            del self._active_tokens[token]
+            logging.info(f"Handshake successful for agent {agent_id}.")
+            return True
+
+        logging.warning(f"Handshake failed for agent {agent_id} with invalid token.")
+        return False
+
+    def is_peer_authorized(self, agent_id: str) -> bool:
+        """
+        Checks if a peer agent is currently authorized.
+
+        Args:
+            agent_id (str): The ID of the peer agent to check.
+
+        Returns:
+            bool: True if authorized, False otherwise.
+        """
+        return agent_id in self._authorized_peers
+
+    def revoke_authorization(self, agent_id: str) -> bool:
+        """
+        Revokes the authorization for a peer agent.
+
+        Args:
+            agent_id (str): The ID of the agent to revoke.
+
+        Returns:
+            bool: True if successfully revoked, False if the agent was not authorized.
+        """
+        if agent_id in self._authorized_peers:
+            del self._authorized_peers[agent_id]
+            logging.info(f"Revoked authorization for agent {agent_id}.")
+            return True
+        return False

--- a/tests/test_a2a_auth_handshake_v1.py
+++ b/tests/test_a2a_auth_handshake_v1.py
@@ -1,0 +1,78 @@
+import pytest
+from magda_agent.integration.a2a_auth_handshake_v1 import A2AAuthHandshake
+
+def test_successful_handshake():
+    """Tests that a valid token results in a successful handshake."""
+    handshake = A2AAuthHandshake()
+    agent_id = "agent_42"
+
+    # Generate token for agent
+    token = handshake.generate_handshake_token(agent_id)
+
+    # Verify the handshake with the generated token
+    result = handshake.verify_handshake(agent_id, token)
+
+    assert result is True
+    assert handshake.is_peer_authorized(agent_id) is True
+
+def test_rejected_handshake_invalid_token():
+    """Tests that an invalid token is rejected."""
+    handshake = A2AAuthHandshake()
+    agent_id = "agent_42"
+
+    # Try to verify with a fake token
+    result = handshake.verify_handshake(agent_id, "fake_token_123")
+
+    assert result is False
+    assert handshake.is_peer_authorized(agent_id) is False
+
+def test_rejected_handshake_wrong_agent():
+    """Tests that a valid token used by the wrong agent is rejected."""
+    handshake = A2AAuthHandshake()
+    agent1_id = "agent_42"
+    agent2_id = "agent_99"
+
+    # Generate token for agent 1
+    token = handshake.generate_handshake_token(agent1_id)
+
+    # Try to verify with agent 2 using agent 1's token
+    result = handshake.verify_handshake(agent2_id, token)
+
+    assert result is False
+    assert handshake.is_peer_authorized(agent2_id) is False
+    assert handshake.is_peer_authorized(agent1_id) is False
+
+def test_token_is_single_use():
+    """Tests that a token cannot be reused after a successful handshake."""
+    handshake = A2AAuthHandshake()
+    agent_id = "agent_42"
+
+    token = handshake.generate_handshake_token(agent_id)
+
+    # First handshake should succeed
+    assert handshake.verify_handshake(agent_id, token) is True
+
+    # Second handshake with the same token should fail
+    assert handshake.verify_handshake(agent_id, token) is False
+
+def test_revoke_authorization():
+    """Tests that an authorized agent can have its authorization revoked."""
+    handshake = A2AAuthHandshake()
+    agent_id = "agent_42"
+
+    token = handshake.generate_handshake_token(agent_id)
+    handshake.verify_handshake(agent_id, token)
+
+    assert handshake.is_peer_authorized(agent_id) is True
+
+    # Revoke authorization
+    revoke_result = handshake.revoke_authorization(agent_id)
+
+    assert revoke_result is True
+    assert handshake.is_peer_authorized(agent_id) is False
+
+def test_revoke_unauthorized_agent():
+    """Tests revoking an agent that is not authorized."""
+    handshake = A2AAuthHandshake()
+
+    assert handshake.revoke_authorization("unknown_agent") is False


### PR DESCRIPTION
This PR implements the `a2a-enterprise-auth-handshake-v1-4ffcb75b` task from the `agent_tasks.json` queue.

### Changes:
- **`magda_agent/integration/a2a_auth_handshake_v1.py`**: Added `A2AAuthHandshake` class to manage secure token generation, validation, and peer authorization logic.
- **`tests/test_a2a_auth_handshake_v1.py`**: Added unit tests to mock and cover successful token exchanges, invalid token rejection, wrong agent rejections, token revocation, and single-use functionality.
- **`agent_tasks.json`**: Marked the current task as `"done"`. Appended 3 new `"todo"` tasks inspired by AI trends (A2A auth revocation, MCP caching invalidation, and OpenClaw trajectory failure recovery).

### Validation:
- Successfully validated `agent_tasks.json` with `scripts/validate_agent_tasks.py`.
- Tests run and pass. Code is isolated, fully typed, and well-documented.

---
*PR created automatically by Jules for task [13000582090838459737](https://jules.google.com/task/13000582090838459737) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement A2A Enterprise Auth Handshake with single-use token verification
> - Adds [`A2AAuthHandshake`](https://github.com/kazah4359-lgtm/Magda-agent/pull/645/files#diff-fdc79f382e0ffb5b123560f096a6717e025dd698e4943769189f8837557d7890) class supporting token generation, single-use verification, authorization status checks, and revocation for peer agents.
> - Tokens are prefixed `a2a_hs_` + UUID4 and consumed on successful verification, preventing replay.
> - Adds full test coverage in [`tests/test_a2a_auth_handshake_v1.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/645/files#diff-7f5a7e4363fa44f5d1d84b99f83792e5a749b5ca429583a48d49a84acb534863) covering success, invalid tokens, wrong-agent rejection, single-use enforcement, and revocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b672a18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->