### PR TITLE
Feature: Claude-inspired Agent Teams Isolation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10283,7 +10283,7 @@
     },
     {
       "id": "bf068055-80e1-41b2-aa4a-52fe9ea89b41",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "Claude-inspired Agent Teams Isolation",
@@ -23392,6 +23392,57 @@
       "acceptance": [
         "Failure recovery analyzer processes failed trajectories and extracts structural lessons.",
         "Tests mock failed traces and verify lesson generation."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v5-1c01b854",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V5",
+      "description": "Inspired by MCP kernel trends: Implement multi-turn capability negotiation for MCP tools to ensure client and server agree on supported features before execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v5.py",
+        "tests/test_mcp_negotiation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Capability negotiation logic is implemented.",
+        "Tests verify successful capability handshake and fallback mechanisms."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-evaluation-v2-2671077e",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Quality Evaluation",
+      "description": "Inspired by OpenClaw RL Trend: Implement trajectory quality evaluation module to assess full multi-turn conversational rollouts against standard metrics for online learning.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_quality_v2.py",
+        "tests/test_trajectory_quality_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory Quality Evaluator module is created.",
+        "Tests mock trajectory parsing and metric calculation."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v1-1fd47b69",
+      "status": "todo",
+      "area": "isolation",
+      "risk": "medium",
+      "title": "Claude Worktree Pruning and Resource Optimizer",
+      "description": "Inspired by Claude Agent Teams Trend: Create an optimizer to prune inactive Git worktrees and manage disk resources utilized by concurrent parallel subagents.",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_pruning_v1.py",
+        "tests/test_worktree_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worktree Pruning Optimizer module is created.",
+        "Tests mock disk operations and verify correct worktrees are pruned based on TTL."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -335,3 +335,6 @@
 * [x] FEATURE: MCP Tool Taint Tracking Sandbox v5 (mcp-action-tool-taint-tracking-v5-6c2393a2)
 * [x] FEATURE: A2A Task Delegation Streaming Interface v3
 * [x] FEATURE: OpenClaw RL Metrics System v5 (openclaw-rl-metrics-v5-f60b1d89)
+* [ ] FEATURE: MCP Dynamic Capability Negotiation V5 (mcp-dynamic-capability-negotiation-v5)
+* [ ] FEATURE: OpenClaw RL Trajectory Quality Evaluation (openclaw-rl-trajectory-evaluation-v2)
+* [ ] FEATURE: Claude Worktree Pruning and Resource Optimizer (claude-worktree-pruning-optimizer-v1)

--- a/magda_agent/architecture/agent_teams_isolation.py
+++ b/magda_agent/architecture/agent_teams_isolation.py
@@ -1,0 +1,36 @@
+"""
+Module for provisioning isolated virtual workspace environments.
+Inspired by the Claude Agent Teams trend.
+"""
+
+import os
+import tempfile
+import contextlib
+import logging
+from typing import AsyncGenerator
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.asynccontextmanager
+async def provision_isolated_workspace() -> AsyncGenerator[str, None]:
+    """
+    Provisions a temporary, isolated workspace directory.
+
+    Yields the path to the newly created directory and automatically
+    cleans it up when the context exits. This context manager does *not*
+    modify the process-wide current working directory (os.chdir), which is
+    unsafe in concurrent asyncio applications. Calling code should use the
+    yielded path explicitly for all file operations.
+
+    Yields:
+        str: The path to the temporary isolated directory.
+    """
+    temp_dir_manager = tempfile.TemporaryDirectory()
+    temp_dir = temp_dir_manager.name
+    logger.debug(f"Provisioned isolated workspace at {temp_dir}")
+    try:
+        yield temp_dir
+    finally:
+        temp_dir_manager.cleanup()
+        logger.debug(f"Cleaned up isolated workspace at {temp_dir}")

--- a/tests/test_agent_teams_isolation.py
+++ b/tests/test_agent_teams_isolation.py
@@ -107,3 +107,33 @@ async def test_git_worktree_manager_remove_success():
         mock_exec.assert_called_once()
         assert "remove" in mock_exec.call_args[0]
         assert "/tmp/test_worktrees/worktree_abc123" in mock_exec.call_args[0]
+
+from magda_agent.architecture.agent_teams_isolation import provision_isolated_workspace
+import os
+
+@pytest.mark.asyncio
+async def test_virtual_workspace_isolation() -> None:
+    """
+    Verifies that file modifications in one subagent's isolated workspace
+    do not leak into another's, without modifying os.chdir.
+    """
+    async with provision_isolated_workspace() as ws1:
+        file1 = os.path.join(ws1, "agent1_data.txt")
+        with open(file1, "w") as f:
+            f.write("agent 1 data")
+        assert os.path.exists(file1)
+
+        async with provision_isolated_workspace() as ws2:
+            assert ws1 != ws2
+
+            # The file from ws1 should not exist in the context of ws2
+            file1_in_ws2 = os.path.join(ws2, "agent1_data.txt")
+            assert not os.path.exists(file1_in_ws2)
+
+            file2 = os.path.join(ws2, "agent2_data.txt")
+            with open(file2, "w") as f:
+                f.write("agent 2 data")
+            assert os.path.exists(file2)
+
+        # Back in ws1 context
+        assert os.path.exists(file1)


### PR DESCRIPTION
This PR implements the Claude-inspired Agent Teams Isolation task (ID `bf068055-80e1-41b2-aa4a-52fe9ea89b41`). 

It provisions a safe virtual workspace environment for subagents using a standard `contextlib.asynccontextmanager`. Instead of changing the process-wide working directory via `os.chdir()`, which is a critical concurrency hazard in an `asyncio` application, it securely yields the path to the temporary directory, instructing calling code to use this path explicitly.

The PR preserves all existing tests and adds tests for the new `provision_isolated_workspace` feature. It updates the `agent_tasks.json` manifest properly, generating 3 new trend-inspired tasks and maintaining backlog compatibility. No unallowed files (like workflow or DB files) are staged.

---
*PR created automatically by Jules for task [3924402883657680035](https://jules.google.com/task/3924402883657680035) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add isolated temporary workspace provisioning for agent teams
> - Introduces `provision_isolated_workspace`, an async context manager in [`agent_teams_isolation.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/646/files#diff-6eef5872fb51e3d8ae1c146a59a3ed7536fb539199710d1e2584349728753dbe) that creates a scoped temporary directory, yields it to the caller, and cleans it up on exit.
> - The implementation explicitly avoids calling `os.chdir`, keeping the process working directory unchanged.
> - Adds a test in [`test_agent_teams_isolation.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/646/files#diff-5bd15506a853b082c5675a93d6400d3f2745734fe2c2871a3fec7cbf529591b5) verifying that nested workspaces do not leak files between them and that no `chdir` occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 450bcaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->