### PR TITLE
feat: Implement MCP Tool Registry Bridge

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10565,7 +10565,7 @@
     },
     {
       "id": "bacb2725-19cd-40af-8e0c-83948922331e",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Tool Registry Bridge",
@@ -23977,6 +23977,57 @@
         "Policy interceptor validates tool parameters before execution.",
         "Blocks executions that violate dynamic policies.",
         "Tests mock policy violations and verify the block."
+      ]
+    },
+    {
+      "id": "5665e438-fe31-48b3-9732-510c09422d30",
+      "title": "A2A Discovery Secure Token Authentication V2",
+      "description": "Inspired by June 2026 A2A standards trend: Implement an OAuth2 style token validation step during mDNS peer discovery before trusting any remote Agent Card.",
+      "area": "integration",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mdns_secure_v2.py",
+        "tests/test_a2a_mdns_secure_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Discovery requires token authentication before accepting an Agent Card.",
+        "Tests mock token exchange and drop unauthorized cards."
+      ]
+    },
+    {
+      "id": "2cd3ff2d-b00d-4574-a335-75c2e910355f",
+      "title": "OpenClaw Virtual Context Lifecycle Manager V3",
+      "description": "Inspired by OpenClaw trends (June 2026): Implement an intelligent background process that periodically scans and archives idle virtual contexts from subagents to free up memory constraints.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_lifecycle_v3.py",
+        "tests/test_virtual_context_lifecycle_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lifecycle manager detects idle context boundaries and triggers Episodic Memory archiving.",
+        "Tests mock context engine states and verify cleanup."
+      ]
+    },
+    {
+      "id": "2c46d414-a243-4673-a2f4-087c97a9f838",
+      "title": "MCP Server Sandbox Resource Quota Enforcement V1",
+      "description": "Inspired by MCP and Agent Guard trends: Implement CPU and memory resource quota enforcement within the MCP Sandbox execution environment for action tools.",
+      "area": "security",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/security/mcp_sandbox_quota_v1.py",
+        "tests/test_mcp_sandbox_quota_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Quota enforcer bounds container execution by RAM/CPU.",
+        "Tests verify OOM situations are gracefully caught and handled."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_registry_bridge.py
+++ b/magda_agent/skills/mcp_registry_bridge.py
@@ -1,0 +1,50 @@
+"""
+Bridge to register Magda skills exported via MCPSkillExporter directly into an MCPRegistryV7.
+"""
+from typing import Any, Dict
+import logging
+
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_exporter import MCPSkillExporter
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+
+class MCPRegistryBridge:
+    """
+    Bridge that connects Magda's local SkillRegistry to the external MCPRegistryV7.
+    It takes skills generated and formatted by MCPSkillExporter and registers them
+    as dynamic tools into the MCPRegistryV7.
+    """
+
+    def __init__(self, skill_registry: SkillRegistry, skill_exporter: MCPSkillExporter) -> None:
+        """
+        Initialize the MCPRegistryBridge.
+
+        Args:
+            skill_registry (SkillRegistry): The local registry containing dynamically generated skills.
+            skill_exporter (MCPSkillExporter): The exporter used to convert skills to MCP tool schemas.
+        """
+        self.skill_registry = skill_registry
+        self.skill_exporter = skill_exporter
+
+    def bridge_skills(self, mcp_registry: MCPRegistryV7) -> int:
+        """
+        Exports all local skills and registers them into the provided MCPRegistryV7.
+
+        Args:
+            mcp_registry (MCPRegistryV7): The destination MCP registry for the tools.
+
+        Returns:
+            int: The number of skills successfully registered.
+        """
+        tools = self.skill_exporter.list_tools()
+        registered_count = 0
+
+        for tool_schema in tools:
+            success = mcp_registry.register_tool(tool_schema)
+            if success:
+                registered_count += 1
+                logging.info(f"Bridged skill '{tool_schema.get('name')}' to MCP Registry.")
+            else:
+                logging.error(f"Failed to bridge skill '{tool_schema.get('name')}' to MCP Registry.")
+
+        return registered_count

--- a/tests/test_mcp_registry_bridge.py
+++ b/tests/test_mcp_registry_bridge.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_exporter import MCPSkillExporter
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+from magda_agent.skills.mcp_registry_bridge import MCPRegistryBridge
+
+def dummy_skill(arg1: str, arg2: int = 5) -> str:
+    """A dummy skill for testing."""
+    return f"{arg1} {arg2}"
+
+def test_bridge_skills_success():
+    """Test that skills are successfully bridged to MCPRegistryV7."""
+    registry = SkillRegistry()
+    registry.register_skill("dummy_skill", dummy_skill, "A dummy skill for testing.")
+
+    exporter = MCPSkillExporter(registry)
+    mcp_registry = MCPRegistryV7()
+    bridge = MCPRegistryBridge(registry, exporter)
+
+    # Initially, mcp_registry should be empty
+    assert len(mcp_registry.list_tools()) == 0
+
+    registered_count = bridge.bridge_skills(mcp_registry)
+
+    # Should have registered 1 skill
+    assert registered_count == 1
+    assert "dummy_skill" in mcp_registry.list_tools()
+
+    tool = mcp_registry.get_tool("dummy_skill")
+    assert tool["name"] == "dummy_skill"
+    assert tool["description"] == "A dummy skill for testing."
+    assert "inputSchema" in tool
+    assert tool["inputSchema"]["type"] == "object"
+    assert "arg1" in tool["inputSchema"]["properties"]
+
+def test_bridge_skills_failure(monkeypatch):
+    """Test that failed registrations are handled correctly."""
+    registry = SkillRegistry()
+    registry.register_skill("dummy_skill", dummy_skill, "A dummy skill for testing.")
+
+    exporter = MCPSkillExporter(registry)
+    mcp_registry = MCPRegistryV7()
+
+    # Mock the register_tool method to always fail
+    def mock_register_tool(tool_schema):
+        return False
+
+    monkeypatch.setattr(mcp_registry, "register_tool", mock_register_tool)
+
+    bridge = MCPRegistryBridge(registry, exporter)
+    registered_count = bridge.bridge_skills(mcp_registry)
+
+    # Should have registered 0 skills
+    assert registered_count == 0
+    assert len(mcp_registry.list_tools()) == 0


### PR DESCRIPTION
This PR introduces the `MCPRegistryBridge` class, resolving task `bacb2725-19cd-40af-8e0c-83948922331e`.

The bridge connects the local `SkillRegistry` using `MCPSkillExporter` to register generated skills seamlessly as MCP-compatible JSON-RPC tools within `MCPRegistryV7`.
It also includes robust tests with pytest and updates the `agent_tasks.json` queue by adding 3 new trend-inspired tasks (A2A Secure Authentication, OpenClaw Virtual Context Lifecycle Manager V3, and MCP Sandbox Resource Quotas).

Necessary missing dependencies were installed during the workflow and verified to fix the test suite collection failures.

---
*PR created automatically by Jules for task [7167955262275016321](https://jules.google.com/task/7167955262275016321) started by @kazah4359-lgtm*