### PR TITLE
feat: A2A Orchestration Telemetry Integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11192,7 +11192,7 @@
     },
     {
       "id": "a2a-orchestration-telemetry-v1-1a9aa424",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "A2A Orchestration Telemetry Integration",
@@ -25542,6 +25542,42 @@
         "Delegator spawns child subagents with strictly scoped git worktrees.",
         "Context is partitioned and passed to subagents to prevent token overload.",
         "Tests mock git and subprocess to verify isolation boundaries."
+      ]
+    },
+    {
+      "id": "new-a2a-orchestration-evaluator-subagent-v1",
+      "title": "A2A Orchestration Evaluator Subagent V1",
+      "description": "Inspired by Claude Agent SDK (June 2026): Create a subagent specifically designed to evaluate execution graphs returned by A2A peer delegations, isolating bad nodes and returning corrections to the orchestrator.",
+      "area": "multi-agent",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_orchestrator_evaluator_v1.py",
+        "tests/test_a2a_orchestrator_evaluator_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent is initialized with partial results from A2A delegation.",
+        "Subagent successfully evaluates nodes using mock evaluation endpoints.",
+        "Tests verify failed nodes are extracted and properly mapped."
+      ]
+    },
+    {
+      "id": "new-openclaw-interactive-working-memory-tuner-v1",
+      "title": "OpenClaw Interactive Working Memory Tuner V1",
+      "description": "Inspired by OpenClaw MemGPT-like standard: Implement an interactive context tuner that prompts the user for immediate tuning of working memory variables mid-conversation if it detects low confidence when routing capabilities.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/interactive_working_memory_tuner_v1.py",
+        "tests/test_interactive_working_memory_tuner_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Interactive tuner catches low-confidence capabilities.",
+        "Module emits an explicit mock request to prompt the user for variable tuning.",
+        "Tests verify prompt emission logic and state injection."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_orchestrator.py
+++ b/magda_agent/integration/a2a_orchestrator.py
@@ -3,18 +3,20 @@ import logging
 import asyncio
 from magda_agent.integration.a2a_discovery import A2ADiscovery
 from magda_agent.integration.a2a_delegation import A2ADelegator
+from magda_agent.telemetry.a2a_distributed_v7 import A2ADistributedTelemetryV7
 
 class A2AOrchestrator:
     """
     Coordinates dispatching tasks to multiple A2A sub-agents using A2ADelegator.
     Supports concurrent delegation for parallelizable tasks.
     """
-    def __init__(self, discovery: A2ADiscovery, delegator: A2ADelegator):
+    def __init__(self, discovery: A2ADiscovery, delegator: A2ADelegator, telemetry: A2ADistributedTelemetryV7 = None):
         """
         Initializes the orchestrator with discovery and delegator components.
         """
         self.discovery = discovery
         self.delegator = delegator
+        self.telemetry = telemetry
 
     async def dispatch_concurrently(self, sub_plans: List[Dict[str, Any]]) -> Dict[str, str]:
         """
@@ -29,6 +31,13 @@ class A2AOrchestrator:
         results = {}
         tasks = []
 
+        if self.telemetry:
+            self.telemetry.track_event(
+                "orchestrator",
+                "concurrent_delegation_start",
+                {"num_sub_plans": len(sub_plans)}
+            )
+
         async def _delegate_and_record(capability: str, step: Dict[str, Any]):
             step_id = step.get("id")
             result = await self.delegator.delegate_subplan(capability, step)
@@ -41,15 +50,27 @@ class A2AOrchestrator:
 
         completed_tasks = await asyncio.gather(*tasks, return_exceptions=True)
 
+        success_count = 0
+        failure_count = 0
+
         for idx, result in enumerate(completed_tasks):
             if isinstance(result, Exception):
                 logging.error(f"Error during concurrent delegation: {result}")
+                failure_count += 1
                 # We can't easily get the step_id here if the exception happened outside of our inner wrapper,
                 # but because we wrapped it, we should get (step_id, exception/result) unless the wrapper itself failed.
             else:
                 step_id, delegation_result = result
                 if step_id:
                     results[step_id] = delegation_result
+                    success_count += 1
+
+        if self.telemetry:
+            self.telemetry.track_event(
+                "orchestrator",
+                "concurrent_delegation_end",
+                {"success_count": success_count, "failure_count": failure_count}
+            )
 
         return results
 

--- a/tests/test_a2a_orchestrator.py
+++ b/tests/test_a2a_orchestrator.py
@@ -72,6 +72,35 @@ async def test_dispatch_concurrently_with_exception(a2a_orchestrator, caplog):
 
 
 @pytest.mark.asyncio
+async def test_dispatch_concurrently_with_telemetry(a2a_discovery, a2a_delegator):
+    mock_telemetry = MagicMock()
+    orchestrator = A2AOrchestrator(a2a_discovery, a2a_delegator, telemetry=mock_telemetry)
+
+    orchestrator.delegator.delegate_subplan = AsyncMock()
+
+    async def mock_delegate(capability, step):
+        if step['id'] == "step_error":
+            raise Exception("Simulated delegation failure")
+        return f"Delegated {step['id']} for {capability}"
+
+    orchestrator.delegator.delegate_subplan.side_effect = mock_delegate
+
+    sub_plans = [
+        {"capability": "coding", "steps": [{"id": "step_1"}, {"id": "step_error"}]},
+    ]
+
+    results = await orchestrator.dispatch_concurrently(sub_plans)
+
+    assert len(results) == 1
+    assert mock_telemetry.track_event.call_count == 2
+    mock_telemetry.track_event.assert_any_call(
+        "orchestrator", "concurrent_delegation_start", {"num_sub_plans": 1}
+    )
+    mock_telemetry.track_event.assert_any_call(
+        "orchestrator", "concurrent_delegation_end", {"success_count": 1, "failure_count": 1}
+    )
+
+@pytest.mark.asyncio
 async def test_execute_orchestrated_plan_sequential(a2a_orchestrator):
     plan = [
         {"id": "step_1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"}


### PR DESCRIPTION
Implement A2A Orchestration Telemetry Integration

Inspired by A2A Protocol trends, this PR integrates `A2ADistributedTelemetryV7` with `A2AOrchestrator` to broadcast metrics on concurrent delegation overhead. 

Changes include:
- Modifying `A2AOrchestrator` to accept an optional `telemetry` instance.
- Emitting events `concurrent_delegation_start` and `concurrent_delegation_end` inside `dispatch_concurrently`.
- Adding `test_dispatch_concurrently_with_telemetry` to verify the logic.
- Marking the task as done in `agent_tasks.json` and adding two new tasks based on AI agent trends.

---
*PR created automatically by Jules for task [12931411557388934665](https://jules.google.com/task/12931411557388934665) started by @kazah4359-lgtm*