### PR TITLE
feat(skills): implement Hermes-inspired skill telemetry export

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10405,7 +10405,7 @@
     },
     {
       "id": "b5a81083-a558-4e29-a095-ab07fb616d1c",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "Hermes-inspired Skill Telemetry Export",
@@ -23638,6 +23638,42 @@
         "Isolation layer proxies execution for tainted data inputs via a dedicated secure subprocess.",
         "Network access is blocked for isolated tool invocations.",
         "Tests verify invocation patterns correctly detect tainted arguments and restrict access."
+      ]
+    },
+    {
+      "id": "claude-code-memory-compression-v1",
+      "title": "Claude Code Memory Compression Pattern V1",
+      "description": "Inspired by Claude Code agent trend: Implement a specialized summarizer module that uses a rolling window to compress historical episodic memories into dense vector representations before token limits are exhausted.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/rolling_summarizer_v1.py",
+        "tests/test_rolling_summarizer_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Rolling summarizer module compresses episodic memory vectors successfully.",
+        "Tests mock LLM summarization and verify token limit threshold triggers.",
+        "Tests verify dense vector insertion back into the ChromaDB mock."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-vision-feedback-v4",
+      "title": "OpenClaw RL Vision Feedback Alignment v4",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Implement an image parser that processes visual UI sentiment directly from bounding boxes and UI test screenshots to serve as reward scalar signals in the agent's procedural memory weights.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/vision_sentiment_v4.py",
+        "tests/test_vision_sentiment_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Vision sentiment parser maps bounding box interactions to RL rewards.",
+        "Procedural memory weights update based on the scalar signals.",
+        "Tests verify weight adjustments using mock image payload data."
       ]
     }
   ]

--- a/magda_agent/skills/registry.py
+++ b/magda_agent/skills/registry.py
@@ -1,5 +1,7 @@
 from typing import Dict, Callable, Any, Optional, Tuple, TYPE_CHECKING
 import logging
+import time
+from magda_agent.skills.telemetry_export import SkillTelemetryTracker
 
 if TYPE_CHECKING:
     from magda_agent.safety.policy import PolicyLayer
@@ -12,6 +14,7 @@ class SkillRegistry:
         self.skills: Dict[str, Callable] = {}
         self.descriptions: Dict[str, str] = {}
         self.policy_layer = policy_layer
+        self.telemetry_tracker = SkillTelemetryTracker()
 
         # Initialize AgentGuard if policy_layer is provided
         from magda_agent.safety.agent_guard import AgentGuard
@@ -195,8 +198,16 @@ class SkillRegistry:
                     duration=duration
                 )
 
+            self.telemetry_tracker.record_usage(name, success=True, execution_time_ms=duration * 1000)
+
             return result
         except Exception as e:
+            try:
+                exec_time = duration * 1000
+            except NameError:
+                exec_time = 0.0
+
+            self.telemetry_tracker.record_usage(name, success=False, execution_time_ms=exec_time)
             logging.error(f"Error executing skill {name}: {e}")
             return f"Error executing skill {name}: {e}"
 

--- a/magda_agent/skills/telemetry_export.py
+++ b/magda_agent/skills/telemetry_export.py
@@ -1,0 +1,85 @@
+import json
+from typing import Dict, List, Any
+import time
+
+class SkillTelemetryTracker:
+    """
+    A tracker for skill usage metrics that aggregates statistics over time
+    and can export them in an agentskills.io compatible JSON format.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the telemetry tracker with an empty metrics dictionary.
+        """
+        # skill_name -> {"total_calls": int, "success_count": int, "total_execution_time_ms": float}
+        self._metrics: Dict[str, Dict[str, Any]] = {}
+
+    def record_usage(self, skill_name: str, success: bool, execution_time_ms: float) -> None:
+        """
+        Record a single execution of a skill.
+
+        Args:
+            skill_name (str): The name of the skill executed.
+            success (bool): Whether the execution was successful.
+            execution_time_ms (float): The time taken for the execution in milliseconds.
+        """
+        if skill_name not in self._metrics:
+            self._metrics[skill_name] = {
+                "total_calls": 0,
+                "success_count": 0,
+                "total_execution_time_ms": 0.0
+            }
+
+        metrics = self._metrics[skill_name]
+        metrics["total_calls"] += 1
+        if success:
+            metrics["success_count"] += 1
+        metrics["total_execution_time_ms"] += execution_time_ms
+
+    def get_aggregated_metrics(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Get the aggregated metrics for all tracked skills.
+
+        Returns:
+            Dict[str, Dict[str, Any]]: Aggregated metrics per skill.
+        """
+        aggregated: Dict[str, Dict[str, Any]] = {}
+        for skill_name, data in self._metrics.items():
+            total_calls = data["total_calls"]
+            success_count = data["success_count"]
+            total_exec_time = data["total_execution_time_ms"]
+
+            success_rate = (success_count / total_calls) if total_calls > 0 else 0.0
+            avg_exec_time = (total_exec_time / total_calls) if total_calls > 0 else 0.0
+
+            aggregated[skill_name] = {
+                "total_calls": total_calls,
+                "success_rate": round(success_rate, 4),
+                "average_execution_time_ms": round(avg_exec_time, 2)
+            }
+        return aggregated
+
+    def export_agentskills_format(self) -> str:
+        """
+        Export the aggregated telemetry data in an agentskills.io compatible JSON string.
+
+        Returns:
+            str: JSON string representing the telemetry export.
+        """
+        aggregated = self.get_aggregated_metrics()
+
+        skills_payload: List[Dict[str, Any]] = []
+        for skill_name, metrics in aggregated.items():
+            skills_payload.append({
+                "name": skill_name,
+                "metrics": metrics
+            })
+
+        payload = {
+            "skills": skills_payload,
+            "version": "1.0",
+            "exporter": "magda_telemetry"
+        }
+
+        return json.dumps(payload, indent=2)

--- a/tests/test_telemetry_export.py
+++ b/tests/test_telemetry_export.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+from magda_agent.skills.telemetry_export import SkillTelemetryTracker
+
+def test_record_and_aggregate_metrics():
+    tracker = SkillTelemetryTracker()
+
+    # Record usage for skill_a
+    tracker.record_usage("skill_a", success=True, execution_time_ms=100.0)
+    tracker.record_usage("skill_a", success=False, execution_time_ms=50.0)
+    tracker.record_usage("skill_a", success=True, execution_time_ms=150.0)
+
+    # Record usage for skill_b
+    tracker.record_usage("skill_b", success=True, execution_time_ms=200.0)
+
+    aggregated = tracker.get_aggregated_metrics()
+
+    assert "skill_a" in aggregated
+    assert aggregated["skill_a"]["total_calls"] == 3
+    assert aggregated["skill_a"]["success_rate"] == round(2/3, 4)
+    assert aggregated["skill_a"]["average_execution_time_ms"] == 100.0
+
+    assert "skill_b" in aggregated
+    assert aggregated["skill_b"]["total_calls"] == 1
+    assert aggregated["skill_b"]["success_rate"] == 1.0
+    assert aggregated["skill_b"]["average_execution_time_ms"] == 200.0
+
+def test_export_agentskills_format():
+    tracker = SkillTelemetryTracker()
+
+    tracker.record_usage("test_skill", success=True, execution_time_ms=120.5)
+
+    export_json = tracker.export_agentskills_format()
+    parsed = json.loads(export_json)
+
+    assert parsed["version"] == "1.0"
+    assert parsed["exporter"] == "magda_telemetry"
+    assert "skills" in parsed
+
+    skills = parsed["skills"]
+    assert len(skills) == 1
+    assert skills[0]["name"] == "test_skill"
+
+    metrics = skills[0]["metrics"]
+    assert metrics["total_calls"] == 1
+    assert metrics["success_rate"] == 1.0
+    assert metrics["average_execution_time_ms"] == 120.5
+
+def test_empty_export():
+    tracker = SkillTelemetryTracker()
+
+    export_json = tracker.export_agentskills_format()
+    parsed = json.loads(export_json)
+
+    assert parsed["skills"] == []
+    assert parsed["version"] == "1.0"


### PR DESCRIPTION
This PR implements the Hermes-inspired Skill Telemetry Export feature (task id: `b5a81083-a558-4e29-a095-ab07fb616d1c`).

- Created `magda_agent/skills/telemetry_export.py` with `SkillTelemetryTracker`.
- Wired the telemetry tracking directly into the `SkillRegistry` execution path, properly tracking success, failures, and execution times without crashing the main loop.
- Added comprehensive unit tests in `tests/test_telemetry_export.py` asserting the telemetry aggregation and JSON export formats.
- Updated `agent_tasks.json` to mark the task as `done`.
- Added two new AI-trend inspired tasks (`claude-code-memory-compression-v1` and `openclaw-rl-multimodal-vision-feedback-v4`).

---
*PR created automatically by Jules for task [15963732035446627722](https://jules.google.com/task/15963732035446627722) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add skill telemetry tracking and agentskills.io-compatible export to `SkillRegistry`
> - Adds [telemetry_export.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/652/files#diff-b49647cd4da81298041ace7312e18e48b62b6323f4a84e43554b2ab9bd7a346d) with a new `SkillTelemetryTracker` class that records per-skill call counts, success rates, and execution times.
> - Updates [registry.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/652/files#diff-86e5584dfd92efbf66a1e0600c1ab5a5e678bc67b8a389d2501997611f7f2ffa) to instantiate `SkillTelemetryTracker` and call `record_usage` after every skill execution, including failures.
> - Exports aggregated metrics as an agentskills.io-compatible JSON payload with `skills`, `version`, and `exporter` fields.
> - Behavioral Change: all skill executions now incur telemetry recording overhead; failed executions where timing was never captured report 0ms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b88e91c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->