### PR TITLE
Implement Context Engine Live Semantic Re-ranker Plugin

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10459,7 +10459,7 @@
     },
     {
       "id": "eb6a35a2-308e-43d6-bb87-10532e32fadb",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine Live Semantic Re-ranker",

--- a/magda_agent/memory/semantic_reranker.py
+++ b/magda_agent/memory/semantic_reranker.py
@@ -1,0 +1,115 @@
+import logging
+import math
+import re
+from typing import Any, Dict, List, Optional
+from magda_agent.memory.context_engine import ContextPlugin
+
+def tokenize(text: str) -> List[str]:
+    """Tokenize text into lowercase words."""
+    return re.findall(r'\w+', text.lower())
+
+def compute_cosine_similarity(text1: str, text2: str) -> float:
+    """
+    Computes a localized lexical cosine similarity based on word frequencies.
+    Highly deterministic and self-contained.
+    """
+    words1 = tokenize(text1)
+    words2 = tokenize(text2)
+    if not words1 or not words2:
+        return 0.0
+
+    # Calculate term frequencies
+    freq1: Dict[str, int] = {}
+    freq2: Dict[str, int] = {}
+    for w in words1:
+        freq1[w] = freq1.get(w, 0) + 1
+    for w in words2:
+        freq2[w] = freq2.get(w, 0) + 1
+
+    # Dot product
+    all_words = set(freq1.keys()).union(freq2.keys())
+    dot_product = sum(freq1.get(w, 0) * freq2.get(w, 0) for w in all_words)
+
+    # Vector magnitudes
+    mag1 = math.sqrt(sum(val**2 for val in freq1.values()))
+    mag2 = math.sqrt(sum(val**2 for val in freq2.values()))
+
+    if mag1 == 0.0 or mag2 == 0.0:
+        return 0.0
+
+    return dot_product / (mag1 * mag2)
+
+
+class SemanticRerankerPlugin(ContextPlugin):
+    """
+    Context Engine Live Semantic Re-ranker Plugin.
+    Dynamically prioritizes/re-ranks retrieved Episodic Memory entries
+    using localized embeddings (lexical/semantic similarity) before Planner retrieval.
+    """
+
+    def __init__(self, similarity_fn=None) -> None:
+        self.similarity_fn = similarity_fn or compute_cosine_similarity
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration."""
+        if config and "similarity_fn" in config:
+            self.similarity_fn = config["similarity_fn"]
+        logging.debug("SemanticRerankerPlugin initialized successfully.")
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Process incoming content before it is stored or used."""
+        return content
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """Assemble the context string from retrieved items."""
+        return "\n".join([self._get_entry_text(item) for item in context_items])
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact context when limits are reached."""
+        return context_items
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Called before context is retrieved. Can modify the query."""
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """
+        Sort the retrieved context entries dynamically based on semantic similarity to the query.
+        """
+        if not context or not query:
+            return context
+
+        scored_context = []
+        for entry in context:
+            text = self._get_entry_text(entry)
+            score = self.similarity_fn(query, text)
+            scored_context.append((score, entry))
+
+        # Re-rank context based on similarity score (descending)
+        scored_context.sort(key=lambda x: x[0], reverse=True)
+        return [entry for score, entry in scored_context]
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """Called before context is written."""
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """Called after context is written."""
+        pass
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """Called when the overall context is updated."""
+        pass
+
+    def _get_entry_text(self, entry: Any) -> str:
+        """Helper to extract text/content safely from varying entry structures."""
+        if isinstance(entry, str):
+            return entry
+        if isinstance(entry, dict):
+            return entry.get("text") or entry.get("content") or ""
+        for attr in ["text", "content"]:
+            if hasattr(entry, attr):
+                val = getattr(entry, attr)
+                if isinstance(val, str):
+                    return val
+        return str(entry)

--- a/tests/test_semantic_reranker.py
+++ b/tests/test_semantic_reranker.py
@@ -1,0 +1,102 @@
+import pytest
+from magda_agent.memory.semantic_reranker import SemanticRerankerPlugin, compute_cosine_similarity
+from magda_agent.memory.context_engine import ContextEngine
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+def test_cosine_similarity_basic():
+    # Identical strings should be perfectly similar (1.0)
+    assert compute_cosine_similarity("apple banana cherry", "banana cherry apple") == pytest.approx(1.0)
+
+    # Completely disjoint strings should have 0.0 similarity
+    assert compute_cosine_similarity("apple banana", "cherry orange") == 0.0
+
+    # Partial overlaps
+    sim1 = compute_cosine_similarity("apple banana", "apple banana cherry")
+    sim2 = compute_cosine_similarity("apple banana", "apple cherry")
+    assert sim1 > sim2
+
+def test_cosine_similarity_edge_cases():
+    assert compute_cosine_similarity("", "apple") == 0.0
+    assert compute_cosine_similarity("apple", "") == 0.0
+    assert compute_cosine_similarity("   ", "   ") == 0.0
+
+def test_semantic_reranker_sorting():
+    plugin = SemanticRerankerPlugin()
+
+    # Query: find "apple"
+    query = "apple pie"
+
+    # Context entries: different structures
+    entry1 = "This is a cherry tart dessert" # similarity to query should be 0.0
+    entry2 = {"text": "I love eating delicious apple pie!"} # high similarity
+
+    state = PADState(pleasure=0.5, arousal=0.5, dominance=0.5)
+    entry3 = MemoryEntry(content="An apple is a red or green fruit", importance=0.5, emotional_state=state) # medium similarity
+
+    context = [entry1, entry2, entry3]
+
+    reranked = plugin.after_retrieval(context, query, 1)
+
+    # Expected order: entry2 (apple pie overlap), entry3 (apple overlap), entry1 (no overlap)
+    assert len(reranked) == 3
+    assert reranked[0] == entry2
+    assert reranked[1] == entry3
+    assert reranked[2] == entry1
+
+def test_semantic_reranker_mocked_similarity():
+    # Use a custom mock similarity function that returns hardcoded scores
+    mock_scores = {
+        "A": 0.1,
+        "B": 0.9,
+        "C": 0.5
+    }
+    def mock_similarity_fn(q, text):
+        return mock_scores.get(text, 0.0)
+
+    plugin = SemanticRerankerPlugin(similarity_fn=mock_similarity_fn)
+
+    context = ["A", "B", "C"]
+    reranked = plugin.after_retrieval(context, "query", 1)
+
+    # Expected order: B (0.9), C (0.5), A (0.1)
+    assert reranked == ["B", "C", "A"]
+
+def test_semantic_reranker_bootstrap_config():
+    plugin = SemanticRerankerPlugin()
+
+    # Bootstrap with a mock similarity function
+    config = {
+        "similarity_fn": lambda q, t: 1.0 if t == "target" else 0.0
+    }
+    # Create an event loop or run synchronously since bootstrap is async
+    import asyncio
+    asyncio.run(plugin.bootstrap(config))
+
+    context = ["other", "target", "other_too"]
+    reranked = plugin.after_retrieval(context, "query", 1)
+
+    # "target" must be first
+    assert reranked[0] == "target"
+
+def test_context_engine_integration():
+    plugin = SemanticRerankerPlugin()
+    engine = ContextEngine(plugins=[plugin])
+
+    entries = ["strawberry ice cream", "apple crumble dessert", "chocolate cake"]
+
+    def base_retrieval(query: str, user_id: int):
+        return entries
+
+    # Query specifically targetting apple
+    result = engine.retrieve_context("apple crumble", 1, base_retrieval)
+
+    # "apple crumble dessert" must be re-ranked to the front
+    assert len(result) == 3
+    assert result[0] == "apple crumble dessert"
+
+def test_semantic_reranker_empty_or_none():
+    plugin = SemanticRerankerPlugin()
+
+    assert plugin.after_retrieval([], "query", 1) == []
+    assert plugin.after_retrieval(["item"], "", 1) == ["item"]


### PR DESCRIPTION
This PR implements a live semantic re-ranking plugin (SemanticRerankerPlugin) for the Context Engine. It dynamically prioritizes/re-ranks retrieved Episodic Memory entries using localized lexical cosine similarity before returning them to the retrieval caller, ensuring that the most relevant context is presented first. It is fully covered by comprehensive unit tests, integrates cleanly with the existing ContextEngine, and operates purely using localized standard libraries with zero external dependencies.

---
*PR created automatically by Jules for task [9291041388292733726](https://jules.google.com/task/9291041388292733726) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SemanticRerankerPlugin` to re-rank context entries by cosine similarity
> - Adds [semantic_reranker.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/655/files#diff-bde0c4ac5bf8b64ebb89b80b7844a3bd4b13241fff64e2a18cb9980a4c556e80) implementing `SemanticRerankerPlugin`, a `ContextPlugin` that scores and re-orders retrieved context entries by lexical cosine similarity to the query in `after_retrieval`.
> - Similarity is computed via a built-in `compute_cosine_similarity` function using lowercase word-frequency vectors; a custom similarity function can be injected at construction or via bootstrap config.
> - `_get_entry_text` handles string, dict, and object entry types to extract text for scoring.
> - Adds full test coverage in [tests/test_semantic_reranker.py](https://github.com/kazah4359-lgtm/Magda-agent/pull/655/files#diff-d7e9890d51233e99cfa67b761505ff02e367e938005054bafdb89f68b45eb769), including edge cases and an integration test with `ContextEngine`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c14a32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->