### PR TITLE
feat: OpenClaw Virtual Context Engine Extensions

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10300,7 +10300,7 @@
     },
     {
       "id": "bd4738c5-9cbd-4df5-88e6-4647c995241f",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "OpenClaw Virtual Context Engine Extensions",
@@ -23443,6 +23443,60 @@
       "acceptance": [
         "Worktree Pruning Optimizer module is created.",
         "Tests mock disk operations and verify correct worktrees are pruned based on TTL."
+      ]
+    },
+    {
+      "id": "new-hermes-skill-discovery-v2-1f4a92c3",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes-inspired Dynamic Skill Discovery V2",
+      "description": "Inspired by Hermes Agent (June 2026): Implement an automatic skill discovery mechanism that dynamically indexes available actions from agentskills.io and adds them to the agent's active procedural memory context.",
+      "allowed_paths": [
+        "magda_agent/skills/discovery_v2.py",
+        "tests/test_discovery_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Dynamic skill discovery can query simulated agentskills.io endpoints.",
+        "Discovered skills are correctly merged into procedural memory.",
+        "Tests verify skill indexing and loading."
+      ]
+    },
+    {
+      "id": "new-openclaw-canvas-diff-v3-e6b789d2",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas Diff Patching V3",
+      "description": "Inspired by OpenClaw trends: Implement a delta-based patch streamer for the Canvas visualization, significantly reducing websocket bandwidth by only sending state diffs instead of full payloads.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_diff_v3.py",
+        "tests/test_canvas_diff_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Streamer generates valid JSON patches between state ticks.",
+        "Patches are serialized and sent over the active websocket.",
+        "Tests mock states and assert patch format."
+      ]
+    },
+    {
+      "id": "new-claude-planner-evaluator-loop-v2-a9b8c7d6",
+      "status": "todo",
+      "area": "planning",
+      "risk": "high",
+      "title": "Claude Code-inspired Pre-execution Plan Evaluator",
+      "description": "Inspired by Claude Agent SDK: Create a specialized Evaluator subagent that intercepts the output of the Planner and critiques it for safety and logical coherence before execution begins.",
+      "allowed_paths": [
+        "magda_agent/planning/pre_execution_evaluator.py",
+        "tests/test_pre_execution_evaluator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The Evaluator subagent receives the generated plan and outputs a critique.",
+        "If critique fails, the plan is rejected and sent back to the Planner.",
+        "Tests mock plan formats and evaluator LLM responses."
       ]
     }
   ]

--- a/magda_agent/architecture/virtual_context_extensions.py
+++ b/magda_agent/architecture/virtual_context_extensions.py
@@ -1,0 +1,75 @@
+import logging
+import copy
+from typing import Dict, Any, Optional
+
+class VirtualContextEngineExtension:
+    """
+    Extensions to Context Engine to support virtual context isolation across multiple subagents.
+    Provides sandboxing for working memory spaces during parallel task execution.
+    """
+
+    def __init__(self) -> None:
+        self.sandboxed_contexts: Dict[str, Dict[str, Any]] = {}
+        logging.info("Initialized VirtualContextEngineExtension")
+
+    def create_sandbox(self, subagent_id: str, base_context: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Creates an isolated virtual context for a subagent.
+
+        Args:
+            subagent_id: The ID of the subagent to create a sandbox for.
+            base_context: Optional initial context to start with.
+        """
+        if subagent_id in self.sandboxed_contexts:
+            logging.warning(f"Sandbox for {subagent_id} already exists.")
+            return
+
+        self.sandboxed_contexts[subagent_id] = copy.deepcopy(base_context) if base_context else {}
+        logging.info(f"Created isolated context for subagent: {subagent_id}")
+
+    def update_sandbox(self, subagent_id: str, key: str, value: Any) -> None:
+        """
+        Updates the virtual context for a given subagent.
+
+        Args:
+            subagent_id: The ID of the subagent.
+            key: The context key to update.
+            value: The new value.
+
+        Raises:
+            ValueError: If the sandbox does not exist.
+        """
+        if subagent_id not in self.sandboxed_contexts:
+            raise ValueError(f"Sandbox not found for subagent: {subagent_id}")
+
+        self.sandboxed_contexts[subagent_id][key] = value
+        logging.debug(f"Updated context for {subagent_id}: {key} = {value}")
+
+    def get_sandbox(self, subagent_id: str) -> Dict[str, Any]:
+        """
+        Retrieves the virtual context for a given subagent.
+
+        Args:
+            subagent_id: The ID of the subagent.
+
+        Returns:
+            A deep copy of the subagent's virtual context.
+
+        Raises:
+            ValueError: If the sandbox does not exist.
+        """
+        if subagent_id not in self.sandboxed_contexts:
+            raise ValueError(f"Sandbox not found for subagent: {subagent_id}")
+
+        return copy.deepcopy(self.sandboxed_contexts[subagent_id])
+
+    def remove_sandbox(self, subagent_id: str) -> None:
+        """
+        Removes the virtual context for a given subagent.
+
+        Args:
+            subagent_id: The ID of the subagent to remove.
+        """
+        if subagent_id in self.sandboxed_contexts:
+            del self.sandboxed_contexts[subagent_id]
+            logging.info(f"Removed isolated context for subagent: {subagent_id}")

--- a/tests/test_virtual_context_extensions.py
+++ b/tests/test_virtual_context_extensions.py
@@ -1,0 +1,79 @@
+import pytest
+from magda_agent.architecture.virtual_context_extensions import VirtualContextEngineExtension
+
+def test_create_sandbox() -> None:
+    """Tests creation and retrieval of a virtual context sandbox."""
+    engine = VirtualContextEngineExtension()
+    engine.create_sandbox("agent_1", {"key1": "val1"})
+
+    ctx = engine.get_sandbox("agent_1")
+    assert ctx == {"key1": "val1"}
+
+def test_create_sandbox_existing() -> None:
+    """Tests creating a sandbox that already exists logs a warning and doesn't overwrite."""
+    engine = VirtualContextEngineExtension()
+    engine.create_sandbox("agent_1", {"key1": "val1"})
+    engine.create_sandbox("agent_1", {"key2": "val2"})
+
+    ctx = engine.get_sandbox("agent_1")
+    assert ctx == {"key1": "val1"}
+
+def test_update_sandbox() -> None:
+    """Tests updating a value in a virtual context sandbox."""
+    engine = VirtualContextEngineExtension()
+    engine.create_sandbox("agent_1")
+    engine.update_sandbox("agent_1", "key1", "val1")
+
+    ctx = engine.get_sandbox("agent_1")
+    assert ctx["key1"] == "val1"
+
+def test_update_sandbox_not_found() -> None:
+    """Tests updating a sandbox that doesn't exist raises ValueError."""
+    engine = VirtualContextEngineExtension()
+    with pytest.raises(ValueError, match="Sandbox not found"):
+        engine.update_sandbox("missing_agent", "key1", "val1")
+
+def test_get_sandbox_not_found() -> None:
+    """Tests getting a sandbox that doesn't exist raises ValueError."""
+    engine = VirtualContextEngineExtension()
+    with pytest.raises(ValueError, match="Sandbox not found"):
+        engine.get_sandbox("missing_agent")
+
+def test_isolation() -> None:
+    """Tests that memory spaces do not bleed across subagents."""
+    engine = VirtualContextEngineExtension()
+    engine.create_sandbox("agent_1", {"global": True})
+    engine.create_sandbox("agent_2", {"global": True})
+
+    engine.update_sandbox("agent_1", "agent_1_only", True)
+
+    ctx1 = engine.get_sandbox("agent_1")
+    ctx2 = engine.get_sandbox("agent_2")
+
+    assert "agent_1_only" in ctx1
+    assert "agent_1_only" not in ctx2
+
+def test_get_sandbox_returns_copy() -> None:
+    """Tests that get_sandbox returns a copy to prevent accidental mutations."""
+    engine = VirtualContextEngineExtension()
+    engine.create_sandbox("agent_1", {"key1": "val1"})
+
+    ctx = engine.get_sandbox("agent_1")
+    ctx["key1"] = "mutated"
+
+    ctx_stored = engine.get_sandbox("agent_1")
+    assert ctx_stored["key1"] == "val1"
+
+def test_remove_sandbox() -> None:
+    """Tests removing a sandbox."""
+    engine = VirtualContextEngineExtension()
+    engine.create_sandbox("agent_1")
+    engine.remove_sandbox("agent_1")
+
+    with pytest.raises(ValueError):
+        engine.get_sandbox("agent_1")
+
+def test_remove_sandbox_not_found() -> None:
+    """Tests removing a sandbox that doesn't exist is safe."""
+    engine = VirtualContextEngineExtension()
+    engine.remove_sandbox("missing_agent")  # Should not raise


### PR DESCRIPTION
This PR implements the OpenClaw Virtual Context Engine Extensions as requested in the task board.

### Changes:
- **`magda_agent/architecture/virtual_context_extensions.py`**: Added `VirtualContextEngineExtension` class. Provides sandboxed working memory spaces that use `copy.deepcopy` to ensure state is strictly isolated between subagents.
- **`tests/test_virtual_context_extensions.py`**: Implemented comprehensive unit tests to ensure contexts don't bleed across parallel agents.
- **`agent_tasks.json`**: Marked `bd4738c5-9cbd-4df5-88e6-4647c995241f` as `done`. Automatically replenished the queue with 3 new `todo` tasks inspired by trends from `docs/trends.md` (Hermes Agent, OpenClaw Canvas streaming, and Claude Code Pre-execution evaluators).

Validation run: `python scripts/validate_agent_tasks.py agent_tasks.json` ✅
Test coverage: 100% on modified files. ✅

---
*PR created automatically by Jules for task [14112003554456891149](https://jules.google.com/task/14112003554456891149) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `VirtualContextEngineExtension` class for per-subagent isolated context management
> - Introduces [`VirtualContextEngineExtension`](https://github.com/kazah4359-lgtm/Magda-agent/pull/647/files#diff-bc6ee1b7a7be8e0e75ceed1532170d8ec939ca899a506b57717fc4ef84e5521c) with create, update, get, and remove operations on per-subagent sandbox dictionaries.
> - Sandboxes are keyed by `subagent_id`; `get_sandbox` returns a deep copy to prevent external mutation; `create_sandbox` accepts an optional `base_context` to seed the new sandbox.
> - `update_sandbox` and `get_sandbox` raise `ValueError` on missing sandboxes; `create_sandbox` emits a warning and is a no-op on duplicates; `remove_sandbox` is idempotent.
> - Adds a pytest suite in [`tests/test_virtual_context_extensions.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/647/files#diff-af4eb8ac3aac2af4f6ba2d133d14c2639c6db24c87ed481985f18a5b8fb78da4) covering all CRUD paths, isolation across subagents, deep-copy behavior, and idempotent removal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3d6666.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->