### PR TITLE
feat: MCP Action Tool Orchestrator Integration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11209,7 +11209,7 @@
     },
     {
       "id": "mcp-action-tool-orchestrator-integration-v1-a3a8b9a7",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Action Tool Orchestrator Integration",
@@ -25578,6 +25578,58 @@
         "Interactive tuner catches low-confidence capabilities.",
         "Module emits an explicit mock request to prompt the user for variable tuning.",
         "Tests verify prompt emission logic and state injection."
+      ]
+    },
+    {
+      "id": "claude-teams-worktree-garbage-collector-v2-abc",
+      "title": "Claude Teams Worktree Garbage Collector V2",
+      "description": "Inspired by Claude Agent Teams multi-agent architectures: Enhance the periodic garbage collector to also compress leftover state into episodic memory before cleanly deleting abandoned Git worktrees.",
+      "status": "todo",
+      "area": "agents",
+      "risk": "low",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_gc_v2.py",
+        "tests/test_worktree_gc_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Garbage Collector identifies stale worktrees.",
+        "Compresses logs before removal.",
+        "Tests mock file system and verify cleanup."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-memory-plugin-v2-def",
+      "title": "OpenClaw Virtual Memory Pattern Integration V2",
+      "description": "Inspired by OpenClaw trends: Integrate the explicit swapping mechanism for Context Engine to support multiple concurrent users independently inside the FastAPI singleton service.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_memory_v2.py",
+        "tests/test_virtual_memory_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Modular swap mechanism maintains user separation.",
+        "Tests cover independent token limits per user."
+      ]
+    },
+    {
+      "id": "a2a-distributed-telemetry-v8-ghi",
+      "title": "A2A Distributed Telemetry V8",
+      "description": "Inspired by A2A standard trend: Enhance the A2A distributed telemetry module to support OpenTelemetry-compatible tracing payloads and propagate span IDs.",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_distributed_v8.py",
+        "tests/test_a2a_distributed_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry payloads include structured spans.",
+        "Tests verify OpenTelemetry compatibility format."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_orchestrator.py
+++ b/magda_agent/integration/a2a_orchestrator.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, List
 import logging
 import asyncio
+import httpx
 from magda_agent.integration.a2a_discovery import A2ADiscovery
 from magda_agent.integration.a2a_delegation import A2ADelegator
 from magda_agent.telemetry.a2a_distributed_v7 import A2ADistributedTelemetryV7
@@ -77,6 +78,7 @@ class A2AOrchestrator:
     async def execute_orchestrated_plan(self, plan: List[Dict[str, Any]], concurrent: bool = False) -> Dict[str, str]:
         """
         Executes a full plan by splitting it into sub-plans and dispatching them either concurrently or sequentially.
+        Directly executes MCP action tools when 'skill' is 'execute_mcp_tool'.
 
         Args:
             plan: The full execution plan.
@@ -88,9 +90,105 @@ class A2AOrchestrator:
         if not plan:
             return {}
 
-        sub_plans = self.delegator.split_plan(plan)
+        results = {}
+        delegation_plan = []
+        mcp_tasks = []
+
+        for step in plan:
+            skill = step.get("skill")
+            if skill == "execute_mcp_tool":
+                if not concurrent and delegation_plan:
+                    res = await self.delegator.execute_plan(delegation_plan)
+                    results.update(res)
+                    delegation_plan = []
+
+                step_id = step.get("id")
+                kwargs = step.get("skill_kwargs", {})
+                target_agent_id = kwargs.get("target_agent_id")
+                tool_name = kwargs.get("tool_name")
+                tool_kwargs = kwargs.get("tool_kwargs", {})
+
+                if concurrent:
+                    async def _run_mcp(s_id, t_id, t_name, t_kw):
+                        r = await self.execute_direct_mcp_action(t_id, t_name, t_kw)
+                        return s_id, r
+                    mcp_tasks.append(_run_mcp(step_id, target_agent_id, tool_name, tool_kwargs))
+                else:
+                    result = await self.execute_direct_mcp_action(target_agent_id, tool_name, tool_kwargs)
+                    if step_id:
+                        results[step_id] = result
+            elif skill == "delegate_to_agent":
+                delegation_plan.append(step)
+            else:
+                pass
 
         if concurrent:
-            return await self.dispatch_concurrently(sub_plans)
+            if delegation_plan:
+                sub_plans = self.delegator.split_plan(delegation_plan)
+                del_results = await self.dispatch_concurrently(sub_plans)
+                results.update(del_results)
+            if mcp_tasks:
+                mcp_completed = await asyncio.gather(*mcp_tasks, return_exceptions=True)
+                for res in mcp_completed:
+                    if isinstance(res, Exception):
+                        logging.error(f"Error during concurrent MCP execution: {res}")
+                    else:
+                        s_id, r = res
+                        if s_id:
+                            results[s_id] = r
         else:
-            return await self.delegator.execute_plan(plan)
+            if delegation_plan:
+                res = await self.delegator.execute_plan(delegation_plan)
+                results.update(res)
+
+        return results
+
+    async def execute_direct_mcp_action(self, target_agent_id: str, tool_name: str, tool_kwargs: Dict[str, Any]) -> str:
+        """
+        Directly executes an MCP action tool exposed by a peer agent.
+        """
+        target_agent = self.discovery.get_agent_by_id(target_agent_id)
+        if not target_agent:
+            return f"Agent {target_agent_id} not found"
+
+        endpoint = target_agent.endpoints.get("mcp")
+        if not endpoint:
+            return f"Agent {target_agent.name} missing MCP endpoint"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": tool_kwargs
+            }
+        }
+
+        headers = {}
+        security_context = getattr(self.delegator, "security_context", None)
+        if security_context:
+            token = security_context.generate_token()
+            headers["Authorization"] = f"Bearer {token}"
+            security_context.trace_action("execute_direct_mcp_action", {
+                "target_agent": target_agent.name,
+                "tool_name": tool_name
+            })
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(endpoint, json=payload, headers=headers, timeout=10.0)
+                response.raise_for_status()
+                data = response.json()
+
+                if "error" in data:
+                    return str(data["error"].get("message", str(data["error"])))
+
+                result = data.get("result", {})
+                content = result.get("content", [])
+                if content and isinstance(content, list) and len(content) > 0:
+                    return content[0].get("text", str(result))
+                return str(result)
+        except Exception as e:
+            logging.error(f"Failed to execute direct MCP action on {target_agent.name} at {endpoint}: {e}")
+            return f"MCP action execution on {target_agent.name} failed: {e}"

--- a/tests/test_a2a_orchestrator.py
+++ b/tests/test_a2a_orchestrator.py
@@ -133,3 +133,74 @@ async def test_execute_orchestrated_plan_concurrent(a2a_orchestrator):
 async def test_execute_orchestrated_plan_empty(a2a_orchestrator):
     results = await a2a_orchestrator.execute_orchestrated_plan([])
     assert results == {}
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.post', new_callable=AsyncMock)
+async def test_execute_direct_mcp_action(mock_post, a2a_orchestrator, a2a_discovery):
+    # Register the test agent
+    agent_card = AgentCard("target_agent", "Target", "Desc", ["capability_1"], {"mcp": "http://mcp-endpoint"})
+    a2a_discovery._discovered_agents["target_agent"] = agent_card
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "jsonrpc": "2.0",
+        "result": {
+            "content": [{"type": "text", "text": "Action Success"}]
+        }
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    result = await a2a_orchestrator.execute_direct_mcp_action("target_agent", "some_tool", {"arg": "val"})
+
+    assert result == "Action Success"
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert kwargs["json"]["method"] == "tools/call"
+    assert kwargs["json"]["params"]["name"] == "some_tool"
+    assert kwargs["json"]["params"]["arguments"] == {"arg": "val"}
+
+@pytest.mark.asyncio
+async def test_execute_orchestrated_plan_with_mcp_tool_sequential(a2a_orchestrator):
+    plan = [
+        {"id": "step_1", "skill": "execute_mcp_tool", "skill_kwargs": {
+            "target_agent_id": "target_agent",
+            "tool_name": "some_tool",
+            "tool_kwargs": {"arg": "val"}
+        }},
+        {"id": "step_2", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"}
+    ]
+
+    a2a_orchestrator.execute_direct_mcp_action = AsyncMock(return_value="MCP Success")
+    a2a_orchestrator.delegator.execute_plan = AsyncMock(return_value={"step_2": "Sequential Success"})
+
+    results = await a2a_orchestrator.execute_orchestrated_plan(plan, concurrent=False)
+
+    a2a_orchestrator.execute_direct_mcp_action.assert_called_once_with("target_agent", "some_tool", {"arg": "val"})
+    a2a_orchestrator.delegator.execute_plan.assert_called_once()
+
+    assert results["step_1"] == "MCP Success"
+    assert results["step_2"] == "Sequential Success"
+
+@pytest.mark.asyncio
+async def test_execute_orchestrated_plan_with_mcp_tool_concurrent(a2a_orchestrator):
+    plan = [
+        {"id": "step_1", "skill": "execute_mcp_tool", "skill_kwargs": {
+            "target_agent_id": "target_agent",
+            "tool_name": "some_tool",
+            "tool_kwargs": {"arg": "val"}
+        }},
+        {"id": "step_2", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"}
+    ]
+
+    a2a_orchestrator.execute_direct_mcp_action = AsyncMock(return_value="MCP Concurrent Success")
+    a2a_orchestrator.dispatch_concurrently = AsyncMock(return_value={"step_2": "Delegation Concurrent Success"})
+    a2a_orchestrator.delegator.split_plan = MagicMock(return_value=[{"capability": "coding", "steps": [plan[1]]}])
+
+    results = await a2a_orchestrator.execute_orchestrated_plan(plan, concurrent=True)
+
+    a2a_orchestrator.execute_direct_mcp_action.assert_called_once_with("target_agent", "some_tool", {"arg": "val"})
+    a2a_orchestrator.dispatch_concurrently.assert_called_once()
+
+    assert results["step_1"] == "MCP Concurrent Success"
+    assert results["step_2"] == "Delegation Concurrent Success"


### PR DESCRIPTION
Implements the "MCP Action Tool Orchestrator Integration" task:
- Adds `execute_direct_mcp_action` in `A2AOrchestrator` to post JSON-RPC tool-calling payloads via HTTP.
- Modifies `execute_orchestrated_plan` to iterate directly through the full plan and intercept steps with `skill: execute_mcp_tool`.
- Allows sequential interleaving of A2A sub-plan delegations and MCP actions, or parallelizing everything dynamically using `asyncio.gather`.
- Includes focused tests for successful endpoints, mock payloads, and JSON format structure tests.
- Re-populates `agent_tasks.json` with Claude Agent SDK and OpenClaw inspired backlog items.

---
*PR created automatically by Jules for task [1020330699250294854](https://jules.google.com/task/1020330699250294854) started by @kazah4359-lgtm*