### PR TITLE
Implement OpenClaw-RL Interactive Learner v7

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11124,7 +11124,7 @@
     },
     {
       "id": "openclaw-rl-interactive-learner-v7-37436a23",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Interactive Learner v7",

--- a/magda_agent/learning/interactive_learner_v7.py
+++ b/magda_agent/learning/interactive_learner_v7.py
@@ -1,0 +1,122 @@
+import logging
+from typing import Optional, List, Dict, Any
+
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+from magda_agent.user_model.model import UserModel
+
+class OpenClawInteractiveLearnerV7:
+    """
+    OpenClaw-RL Interactive Learner v7.
+    Processes multi-turn conversation traces to evaluate delayed implicit feedback via PAD shifts
+    and updates skill weights and user model preferences.
+    """
+
+    def __init__(
+        self,
+        habit_tracker: HabitTracker,
+        mirror_neurons: MirrorNeurons,
+        user_model: UserModel,
+    ) -> None:
+        """
+        Initializes the learner with habit tracker, mirror neurons, and user model dependencies.
+        """
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+        self.user_model = user_model
+
+    async def process_conversation_trace(
+        self,
+        trace: List[Dict[str, Any]],
+        user_id: int,
+    ) -> Dict[str, Any]:
+        """
+        Processes a multi-turn conversation trace and identifies PAD shifts to compute delayed implicit rewards.
+
+        Args:
+            trace (List[Dict[str, Any]]): List of turn dicts containing conversation signals (e.g., user_reply, action_context, skills_used, tool_output).
+            user_id (int): User identifier.
+
+        Returns:
+            Dict[str, Any]: A summary of the trace processing results including cumulative PAD shifts, total reward, and updated skills.
+        """
+        if not trace:
+            return {"reward": 0.0, "total_turns": 0, "pad_shifts": (0.0, 0.0, 0.0)}
+
+        total_p = 0.0
+        total_a = 0.0
+        total_d = 0.0
+        all_skills: List[str] = []
+        action_contexts: List[str] = []
+
+        for turn in trace:
+            user_reply = turn.get("user_reply", "") or turn.get("user_message", "")
+            action_ctx = turn.get("action_context", "") or turn.get("input_text", "")
+            tool_output = turn.get("tool_output", "")
+            skills = turn.get("skills_used", []) or turn.get("skills", [])
+
+            if action_ctx:
+                action_contexts.append(action_ctx)
+
+            for s in skills:
+                if s not in all_skills:
+                    all_skills.append(s)
+
+            signal_text = user_reply
+            if tool_output:
+                signal_text += f" [Tool Output: {tool_output}]"
+
+            if signal_text:
+                p_shift, a_shift, d_shift = self.mirror_neurons.empathize(signal_text)
+                total_p += p_shift
+                total_a += a_shift
+                total_d += d_shift
+
+        num_turns = len(trace)
+        avg_p = total_p / num_turns
+
+        # Calculate delayed implicit reward (scale from 0.0 to 10.0)
+        base_reward = (avg_p + 1.0) * 5.0
+        # Give bonus for positive pleasure trend over turns
+        if total_p > 0.0:
+            base_reward += min(2.0, total_p * 2.0)
+
+        delayed_reward = max(0.0, min(10.0, base_reward))
+
+        # Retrieve and update user model
+        model_data = self.user_model.get_model(user_id)
+        if "rl_v7_trace_metrics" not in model_data:
+            model_data["rl_v7_trace_metrics"] = []
+
+        model_data["rl_v7_trace_metrics"].append({
+            "reward": delayed_reward,
+            "turns": num_turns,
+            "avg_p_shift": avg_p,
+        })
+
+        if delayed_reward >= 5.0:
+            for skill in all_skills:
+                ctx_summary = " -> ".join(action_contexts) if action_contexts else "trace_context"
+                self.habit_tracker.record_usage(
+                    input_text=ctx_summary,
+                    skill_used=skill,
+                    evaluation_score=delayed_reward,
+                    user_id=user_id,
+                )
+            logging.info(
+                f"OpenClawRLV7: Positive delayed trace feedback (reward={delayed_reward:.2f}). "
+                f"Reinforced skills: {all_skills}"
+            )
+            model_data["communication_style"] = f"{model_data.get('communication_style', 'default')} (trace_validated)"
+        else:
+            logging.info(f"OpenClawRLV7: Low/Negative trace feedback (reward={delayed_reward:.2f}).")
+            model_data["communication_style"] = f"{model_data.get('communication_style', 'default')} (trace_cautious)"
+
+        self.user_model.save_model(user_id, model_data)
+
+        return {
+            "reward": delayed_reward,
+            "total_turns": num_turns,
+            "pad_shifts": (total_p, total_a, total_d),
+            "skills_updated": all_skills if delayed_reward >= 5.0 else [],
+        }

--- a/tests/test_interactive_learner_v7.py
+++ b/tests/test_interactive_learner_v7.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.interactive_learner_v7 import OpenClawInteractiveLearnerV7
+
+@pytest.mark.asyncio
+async def test_process_conversation_trace_positive():
+    habit_tracker = MagicMock()
+    mirror_neurons = MagicMock()
+    user_model = MagicMock()
+
+    user_model.get_model.return_value = {"communication_style": "friendly"}
+    mirror_neurons.empathize.return_value = (0.3, 0.1, 0.0)
+
+    learner = OpenClawInteractiveLearnerV7(
+        habit_tracker=habit_tracker,
+        mirror_neurons=mirror_neurons,
+        user_model=user_model,
+    )
+
+    trace = [
+        {
+            "user_reply": "That was great and amazing!",
+            "action_context": "code_search",
+            "skills_used": ["search_code_skill"],
+            "tool_output": "Success",
+        },
+        {
+            "user_reply": "Awesome work, excellent results!",
+            "action_context": "file_write",
+            "skills_used": ["write_file_skill"],
+            "tool_output": "Written 100 bytes",
+        },
+    ]
+
+    result = await learner.process_conversation_trace(trace=trace, user_id=101)
+
+    assert result["total_turns"] == 2
+    assert result["reward"] > 5.0
+    assert "search_code_skill" in result["skills_updated"]
+    assert "write_file_skill" in result["skills_updated"]
+
+    assert habit_tracker.record_usage.call_count == 2
+    user_model.save_model.assert_called_once()
+    saved_model = user_model.save_model.call_args[0][1]
+    assert "(trace_validated)" in saved_model["communication_style"]
+
+@pytest.mark.asyncio
+async def test_process_conversation_trace_negative():
+    habit_tracker = MagicMock()
+    mirror_neurons = MagicMock()
+    user_model = MagicMock()
+
+    user_model.get_model.return_value = {"communication_style": "neutral"}
+    mirror_neurons.empathize.return_value = (-0.4, 0.1, 0.0)
+
+    learner = OpenClawInteractiveLearnerV7(
+        habit_tracker=habit_tracker,
+        mirror_neurons=mirror_neurons,
+        user_model=user_model,
+    )
+
+    trace = [
+        {
+            "user_reply": "This is terrible and bad error",
+            "action_context": "execute_code",
+            "skills_used": ["run_code_skill"],
+            "tool_output": "Error 500",
+        }
+    ]
+
+    result = await learner.process_conversation_trace(trace=trace, user_id=202)
+
+    assert result["total_turns"] == 1
+    assert result["reward"] < 5.0
+    assert result["skills_updated"] == []
+
+    habit_tracker.record_usage.assert_not_called()
+    user_model.save_model.assert_called_once()
+    saved_model = user_model.save_model.call_args[0][1]
+    assert "(trace_cautious)" in saved_model["communication_style"]
+
+@pytest.mark.asyncio
+async def test_process_empty_trace():
+    habit_tracker = MagicMock()
+    mirror_neurons = MagicMock()
+    user_model = MagicMock()
+
+    learner = OpenClawInteractiveLearnerV7(
+        habit_tracker=habit_tracker,
+        mirror_neurons=mirror_neurons,
+        user_model=user_model,
+    )
+
+    result = await learner.process_conversation_trace(trace=[], user_id=303)
+
+    assert result["total_turns"] == 0
+    assert result["reward"] == 0.0
+    habit_tracker.record_usage.assert_not_called()
+    user_model.save_model.assert_not_called()


### PR DESCRIPTION
Implemented OpenClawInteractiveLearnerV7 in magda_agent/learning/interactive_learner_v7.py to process multi-turn conversation traces, analyze delayed implicit feedback using MirrorNeurons PAD shifts, update habit weights in HabitTracker, and update user preferences in UserModel. Added unit tests in tests/test_interactive_learner_v7.py and updated task status in agent_tasks.json.

---
*PR created automatically by Jules for task [3213545265619104699](https://jules.google.com/task/3213545265619104699) started by @kazah4359-lgtm*