### PR TITLE
Implement Claude SDK Subagent Context Compression

### DIFF
--- a/magda_agent/agents/context_compression.py
+++ b/magda_agent/agents/context_compression.py
@@ -112,3 +112,83 @@ class RPCPayloadCompressor:
         except Exception as e:
             logging.error(f"Failed to compress payload dynamically: {e}")
             return payload
+
+
+class ClaudeSubagentContextWrapper:
+    """
+    ClaudeSubagentContextWrapper intercepts subagent context payloads and shrinks them according to token limits
+    before delegating subtasks to minimize token overhead while preserving critical rules and constraints.
+    """
+
+    def __init__(self, llm: Optional[LLMClient] = None, compressor: Optional[Any] = None, max_length: int = 2000) -> None:
+        """
+        Initializes the ClaudeSubagentContextWrapper.
+
+        Args:
+            llm: Optional Language Model client to be used for summarization if compressor is not provided.
+            compressor: Optional compressor instance (e.g. SubagentContextCompressorV3 or RPCPayloadCompressor).
+            max_length: Maximum allowed context length before compression is triggered.
+        """
+        self.llm = llm
+        if compressor is not None:
+            self.compressor = compressor
+        elif llm is not None:
+            self.compressor = RPCPayloadCompressor(llm)
+        else:
+            self.compressor = None
+        self.max_length = max_length
+
+    async def wrap_payload(self, payload: Dict[str, Any], task: Optional[str] = None, max_length: Optional[int] = None) -> Dict[str, Any]:
+        """
+        Intercepts and compresses subagent payload dictionary before delegation.
+
+        Args:
+            payload: Payload dictionary containing subagent parameters (e.g., 'context', 'task', 'messages').
+            task: Optional subagent task description override.
+            max_length: Optional maximum length threshold override.
+
+        Returns:
+            The compressed payload dictionary.
+        """
+        limit = max_length if max_length is not None else self.max_length
+        result_payload = dict(payload)
+        if task and "task" not in result_payload:
+            result_payload["task"] = task
+
+        if self.compressor is None:
+            # Fallback simple truncation if no LLM/compressor is configured
+            context = result_payload.get("context", "")
+            if len(context) > limit:
+                result_payload["context"] = context[:limit]
+            return result_payload
+
+        if hasattr(self.compressor, "compress_payload"):
+            return await self.compressor.compress_payload(result_payload, max_length=limit)
+        elif hasattr(self.compressor, "compress_context"):
+            context = result_payload.get("context", "")
+            subagent_task = result_payload.get("task", task or "")
+            compressed_context = await self.compressor.compress_context(context, subagent_task, max_length=limit)
+            result_payload["context"] = compressed_context
+            return result_payload
+
+        return result_payload
+
+    async def wrap_context(self, context: str, task: str = "", max_length: Optional[int] = None) -> str:
+        """
+        Intercepts raw context string and compresses it if exceeding threshold.
+
+        Args:
+            context: Raw context string.
+            task: Subagent task description.
+            max_length: Optional maximum length threshold override.
+
+        Returns:
+            Compressed context string.
+        """
+        limit = max_length if max_length is not None else self.max_length
+        if len(context) <= limit:
+            return context
+
+        payload = {"context": context, "task": task}
+        wrapped = await self.wrap_payload(payload, task=task, max_length=limit)
+        return wrapped.get("context", context[:limit])

--- a/tests/test_context_compression_wrapper.py
+++ b/tests/test_context_compression_wrapper.py
@@ -1,0 +1,80 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.agents.context_compression import ClaudeSubagentContextWrapper, RPCPayloadCompressor
+
+
+@pytest.mark.asyncio
+async def test_wrapper_skips_compression_when_within_limit():
+    llm_mock = MagicMock()
+    llm_mock.chat_completion = AsyncMock(return_value="Compressed context output")
+
+    wrapper = ClaudeSubagentContextWrapper(llm=llm_mock, max_length=500)
+
+    short_context = "This is a short context well under five hundred characters."
+    payload = {"context": short_context, "task": "Analyze logs"}
+
+    result = await wrapper.wrap_payload(payload)
+
+    assert result["context"] == short_context
+    llm_mock.chat_completion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wrapper_compresses_large_payload_context():
+    llm_mock = MagicMock()
+    llm_mock.chat_completion = AsyncMock(return_value="Condensed context focusing on task. MUST follow safety rules.")
+
+    wrapper = ClaudeSubagentContextWrapper(llm=llm_mock, max_length=50)
+
+    long_context = "A" * 100 + " MUST follow safety rules."
+    payload = {"context": long_context, "task": "Execute step"}
+
+    result = await wrapper.wrap_payload(payload)
+
+    assert "Condensed context" in result["context"]
+    assert llm_mock.chat_completion.called
+
+
+@pytest.mark.asyncio
+async def test_wrapper_wrap_context_string():
+    llm_mock = MagicMock()
+    llm_mock.chat_completion = AsyncMock(return_value="Summarized context for task")
+
+    wrapper = ClaudeSubagentContextWrapper(llm=llm_mock, max_length=50)
+
+    long_context = "B" * 120
+    res_str = await wrapper.wrap_context(long_context, task="Subtask 1")
+
+    assert res_str == "Summarized context for task"
+
+
+@pytest.mark.asyncio
+async def test_wrapper_fallback_truncation_without_compressor():
+    wrapper = ClaudeSubagentContextWrapper(llm=None, compressor=None, max_length=30)
+
+    long_context = "1234567890" * 5
+    payload = {"context": long_context, "task": "No LLM task"}
+
+    result = await wrapper.wrap_payload(payload)
+
+    assert len(result["context"]) == 30
+    assert result["context"] == long_context[:30]
+
+
+@pytest.mark.asyncio
+async def test_critical_constraint_reinjection():
+    llm_mock = MagicMock()
+    # LLM summary accidentally omits the mandatory requirement keyword
+    llm_mock.chat_completion = AsyncMock(return_value="Summarized text without rules")
+
+    compressor = RPCPayloadCompressor(llm=llm_mock)
+    wrapper = ClaudeSubagentContextWrapper(compressor=compressor, max_length=20)
+
+    context_with_rule = "User info long text...\nYou MUST NOT delete production database."
+    payload = {"context": context_with_rule, "task": "Database maintenance"}
+
+    result = await wrapper.wrap_payload(payload)
+
+    assert "Summarized text without rules" in result["context"]
+    assert "PRESERVED CRITICAL CONSTRAINTS" in result["context"]
+    assert "You MUST NOT delete production database." in result["context"]


### PR DESCRIPTION
Implemented ClaudeSubagentContextWrapper in magda_agent/agents/context_compression.py to intercept subagent payloads and shrink context according to token limits before delegation, reducing token usage while preserving critical constraints. Added unit tests in tests/test_context_compression_wrapper.py.

---
*PR created automatically by Jules for task [15100064868744115067](https://jules.google.com/task/15100064868744115067) started by @kazah4359-lgtm*