### PR TITLE
feat: implement Claude-inspired Generator/Evaluator subagent spawning

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10635,7 +10635,7 @@
     },
     {
       "id": "3d8247a3-5763-457d-a5d1-64320a49d5af",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "high",
       "title": "Claude-inspired Generator/Evaluator Subagent Spawning",
@@ -24134,6 +24134,60 @@
         "Wrapper intercepts all executions and runs taint tracking.",
         "Blocks executions found to have untrusted external source state in sensitive fields.",
         "Tests mock tool inputs and test both allowed and blocked states."
+      ]
+    },
+    {
+      "id": "new-hermes-procedural-workflows-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Procedural Workflows Conversion",
+      "description": "Inspired by Hermes Agent trend (June 2026): Implement a module that parses long-horizon tasks from agent memory and automatically converts them into reusable procedural workflow templates.",
+      "allowed_paths": [
+        "magda_agent/skills/hermes_workflows_v1.py",
+        "tests/test_hermes_workflows_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module correctly extracts sequence of steps from memory.",
+        "Generates a valid skill template from the sequence.",
+        "Tests mock memory contexts and assert generated template format."
+      ]
+    },
+    {
+      "id": "new-openclaw-rl-visualizer-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "title": "OpenClaw RL Weight Live Visualizer",
+      "description": "Inspired by OpenClaw Canvas visualization trend (June 2026): Build a websocket streamer that broadcasts live changes in RL habit weights to the external canvas for real-time monitoring.",
+      "allowed_paths": [
+        "magda_agent/learning/rl_canvas_visualizer_v2.py",
+        "tests/test_rl_canvas_visualizer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Visualizer module subscribes to weight change events.",
+        "Broadcasts correctly formatted JSON payloads over the websocket.",
+        "Tests mock connection and confirm expected data transmission."
+      ]
+    },
+    {
+      "id": "new-mcp-concurrency-limiter-v1",
+      "status": "todo",
+      "area": "security",
+      "risk": "medium",
+      "title": "MCP Tool Concurrency Rate Limiter",
+      "description": "Inspired by MCP runtime concurrency trend (June 2026): Introduce a rate limiter within the MCP Batching Executor to prevent external services from being overwhelmed by parallel subagent tool calls.",
+      "allowed_paths": [
+        "magda_agent/execution/mcp_rate_limiter_v1.py",
+        "tests/test_mcp_rate_limiter_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Rate limiter correctly throttles concurrent tool execution based on configured limits.",
+        "Queues requests when limit is reached without dropping them.",
+        "Tests simulate high concurrency and verify throttle boundaries."
       ]
     }
   ]

--- a/magda_agent/architecture/generator_evaluator.py
+++ b/magda_agent/architecture/generator_evaluator.py
@@ -1,0 +1,125 @@
+"""
+Generator/Evaluator Subagent Spawning.
+
+This module provides the PairedSubagentSpawner class which enables dynamic
+subagent spawning of paired Generator and Evaluator sub-agents for complex
+code synthesis tasks, inspired by the Claude Agent SDK three-agent architecture trend.
+"""
+
+import logging
+from typing import List, Dict, Any
+
+from magda_agent.architecture.subagent_spawning import SubagentSpawner
+
+
+class PairedSubagentSpawner(SubagentSpawner):
+    """
+    Manages the dynamic spawning of paired Generator and Evaluator sub-agents.
+    """
+
+    def __init__(self, max_context_tokens: int = 4000) -> None:
+        """
+        Initialize the PairedSubagentSpawner.
+
+        Args:
+            max_context_tokens: Maximum allowed token threshold for context.
+        """
+        super().__init__(max_context_tokens=max_context_tokens)
+
+    async def spawn_paired_agents(
+        self,
+        task_description: str,
+        full_context: List[Dict[str, Any]],
+        generator_executor: Any,
+        evaluator_executor: Any,
+        max_retries: int = 3
+    ) -> Dict[str, Any]:
+        """
+        Spawns paired Generator and Evaluator sub-agents to execute a specific task.
+        The Generator proposes a solution, and the Evaluator checks it. If the Evaluator
+        rejects it, the feedback is fed back to the Generator for a retry.
+
+        Args:
+            task_description: The task the subagents should perform.
+            full_context: The full conversation or execution context.
+            generator_executor: An async callable or object with an `execute` method
+                                that runs the Generator subagent.
+            evaluator_executor: An async callable or object with an `execute` method
+                                that runs the Evaluator subagent. Expected to return
+                                a dict with "approved" (bool) and "feedback" (str).
+            max_retries: The maximum number of generation attempts.
+
+        Returns:
+            The final result of the generation process as a dict.
+        """
+        compressed_context = self.compress_context(full_context)
+
+        execution_context = compressed_context.copy()
+        execution_context.append({
+            "role": "user",
+            "content": f"Task: {task_description}"
+        })
+
+        for attempt in range(1, max_retries + 1):
+            logging.info(f"Spawn Paired Agents: Attempt {attempt} of {max_retries} for task: {task_description}")
+
+            # Run Generator
+            if hasattr(generator_executor, "execute") and callable(generator_executor.execute):
+                proposal = await generator_executor.execute(execution_context)
+            elif callable(generator_executor):
+                proposal = await generator_executor(execution_context)
+            else:
+                raise TypeError("generator_executor must be callable or have an execute method")
+
+            # Prepare Evaluator context
+            eval_context = [
+                {"role": "system", "content": "You are the Evaluator subagent. Review the proposal against the task."},
+                {"role": "user", "content": f"Task: {task_description}\nProposal: {proposal}"}
+            ]
+
+            # Run Evaluator
+            if hasattr(evaluator_executor, "execute") and callable(evaluator_executor.execute):
+                evaluation = await evaluator_executor.execute(eval_context)
+            elif callable(evaluator_executor):
+                evaluation = await evaluator_executor(eval_context)
+            else:
+                raise TypeError("evaluator_executor must be callable or have an execute method")
+
+            # Try to handle MagicMock objects for testing context if it is mimicking a dict
+            if not isinstance(evaluation, dict) and not (hasattr(evaluation, "__getitem__") and hasattr(evaluation, "get")):
+                logging.warning("Evaluator response malformed, defaulting to rejected.")
+                evaluation = {"approved": False, "feedback": "Malformed evaluation response"}
+            elif isinstance(evaluation, dict) and "approved" not in evaluation:
+                logging.warning("Evaluator response malformed, defaulting to rejected.")
+                evaluation = {"approved": False, "feedback": "Malformed evaluation response"}
+            elif not isinstance(evaluation, dict) and hasattr(evaluation, "get"):
+                try:
+                    if evaluation.get("approved") is None and evaluation.get("feedback") is None:
+                        # Probably a MagicMock not configured properly, but fallback
+                        pass
+                except Exception:
+                    logging.warning("Evaluator response malformed, defaulting to rejected.")
+                    evaluation = {"approved": False, "feedback": "Malformed evaluation response"}
+
+            if evaluation.get("approved"):
+                logging.info(f"Evaluator approved proposal on attempt {attempt}")
+                return {
+                    "status": "success",
+                    "proposal": proposal,
+                    "attempts": attempt,
+                    "final_feedback": evaluation.get("feedback", "")
+                }
+            else:
+                feedback = evaluation.get("feedback", "No feedback provided.")
+                logging.info(f"Evaluator rejected proposal on attempt {attempt}: {feedback}")
+
+                # Append rejection feedback to Generator context for next attempt
+                execution_context.append({"role": "assistant", "content": str(proposal)})
+                execution_context.append({"role": "user", "content": f"Feedback: {feedback}. Please revise."})
+
+        logging.error(f"Paired agents failed to reach approval after {max_retries} attempts.")
+        return {
+            "status": "failed",
+            "attempts": max_retries,
+            "last_feedback": evaluation.get("feedback", "Max retries reached") if 'evaluation' in locals() else ""
+        }

--- a/tests/test_generator_evaluator.py
+++ b/tests/test_generator_evaluator.py
@@ -1,0 +1,111 @@
+"""
+Tests for the Generator/Evaluator Subagent Spawning module.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from magda_agent.architecture.generator_evaluator import PairedSubagentSpawner
+
+class AsyncExecutor:
+    def __init__(self, responses):
+        self.responses = responses
+        self.call_count = 0
+
+    async def execute(self, context):
+        resp = self.responses[self.call_count]
+        self.call_count += 1
+        return resp
+
+@pytest.mark.asyncio
+async def test_spawn_paired_agents_success_first_attempt():
+    spawner = PairedSubagentSpawner()
+
+    generator_executor = AsyncExecutor(["Proposed Code v1"])
+    evaluator_executor = AsyncExecutor([{"approved": True, "feedback": "Looks good."}])
+
+    result = await spawner.spawn_paired_agents(
+        task_description="Write a hello world function",
+        full_context=[{"role": "system", "content": "System"}],
+        generator_executor=generator_executor,
+        evaluator_executor=evaluator_executor,
+        max_retries=3
+    )
+
+    assert result["status"] == "success"
+    assert result["attempts"] == 1
+    assert result["proposal"] == "Proposed Code v1"
+
+    assert generator_executor.call_count == 1
+    assert evaluator_executor.call_count == 1
+
+@pytest.mark.asyncio
+async def test_spawn_paired_agents_success_after_retries():
+    spawner = PairedSubagentSpawner()
+
+    # Generator returns different proposals on each call
+    generator_executor = AsyncExecutor(["Proposed Code v1", "Proposed Code v2"])
+
+    # Evaluator rejects first, approves second
+    evaluator_executor = AsyncExecutor([
+        {"approved": False, "feedback": "Missing type hints."},
+        {"approved": True, "feedback": "Perfect."}
+    ])
+
+    result = await spawner.spawn_paired_agents(
+        task_description="Write a hello world function",
+        full_context=[{"role": "system", "content": "System"}],
+        generator_executor=generator_executor,
+        evaluator_executor=evaluator_executor,
+        max_retries=3
+    )
+
+    assert result["status"] == "success"
+    assert result["attempts"] == 2
+    assert result["proposal"] == "Proposed Code v2"
+
+    assert generator_executor.call_count == 2
+    assert evaluator_executor.call_count == 2
+
+@pytest.mark.asyncio
+async def test_spawn_paired_agents_failure_exceeds_retries():
+    spawner = PairedSubagentSpawner()
+
+    generator_executor = AsyncExecutor(["Flawed Code", "Flawed Code", "Flawed Code"])
+
+    # Evaluator always rejects
+    evaluator_executor = AsyncExecutor([
+        {"approved": False, "feedback": "Still wrong."},
+        {"approved": False, "feedback": "Still wrong."},
+        {"approved": False, "feedback": "Still wrong."}
+    ])
+
+    result = await spawner.spawn_paired_agents(
+        task_description="Write a hello world function",
+        full_context=[{"role": "system", "content": "System"}],
+        generator_executor=generator_executor,
+        evaluator_executor=evaluator_executor,
+        max_retries=2
+    )
+
+    assert result["status"] == "failed"
+    assert result["attempts"] == 2
+    assert result["last_feedback"] == "Still wrong."
+
+    assert generator_executor.call_count == 2
+    assert evaluator_executor.call_count == 2
+
+@pytest.mark.asyncio
+async def test_spawn_paired_agents_invalid_executors():
+    spawner = PairedSubagentSpawner()
+
+    generator_executor = "not a callable"
+    evaluator_executor = AsyncMock()
+
+    with pytest.raises(TypeError):
+        await spawner.spawn_paired_agents(
+            task_description="Write a hello world function",
+            full_context=[],
+            generator_executor=generator_executor,
+            evaluator_executor=evaluator_executor
+        )


### PR DESCRIPTION
This PR implements the Claude-inspired Generator/Evaluator Subagent Spawning task from `agent_tasks.json`.

**Changes Included:**
- `magda_agent/architecture/generator_evaluator.py`: Introduces `PairedSubagentSpawner` that inherits from `SubagentSpawner` to facilitate a generator-evaluator interactive loop.
- `tests/test_generator_evaluator.py`: Validates success on first attempt, success after multiple tries with feedback, failure handling after exhausting max retries, and properly catches invalid executor parameters.
- `agent_tasks.json`: Marked the completed task as `"done"` and added three new AI trend-based "todo" tasks (Hermes procedural workflows, OpenClaw RL visualizer, MCP concurrency limiter).
- `requirements.txt`/Poetry dependencies implicitly handled via virtualenv (installed `pytest-asyncio`). Tests successfully pass on the codebase.

---
*PR created automatically by Jules for task [5827798163166460913](https://jules.google.com/task/5827798163166460913) started by @kazah4359-lgtm*