### PR TITLE
feat: Context Engine Metric Plugin V2 Implementation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10757,7 +10757,7 @@
     },
     {
       "id": "context-engine-metric-plugin-v2",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "low",
       "title": "Context Engine Metric Plugin V2",
@@ -24494,6 +24494,42 @@
         "Garbage collector safely deletes stale Git worktrees.",
         "Active directories are preserved correctly.",
         "Tests mock the OS module to verify file operations."
+      ]
+    },
+    {
+      "id": "claude-subagent-spawning-v8",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Subagent Spawning with Context Compression V8",
+      "description": "Inspired by Claude Agent SDK multi-agent trends: Implement an advanced subagent spawner that automatically compresses the parent agent's context using an LLM mock before spinning up a temporary isolated Git worktree for the subagent, ensuring low token usage.",
+      "allowed_paths": [
+        "magda_agent/architecture/subagent_spawning_v8.py",
+        "tests/test_subagent_spawning_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent is initialized with compressed context from the parent.",
+        "Subagent operates within an isolated git worktree.",
+        "Tests verify context compression size constraints and worktree isolation."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-ui-mcp-diff-v1",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "Canvas UI MCP Diff Streamer V1",
+      "description": "Inspired by OpenClaw Canvas Live Visualization and MCP tools trends: Create a specialized Canvas UI visualizer that exposes diff-based state updates of MCP tool executions over a WebSocket, rendering real-time JSON patches of tool outputs.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_mcp_diff_v1.py",
+        "tests/test_canvas_mcp_diff_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Visualizer component properly hooks into MCP execution layers to grab outputs.",
+        "Visualizer diffs state changes and streams valid JSON patches.",
+        "Tests mock MCP tool outputs and verify diff accuracy and websocket transmission format."
       ]
     }
   ]

--- a/magda_agent/memory/metric_plugin_v2.py
+++ b/magda_agent/memory/metric_plugin_v2.py
@@ -1,0 +1,88 @@
+import time
+from typing import Any, Dict, List, Optional
+from magda_agent.memory.context_engine import ContextPlugin
+from magda_agent.safety.audit_trail import AuditTrail
+
+class MetricPluginV2(ContextPlugin):
+    """
+    A ContextEngine plugin that measures token usage and latency of memory retrievals,
+    specifically tracking token length and latency during the assemble phase,
+    outputting to the AuditTrail.
+    """
+
+    def __init__(self, audit_trail: Optional[AuditTrail] = None):
+        """
+        Initialize the MetricPluginV2.
+
+        Args:
+            audit_trail: The AuditTrail instance to log to. If None, a new instance is created.
+        """
+        self.audit_trail = audit_trail or AuditTrail()
+
+    async def bootstrap(self, config: Dict[str, Any]) -> None:
+        """Initialize the plugin with configuration."""
+        pass
+
+    async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Process incoming content before it is stored or used."""
+        return content
+
+    def _estimate_tokens(self, text: str) -> int:
+        """
+        Rough estimation of tokens based on word count.
+        Using standard heuristic of 1 word ~ 1.33 tokens (or words / 0.75).
+        """
+        words = len(text.split())
+        return int(words / 0.75)
+
+    async def assemble(self, context_items: List[Any], metadata: Dict[str, Any]) -> str:
+        """
+        Assemble the context string from retrieved items for the LLM.
+        Tracks the token length and retrieval latency during this phase.
+        """
+        start_time = time.time()
+
+        assembled_str = "\n".join([str(item) for item in context_items])
+
+        end_time = time.time()
+        latency = end_time - start_time
+
+        token_count = self._estimate_tokens(assembled_str)
+
+        # Log to AuditTrail
+        self.audit_trail.log_call(
+            tool_name="context_assemble",
+            kwargs={
+                "metadata": metadata,
+                "estimated_tokens": token_count,
+            },
+            why="ContextEngine assemble metric logging",
+            result=f"Assembled {len(context_items)} items",
+            duration=latency,
+        )
+
+        return assembled_str
+
+    async def compact(self, context_items: List[Any], metadata: Dict[str, Any]) -> List[Any]:
+        """Compact or summarize the context when limits are reached."""
+        return context_items
+
+    def before_retrieval(self, query: str, user_id: int) -> str:
+        """Called before context is retrieved."""
+        return query
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """Called after context is retrieved."""
+        return context
+
+    def before_write(self, context: Any, user_id: int) -> Any:
+        """Called before context is written. Can modify the context."""
+        return context
+
+    def after_write(self, context: Any, user_id: int) -> None:
+        """Called after context is written."""
+        pass
+
+    def on_context_update(self, new_context: Any, user_id: int) -> None:
+        """Called when the overall context is updated."""
+        pass

--- a/tests/test_metric_plugin_v2.py
+++ b/tests/test_metric_plugin_v2.py
@@ -1,0 +1,59 @@
+import pytest
+from typing import Any, List, Dict
+from unittest.mock import MagicMock
+from magda_agent.memory.metric_plugin_v2 import MetricPluginV2
+from magda_agent.safety.audit_trail import AuditTrail
+from magda_agent.memory.context_engine import ContextEngine
+import time
+
+@pytest.mark.asyncio
+async def test_metric_plugin_v2_assemble_metrics() -> None:
+    """Test that MetricPluginV2 accurately captures token length and latency during the assemble phase."""
+    mock_audit_trail = MagicMock(spec=AuditTrail)
+    plugin = MetricPluginV2(audit_trail=mock_audit_trail)
+
+    # We test the plugin directly for its assemble hook behavior
+    context_items = ["item1", "item2 with some more text"]
+    metadata = {"user_id": 123, "some_key": "some_value"}
+
+    assembled_str = await plugin.assemble(context_items, metadata)
+
+    assert assembled_str == "item1\nitem2 with some more text"
+
+    assert mock_audit_trail.log_call.called
+
+    call_kwargs = mock_audit_trail.log_call.call_args.kwargs
+    assert call_kwargs["tool_name"] == "context_assemble"
+    assert call_kwargs["why"] == "ContextEngine assemble metric logging"
+    assert call_kwargs["result"] == "Assembled 2 items"
+
+    assert "duration" in call_kwargs
+    assert call_kwargs["duration"] >= 0.0
+
+    assert "kwargs" in call_kwargs
+    assert "metadata" in call_kwargs["kwargs"]
+    assert call_kwargs["kwargs"]["metadata"] == metadata
+
+    # tokens logic: "item1\nitem2 with some more text" has 6 words.
+    # int(6 / 0.75) = 8
+    assert call_kwargs["kwargs"]["estimated_tokens"] == 8
+
+def test_metric_plugin_v2_estimate_tokens() -> None:
+    """Test token estimation logic for MetricPluginV2."""
+    plugin = MetricPluginV2()
+    assert plugin._estimate_tokens("word one two three") == int(4 / 0.75) # 5
+
+@pytest.mark.asyncio
+async def test_metric_plugin_v2_empty_assemble() -> None:
+    """Test the assemble phase metrics when context items list is empty."""
+    mock_audit_trail = MagicMock(spec=AuditTrail)
+    plugin = MetricPluginV2(audit_trail=mock_audit_trail)
+
+    assembled_str = await plugin.assemble([], {})
+
+    assert assembled_str == ""
+
+    assert mock_audit_trail.log_call.called
+    call_kwargs = mock_audit_trail.log_call.call_args.kwargs
+    assert call_kwargs["kwargs"]["estimated_tokens"] == 0
+    assert call_kwargs["result"] == "Assembled 0 items"


### PR DESCRIPTION
This pull request implements the first "todo" task in `agent_tasks.json`, titled "Context Engine Metric Plugin V2".

**Implementation Details:**
- Created `MetricPluginV2` which inherits from `ContextPlugin`.
- Overrode the `assemble` hook to track the token length and the time taken during the context assembly.
- Logged the collected metrics to the `AuditTrail`.
- Provided proper type hints and docstrings.
- Created `pytest` tests using mocked dependencies for `AuditTrail`.

**Updates:**
- Marked `context-engine-metric-plugin-v2` as `"done"`.
- Appended two new trend-inspired tasks (`claude-subagent-spawning-v8` and `openclaw-canvas-ui-mcp-diff-v1`) to `agent_tasks.json`.
- Successfully validated `agent_tasks.json`.

---
*PR created automatically by Jules for task [1647284149693665253](https://jules.google.com/task/1647284149693665253) started by @kazah4359-lgtm*