### PR TITLE
feat(memory): Implement RLFeedbackPagerPlugin for feedback-based memory eviction

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10423,7 +10423,7 @@
     },
     {
       "id": "0cbbda33-a878-4732-a158-0e5a515d0a89",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "high",
       "title": "OpenClaw-RL Virtual Context Feedback Paging",
@@ -23668,6 +23668,42 @@
       "allowed_paths": [
         "magda_agent/learning/vision_sentiment_v4.py",
         "tests/test_vision_sentiment_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Vision sentiment parser maps bounding box interactions to RL rewards.",
+        "Procedural memory weights update based on the scalar signals.",
+        "Tests verify weight adjustments using mock image payload data."
+      ]
+    },
+    {
+      "id": "new-hermes-skill-experience-synthesizer-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes-inspired Skill Experience Synthesizer v2",
+      "description": "Inspired by Hermes Agent trend (June 2026): Create a learning module that reviews past episodic memory trajectories and synthesizes new reusable Python skills, saving them to the persistent registry if they pass static AST checks.",
+      "allowed_paths": [
+        "magda_agent/learning/skill_synthesizer_v2.py",
+        "tests/test_skill_synthesizer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module reads success signals from episodic memory.",
+        "Module drafts a composite Python skill and validates it via AST.",
+        "Tests mock successful memory chunks and assert valid generated skill source code."
+      ]
+    },
+    {
+      "id": "new-openclaw-rl-multimodal-vision-feedback-v5",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Vision Feedback Alignment v5",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Implement an image parser that processes visual UI sentiment directly from bounding boxes and UI test screenshots to serve as reward scalar signals in the agent's procedural memory weights.",
+      "allowed_paths": [
+        "magda_agent/learning/vision_sentiment_v5.py",
+        "tests/test_vision_sentiment_v5.py",
         "agent_tasks.json"
       ],
       "acceptance": [

--- a/magda_agent/memory/rl_feedback_pager.py
+++ b/magda_agent/memory/rl_feedback_pager.py
@@ -1,0 +1,118 @@
+import logging
+import asyncio
+from typing import Any, Dict, List, Optional
+from magda_agent.memory.context_engine import ContextPlugin
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+
+class RLFeedbackPagerPlugin(ContextPlugin):
+    """
+    Virtual Context component inside Context Engine to handle long conversational memory
+    pagination by splitting it into pages of working memory and episodic memory,
+    prioritizing the eviction of entries with negative user feedback.
+    """
+
+    def __init__(self, max_tokens: int = 4000) -> None:
+        """
+        Initializes the RLFeedbackPagerPlugin.
+
+        Args:
+            max_tokens: The maximum number of tokens allowed in working memory.
+        """
+        self.config: Dict[str, Any] = {}
+        self.working_memory: Optional[WorkingMemory] = None
+        self.episodic_memory: Optional[EpisodicMemory] = None
+        self.max_tokens = max_tokens
+        logging.debug(f"Initialized RLFeedbackPagerPlugin with max_tokens={max_tokens}")
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """
+        Bootstrap lifecycle hook. Initializes plugin state from config.
+
+        Args:
+            config: Configuration dictionary injected by ContextEngine.
+        """
+        self.config = config
+        self.working_memory = config.get("working_memory")
+        self.episodic_memory = config.get("episodic_memory")
+        if "max_tokens" in config:
+            self.max_tokens = config["max_tokens"]
+        logging.info("RLFeedbackPagerPlugin bootstrapped with config.")
+
+    def get_token_length(self, entries: List[MemoryEntry]) -> int:
+        """
+        Calculates a heuristic token length for the given memory entries.
+
+        Args:
+            entries: A list of MemoryEntry objects.
+
+        Returns:
+            The estimated token count.
+        """
+        total_words = sum(len(e.content.split()) for e in entries)
+        return int(total_words * 1.3)
+
+    def page_out_feedback_based(self, user_id: int) -> None:
+        """
+        Pages out the lowest feedback scored half of working memory to episodic memory.
+        """
+        if not self.working_memory or not self.episodic_memory:
+            return
+
+        entries = self.working_memory.get_entries(user_id=user_id)
+        if not entries:
+            return
+
+        count_to_remove = max(1, len(entries) // 2)
+
+        # Sort entries by user_feedback_score (ascending) and then timestamp (ascending).
+        # This prioritizes eviction of entries with the lowest feedback scores,
+        # breaking ties by evicting older entries first.
+        sorted_entries = sorted(entries, key=lambda e: (getattr(e, 'user_feedback_score', 0.0), e.timestamp))
+        to_remove = sorted_entries[:count_to_remove]
+
+        for entry in to_remove:
+            metadata = {
+                "paged_out_explicitly": True,
+                "importance": entry.importance,
+                "pad_p": entry.emotional_state.pleasure,
+                "pad_a": entry.emotional_state.arousal,
+                "pad_d": entry.emotional_state.dominance,
+                "user_feedback_score": getattr(entry, 'user_feedback_score', 0.0)
+            }
+            if entry.tags:
+                metadata["tags"] = ",".join(entry.tags)
+
+            self.episodic_memory.store_event(
+                text=entry.content,
+                metadata=metadata,
+                user_id=user_id
+            )
+            logging.debug(f"Paged out memory entry {entry.id} (feedback_score={getattr(entry, 'user_feedback_score', 0.0)}) for user {user_id}")
+            self.working_memory.remove(entry.id, user_id=user_id)
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """
+        Synchronous hook before context retrieval.
+        Checks if working memory size exceeds limits and paginates if necessary based on feedback.
+
+        Args:
+            query: The original search query.
+            user_id: ID of the user requesting context.
+
+        Returns:
+            The original query.
+        """
+        if not self.working_memory or not self.episodic_memory:
+            return query
+
+        entries = self.working_memory.get_entries(user_id=user_id)
+        current_tokens = self.get_token_length(entries)
+
+        if current_tokens > self.max_tokens:
+            logging.info(f"RLFeedbackPagerPlugin: Working memory context length ({current_tokens} tokens) exceeds limit ({self.max_tokens} tokens). Paginating out...")
+            # Iteratively page out entries until the total token count is within max_tokens
+            while self.get_token_length(self.working_memory.get_entries(user_id=user_id)) > self.max_tokens and len(self.working_memory.get_entries(user_id=user_id)) > 0:
+                self.page_out_feedback_based(user_id)
+
+        return query

--- a/tests/test_rl_feedback_pager.py
+++ b/tests/test_rl_feedback_pager.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.memory.rl_feedback_pager import RLFeedbackPagerPlugin
+from magda_agent.memory.working import WorkingMemory, MemoryEntry
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.emotions.engine import PADState
+import time
+
+@pytest.mark.asyncio
+async def test_rl_feedback_pager_bootstrap() -> None:
+    plugin = RLFeedbackPagerPlugin(max_tokens=20)
+    wm = WorkingMemory()
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_rl_episodic_memory_bootstrap"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+
+    config = {
+        "working_memory": wm,
+        "episodic_memory": em,
+        "max_tokens": 50
+    }
+
+    await plugin.bootstrap(config)
+
+    assert plugin.working_memory == wm
+    assert plugin.episodic_memory == em
+    assert plugin.max_tokens == 50
+
+@pytest.mark.asyncio
+async def test_rl_feedback_pager_no_pagination() -> None:
+    plugin = RLFeedbackPagerPlugin(max_tokens=50)
+    wm = WorkingMemory()
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_rl_episodic_memory_no_pagination"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+
+    config = {
+        "working_memory": wm,
+        "episodic_memory": em,
+    }
+    await plugin.bootstrap(config)
+
+    state = PADState(0, 0, 0)
+
+    e1 = MemoryEntry("short context", 0.5, state, user_id=1)
+    await wm.add(e1)
+
+    assert len(wm.get_entries(user_id=1)) == 1
+
+    query = "test query"
+    result = plugin.before_retrieval(query, user_id=1)
+
+    assert result == query
+    assert len(wm.get_entries(user_id=1)) == 1
+    assert len(em.get_all_events(user_id=1)) == 0
+
+@pytest.mark.asyncio
+async def test_rl_feedback_pager_with_feedback_prioritization() -> None:
+    plugin = RLFeedbackPagerPlugin(max_tokens=15)
+    wm = WorkingMemory(limit=10)
+    em = EpisodicMemory(persist_directory=":memory:")
+    em.collection_name = "test_rl_episodic_memory_prioritization"
+    em.collection = em.client.get_or_create_collection(name=em.collection_name)
+
+    config = {
+        "working_memory": wm,
+        "episodic_memory": em,
+    }
+    await plugin.bootstrap(config)
+
+    state = PADState(0, 0, 0)
+
+    # 4 entries, each around 5 tokens. Total ~20 tokens.
+    e1 = MemoryEntry("word1 word2 word3 word4", 0.5, state, user_id=1)
+    e1.user_feedback_score = 1.0  # High score, older
+    time.sleep(0.01)
+
+    e2 = MemoryEntry("word5 word6 word7 word8", 0.6, state, user_id=1)
+    e2.user_feedback_score = -1.0 # Very negative score
+    time.sleep(0.01)
+
+    e3 = MemoryEntry("word9 word10 word11 word12", 0.7, state, user_id=1)
+    e3.user_feedback_score = 2.0  # Very high score
+    time.sleep(0.01)
+
+    e4 = MemoryEntry("word13 word14 word15 word16", 0.8, state, user_id=1)
+    # e4 has no explicit user_feedback_score, defaults to 0.0
+    time.sleep(0.01)
+
+    await wm.add(e1)
+    await wm.add(e2)
+    await wm.add(e3)
+    await wm.add(e4)
+
+    assert len(wm.get_entries(user_id=1)) == 4
+    # Check that initial token size is greater than max_tokens
+    assert plugin.get_token_length(wm.get_entries(user_id=1)) > 15
+
+    query = "trigger pagination"
+    result = plugin.before_retrieval(query, user_id=1)
+
+    assert result == query
+
+    # After pagination, the size should be within limit (15 tokens -> ~2 entries max out of 4 to stay <= 15)
+    # The plugin removes half of entries per loop. It had 4, half is 2.
+    # It sorts by score: e2 (-1.0), e4 (0.0), e1 (1.0), e3 (2.0)
+    # So it should remove e2 and e4.
+    # Remaining should be e1 and e3.
+    entries = wm.get_entries(user_id=1)
+    assert len(entries) == 2
+
+    remaining_contents = [e.content for e in entries]
+    assert "word1 word2 word3 word4" in remaining_contents # e1 kept
+    assert "word9 word10 word11 word12" in remaining_contents # e3 kept
+
+    # Check episodic memory
+    events = em.get_all_events(user_id=1)
+    assert len(events) == 2
+    paged_contents = [event["text"] for event in events]
+    assert "word5 word6 word7 word8" in paged_contents # e2 removed
+    assert "word13 word14 word15 word16" in paged_contents # e4 removed
+    assert events[0]["metadata"]["paged_out_explicitly"] == True


### PR DESCRIPTION
This PR implements the OpenClaw-RL Virtual Context Feedback Paging task.
- Adds `RLFeedbackPagerPlugin` to `magda_agent/memory/rl_feedback_pager.py` to prioritize evicting entries from working memory that have low feedback scores.
- Implements related isolated pytests in `tests/test_rl_feedback_pager.py`.
- Updates `agent_tasks.json` with the new completed state and adds 2 new AI-trend-inspired tasks (Hermes Agent and OpenClaw RL trends).

---
*PR created automatically by Jules for task [14256039592010720161](https://jules.google.com/task/14256039592010720161) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RLFeedbackPagerPlugin` for feedback-based working memory eviction to episodic memory
> - Introduces [`RLFeedbackPagerPlugin`](https://github.com/kazah4359-lgtm/Magda-agent/pull/653/files#diff-4fdd5f5d5a503b3d5ff45fc6b0a10d0012a25139c1143f79ac5aec08c1109b0f), a `ContextPlugin` that monitors working memory token usage before each retrieval and evicts entries when a configurable `max_tokens` limit is exceeded.
> - Eviction sorts entries by `user_feedback_score` ascending (ties broken by timestamp), then moves the lowest-scored half to episodic memory with metadata attached, including feedback score and PAD state.
> - Token estimation uses a word-count heuristic multiplied by 1.3 rather than a true tokenizer.
> - Tests in [`tests/test_rl_feedback_pager.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/653/files#diff-f5b832550d8d3b1db5a3a5367345a3aec7418a6dadf6e71c256e587bdfd28468) cover bootstrap, no-op short-context, and feedback-prioritized eviction scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48ea8c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->