### PR TITLE
feat: A2A Workflow Orchestration via mDNS

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10441,7 +10441,7 @@
     },
     {
       "id": "5b6d9420-5611-4563-9045-ad5bc4feb9dc",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "A2A Workflow Orchestration via mDNS",
@@ -23710,6 +23710,58 @@
         "Vision sentiment parser maps bounding box interactions to RL rewards.",
         "Procedural memory weights update based on the scalar signals.",
         "Tests verify weight adjustments using mock image payload data."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-worktree-pruning",
+      "title": "Claude Agent Teams Worktree Pruning",
+      "description": "Inspired by Claude Agent Teams trend (June 2026): Implement an aggressive pruning strategy for temporary Git worktrees spawned during parallel multi-agent task execution to prevent disk exhaustion.",
+      "area": "isolation",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_pruning.py",
+        "tests/test_worktree_pruning.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Worktree pruner identifies and deletes stale Git worktrees.",
+        "Tests mock disk operations and verify deletion logic."
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-sync-v1",
+      "title": "Hermes Skill Marketplace Background Sync",
+      "description": "Inspired by Hermes Agent trend (June 2026): Implement a background process to periodically synchronize verified skills from an external agentskills.io mock registry into the local Procedural Memory.",
+      "area": "learning",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/skill_sync.py",
+        "tests/test_skill_sync.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sync service fetches skills from mock agentskills.io endpoint.",
+        "Successfully fetched skills are persisted locally.",
+        "Tests mock the HTTP call and verify local persistence."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation",
+      "title": "MCP Dynamic Capability Negotiation",
+      "description": "Inspired by MCP trends (June 2026): Introduce semantic embedding matching for capability negotiation, allowing MCP clients to fuzzy-match requested tool capabilities even when schemas differ slightly.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation.py",
+        "tests/test_mcp_negotiation.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Negotiation protocol handles fuzzy-matching using embeddings.",
+        "Tests mock vector retrieval and fallback loop logic."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_orchestrator_mdns.py
+++ b/magda_agent/integration/a2a_orchestrator_mdns.py
@@ -1,0 +1,66 @@
+from typing import Dict, Any, List
+import logging
+from magda_agent.integration.a2a_mdns import A2AMDNSDiscovery
+from magda_agent.integration.a2a_delegation import A2ADelegator
+
+class A2AOrchestratorMDNS:
+    """
+    Coordinates dispatching tasks to multiple A2A sub-agents using A2AMDNSDiscovery for peer discovery.
+    """
+    def __init__(self, discovery: A2AMDNSDiscovery, delegator: A2ADelegator) -> None:
+        """
+        Initializes the orchestrator with mDNS discovery and delegator components.
+
+        Args:
+            discovery: The A2AMDNSDiscovery instance.
+            delegator: The A2ADelegator instance.
+        """
+        self.discovery = discovery
+        self.delegator = delegator
+
+    async def execute_plan(self, plan: list[Dict[str, Any]]) -> Dict[str, str]:
+        """
+        Executes a full plan by splitting it into sub-plans and dispatching them dynamically
+        to peers discovered via mDNS.
+
+        Args:
+            plan: The full execution plan.
+
+        Returns:
+            A dictionary mapping step IDs to their delegation result.
+        """
+        if not plan:
+            return {}
+
+        results: Dict[str, str] = {}
+        sub_plans = self.delegator.split_plan(plan)
+
+        for sub_plan in sub_plans:
+            capability = sub_plan.get("capability")
+            if not capability:
+                logging.warning("Sub-plan missing 'capability'. Skipping.")
+                continue
+
+            steps = sub_plan.get("steps", [])
+            agents = self.discovery.find_agents_by_capability(capability)
+
+            for step in steps:
+                step_id = step.get("id")
+                if not step_id:
+                    continue
+
+                if not agents:
+                    logging.warning(f"No agents found for capability: {capability}")
+                    results[step_id] = f"No agent found with capability: {capability}"
+                else:
+                    target_agent = agents[0]
+                    logging.info(f"Delegating step {step_id} to Agent: {target_agent.name} (ID: {target_agent.agent_id}) for capability: {capability}")
+
+                    try:
+                        result = await self.delegator.delegate_to_peer(target_agent, step)
+                        results[step_id] = result
+                    except Exception as e:
+                        logging.error(f"Error delegating step {step_id} to {target_agent.name}: {e}")
+                        results[step_id] = f"Delegation error: {e}"
+
+        return results

--- a/tests/test_a2a_orchestrator_mdns.py
+++ b/tests/test_a2a_orchestrator_mdns.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from typing import Dict, Any
+
+from magda_agent.integration.a2a_mdns import A2AMDNSDiscovery
+from magda_agent.integration.a2a_delegation import A2ADelegator
+from magda_agent.integration.a2a_discovery import AgentCard
+from magda_agent.integration.a2a_orchestrator_mdns import A2AOrchestratorMDNS
+
+
+@pytest.fixture
+def mock_discovery() -> MagicMock:
+    """Provides a mocked A2AMDNSDiscovery instance."""
+    discovery = MagicMock(spec=A2AMDNSDiscovery)
+    return discovery
+
+
+@pytest.fixture
+def mock_delegator() -> MagicMock:
+    """Provides a mocked A2ADelegator instance."""
+    delegator = MagicMock(spec=A2ADelegator)
+    return delegator
+
+
+@pytest.fixture
+def orchestrator(mock_discovery: MagicMock, mock_delegator: MagicMock) -> A2AOrchestratorMDNS:
+    """Provides an instance of A2AOrchestratorMDNS with mocked dependencies."""
+    return A2AOrchestratorMDNS(mock_discovery, mock_delegator)
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_success(orchestrator: A2AOrchestratorMDNS, mock_discovery: MagicMock, mock_delegator: MagicMock) -> None:
+    """Tests successful delegation of a plan to a discovered peer."""
+    plan = [
+        {"id": "step_1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}}
+    ]
+
+    mock_delegator.split_plan.return_value = [
+        {"capability": "coding", "steps": plan}
+    ]
+
+    mock_agent = AgentCard(
+        agent_id="agent-123",
+        name="TestAgent",
+        description="A test agent",
+        capabilities=["coding"],
+        endpoints={"rpc": "http://localhost:8000"}
+    )
+    mock_discovery.find_agents_by_capability.return_value = [mock_agent]
+    mock_delegator.delegate_to_peer = AsyncMock(return_value="Success")
+
+    results = await orchestrator.execute_plan(plan)
+
+    assert results == {"step_1": "Success"}
+    mock_discovery.find_agents_by_capability.assert_called_once_with("coding")
+    mock_delegator.delegate_to_peer.assert_called_once_with(mock_agent, plan[0])
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_no_agents(orchestrator: A2AOrchestratorMDNS, mock_discovery: MagicMock, mock_delegator: MagicMock) -> None:
+    """Tests plan execution when no agents are found for a capability."""
+    plan = [
+        {"id": "step_2", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "analysis"}}
+    ]
+
+    mock_delegator.split_plan.return_value = [
+        {"capability": "analysis", "steps": plan}
+    ]
+    mock_discovery.find_agents_by_capability.return_value = []
+
+    results = await orchestrator.execute_plan(plan)
+
+    assert results == {"step_2": "No agent found with capability: analysis"}
+    mock_discovery.find_agents_by_capability.assert_called_once_with("analysis")
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_with_exception(orchestrator: A2AOrchestratorMDNS, mock_discovery: MagicMock, mock_delegator: MagicMock) -> None:
+    """Tests plan execution when delegation raises an exception."""
+    plan = [
+        {"id": "step_3", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "search"}}
+    ]
+
+    mock_delegator.split_plan.return_value = [
+        {"capability": "search", "steps": plan}
+    ]
+    mock_agent = AgentCard(
+        agent_id="agent-456",
+        name="TestAgent2",
+        description="A test agent",
+        capabilities=["search"],
+        endpoints={"rpc": "http://localhost:8001"}
+    )
+    mock_discovery.find_agents_by_capability.return_value = [mock_agent]
+
+    mock_delegator.delegate_to_peer = AsyncMock(side_effect=Exception("Network error"))
+
+    results = await orchestrator.execute_plan(plan)
+
+    assert "Delegation error: Network error" in results["step_3"]
+    mock_discovery.find_agents_by_capability.assert_called_once_with("search")
+
+
+@pytest.mark.asyncio
+async def test_execute_plan_empty(orchestrator: A2AOrchestratorMDNS) -> None:
+    """Tests execution with an empty plan."""
+    results = await orchestrator.execute_plan([])
+    assert results == {}


### PR DESCRIPTION
This PR fulfills the first "todo" task by implementing a robust multi-agent orchestration component that delegates task execution plans dynamically across a peer-to-peer network utilizing mDNS for zero-configuration capability discovery. It incorporates the `A2AMDNSDiscovery` and `A2ADelegator` components. Thorough test cases using `unittest.mock` have been added. Additionally, the task queue has been populated with future-forward, trend-inspired capabilities.

---
*PR created automatically by Jules for task [643671998438254959](https://jules.google.com/task/643671998438254959) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add A2A workflow orchestration via mDNS discovery in `A2AOrchestratorMDNS`
> - Adds [`a2a_orchestrator_mdns.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/654/files#diff-e2220b020d9dd5badb48cb559687907605ac0258bb5920fd70addcbb0b353283) with `A2AOrchestratorMDNS`, an async orchestrator that splits a plan into sub-plans and delegates each step to a discovered agent matching the required capability.
> - Uses `A2AMDNSDiscovery.find_agents_by_capability` to locate agents and `A2ADelegator.delegate_to_peer` to dispatch steps, collecting per-step results keyed by step ID.
> - Records structured error strings (`"No agent found with capability: ..."`, `"Delegation error: ..."`) in the result dict when agents are missing or delegation fails, rather than raising.
> - Adds [`tests/test_a2a_orchestrator_mdns.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/654/files#diff-3fc475b1ee83ebab0e0066df1f9fd490d9321ee81964eff242b5da4a3a07a686) with async tests covering success, missing agents, delegation exceptions, and empty plan.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d984ba2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->