### PR TITLE
feat: implement MCP Tool Pre-flight Validation V6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11141,7 +11141,7 @@
     },
     {
       "id": "mcp-action-tool-preflight-validation-v6-131f0c68",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Tool Pre-flight Validation V6",
@@ -25400,6 +25400,40 @@
         "Pruner correctly identifies worktrees that have not been modified recently.",
         "Pruner safely deletes stale worktrees without crashing active subagents.",
         "Tests mock os and subprocess to verify pruning logic."
+      ]
+    },
+    {
+      "id": "openclaw-rl-next-state-pipeline-v9-2b4a7812",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Next State Pipeline V9",
+      "description": "Inspired by OpenClaw RL trend: Implement a dedicated pipeline to parse next-state interaction signals directly from user text and map them to reward values for real-time tuning.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_pipeline_v9.py",
+        "tests/test_openclaw_rl_pipeline_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pipeline parses next-state signals.",
+        "Tests verify reward extraction."
+      ]
+    },
+    {
+      "id": "canvas-memory-telemetry-v5-9a8b7c6d",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "Canvas Memory Telemetry V5",
+      "description": "Inspired by OpenClaw Canvas visualization trend: Implement an export module to dynamically broadcast episodic memory consolidation events to a live dashboard via websocket.",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_memory_v5.py",
+        "tests/test_canvas_memory_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Events are formatted for Canvas UI.",
+        "Tests mock websocket broadcast."
       ]
     }
   ]

--- a/magda_agent/integration/mcp_concurrency_v3.py
+++ b/magda_agent/integration/mcp_concurrency_v3.py
@@ -5,8 +5,8 @@ import threading
 import uuid
 from typing import List, Dict, Any, Optional
 
+from magda_agent.integration.mcp_preflight_v6 import PreflightMCPServerWrapperV6
 from magda_agent.integration.mcp_server import MCPServer
-from magda_agent.integration.mcp_preflight_v5 import PreflightMCPServerWrapperV5
 
 
 class MCPConcurrentHandlerV3:
@@ -52,9 +52,9 @@ class MCPConcurrentHandlerV3:
             prefix: The server prefix/namespace.
             server: The MCPServer instance.
         """
-        # Since PreflightMCPServerWrapperV5 acts as a wrapper proxying handle_request,
+        # Since PreflightMCPServerWrapperV6 acts as a wrapper proxying handle_request,
         # but the concurrency handler accesses exporter and list_tools, we attach them.
-        preflight_server = PreflightMCPServerWrapperV5(server)
+        preflight_server = PreflightMCPServerWrapperV6(server)
         preflight_server.list_tools = server.list_tools
         preflight_server.exporter = server.exporter
         preflight_server.server_id = getattr(server, "server_id", None)

--- a/magda_agent/integration/mcp_preflight_v6.py
+++ b/magda_agent/integration/mcp_preflight_v6.py
@@ -1,0 +1,235 @@
+"""MCP Action Tools Pre-flight Validation V6.
+
+Provides a pre-flight validation mechanism for all MCP action tools before invoking JSON-RPC.
+"""
+
+import json
+import re
+import logging
+from typing import Any, Dict, List, Tuple, Optional
+from jsonschema import validate, ValidationError
+from magda_agent.skills.registry import SkillRegistry
+from magda_agent.skills.mcp_exporter import MCPSkillExporter
+from magda_agent.safety.taint import is_tainted
+from magda_agent.integration.mcp_server import MCPServer
+
+logger = logging.getLogger(__name__)
+
+# Common hazardous injection and path traversal pattern compiled regexes
+_HAZARDOUS_SHELL_PATTERNS = [
+    re.compile(r"rm\s+-rf", re.IGNORECASE),
+    re.compile(r";\s*bash", re.IGNORECASE),
+    re.compile(r";\s*sh", re.IGNORECASE),
+    re.compile(r"\bcurl\b", re.IGNORECASE),
+    re.compile(r"\bwget\b", re.IGNORECASE),
+]
+
+_PATH_TRAVERSAL_PATTERNS = [
+    re.compile(r"\.\./\.\."),
+    re.compile(r"/etc/passwd"),
+    re.compile(r"/etc/hosts"),
+    re.compile(r"\.env\b", re.IGNORECASE),
+    re.compile(r"id_rsa", re.IGNORECASE),
+]
+
+_SQL_INJECTION_PATTERNS = [
+    re.compile(r"'\s*or\s*'\d+'\s*=\s*'\d+", re.IGNORECASE),
+    re.compile(r"'\s*or\s*\d+\s*=\s*\d+", re.IGNORECASE),
+    re.compile(r"union\s+select", re.IGNORECASE),
+]
+
+
+class MCPPreflightValidatorV6:
+    """
+    Validator to perform pre-flight checks on MCP JSON-RPC requests
+    before executing the underlying tool or invoking the client.
+    """
+
+    def __init__(
+        self,
+        registry: Optional[SkillRegistry] = None,
+        forbidden_tools: Optional[List[str]] = None
+    ) -> None:
+        """
+        Initializes the MCPPreflightValidatorV6.
+
+        Args:
+            registry (Optional[SkillRegistry]): The skill registry to validate against.
+            forbidden_tools (Optional[List[str]]): List of explicitly blacklisted tool names.
+        """
+        self.registry = registry
+        self.forbidden_tools = forbidden_tools or ["forbidden_tool", "unsafe_execute", "nuke_system"]
+
+    def _check_string_for_hazards(self, val: str) -> Tuple[bool, str]:
+        """
+        Inspects a single string for hazardous patterns (shell injection, path traversal, SQLi).
+
+        Args:
+            val (str): The string parameter to check.
+
+        Returns:
+            Tuple[bool, str]: (is_safe, error_reason)
+        """
+        for pattern in _HAZARDOUS_SHELL_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous shell pattern detected: {pattern.pattern}"
+
+        for pattern in _PATH_TRAVERSAL_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous path traversal pattern detected: {pattern.pattern}"
+
+        for pattern in _SQL_INJECTION_PATTERNS:
+            if pattern.search(val):
+                return False, f"Hazardous SQL injection pattern detected: {pattern.pattern}"
+
+        return True, ""
+
+    def _validate_value_recursively(self, val: Any) -> Tuple[bool, str]:
+        """
+        Recursively checks parameter values for hazardous strings or taint.
+
+        Args:
+            val (Any): Any value to check.
+
+        Returns:
+            Tuple[bool, str]: (is_safe, error_reason)
+        """
+        if is_tainted(val):
+            return False, "Tainted data detected in parameters."
+
+        if isinstance(val, str):
+            is_safe, reason = self._check_string_for_hazards(val)
+            if not is_safe:
+                return False, reason
+
+        elif isinstance(val, list):
+            for item in val:
+                is_safe, reason = self._validate_value_recursively(item)
+                if not is_safe:
+                    return False, reason
+
+        elif isinstance(val, dict):
+            for k, v in val.items():
+                is_safe, reason = self._validate_value_recursively(k)
+                if not is_safe:
+                    return False, reason
+                is_safe, reason = self._validate_value_recursively(v)
+                if not is_safe:
+                    return False, reason
+
+        return True, ""
+
+    def validate_request_dict(self, request: Dict[str, Any]) -> Tuple[bool, int, str]:
+        """
+        Validates a parsed JSON-RPC request dictionary.
+
+        Args:
+            request (Dict[str, Any]): The JSON-RPC request dictionary.
+
+        Returns:
+            Tuple[bool, int, str]: (is_valid, error_code, error_message)
+        """
+        if not isinstance(request, dict):
+            return False, -32600, "Invalid Request: request must be an object."
+
+        if request.get("jsonrpc") != "2.0":
+            return False, -32600, "Invalid Request: jsonrpc version must be '2.0'."
+
+        method = request.get("method")
+        if not method or not isinstance(method, str):
+            return False, -32600, "Invalid Request: 'method' must be a non-empty string."
+
+        if is_tainted(method):
+            return False, -32000, "Pre-flight Blocked: tool name is tainted."
+
+        if method in self.forbidden_tools:
+            return False, -32000, f"Pre-flight Blocked: Tool '{method}' is blacklisted."
+
+        params = request.get("params", {})
+        if not isinstance(params, dict):
+            return False, -32602, "Invalid params: 'params' must be an object."
+
+        is_safe, reason = self._validate_value_recursively(params)
+        if not is_safe:
+            return False, -32000, f"Pre-flight Blocked: {reason}"
+
+        if self.registry:
+            if not self.registry.has_skill(method):
+                return False, -32601, f"Method not found: '{method}' is not registered."
+
+            func = self.registry.skills.get(method)
+            if func:
+                exporter = MCPSkillExporter(self.registry)
+                schema = exporter._get_json_schema(func)
+                try:
+                    validate(instance=params, schema=schema)
+                except ValidationError as e:
+                    return False, -32602, f"Invalid params: schema validation failed. {e.message}"
+
+        return True, 0, ""
+
+    def validate_payload(self, payload: str) -> Tuple[bool, int, str]:
+        """
+        Validates a raw JSON-RPC payload string.
+
+        Args:
+            payload (str): The raw JSON-RPC payload string.
+
+        Returns:
+            Tuple[bool, int, str]: (is_valid, error_code, error_message)
+        """
+        try:
+            request = json.loads(payload)
+        except json.JSONDecodeError:
+            return False, -32700, "Parse error: payload is not valid JSON."
+
+        return self.validate_request_dict(request)
+
+
+class PreflightMCPServerWrapperV6:
+    """
+    Wrapper for MCPServer to intercept JSON-RPC payload executions
+    and perform pre-flight validation before passing the request to the underlying server.
+    """
+
+    def __init__(self, server: MCPServer, validator: Optional[MCPPreflightValidatorV6] = None) -> None:
+        """
+        Initializes the PreflightMCPServerWrapperV6.
+
+        Args:
+            server (MCPServer): The MCPServer instance to wrap.
+            validator (Optional[MCPPreflightValidatorV6]): The validator to use.
+        """
+        self.server = server
+        self.validator = validator or MCPPreflightValidatorV6(registry=getattr(server.exporter, "registry", None))
+
+    async def handle_request(self, payload: str) -> str:
+        """
+        Intercepts and processes a JSON-RPC payload string with pre-flight checks.
+
+        Args:
+            payload (str): A JSON string representing the RPC request.
+
+        Returns:
+            str: A JSON string representing the RPC response.
+        """
+        is_valid, err_code, err_msg = self.validator.validate_payload(payload)
+
+        if not is_valid:
+            logger.warning(f"MCP Pre-flight intercept: code={err_code}, message={err_msg}")
+            try:
+                request = json.loads(payload)
+                req_id = request.get("id")
+            except Exception:
+                req_id = None
+
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {
+                    "code": err_code,
+                    "message": err_msg
+                }
+            })
+
+        return await self.server.handle_request(payload)

--- a/tests/test_mcp_preflight_v6.py
+++ b/tests/test_mcp_preflight_v6.py
@@ -1,0 +1,227 @@
+"""Tests for MCP Action Tools Pre-flight Validation V6."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.integration.mcp_preflight_v6 import MCPPreflightValidatorV6, PreflightMCPServerWrapperV6
+from magda_agent.integration.mcp_server import MCPServer
+from magda_agent.skills.registry import SkillRegistry
+
+
+@pytest.fixture
+def mock_registry():
+    registry = MagicMock(spec=SkillRegistry)
+    # By default, mock registry says all skills exist
+    registry.has_skill.return_value = True
+
+    # Provide a mock skill and its schema
+    def dummy_skill(arg1: str, arg2: int):
+        pass
+
+    registry.skills = {"safe_tool": dummy_skill}
+    return registry
+
+
+@pytest.fixture
+def validator(mock_registry):
+    return MCPPreflightValidatorV6(registry=mock_registry, forbidden_tools=["nuke_system", "rm_rf"])
+
+
+def test_validator_valid_request(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"arg1": "value1", "arg2": 42}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is True
+    assert code == 0
+
+
+def test_validator_invalid_jsonrpc(validator):
+    request = {
+        "jsonrpc": "1.0",
+        "id": 1,
+        "method": "safe_tool"
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32600
+    assert "jsonrpc version must be '2.0'" in msg
+
+
+def test_validator_blacklisted_tool(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "nuke_system"
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "blacklisted" in msg
+
+
+def test_validator_hazardous_shell_pattern(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"cmd": "echo hello ; bash"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous shell pattern" in msg
+
+
+def test_validator_hazardous_path_traversal(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"file": "../../secret.txt"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous path traversal" in msg
+
+
+def test_validator_hazardous_sqli(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"query": "' OR '1'='1"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous SQL injection" in msg
+
+
+def test_validator_nested_hazard(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {
+            "outer": {
+                "inner_list": ["safe", "curl http://evil.com"]
+            }
+        }
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32000
+    assert "Hazardous shell pattern" in msg
+
+
+def test_validator_unregistered_tool(validator, mock_registry):
+    mock_registry.has_skill.return_value = False
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "unknown_tool",
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32601
+    assert "not registered" in msg
+
+
+def test_validator_valid_schema(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"arg1": "hello", "arg2": 42}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is True
+    assert code == 0
+
+
+def test_validator_invalid_schema_missing_property(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        # Missing arg2
+        "params": {"arg1": "hello"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32602
+    assert "schema validation failed" in msg
+
+
+def test_validator_invalid_schema_wrong_type(validator):
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"arg1": "hello", "arg2": "not_an_integer"}
+    }
+    is_valid, code, msg = validator.validate_request_dict(request)
+    assert is_valid is False
+    assert code == -32602
+    assert "schema validation failed" in msg
+
+
+@pytest.mark.asyncio
+async def test_wrapper_delegates_valid_request():
+    mock_server = MagicMock(spec=MCPServer)
+    mock_server.handle_request = AsyncMock(return_value='{"jsonrpc": "2.0", "id": 1, "result": "success"}')
+
+    mock_registry = MagicMock(spec=SkillRegistry)
+    mock_registry.has_skill.return_value = True
+    def dummy_skill():
+        pass
+    mock_registry.skills = {"safe_tool": dummy_skill}
+
+    validator = MCPPreflightValidatorV6(registry=mock_registry)
+    wrapper = PreflightMCPServerWrapperV6(server=mock_server, validator=validator)
+
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool"
+    })
+
+    response = await wrapper.handle_request(payload)
+    mock_server.handle_request.assert_called_once_with(payload)
+    assert "success" in response
+
+
+@pytest.mark.asyncio
+async def test_wrapper_blocks_invalid_request():
+    mock_server = MagicMock(spec=MCPServer)
+    mock_server.handle_request = AsyncMock()
+
+    mock_registry = MagicMock(spec=SkillRegistry)
+    mock_registry.has_skill.return_value = True
+    def dummy_skill(cmd: str):
+        pass
+    mock_registry.skills = {"safe_tool": dummy_skill}
+
+    validator = MCPPreflightValidatorV6(registry=mock_registry)
+    wrapper = PreflightMCPServerWrapperV6(server=mock_server, validator=validator)
+
+    payload = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "safe_tool",
+        "params": {"cmd": "rm -rf /"}
+    })
+
+    response = await wrapper.handle_request(payload)
+
+    # Should not call the underlying server
+    mock_server.handle_request.assert_not_called()
+
+    resp_dict = json.loads(response)
+    assert resp_dict["error"]["code"] == -32000
+    assert "Hazardous shell pattern" in resp_dict["error"]["message"]


### PR DESCRIPTION
- Created `mcp_preflight_v6.py` defining `MCPPreflightValidatorV6` and `PreflightMCPServerWrapperV6`.
- Implemented static schema validation in `MCPPreflightValidatorV6.validate_request_dict` using `jsonschema.validate` and `MCPSkillExporter`.
- Integrated `PreflightMCPServerWrapperV6` in `mcp_concurrency_v3.py`.
- Added mock tests for schema validation in `tests/test_mcp_preflight_v6.py`.
- Updated `agent_tasks.json` by marking the V6 task as "done" and adding new OpenClaw RL and Canvas Memory Telemetry tasks.

---
*PR created automatically by Jules for task [6907788294075355029](https://jules.google.com/task/6907788294075355029) started by @kazah4359-lgtm*