### PR TITLE
feat: Implement MCP Schema Export CLI and update tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10722,7 +10722,7 @@
     },
     {
       "id": "mcp-schema-export-cli",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Schema Export CLI",
@@ -24404,6 +24404,42 @@
         "Telemetry module aggregates MCP tool metrics.",
         "Broadcasts structured reports over mock network interface.",
         "Tests verify data capture and proper formatting."
+      ]
+    },
+    {
+      "id": "a2a-discovery-dynamic-polling",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Discovery Dynamic Polling",
+      "description": "Inspired by the A2A (Agent-to-Agent Protocol) Standard trend: Implement a background polling mechanism for the A2ADiscovery service to periodically refresh available peer agents via mDNS, ensuring the Agent Cards list remains up-to-date and stale agents are evicted.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery.py",
+        "tests/test_a2a_discovery.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Background task periodically refreshes peer agent status.",
+        "Stale agent cards are removed after a configured timeout.",
+        "Unit tests verify polling behavior and eviction logic."
+      ]
+    },
+    {
+      "id": "context-engine-selective-compression",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "title": "Context Engine Selective Compression Plugin",
+      "description": "Inspired by Context Engine and Memory Architecture trends: Create a ContextEngine plugin that compresses semantic memory entries based on relevance scores to keep the context window small without losing important historical facts.",
+      "allowed_paths": [
+        "magda_agent/memory/context_compression_plugin.py",
+        "tests/test_context_compression_plugin.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin calculates relevance scores before passing them to the main context loop.",
+        "Entries falling below a threshold are summarily compressed using an LLM mock.",
+        "Tests verify the logic keeps overall token usage down."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_export_cli.py
+++ b/magda_agent/skills/mcp_export_cli.py
@@ -1,0 +1,49 @@
+"""CLI tool to export Magda's active skills as an MCP-compatible JSON schema document."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from magda_agent.skills import initialize_skills
+from magda_agent.skills.mcp_exporter import MCPSkillExporter
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    export_parser = subparsers.add_parser("export", help="Export active skills as MCP JSON schema")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "export":
+        try:
+            # Initialize registry with active skills
+            registry = initialize_skills()
+
+            # Use MCPSkillExporter to export schemas
+            exporter = MCPSkillExporter(registry)
+            tools = exporter.list_tools()
+
+            # Print the schema as formatted JSON
+            print(json.dumps(tools, ensure_ascii=False, indent=2))
+            return 0
+        except Exception as exc:
+            print(f"Failed to export skills: {exc}", file=sys.stderr)
+            return 1
+
+    parser.error(f"unknown command {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_mcp_export_cli.py
+++ b/tests/test_mcp_export_cli.py
@@ -1,0 +1,60 @@
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from magda_agent.skills.mcp_export_cli import main
+
+def test_mcp_export_cli_help(capsys):
+    """Test that the CLI prints help and exits with 0 on --help."""
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--help"])
+
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert "CLI tool to export Magda's active skills as an MCP-compatible JSON schema" in captured.out
+    assert "export" in captured.out
+
+def test_mcp_export_cli_export(capsys):
+    """Test that the CLI exports skills to standard output as valid JSON."""
+    result = main(["export"])
+
+    assert result == 0
+    captured = capsys.readouterr()
+
+    # Verify the output is valid JSON
+    output_json = json.loads(captured.out)
+
+    # Verify it is a list of tools
+    assert isinstance(output_json, list)
+
+    # Verify the structure matches MCP JSON schema requirements
+    if len(output_json) > 0:
+        first_tool = output_json[0]
+        assert "name" in first_tool
+        assert "description" in first_tool
+        assert "inputSchema" in first_tool
+
+        schema = first_tool["inputSchema"]
+        assert "type" in schema
+        assert schema["type"] == "object"
+        assert "properties" in schema
+
+@patch("magda_agent.skills.mcp_export_cli.initialize_skills")
+def test_mcp_export_cli_export_error(mock_initialize, capsys):
+    """Test that the CLI handles errors during export gracefully."""
+    mock_initialize.side_effect = Exception("Test exception")
+
+    result = main(["export"])
+
+    assert result == 1
+    captured = capsys.readouterr()
+
+    # Should print to stderr
+    assert "Failed to export skills: Test exception" in captured.err
+
+def test_mcp_export_cli_invalid_command(capsys):
+    """Test that the CLI handles invalid commands."""
+    with pytest.raises(SystemExit) as excinfo:
+        main(["invalid_command"])
+
+    assert excinfo.value.code != 0


### PR DESCRIPTION
This PR implements the `mcp-schema-export-cli` task. 

It introduces a new CLI script `magda_agent/skills/mcp_export_cli.py` that utilizes the existing `MCPSkillExporter` and `initialize_skills` to dump Magda's active skill registry into a well-formatted MCP JSON schema. 

I've also added tests mimicking the `codex_bridge.py` style to verify correct console output and handling of erroneous inputs. 

Finally, `agent_tasks.json` has been updated and two new tasks based on AI trends (A2A dynamic polling, Context engine selective compression) have been added to the backlog. Validation scripts pass successfully.

---
*PR created automatically by Jules for task [7770114790163607953](https://jules.google.com/task/7770114790163607953) started by @kazah4359-lgtm*