### PR TITLE
feat(skills): implement MCP Dynamic Tool Registry Synchronization

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -10930,7 +10930,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registry-sync",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registry Synchronization",
@@ -24938,6 +24938,60 @@
         "Pagination manager automatically chunks long strings based on token length.",
         "Preserves semantic context by grouping by message or episode.",
         "Tests verify chunking logic avoids splitting in the middle of sentences."
+      ]
+    },
+    {
+      "id": "a2a-swarm-intelligence-gossip-v2",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Swarm Intelligence Gossip Protocol v2",
+      "description": "Inspired by A2A standard trend: Implement an async gossip protocol module for the A2A Discovery Service, enabling agents to periodically broadcast and cache neighboring agent capabilities efficiently without central registries.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_gossip_v2.py",
+        "tests/test_a2a_gossip_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent capabilities are broadcast asynchronously to known peers.",
+        "Peer cache is updated securely with latest Agent Cards.",
+        "Tests verify gossip propagation and cache integrity using mocked network events."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-pruning-v4",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Pruning v4",
+      "description": "Inspired by OpenClaw RL online learning trend: Implement a background module that periodically reviews episodic memory trajectories, identifies sequences with consistent negative PAD shifts (failures), and prunes or compresses them to optimize context and vector storage.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_pruning_v4.py",
+        "tests/test_trajectory_pruning_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pruner module iterates over episodic memories.",
+        "Scores memory quality and evicts or compresses data below a configured reward threshold.",
+        "Tests use mocked ChromaDB interactions to verify eviction logic."
+      ]
+    },
+    {
+      "id": "claude-code-git-branch-protection-v2",
+      "status": "todo",
+      "area": "isolation",
+      "risk": "high",
+      "title": "Claude Code Feature Branch Protection Subagent v2",
+      "description": "Inspired by Claude Agent Teams Git Worktree Isolation (June 2026): Create an advanced sub-agent that wraps GitWorktreeManager, strictly enforcing git branching and pull request scoping rules before allowing parallel sub-agents to commit to shared branches.",
+      "allowed_paths": [
+        "magda_agent/isolation/git_branch_protection_v2.py",
+        "tests/test_git_branch_protection_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sub-agent is implemented to wrap Git operations.",
+        "It validates branch scoping rules and blocks unauthorized commits.",
+        "Tests verify behavior using mock git environments."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_registry_sync.py
+++ b/magda_agent/skills/mcp_registry_sync.py
@@ -1,0 +1,127 @@
+import asyncio
+import logging
+from typing import Dict, Any, Optional
+
+import httpx
+
+from magda_agent.skills.mcp_registry import MCPRegistry
+
+class MCPRegistrySync:
+    """
+    Background loop that periodically polls a configured MCP server URL
+    and dynamically registers or unregisters tools in the local MCPRegistry.
+    """
+
+    def __init__(self, registry: MCPRegistry, mcp_server_url: str, sync_interval: int = 60) -> None:
+        """
+        Initialize the MCPRegistrySync.
+
+        Args:
+            registry (MCPRegistry): The local registry to keep synchronized.
+            mcp_server_url (str): The remote MCP server URL to poll for tools.
+            sync_interval (int): Time in seconds between polling attempts. Defaults to 60.
+        """
+        self.registry = registry
+        self.mcp_server_url = mcp_server_url
+        self.sync_interval = sync_interval
+        self._running = False
+        self._task: Optional[asyncio.Task[None]] = None
+        self.logger = logging.getLogger(__name__)
+
+    async def _sync_loop(self) -> None:
+        """
+        The main background loop that periodically synchronizes the registry.
+        """
+        while self._running:
+            await self.sync_once()
+            if self._running:
+                try:
+                    await asyncio.sleep(self.sync_interval)
+                except asyncio.CancelledError:
+                    break
+
+    async def sync_once(self) -> None:
+        """
+        Performs a single synchronization cycle by querying the remote MCP server.
+        """
+        self.logger.debug(f"Starting sync cycle with MCP server: {self.mcp_server_url}")
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{self.mcp_server_url}/tools")
+                response.raise_for_status()
+                data = response.json()
+        except Exception as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: {e}")
+            return
+
+        if not isinstance(data, dict) or "tools" not in data or not isinstance(data["tools"], list):
+            self.logger.error(f"Invalid response format from MCP server {self.mcp_server_url}: 'tools' list not found.")
+            return
+
+        remote_tools: Dict[str, Dict[str, Any]] = {}
+        for tool in data["tools"]:
+            if isinstance(tool, dict) and "name" in tool:
+                remote_tools[tool["name"]] = tool
+
+        local_tools_names = set(self.registry.list_tools())
+        remote_tools_names = set(remote_tools.keys())
+
+        # Tools to add or update
+        for name, tool_schema in remote_tools.items():
+            if name not in local_tools_names:
+                # Add new tool
+                try:
+                    success = self.registry.load_tool(tool_schema)
+                    if not success:
+                        self.logger.warning(f"Failed to load new MCP tool: {name}")
+                except Exception as e:
+                     self.logger.error(f"Error loading new MCP tool {name}: {e}")
+            else:
+                # Tool already exists, we might need to update it (reload)
+                # To simplify, we'll reload it to ensure we have the latest schema
+                try:
+                     self.registry.reload_tool(tool_schema)
+                except Exception as e:
+                     self.logger.error(f"Error reloading existing MCP tool {name}: {e}")
+
+
+        # Tools to remove
+        tools_to_remove = local_tools_names - remote_tools_names
+        for name in tools_to_remove:
+             try:
+                 self.registry.unload_tool(name)
+                 self.logger.info(f"Unloaded MCP tool {name} as it is no longer present on the remote server.")
+             except Exception as e:
+                 self.logger.error(f"Error unloading MCP tool {name}: {e}")
+
+
+    def start(self) -> None:
+        """
+        Starts the background synchronization loop.
+        """
+        if self._running:
+            self.logger.warning("Sync loop is already running.")
+            return
+
+        self._running = True
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._sync_loop())
+        self.logger.info(f"Started MCPRegistrySync loop with interval {self.sync_interval}s.")
+
+    async def stop(self) -> None:
+        """
+        Stops the background synchronization loop.
+        """
+        if not self._running:
+            return
+
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        self.logger.info("Stopped MCPRegistrySync loop.")

--- a/tests/test_mcp_registry_sync.py
+++ b/tests/test_mcp_registry_sync.py
@@ -1,0 +1,128 @@
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import httpx
+import pytest
+
+from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.skills.mcp_registry_sync import MCPRegistrySync
+
+@pytest.fixture
+def registry() -> MCPRegistry:
+    return MCPRegistry()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_add_tool(registry: MCPRegistry) -> None:
+    sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "tools": [
+            {
+                "name": "test_tool_1",
+                "description": "A test tool"
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert "test_tool_1" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_remove_tool(registry: MCPRegistry) -> None:
+    # Pre-load a tool
+    registry.load_tool({
+        "name": "test_tool_to_remove",
+        "description": "Will be removed"
+    })
+    assert "test_tool_to_remove" in registry.list_tools()
+
+    sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=60)
+
+    # Remote server returns empty list of tools
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"tools": []}
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert "test_tool_to_remove" not in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_update_tool(registry: MCPRegistry) -> None:
+    # Pre-load a tool
+    registry.load_tool({
+        "name": "test_tool_to_update",
+        "description": "Old description"
+    })
+
+    sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=60)
+
+    # Remote server returns updated tool
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "tools": [
+            {
+                "name": "test_tool_to_update",
+                "description": "New description"
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    tool = registry.get_tool("test_tool_to_update")
+    assert tool["description"] == "New description"
+
+
+@pytest.mark.asyncio
+async def test_sync_once_http_error(registry: MCPRegistry) -> None:
+    registry.load_tool({
+        "name": "test_tool",
+        "description": "Should remain"
+    })
+
+    sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.side_effect = httpx.HTTPError("Network error")
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    # Tool should still be there because sync failed
+    assert "test_tool" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_start_stop() -> None:
+    registry = MCPRegistry()
+    sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=1)
+
+    with patch.object(sync, 'sync_once', new_callable=AsyncMock) as mock_sync_once:
+        sync.start()
+        assert sync._running is True
+        assert sync._task is not None
+
+        # let it run one cycle
+        await asyncio.sleep(0.1)
+
+        await sync.stop()
+        assert sync._running is False
+        assert sync._task is None
+
+        mock_sync_once.assert_called()


### PR DESCRIPTION
This PR implements the MCP Dynamic Tool Registry Synchronization module (`mcp-dynamic-tool-registry-sync`).

- **Implementation**: Created `MCPRegistrySync` (`magda_agent/skills/mcp_registry_sync.py`), which runs as a background asyncio task to poll a given remote MCP server endpoint (e.g. `/tools`) and synchronize the fetched tool schemas into the local `MCPRegistry`.
- **Testing**: Added `tests/test_mcp_registry_sync.py` using `pytest` and `unittest.mock.AsyncMock` to ensure no real network requests are made. The suite verifies proper tool addition, removal, updates, and error handling.
- **Manifest Updates**: Marked the task `mcp-dynamic-tool-registry-sync` as `done` in `agent_tasks.json`. Also added 3 new "todo" tasks inspired by June 2026 trends: A2A Swarm Intelligence Gossip, OpenClaw RL Trajectory Pruning, and Claude Code Feature Branch Protection. Validation passed.

---
*PR created automatically by Jules for task [13831633344758056217](https://jules.google.com/task/13831633344758056217) started by @kazah4359-lgtm*