### PR TITLE
Implement Hermes Cron Scheduler Loop v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10774,7 +10774,7 @@
     },
     {
       "id": "hermes-cron-scheduler-loop-v2",
-      "status": "todo",
+      "status": "done",
       "area": "core",
       "risk": "medium",
       "title": "Hermes Cron Scheduler Loop v2",
@@ -24530,6 +24530,57 @@
         "Visualizer component properly hooks into MCP execution layers to grab outputs.",
         "Visualizer diffs state changes and streams valid JSON patches.",
         "Tests mock MCP tool outputs and verify diff accuracy and websocket transmission format."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-caching-invalidation-v3",
+      "title": "MCP Tool Action Result Caching Invalidation V3",
+      "description": "Inspired by MCP kernel trends: Implement an explicit caching invalidation strategy for MCP read-only tools, clearing cached results intelligently based on configurable TTLs to ensure agents do not act on stale data.",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_caching_invalidation_v3.py",
+        "tests/test_mcp_caching_invalidation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP cache TTL invalidation is implemented.",
+        "Tests mock time and verify cache correctly evicts expired data."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-auth-handshake-revocation-v3",
+      "title": "A2A Enterprise Auth Handshake Revocation System V3",
+      "description": "Inspired by A2A standard trends: Build upon the token exchange handshake to implement a robust revocation system where a compromised peer can be instantly blacklisted and its tokens invalidated across the A2A sub-agent mesh.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth_revocation_v3.py",
+        "tests/test_a2a_auth_revocation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A token revocation registry is implemented.",
+        "Tests verify tokens are successfully revoked and denied upon subsequent handshake requests."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-failure-recovery-v2",
+      "title": "OpenClaw Trajectory Failure Recovery Analysis V2",
+      "description": "Inspired by OpenClaw Trajectory Quality Evaluation trends: Build a failure recovery analyzer that parses failed multi-turn RL trajectories to identify the exact step where context loss occurred, generating a lesson for procedural memory.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "low",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_failure_recovery_v2.py",
+        "tests/test_trajectory_failure_recovery_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Failure recovery analyzer processes failed trajectories and extracts structural lessons.",
+        "Tests mock failed traces and verify lesson generation."
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -34,6 +34,7 @@ from magda_agent.integration.a2a_security import A2ASecurityContext
 from magda_agent.consciousness.core import Consciousness
 from magda_agent.subconsciousness.reflection import Subconsciousness
 from magda_agent.evaluation.agentbench import daily_agentbench_eval
+from magda_agent.core.cron_scheduler_v2 import CronSchedulerV2
 from magda_agent.scheduler.cron import CronScheduler
 from magda_agent.scheduler.cron_reports import DailyReportScheduler
 from magda_agent.scheduler.cron_backups import perform_sqlite_backups
@@ -211,6 +212,7 @@ subconsciousness = Subconsciousness(
     interval=300
 )
 
+cron_scheduler_v2 = CronSchedulerV2()
 cron_scheduler = CronScheduler()
 daily_report_scheduler = DailyReportScheduler(scheduler=cron_scheduler)
 operations_scheduler = HermesCronSchedulerV3(db_path="operations.sqlite3")
@@ -257,6 +259,7 @@ cross_platform_dispatcher.register_platform("discord", discord_bridge)
 async def lifespan(app: FastAPI):
     # Startup
     await context_engine.bootstrap_all({})
+    cron_scheduler_v2.start()
     asyncio.create_task(cron_scheduler.start())
     asyncio.create_task(daily_report_scheduler.start())
     asyncio.create_task(operations_scheduler.start())
@@ -266,6 +269,7 @@ async def lifespan(app: FastAPI):
     asyncio.create_task(discord_bridge.start())
     yield
     # Shutdown
+    await cron_scheduler_v2.stop()
     await cron_scheduler.stop()
     await daily_report_scheduler.stop()
     await operations_scheduler.stop()

--- a/magda_agent/core/cron_scheduler_v2.py
+++ b/magda_agent/core/cron_scheduler_v2.py
@@ -1,0 +1,119 @@
+import asyncio
+import logging
+from datetime import datetime
+from typing import Callable, Coroutine, Dict, Any
+
+from croniter import croniter
+
+logger = logging.getLogger(__name__)
+
+
+class CronSchedulerV2:
+    """
+    A background loop scheduler for executing cron-like tasks.
+    Inspired by Hermes Agent scheduled operations.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the CronSchedulerV2."""
+        self.tasks: Dict[str, Dict[str, Any]] = {}
+        self._running: bool = False
+        self._task: asyncio.Task | None = None
+        self._sleep_task: asyncio.Task | None = None
+
+    def add_task(self, name: str, cron_expr: str, func: Callable[[], Coroutine[Any, Any, None]]) -> None:
+        """
+        Add a task to be scheduled.
+
+        Args:
+            name: A unique identifier for the task.
+            cron_expr: A cron expression string (e.g., "* * * * *").
+            func: An async callable to execute.
+        """
+        if not croniter.is_valid(cron_expr):
+            raise ValueError(f"Invalid cron expression: {cron_expr}")
+
+        self.tasks[name] = {
+            "cron_expr": cron_expr,
+            "func": func,
+            "next_run": croniter(cron_expr, datetime.now()).get_next(datetime)
+        }
+        logger.info(f"Added scheduled task: {name} with cron {cron_expr}")
+
+        # Wake up the loop if a task is added and it might need to run sooner
+        if self._running and self._sleep_task and not self._sleep_task.done():
+            self._sleep_task.cancel()
+
+    async def _loop(self) -> None:
+        """The main background loop that waits and executes tasks."""
+        while self._running:
+            now = datetime.now()
+
+            # Find tasks that are ready to run
+            to_run = []
+            for name, task_info in self.tasks.items():
+                if now >= task_info["next_run"]:
+                    to_run.append((name, task_info))
+
+            # Execute ready tasks concurrently
+            if to_run:
+                for name, task_info in to_run:
+                    logger.info(f"Executing scheduled task: {name}")
+                    try:
+                        asyncio.create_task(task_info["func"]())
+                    except Exception as e:
+                        logger.error(f"Failed to start task {name}: {e}", exc_info=True)
+
+                    # Schedule next run
+                    task_info["next_run"] = croniter(task_info["cron_expr"], datetime.now()).get_next(datetime)
+
+            # Calculate sleep time until the next earliest task
+            if self.tasks:
+                next_runs = [t["next_run"] for t in self.tasks.values()]
+                earliest_next_run = min(next_runs)
+                now = datetime.now()
+                sleep_seconds = (earliest_next_run - now).total_seconds()
+                if sleep_seconds < 0:
+                    sleep_seconds = 0
+            else:
+                sleep_seconds = 3600  # Default sleep if no tasks
+
+            # Sleep until next task or cancelled
+            if sleep_seconds > 0 and self._running:
+                try:
+                    self._sleep_task = asyncio.create_task(asyncio.sleep(sleep_seconds))
+                    await self._sleep_task
+                except asyncio.CancelledError:
+                    pass
+            elif self._running:
+                # Yield control to event loop to avoid infinite synchronous loop
+                await asyncio.sleep(0.01)
+
+    def start(self) -> None:
+        """Start the background scheduler loop."""
+        if self._running:
+            return
+
+        self._running = True
+
+        # Reset next run times
+        now = datetime.now()
+        for task_info in self.tasks.values():
+            task_info["next_run"] = croniter(task_info["cron_expr"], now).get_next(datetime)
+
+        self._task = asyncio.create_task(self._loop())
+        logger.info("CronSchedulerV2 started.")
+
+    async def stop(self) -> None:
+        """Stop the background scheduler loop gracefully."""
+        self._running = False
+        if self._sleep_task and not self._sleep_task.done():
+            self._sleep_task.cancel()
+
+        if self._task:
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+        logger.info("CronSchedulerV2 stopped.")

--- a/tests/test_cron_scheduler_v2.py
+++ b/tests/test_cron_scheduler_v2.py
@@ -1,0 +1,92 @@
+import asyncio
+from datetime import datetime, timedelta
+import pytest
+from unittest.mock import patch, MagicMock
+from magda_agent.core.cron_scheduler_v2 import CronSchedulerV2
+
+@pytest.fixture
+def scheduler():
+    """Returns a new instance of CronSchedulerV2."""
+    return CronSchedulerV2()
+
+@pytest.mark.asyncio
+async def test_add_task_invalid_cron(scheduler):
+    """Test adding a task with an invalid cron expression."""
+    async def dummy_task():
+        pass
+    with pytest.raises(ValueError, match="Invalid cron expression"):
+        scheduler.add_task("test_task", "invalid_cron", dummy_task)
+
+@pytest.mark.asyncio
+async def test_add_task_valid_cron(scheduler):
+    """Test adding a task with a valid cron expression."""
+    async def dummy_task():
+        pass
+    scheduler.add_task("test_task", "* * * * *", dummy_task)
+    assert "test_task" in scheduler.tasks
+    assert scheduler.tasks["test_task"]["cron_expr"] == "* * * * *"
+
+@pytest.mark.asyncio
+async def test_scheduler_start_stop(scheduler):
+    """Test starting and stopping the scheduler loop."""
+    assert not scheduler._running
+
+    # Need to mock the loop behavior to not get stuck
+    with patch.object(scheduler, '_loop', new_callable=MagicMock) as mock_loop:
+        async def dummy_loop():
+            pass
+        mock_loop.side_effect = dummy_loop
+
+        scheduler.start()
+        assert scheduler._running
+        assert scheduler._task is not None
+
+        await scheduler.stop()
+        assert not scheduler._running
+
+@pytest.mark.asyncio
+async def test_scheduler_executes_task_on_schedule(scheduler):
+    """Test that the scheduler triggers a task when its schedule arrives."""
+    task_executed = asyncio.Event()
+
+    async def dummy_task():
+        task_executed.set()
+
+    scheduler.add_task("test_task", "* * * * *", dummy_task)
+
+    past_time = datetime.now() - timedelta(minutes=1)
+    scheduler.tasks["test_task"]["next_run"] = past_time
+
+    with patch('magda_agent.core.cron_scheduler_v2.croniter.get_next') as mock_get_next:
+        mock_get_next.return_value = datetime.now() + timedelta(minutes=60)
+
+        # Stop loop after one iteration
+        with patch('magda_agent.core.cron_scheduler_v2.asyncio.sleep') as mock_sleep:
+            async def stop_loop(*args, **kwargs):
+                scheduler._running = False
+            mock_sleep.side_effect = stop_loop
+
+            scheduler._running = True
+            await scheduler._loop()
+
+        assert task_executed.is_set()
+
+@pytest.mark.asyncio
+async def test_add_task_wakes_loop(scheduler):
+    """Test that adding a new task wakes up the sleeping loop."""
+    sleep_task = asyncio.create_task(asyncio.sleep(100))
+    scheduler._sleep_task = sleep_task
+    scheduler._running = True
+
+    async def dummy_task():
+        pass
+
+    scheduler.add_task("test_task", "* * * * *", dummy_task)
+
+    # cancel() schedules the cancellation but doesn't complete it instantly
+    # yield to the event loop so the cancellation is processed
+    await asyncio.sleep(0)
+
+    assert scheduler._sleep_task.cancelled() or scheduler._sleep_task.done()
+
+    scheduler._running = False


### PR DESCRIPTION
Implemented the `hermes-cron-scheduler-loop-v2` task according to `agent_tasks.json`. This adds a new background scheduler `CronSchedulerV2` that manages executing recurrent tasks defined by cron expressions. Tests are provided and it is integrated into the API lifecycle without disrupting existing schedulers. I also added three new "todo" tasks inspired by trends into `agent_tasks.json`.

---
*PR created automatically by Jules for task [14618985954194468687](https://jules.google.com/task/14618985954194468687) started by @kazah4359-lgtm*