### PR TITLE
feat: implement OpenClaw RL Canvas Dashboard v8 hook

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10913,7 +10913,7 @@
     },
     {
       "id": "openclaw-rl-canvas-dashboard-v8",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw RL Canvas Dashboard v8",
@@ -24884,6 +24884,60 @@
         "Agents can securely propose execution plans to peers.",
         "A consensus score determines which plan proceeds.",
         "Tests verify voting mechanics over mocked A2A interfaces."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-v2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Action Tool Exporter V2",
+      "description": "Inspired by the rising MCP (Model Context Protocol) trend: Implement an integration layer extending MCPSkillExporter to accurately register Magda's internal actions directly into an external MCP action tool registry, enabling cross-platform utility mapping.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_action_exporter_v2.py",
+        "tests/test_mcp_action_exporter_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter can construct valid MCP tool JSON schemas for registered skills.",
+        "Exporter gracefully handles missing parameter schemas.",
+        "Tests verify the output matches expected MCP JSON-RPC standards."
+      ]
+    },
+    {
+      "id": "agent-teams-git-worktree-v3",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Agent Teams Git Worktree V3",
+      "description": "Inspired by Claude Agent SDK's Agent Teams isolation: Implement a workspace manager that dynamically spins up isolated git worktrees for subagents to test code changes independently before committing.",
+      "allowed_paths": [
+        "magda_agent/architecture/git_worktree_v3.py",
+        "tests/test_git_worktree_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Manager successfully provisions a git worktree for a given subagent ID.",
+        "Manager cleans up the git worktree effectively after task completion or failure.",
+        "Tests verify worktree creation and teardown sequences using mocks."
+      ]
+    },
+    {
+      "id": "memory-context-pagination-letta-v1",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Memory Context Pagination Letta V1",
+      "description": "Inspired by MemGPT/Letta patterns: Create a context pagination manager for episodic memory that chunks lengthy interaction sequences to stay within strict token limits.",
+      "allowed_paths": [
+        "magda_agent/memory/letta_pagination_v1.py",
+        "tests/test_letta_pagination_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pagination manager automatically chunks long strings based on token length.",
+        "Preserves semantic context by grouping by message or episode.",
+        "Tests verify chunking logic avoids splitting in the middle of sentences."
       ]
     }
   ]

--- a/magda_agent/visualization/rl_dashboard_v8.py
+++ b/magda_agent/visualization/rl_dashboard_v8.py
@@ -1,0 +1,61 @@
+import logging
+import json
+import time
+from typing import Any, Dict, Optional
+
+class RLDashboardV8:
+    """
+    An OpenClaw Canvas-inspired telemetry hook for streaming online RL metric
+    shifts (PAD changes) to an external dashboard via WebSockets.
+    """
+
+    def __init__(self, websocket: Optional[Any] = None) -> None:
+        """
+        Initialize the RLDashboardV8.
+
+        Args:
+            websocket (Optional[Any]): An open asynchronous websocket connection.
+        """
+        self.websocket = websocket
+        self.logger = logging.getLogger(__name__)
+
+    async def broadcast_pad_shift(self, user_id: int, pad_shift: Dict[str, float]) -> None:
+        """
+        Broadcast an online RL PAD metric shift to the connected dashboard.
+
+        Args:
+            user_id (int): The ID of the user triggering the PAD shift.
+            pad_shift (Dict[str, float]): A dictionary containing 'pleasure', 'arousal', and 'dominance' float values.
+        """
+        payload = {
+            "type": "rl_pad_shift",
+            "timestamp": time.time(),
+            "data": {
+                "user_id": user_id,
+                "pad_shift": pad_shift
+            }
+        }
+        await self._broadcast(payload)
+
+    async def _broadcast(self, payload: Dict[str, Any]) -> None:
+        """
+        Helper method to format and send JSON payload over the websocket.
+
+        Args:
+            payload (Dict[str, Any]): The payload of the event.
+        """
+        if self.websocket is None:
+            self.logger.debug(f"Skipping broadcast for {payload.get('type')} - no websocket connected.")
+            return
+
+        try:
+            message = json.dumps(payload)
+            # Support send_text (standard FastAPI style used in tests)
+            if hasattr(self.websocket, "send_text"):
+                await self.websocket.send_text(message)
+            else:
+                # Fallback to standard send if send_text is not present
+                await self.websocket.send(message)
+            self.logger.debug(f"Successfully broadcasted {payload.get('type')} event.")
+        except Exception as e:
+            self.logger.error(f"Failed to broadcast {payload.get('type')} event: {e}")

--- a/tests/test_rl_dashboard_v8.py
+++ b/tests/test_rl_dashboard_v8.py
@@ -1,0 +1,80 @@
+import json
+import logging
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from magda_agent.visualization.rl_dashboard_v8 import RLDashboardV8
+
+@pytest.fixture
+def mock_websocket() -> MagicMock:
+    """Fixture providing a mock websocket with async send methods."""
+    mock_ws = MagicMock()
+    mock_ws.send_text = AsyncMock()
+    mock_ws.send = AsyncMock()
+    return mock_ws
+
+@pytest.mark.asyncio
+async def test_broadcast_pad_shift_with_send_text(mock_websocket: MagicMock) -> None:
+    """Test broadcasting PAD shift when websocket has send_text."""
+    # Delete send so we know send_text is used
+    del mock_websocket.send
+
+    dashboard = RLDashboardV8(websocket=mock_websocket)
+    pad_shift = {"pleasure": 0.1, "arousal": -0.05, "dominance": 0.2}
+
+    with patch('magda_agent.visualization.rl_dashboard_v8.time.time', return_value=12345.0):
+        await dashboard.broadcast_pad_shift(user_id=42, pad_shift=pad_shift)
+
+    mock_websocket.send_text.assert_called_once()
+    sent_message = mock_websocket.send_text.call_args[0][0]
+    payload = json.loads(sent_message)
+
+    assert payload["type"] == "rl_pad_shift"
+    assert payload["timestamp"] == 12345.0
+    assert payload["data"]["user_id"] == 42
+    assert payload["data"]["pad_shift"] == pad_shift
+
+@pytest.mark.asyncio
+async def test_broadcast_pad_shift_with_send(mock_websocket: MagicMock) -> None:
+    """Test broadcasting PAD shift when websocket only has send."""
+    # Delete send_text so we know send is used
+    del mock_websocket.send_text
+
+    dashboard = RLDashboardV8(websocket=mock_websocket)
+    pad_shift = {"pleasure": -0.1, "arousal": 0.5, "dominance": -0.2}
+
+    with patch('magda_agent.visualization.rl_dashboard_v8.time.time', return_value=54321.0):
+        await dashboard.broadcast_pad_shift(user_id=10, pad_shift=pad_shift)
+
+    mock_websocket.send.assert_called_once()
+    sent_message = mock_websocket.send.call_args[0][0]
+    payload = json.loads(sent_message)
+
+    assert payload["type"] == "rl_pad_shift"
+    assert payload["timestamp"] == 54321.0
+    assert payload["data"]["user_id"] == 10
+    assert payload["data"]["pad_shift"] == pad_shift
+
+@pytest.mark.asyncio
+async def test_broadcast_without_websocket(caplog: pytest.LogCaptureFixture) -> None:
+    """Test broadcasting when no websocket is connected."""
+    caplog.set_level(logging.DEBUG)
+    dashboard = RLDashboardV8(websocket=None)
+    pad_shift = {"pleasure": 0.0, "arousal": 0.0, "dominance": 0.0}
+
+    # Run the broadcast
+    await dashboard.broadcast_pad_shift(user_id=99, pad_shift=pad_shift)
+
+    # Check that debug log was written
+    assert "Skipping broadcast for rl_pad_shift - no websocket connected." in caplog.text
+
+@pytest.mark.asyncio
+async def test_broadcast_error_handling(mock_websocket: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
+    """Test error handling during broadcast."""
+    mock_websocket.send_text.side_effect = Exception("Websocket connection closed")
+    dashboard = RLDashboardV8(websocket=mock_websocket)
+
+    pad_shift = {"pleasure": 0.1, "arousal": 0.1, "dominance": 0.1}
+    await dashboard.broadcast_pad_shift(user_id=1, pad_shift=pad_shift)
+
+    assert "Failed to broadcast rl_pad_shift event: Websocket connection closed" in caplog.text


### PR DESCRIPTION
Implement an external dashboard hook for streaming OpenClaw online RL PAD metric shifts.

1. **New Module:** `magda_agent/visualization/rl_dashboard_v8.py` providing `RLDashboardV8` with async event broadcasting formatting to standard JSON `type`/`timestamp`/`data` format. Includes fallback logging when no websocket is provided.
2. **Testing:** Added `tests/test_rl_dashboard_v8.py` containing four pytest-asyncio tests verifying send, send_text handlers, logging output on fallback, and error boundaries without hitting external networks.
3. **Task Advancement:** Updated `agent_tasks.json`.
   - Set `openclaw-rl-canvas-dashboard-v8` to `"done"`.
   - Populated queue with three new low-to-medium risk tasks tracking the latest industry trends: "MCP Action Tool Exporter V2", "Agent Teams Git Worktree V3", and "Memory Context Pagination Letta V1". Validate tests run properly.

---
*PR created automatically by Jules for task [7557507230066105860](https://jules.google.com/task/7557507230066105860) started by @kazah4359-lgtm*