### PR TITLE
feat: Implement Hermes-inspired Parallel Step Planner

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10317,7 +10317,7 @@
     },
     {
       "id": "d660ef26-e11f-4710-a298-033255ee0556",
-      "status": "todo",
+      "status": "done",
       "area": "execution",
       "risk": "high",
       "title": "Hermes Parallel Step Planner",
@@ -23497,6 +23497,57 @@
         "The Evaluator subagent receives the generated plan and outputs a critique.",
         "If critique fails, the plan is rejected and sent back to the Planner.",
         "Tests mock plan formats and evaluator LLM responses."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-quality-v5-abc",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Quality Evaluator V5",
+      "description": "Inspired by OpenClaw RL Trend: Enhance trajectory evaluation to include subagent delegation accuracy and task success rates, extracting this information from the EpisodicMemory.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_quality_v5.py",
+        "tests/test_trajectory_quality_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory Evaluator assesses delegation patterns.",
+        "Tests mock trajectory parsing and evaluate accuracy correctly."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v3-def",
+      "status": "todo",
+      "area": "isolation",
+      "risk": "medium",
+      "title": "Claude Worktree Pruning and Resource Optimizer V3",
+      "description": "Inspired by Claude Agent Teams Trend: Enhance the optimizer to track and limit concurrent subagent disk usage aggressively using cgroups constraints, pruning dynamically based on system memory pressure.",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_pruning_v3.py",
+        "tests/test_worktree_pruning_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worktree Pruning Optimizer integrates with cgroups limits.",
+        "Tests mock disk pressure events and verify correct worktrees are evicted."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v9-ghi",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V9",
+      "description": "Inspired by MCP Trends: Introduce semantic embedding matching for capability negotiation, allowing MCP clients to fuzzy-match requested tool capabilities even when schemas differ slightly.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v9.py",
+        "tests/test_mcp_negotiation_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Negotiation protocol handles fuzzy-matching using embeddings.",
+        "Tests mock vector retrieval and fallback loop logic."
       ]
     }
   ]

--- a/magda_agent/execution/parallel_planner.py
+++ b/magda_agent/execution/parallel_planner.py
@@ -1,0 +1,95 @@
+import asyncio
+import logging
+from typing import Any, Callable, Dict, List, Awaitable
+from magda_agent.planning.planner import PlanStep, TypedPlan
+
+logger = logging.getLogger(__name__)
+
+class ParallelPlanner:
+    """
+    A planner designed for orchestrating parallel task execution based on dependencies.
+    Inspired by Hermes parallel execution trends.
+    """
+
+    def __init__(self, skill_executor_func: Callable[[str, Dict[str, Any]], Awaitable[Any]]) -> None:
+        """
+        Initializes the ParallelPlanner.
+
+        Args:
+            skill_executor_func: An async function that takes a skill name and kwargs and executes the skill.
+                                 This allows wiring the planner to any execution backend in the existing architecture.
+        """
+        self.skill_executor_func = skill_executor_func
+
+    def parse_intent(self, plan: TypedPlan) -> List[PlanStep]:
+        """
+        Parses a TypedPlan (which captures the user's intent as a DAG) and prepares it for execution.
+        Validates dependencies to ensure there are no missing references, outputting a safe list of steps
+        ready for gathered concurrent execution.
+
+        Args:
+            plan: The TypedPlan object containing steps and their dependencies.
+
+        Returns:
+            A validated list of PlanStep objects ready for execution.
+        """
+        logger.info(f"Parsing parallel intent for plan with {len(plan.steps)} steps.")
+        step_ids = {step.id for step in plan.steps}
+
+        for step in plan.steps:
+            # We must iterate over a copy of the list since we might modify it
+            for dep in list(step.dependencies):
+                if dep not in step_ids:
+                    logger.warning(f"Step {step.id} depends on unknown step {dep}. Removing dependency.")
+                    step.dependencies.remove(dep)
+
+        return plan.steps
+
+    async def execute_plan(self, steps: List[PlanStep]) -> Dict[str, Any]:
+        """
+        Executes a plan (list of PlanStep objects) concurrently, respecting their dependencies
+        via an asyncio gathered execution tree.
+
+        Args:
+            steps: A list of PlanStep objects representing the execution plan.
+
+        Returns:
+            A dictionary mapping step IDs to their execution results.
+        """
+        logger.info(f"Executing parallel plan with {len(steps)} steps.")
+
+        results: Dict[str, Any] = {}
+        events: Dict[str, asyncio.Event] = {step.id: asyncio.Event() for step in steps}
+
+        async def _execute_step(step: PlanStep) -> None:
+            # Wait for all dependencies to finish
+            for dep in step.dependencies:
+                if dep in events:
+                    await events[dep].wait()
+                    # If a dependency failed, we also fail this step
+                    if isinstance(results.get(dep), Exception):
+                        results[step.id] = Exception(f"Dependency {dep} failed.")
+                        events[step.id].set()
+                        return
+
+            # Execute the current step
+            try:
+                if step.skill:
+                    kwargs = step.skill_kwargs or {}
+                    result = await self.skill_executor_func(step.skill, kwargs)
+                    results[step.id] = result
+                else:
+                    results[step.id] = None
+            except Exception as e:
+                logger.error(f"Error executing step {step.id}: {e}")
+                results[step.id] = e
+            finally:
+                events[step.id].set()
+
+        # Create an asyncio gathered execution tree
+        tasks = [asyncio.create_task(_execute_step(step)) for step in steps]
+
+        # Gather all tasks to run them concurrently, handling dependencies via events
+        await asyncio.gather(*tasks)
+
+        return results

--- a/tests/test_parallel_planner.py
+++ b/tests/test_parallel_planner.py
@@ -1,0 +1,114 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from magda_agent.planning.planner import PlanStep, TypedPlan
+from magda_agent.execution.parallel_planner import ParallelPlanner
+
+@pytest.fixture
+def mock_executor():
+    """Mock execution backend to trace which skills are called and simulate delays."""
+    async def executor(skill_name, kwargs):
+        if skill_name == "fast_skill":
+            return kwargs.get("val", "fast")
+        elif skill_name == "slow_skill":
+            await asyncio.sleep(0.1)
+            return kwargs.get("val", "slow")
+        elif skill_name == "error_skill":
+            raise ValueError(f"Error triggered for {kwargs.get('val')}")
+        return "default"
+    return executor
+
+@pytest.fixture
+def planner(mock_executor):
+    return ParallelPlanner(skill_executor_func=mock_executor)
+
+@pytest.mark.asyncio
+async def test_parse_intent(planner):
+    """Test that parse_intent returns the intended execution plan, cleaning up invalid dependencies."""
+    plan = TypedPlan(
+        goal="Test parsing",
+        risk="low",
+        steps=[
+            PlanStep(id="1", description="Step 1", skill="fast_skill", dependencies=[]),
+            PlanStep(id="2", description="Step 2", skill="fast_skill", dependencies=["1", "invalid_dep"]),
+        ]
+    )
+
+    result = planner.parse_intent(plan)
+
+    assert len(result) == 2
+    assert result[0].id == "1"
+    assert result[1].id == "2"
+    # invalid_dep should be stripped
+    assert result[1].dependencies == ["1"]
+
+@pytest.mark.asyncio
+async def test_execute_plan_concurrent(planner):
+    """Test that execute_plan runs independent tasks concurrently."""
+    steps = [
+        PlanStep(id="s1", description="Slow 1", skill="slow_skill", skill_kwargs={"val": 1}),
+        PlanStep(id="s2", description="Slow 2", skill="slow_skill", skill_kwargs={"val": 2}),
+        PlanStep(id="s3", description="Slow 3", skill="slow_skill", skill_kwargs={"val": 3}),
+    ]
+
+    start_time = asyncio.get_event_loop().time()
+    results = await planner.execute_plan(steps)
+    end_time = asyncio.get_event_loop().time()
+
+    duration = end_time - start_time
+
+    # Should take around 0.1s instead of 0.3s
+    assert duration < 0.2
+    assert results == {"s1": 1, "s2": 2, "s3": 3}
+
+@pytest.mark.asyncio
+async def test_execute_plan_dependencies(planner):
+    """Test that execute_plan respects dependencies."""
+    # We will trace the execution order by appending to a list
+    execution_order = []
+
+    async def tracking_executor(skill_name, kwargs):
+        val = kwargs.get("val")
+        if skill_name == "slow_skill":
+            await asyncio.sleep(0.05)
+        execution_order.append(val)
+        return val
+
+    tracking_planner = ParallelPlanner(skill_executor_func=tracking_executor)
+
+    # s1 is slow but has no dependencies.
+    # s2 is fast but depends on s1.
+    # s3 is fast, no dependencies, should run alongside s1 and finish before s2.
+    steps = [
+        PlanStep(id="s1", description="Slow dep", skill="slow_skill", skill_kwargs={"val": "s1"}),
+        PlanStep(id="s2", description="Fast dep on s1", skill="fast_skill", skill_kwargs={"val": "s2"}, dependencies=["s1"]),
+        PlanStep(id="s3", description="Fast no dep", skill="fast_skill", skill_kwargs={"val": "s3"}),
+    ]
+
+    results = await tracking_planner.execute_plan(steps)
+
+    assert results == {"s1": "s1", "s2": "s2", "s3": "s3"}
+    # s3 should finish before s1 and s2 because s1 is slow and s2 waits for s1.
+    assert execution_order.index("s3") < execution_order.index("s1")
+    # s2 must finish after s1
+    assert execution_order.index("s1") < execution_order.index("s2")
+
+@pytest.mark.asyncio
+async def test_execute_plan_with_exception(planner):
+    """Test that execute_plan handles exceptions and cascades failures to dependents."""
+    steps = [
+        PlanStep(id="ok_step", description="OK", skill="fast_skill", skill_kwargs={"val": "ok"}),
+        PlanStep(id="err_step", description="Error", skill="error_skill", skill_kwargs={"val": "err"}),
+        PlanStep(id="dep_step", description="Depends on Error", skill="fast_skill", skill_kwargs={"val": "dep"}, dependencies=["err_step"]),
+    ]
+
+    results = await planner.execute_plan(steps)
+
+    assert results["ok_step"] == "ok"
+    assert isinstance(results["err_step"], ValueError)
+    assert "Error triggered for err" in str(results["err_step"])
+
+    # dep_step should also fail because its dependency failed
+    assert isinstance(results["dep_step"], Exception)
+    assert "Dependency err_step failed" in str(results["dep_step"])


### PR DESCRIPTION
This PR implements the `Hermes Parallel Step Planner` feature.

It introduces a new `ParallelPlanner` class that takes a `TypedPlan` (which represents tasks as a Directed Acyclic Graph) and executes the tasks concurrently where possible, enforcing sequential constraints using `asyncio.Event` when dependencies exist. 

A full test suite using `pytest-asyncio` covers standard concurrent execution, sequential dependency mapping, and cascading failures. The `agent_tasks.json` manifest is successfully updated to mark this task as done and add 3 new trend-inspired tasks (e.g. MCP fuzzy negotiation, OpenClaw RL evaluator, Claude worktree resource optimization).

---
*PR created automatically by Jules for task [10439328928659167227](https://jules.google.com/task/10439328928659167227) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement `ParallelPlanner` for concurrent, dependency-aware plan execution
> - Adds [parallel_planner.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/648/files#diff-5c6f78c49b8c2c6c792090eb2d99075ff1c544b2c62582ab72c79a92ca208398) with a `ParallelPlanner` class that accepts an injected async skill executor and runs `PlanStep` tasks concurrently using `asyncio`.
> - `parse_intent` validates a `TypedPlan` by stripping dependencies referencing non-existent step IDs before execution.
> - `execute_plan` enforces step ordering via per-step events; if a dependency raises an exception, dependent steps are marked failed with a cascaded error rather than running.
> - Adds tests covering concurrency (wall-clock timing), dependency ordering, invalid dependency pruning, and exception propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3bf8bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->