### PR TITLE
Implement A2A Task Status Ping

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10740,7 +10740,7 @@
     },
     {
       "id": "a2a-task-status-ping",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "low",
       "title": "A2A Task Status Ping",
@@ -24440,6 +24440,60 @@
         "Plugin calculates relevance scores before passing them to the main context loop.",
         "Entries falling below a threshold are summarily compressed using an LLM mock.",
         "Tests verify the logic keeps overall token usage down."
+      ]
+    },
+    {
+      "id": "a2a-swarm-intelligence-strategy-v5",
+      "title": "A2A Swarm Intelligence Strategy V5",
+      "description": "Inspired by Swarm Intelligence trends (June 2026): Implement an A2A strategy where multiple peer sub-agents collaboratively vote on the best task execution plan before any code changes are made.",
+      "area": "multi-agent",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_swarm_strategy_v5.py",
+        "tests/test_a2a_swarm_strategy_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Swarm strategy module coordinates proposals from peers.",
+        "Selects the most highly rated plan securely.",
+        "Tests verify mock peers voting logic."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-auth-v3",
+      "title": "MCP Dynamic Capability Auth V3",
+      "description": "Inspired by ACS security trends (June 2026): Implement dynamic runtime authentication constraints where specific MCP tools require re-authentication from the human operator mid-execution.",
+      "area": "security",
+      "risk": "critical",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/security/mcp_dynamic_auth_v3.py",
+        "tests/test_mcp_dynamic_auth_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module interrupts execution when tool requires runtime auth.",
+        "Awaits human approval context properly.",
+        "Tests use mock prompts for approval validation."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v3",
+      "title": "Claude Worktree Pruning and Resource Optimizer V3",
+      "description": "Inspired by Claude SDK trends (June 2026): Create a garbage collection routine that prunes idle Git worktrees created by subagents to optimize storage and system resource consumption.",
+      "area": "architecture",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/worktree_pruning_v3.py",
+        "tests/test_worktree_pruning_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Garbage collector safely deletes stale Git worktrees.",
+        "Active directories are preserved correctly.",
+        "Tests mock the OS module to verify file operations."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_ping.py
+++ b/magda_agent/integration/a2a_ping.py
@@ -1,0 +1,62 @@
+"""
+A2A Task Status Ping
+
+Inspired by the A2A Enterprise-ready trend, this module implements a status
+ping mechanism that allows Magda to check the progress of a delegated sub-task
+asynchronously over A2A without blocking.
+"""
+
+import httpx
+from typing import Dict, Any, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+class A2APingError(Exception):
+    """Base exception for A2A ping errors."""
+    pass
+
+class A2APingClient:
+    """
+    Client for checking the progress of delegated sub-tasks asynchronously via A2A.
+    """
+    def __init__(self, timeout: float = 5.0):
+        """
+        Initializes the A2A ping client.
+
+        Args:
+            timeout (float): The timeout for the HTTP request in seconds.
+        """
+        self.timeout = timeout
+
+    async def ping_task_status(self, endpoint_url: str, task_id: str) -> Dict[str, Any]:
+        """
+        Pings a peer agent to check the status of a specific delegated task.
+
+        Args:
+            endpoint_url (str): The HTTP(S) base URL of the remote agent.
+            task_id (str): The ID of the delegated task.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing the status of the task.
+
+        Raises:
+            A2APingError: If the remote agent is unreachable or returns an error.
+        """
+        url = f"{endpoint_url.rstrip('/')}/a2a/tasks/{task_id}/status"
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+                data = response.json()
+                logger.debug(f"Received status for task {task_id}: {data}")
+                return data
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error occurred while pinging task {task_id}: {e}")
+            raise A2APingError(f"Failed to ping task {task_id}: HTTP {e.response.status_code}") from e
+        except httpx.RequestError as e:
+            logger.error(f"Request error occurred while pinging task {task_id}: {e}")
+            raise A2APingError(f"Network error while pinging task {task_id}") from e
+        except Exception as e:
+            logger.error(f"Unexpected error while pinging task {task_id}: {e}")
+            raise A2APingError(f"Unexpected error while pinging task {task_id}") from e

--- a/tests/test_a2a_ping.py
+++ b/tests/test_a2a_ping.py
@@ -1,0 +1,46 @@
+import pytest
+import httpx
+from unittest.mock import AsyncMock, patch
+
+from magda_agent.integration.a2a_ping import A2APingClient, A2APingError
+
+@pytest.mark.asyncio
+async def test_ping_task_status_success():
+    client = A2APingClient(timeout=2.0)
+    mock_request = httpx.Request("GET", "http://peer-agent:8000/a2a/tasks/task-123/status")
+    mock_response = httpx.Response(200, json={"status": "in_progress", "progress": 50}, request=mock_request)
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response
+
+        result = await client.ping_task_status("http://peer-agent:8000", "task-123")
+
+        mock_get.assert_called_once_with("http://peer-agent:8000/a2a/tasks/task-123/status")
+        assert result == {"status": "in_progress", "progress": 50}
+
+@pytest.mark.asyncio
+async def test_ping_task_status_http_error():
+    client = A2APingClient(timeout=2.0)
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_request = httpx.Request("GET", "http://peer-agent:8000/a2a/tasks/task-404/status")
+        mock_response = httpx.Response(404, request=mock_request)
+        mock_get.side_effect = httpx.HTTPStatusError("Not Found", request=mock_request, response=mock_response)
+
+        with pytest.raises(A2APingError) as exc_info:
+            await client.ping_task_status("http://peer-agent:8000", "task-404")
+
+        assert "HTTP 404" in str(exc_info.value)
+
+@pytest.mark.asyncio
+async def test_ping_task_status_timeout():
+    client = A2APingClient(timeout=2.0)
+
+    with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_request = httpx.Request("GET", "http://peer-agent:8000/a2a/tasks/task-timeout/status")
+        mock_get.side_effect = httpx.RequestError("Timeout", request=mock_request)
+
+        with pytest.raises(A2APingError) as exc_info:
+            await client.ping_task_status("http://peer-agent:8000", "task-timeout")
+
+        assert "Network error while pinging task" in str(exc_info.value)


### PR DESCRIPTION
This PR completes the `a2a-task-status-ping` task from `agent_tasks.json`.

Changes:
1. Created `A2APingClient` in `magda_agent/integration/a2a_ping.py` to allow status checks via HTTP async pinging.
2. Wrote extensive pytest tests mocking the `httpx.AsyncClient.get` method in `tests/test_a2a_ping.py`.
3. Updated `agent_tasks.json` status to "done".
4. Appended 3 new trend-inspired (June 2026) AI tasks (`a2a-swarm-intelligence-strategy-v5`, `mcp-dynamic-capability-auth-v3`, `claude-worktree-pruning-optimizer-v3`).
5. Validated task structure via the validation script.

---
*PR created automatically by Jules for task [15446203075423447581](https://jules.google.com/task/15446203075423447581) started by @kazah4359-lgtm*