### PR TITLE
feat: OpenClaw Canvas Live Memory Telemetry V6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11175,7 +11175,7 @@
     },
     {
       "id": "openclaw-canvas-live-memory-telemetry-v6-0587cf1e",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw Canvas Live Memory Telemetry V6",
@@ -25488,6 +25488,60 @@
         "Bridge can serialize Magda payloads to Semantic Kernel format.",
         "Bridge can deserialize incoming Semantic Kernel messages.",
         "Tests verify translation logic using mocked messages."
+      ]
+    },
+    {
+      "id": "mcp-skill-export-dynamic-v2-bf07cd86",
+      "title": "MCP Skill Dynamic Export V2",
+      "description": "Inspired by MCP standards trend (June 2026): Develop a dynamic exporter module that serializes Magda's active procedural skills into an MCP-compliant JSON schema in real time for external server integration.",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_dynamic_exporter_v2.py",
+        "tests/test_mcp_dynamic_exporter_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter correctly maps Magda skills to MCP JSON schema format.",
+        "Real-time updates trigger schema re-generation.",
+        "Pytest suite verifies schema compliance using mocked skills."
+      ]
+    },
+    {
+      "id": "hermes-autonomous-cron-scheduler-v3-f5403db4",
+      "title": "Hermes Autonomous Cron Scheduler V3",
+      "description": "Inspired by Hermes Agent scheduled operations (June 2026): Implement an asynchronous cron scheduler service that triggers background maintenance tasks (e.g., nightly backups, daily reports) without active human input.",
+      "status": "todo",
+      "area": "core",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/core/hermes_cron_scheduler_v3.py",
+        "tests/test_hermes_cron_scheduler_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler executes tasks on predefined cron schedules asynchronously.",
+        "Scheduler cleanly shuts down without hanging the event loop.",
+        "Tests use freeze_gun or mocked time to verify schedule triggers."
+      ]
+    },
+    {
+      "id": "claude-hierarchical-delegator-v5-719d65a4",
+      "title": "Claude Hierarchical Team Delegator V5",
+      "description": "Inspired by Claude Agent Teams trend (June 2026): Create a delegator subagent spawner that isolates context-heavy tasks into distinct Git worktrees, allowing parallel task execution without context pollution.",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/architecture/claude_team_delegator_v5.py",
+        "tests/test_claude_team_delegator_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Delegator spawns child subagents with strictly scoped git worktrees.",
+        "Context is partitioned and passed to subagents to prevent token overload.",
+        "Tests mock git and subprocess to verify isolation boundaries."
       ]
     }
   ]

--- a/magda_agent/telemetry/canvas_memory_v6.py
+++ b/magda_agent/telemetry/canvas_memory_v6.py
@@ -1,0 +1,62 @@
+import logging
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+class CanvasMemoryTelemetryV6:
+    """
+    An export module to broadcast episodic memory consolidation events
+    dynamically to a live dashboard using WebSockets, inspired by OpenClaw Canvas.
+    """
+
+    def __init__(self, websocket: Optional[Any] = None) -> None:
+        """
+        Initialize the CanvasMemoryTelemetryV6.
+
+        Args:
+            websocket (Optional[Any]): An open asynchronous websocket connection.
+        """
+        self.websocket = websocket
+        self.logger = logging.getLogger(__name__)
+
+    async def broadcast_consolidation_event(self, user_id: int, memories: List[Dict[str, Any]]) -> None:
+        """
+        Broadcast an episodic memory consolidation event to the connected Canvas client.
+
+        Args:
+            user_id (int): The ID of the user whose memories are being consolidated.
+            memories (List[Dict[str, Any]]): A list of memory dictionaries being consolidated.
+        """
+        payload = {
+            "type": "episodic_memory_consolidation",
+            "timestamp": time.time(),
+            "data": {
+                "user_id": user_id,
+                "consolidated_count": len(memories),
+                "memories": memories
+            }
+        }
+        await self._broadcast(payload)
+
+    async def _broadcast(self, payload: Dict[str, Any]) -> None:
+        """
+        Helper method to format and send JSON payload over the websocket.
+
+        Args:
+            payload (Dict[str, Any]): The payload of the event.
+        """
+        if self.websocket is None:
+            self.logger.debug(f"Skipping broadcast for {payload.get('type')} - no websocket connected.")
+            return
+
+        try:
+            message = json.dumps(payload)
+            # Support send_text (standard FastAPI style used in tests)
+            if hasattr(self.websocket, "send_text"):
+                await self.websocket.send_text(message)
+            else:
+                # Fallback to standard send if send_text is not present
+                await self.websocket.send(message)
+            self.logger.debug(f"Successfully broadcasted {payload.get('type')} event.")
+        except Exception as e:
+            self.logger.error(f"Failed to broadcast {payload.get('type')} event: {e}")

--- a/tests/test_canvas_memory_v6.py
+++ b/tests/test_canvas_memory_v6.py
@@ -1,0 +1,94 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from magda_agent.telemetry.canvas_memory_v6 import CanvasMemoryTelemetryV6
+
+@pytest.mark.asyncio
+async def test_broadcast_consolidation_event_send_text() -> None:
+    """Test broadcasting an event when websocket has send_text."""
+    mock_websocket = AsyncMock()
+    # Ensure send_text is a coroutine mock
+    mock_websocket.send_text = AsyncMock()
+
+    telemetry = CanvasMemoryTelemetryV6(websocket=mock_websocket)
+
+    user_id = 123
+    memories = [{"id": "mem_1", "content": "test memory 1"}]
+
+    with patch("time.time", return_value=1234567890.0):
+        await telemetry.broadcast_consolidation_event(user_id, memories)
+
+    expected_payload = {
+        "type": "episodic_memory_consolidation",
+        "timestamp": 1234567890.0,
+        "data": {
+            "user_id": user_id,
+            "consolidated_count": 1,
+            "memories": memories
+        }
+    }
+    expected_message = json.dumps(expected_payload)
+
+    mock_websocket.send_text.assert_awaited_once_with(expected_message)
+
+@pytest.mark.asyncio
+async def test_broadcast_consolidation_event_send() -> None:
+    """Test broadcasting an event when websocket only has send."""
+    mock_websocket = AsyncMock()
+    # Remove send_text attribute to trigger fallback to send
+    del mock_websocket.send_text
+    mock_websocket.send = AsyncMock()
+
+    telemetry = CanvasMemoryTelemetryV6(websocket=mock_websocket)
+
+    user_id = 456
+    memories = [{"id": "mem_2", "content": "test memory 2"}]
+
+    with patch("time.time", return_value=1234567891.0):
+        await telemetry.broadcast_consolidation_event(user_id, memories)
+
+    expected_payload = {
+        "type": "episodic_memory_consolidation",
+        "timestamp": 1234567891.0,
+        "data": {
+            "user_id": user_id,
+            "consolidated_count": 1,
+            "memories": memories
+        }
+    }
+    expected_message = json.dumps(expected_payload)
+
+    mock_websocket.send.assert_awaited_once_with(expected_message)
+
+@pytest.mark.asyncio
+async def test_broadcast_consolidation_event_no_websocket() -> None:
+    """Test broadcasting an event when no websocket is provided."""
+    telemetry = CanvasMemoryTelemetryV6(websocket=None)
+    telemetry.logger = MagicMock()
+
+    user_id = 789
+    memories = []
+
+    # Should not raise an exception
+    await telemetry.broadcast_consolidation_event(user_id, memories)
+
+    # Verify logger was called
+    telemetry.logger.debug.assert_called_once_with("Skipping broadcast for episodic_memory_consolidation - no websocket connected.")
+
+@pytest.mark.asyncio
+async def test_broadcast_consolidation_event_exception() -> None:
+    """Test handling of exceptions during broadcast."""
+    mock_websocket = AsyncMock()
+    mock_websocket.send_text = AsyncMock(side_effect=Exception("Connection lost"))
+
+    telemetry = CanvasMemoryTelemetryV6(websocket=mock_websocket)
+    telemetry.logger = MagicMock()
+
+    user_id = 101
+    memories = [{"id": "mem_3", "content": "error test"}]
+
+    # Should catch the exception and not raise
+    await telemetry.broadcast_consolidation_event(user_id, memories)
+
+    telemetry.logger.error.assert_called_once()
+    assert "Failed to broadcast episodic_memory_consolidation event: Connection lost" in str(telemetry.logger.error.call_args)


### PR DESCRIPTION
Implemented `CanvasMemoryTelemetryV6` in `magda_agent/telemetry/canvas_memory_v6.py` to broadcast episodic memory consolidation events via WebSockets, following the OpenClaw Canvas Live Visualization trend. Included tests using `pytest` and `unittest.mock.AsyncMock` in `tests/test_canvas_memory_v6.py`. Updated `agent_tasks.json` to mark the task as done and appended 3 new actionable AI trend-inspired tasks. Evaluated successfully.

---
*PR created automatically by Jules for task [3832196498410950022](https://jules.google.com/task/3832196498410950022) started by @kazah4359-lgtm*