### PR TITLE
feat: OpenClaw-RL Real-time Policy Gradient Updater

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10476,7 +10476,7 @@
     },
     {
       "id": "a1027164-23de-483e-b86a-070a82924066",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "high",
       "title": "OpenClaw-RL Real-time Policy Gradient Updater",
@@ -23762,6 +23762,60 @@
       "acceptance": [
         "Negotiation protocol handles fuzzy-matching using embeddings.",
         "Tests mock vector retrieval and fallback loop logic."
+      ]
+    },
+    {
+      "id": "new-openai-realtime-guardrail-fallback",
+      "title": "Realtime Guardrail Fallback mechanism",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a realtime guardrail fallback that intercepts failed policy layers and routes immediately to a safe fallback skill without interrupting the core agent loop.",
+      "area": "safety",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/guardrails.py",
+        "tests/test_guardrails.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Realtime fallback intercepts policy violation exceptions.",
+        "Routes execution to a safe fallback state.",
+        "Tests mock policy violations and verify safe fallback."
+      ]
+    },
+    {
+      "id": "new-claude-context-compression-v1",
+      "title": "Context Compression for Selective Retrieval",
+      "description": "Inspired by Claude Agent SDK trend: Implement a context compression module that dynamically reduces the working memory footprint by summarizing non-essential information before generating a plan.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/context_compression.py",
+        "tests/test_context_compression.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module identifies older or less important working memory context.",
+        "Compresses the context via summary while retaining semantic meaning.",
+        "Tests verify memory size reduction and semantic retention."
+      ]
+    },
+    {
+      "id": "new-claude-subagent-spawning-v1",
+      "title": "Subagent Spawning with Isolation",
+      "description": "Inspired by Claude Agent SDK trend: Implement a specialized subagent spawner module that allows the agent to spin up a focused sub-task agent in an isolated context namespace.",
+      "area": "architecture",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/subagent_spawning.py",
+        "tests/test_subagent_spawning.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent is initialized with an isolated context window.",
+        "Subagent successfully executes a mock task.",
+        "Tests verify context does not bleed between the parent and subagent."
       ]
     }
   ]

--- a/magda_agent/learning/policy_gradient.py
+++ b/magda_agent/learning/policy_gradient.py
@@ -1,0 +1,73 @@
+from typing import Dict, Optional
+import logging
+
+class RealtimePolicyGradientUpdater:
+    """
+    A real-time policy gradient module that modifies action weights dynamically
+    mid-session based on cumulative PAD emotion shifts without full consolidation.
+    """
+    def __init__(self) -> None:
+        """
+        Initializes the RealtimePolicyGradientUpdater with empty in-memory weight storage.
+        """
+        # Maps user_id to a dictionary mapping action_name to weight.
+        self._user_weights: Dict[str, Dict[str, float]] = {}
+
+    def process_mid_session_emotion_shift(
+        self,
+        user_id: str,
+        action_taken: str,
+        pleasure_shift: float,
+        arousal_shift: float,
+        dominance_shift: float
+    ) -> None:
+        """
+        Processes mid-session cumulative PAD emotion shifts and adjusts action weights
+        dynamically in-memory.
+
+        Args:
+            user_id (str): The ID of the user session.
+            action_taken (str): The action that was taken to cause this shift.
+            pleasure_shift (float): The change in the pleasure dimension (-1.0 to 1.0).
+            arousal_shift (float): The change in the arousal dimension (-1.0 to 1.0).
+            dominance_shift (float): The change in the dominance dimension (-1.0 to 1.0).
+        """
+        if user_id not in self._user_weights:
+            self._user_weights[user_id] = {}
+
+        user_session = self._user_weights[user_id]
+
+        if action_taken not in user_session:
+            user_session[action_taken] = 1.0
+
+        current_weight = user_session[action_taken]
+
+        # Simple heuristic for real-time update based on pleasure and arousal shifts.
+        # High pleasure increases weight, low pleasure decreases it.
+        # High arousal magnifies the effect.
+        magnifier = 1.0 + max(0.0, arousal_shift)
+        weight_shift = (pleasure_shift * 0.2) * magnifier
+
+        new_weight = current_weight + weight_shift
+        # Bounding the weights between 0.1 and 3.0
+        new_weight = max(0.1, min(3.0, new_weight))
+
+        user_session[action_taken] = new_weight
+
+        logging.info(
+            f"PolicyGradientUpdater: User '{user_id}' action '{action_taken}' "
+            f"weight updated from {current_weight:.2f} to {new_weight:.2f} "
+            f"(P_shift={pleasure_shift:.2f}, A_shift={arousal_shift:.2f})"
+        )
+
+    def get_dynamic_action_weights(self, user_id: str) -> Dict[str, float]:
+        """
+        Retrieves the dynamically adjusted action weights for a given user.
+
+        Args:
+            user_id (str): The ID of the user session.
+
+        Returns:
+            Dict[str, float]: A dictionary mapping action names to their current weights.
+        """
+        return self._user_weights.get(user_id, {})

--- a/tests/test_policy_gradient.py
+++ b/tests/test_policy_gradient.py
@@ -1,0 +1,99 @@
+import pytest
+from magda_agent.learning.policy_gradient import RealtimePolicyGradientUpdater
+
+def test_initial_weights_empty() -> None:
+    """Test that initially there are no weights for a new user."""
+    updater = RealtimePolicyGradientUpdater()
+    weights = updater.get_dynamic_action_weights("user_1")
+    assert weights == {}
+
+def test_positive_emotion_shift_increases_weight() -> None:
+    """Test that a positive pleasure shift increases the action weight."""
+    updater = RealtimePolicyGradientUpdater()
+
+    updater.process_mid_session_emotion_shift(
+        user_id="user_1",
+        action_taken="tell_joke",
+        pleasure_shift=0.5,
+        arousal_shift=0.0,
+        dominance_shift=0.0
+    )
+
+    weights = updater.get_dynamic_action_weights("user_1")
+    assert "tell_joke" in weights
+    assert weights["tell_joke"] > 1.0
+    assert abs(weights["tell_joke"] - 1.1) < 1e-6
+
+def test_negative_emotion_shift_decreases_weight() -> None:
+    """Test that a negative pleasure shift decreases the action weight."""
+    updater = RealtimePolicyGradientUpdater()
+
+    updater.process_mid_session_emotion_shift(
+        user_id="user_2",
+        action_taken="send_alert",
+        pleasure_shift=-0.5,
+        arousal_shift=0.0,
+        dominance_shift=0.0
+    )
+
+    weights = updater.get_dynamic_action_weights("user_2")
+    assert "send_alert" in weights
+    assert weights["send_alert"] < 1.0
+    assert abs(weights["send_alert"] - 0.9) < 1e-6
+
+def test_arousal_magnifies_shift() -> None:
+    """Test that high arousal magnifies the effect of the pleasure shift."""
+    updater1 = RealtimePolicyGradientUpdater()
+    updater2 = RealtimePolicyGradientUpdater()
+
+    updater1.process_mid_session_emotion_shift(
+        user_id="user_3",
+        action_taken="dance",
+        pleasure_shift=0.5,
+        arousal_shift=0.0,
+        dominance_shift=0.0
+    )
+
+    updater2.process_mid_session_emotion_shift(
+        user_id="user_3",
+        action_taken="dance",
+        pleasure_shift=0.5,
+        arousal_shift=1.0,
+        dominance_shift=0.0
+    )
+
+    weights1 = updater1.get_dynamic_action_weights("user_3")
+    weights2 = updater2.get_dynamic_action_weights("user_3")
+
+    assert weights2["dance"] > weights1["dance"]
+    assert abs(weights2["dance"] - 1.2) < 1e-6
+
+def test_weight_bounding() -> None:
+    """Test that weights remain within the 0.1 to 3.0 bounds."""
+    updater = RealtimePolicyGradientUpdater()
+
+    # Try to push below 0.1
+    for _ in range(20):
+        updater.process_mid_session_emotion_shift(
+            user_id="user_4",
+            action_taken="annoy",
+            pleasure_shift=-1.0,
+            arousal_shift=1.0,
+            dominance_shift=0.0
+        )
+
+    weights = updater.get_dynamic_action_weights("user_4")
+    assert weights["annoy"] == 0.1
+
+    # Try to push above 3.0
+    for _ in range(40):
+        updater.process_mid_session_emotion_shift(
+            user_id="user_5",
+            action_taken="praise",
+            pleasure_shift=1.0,
+            arousal_shift=1.0,
+            dominance_shift=0.0
+        )
+
+    weights_high = updater.get_dynamic_action_weights("user_5")
+    assert weights_high["praise"] == 3.0


### PR DESCRIPTION
This PR addresses the task `a1027164-23de-483e-b86a-070a82924066` for implementing a Realtime Policy Gradient Updater.

## Changes:
- Implemented `RealtimePolicyGradientUpdater` in `magda_agent/learning/policy_gradient.py` that processes Pleasure-Arousal-Dominance (PAD) shifts and bounds weights dynamically.
- Implemented comprehensive mocked unit tests in `tests/test_policy_gradient.py`.
- Updated `agent_tasks.json` to mark the target task as "done".
- Generated and appended three new actionable "todo" tasks in `agent_tasks.json` inspired by June 2026 AI trends: Realtime guardrail fallback, Context compression for selective retrieval, and Subagent spawning with isolation.

All unit tests pass and task constraints have been strictly followed.

---
*PR created automatically by Jules for task [1624406237281336137](https://jules.google.com/task/1624406237281336137) started by @kazah4359-lgtm*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RealtimePolicyGradientUpdater` to adjust per-user action weights from PAD emotion shifts
> - Adds [`RealtimePolicyGradientUpdater`](https://github.com/kazah4359-lgtm/Magda-agent/pull/656/files#diff-d0ddec95d8cbc3730e709806ee7de301fc7e3f35934e433c1ef1a08781ab03a5) which stores per-user action weights in-memory and updates them based on pleasure and arousal shift inputs from the PAD emotion model.
> - Weight updates multiply the pleasure shift by 0.2, scaled by `1.0 + max(0, arousal_shift)`, and clamp the result to `[0.1, 3.0]`. Weights default to `1.0` on first access.
> - Adds five unit tests in [`tests/test_policy_gradient.py`](https://github.com/kazah4359-lgtm/Magda-agent/pull/656/files#diff-49f5b647599087c7076571cec3154b4edf31a11d1fea6396cba6562c8232ec9c) covering empty initial state, positive/negative shifts, arousal magnification, and clamping bounds.
> - Risk: weights are in-memory only and are lost on process restart; there is no persistence layer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be40570.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->