### PR TITLE
feat: A2A Orchestrator Fallback Handling

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11226,7 +11226,7 @@
     },
     {
       "id": "a2a-orchestrator-fallback-v1-8b09e06f",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Orchestrator Fallback Handling",
@@ -25630,6 +25630,57 @@
       "acceptance": [
         "Telemetry payloads include structured spans.",
         "Tests verify OpenTelemetry compatibility format."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v5-6a5b4c",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V5",
+      "description": "Inspired by MCP standards trend (June 2026): Implement multi-turn capability negotiation for MCP tools, allowing agents to query and adjust capabilities dynamically.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_negotiation_v5.py",
+        "tests/test_mcp_negotiation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Negotiation mechanism accurately queries capabilities.",
+        "Tests verify capability adjustments with mock responses."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v1-9f8e7d",
+      "status": "todo",
+      "area": "agents",
+      "risk": "medium",
+      "title": "Claude Worktree Pruning and Resource Optimizer V1",
+      "description": "Inspired by Claude Agent Teams multi-agent architecture (June 2026): Implement an active worktree optimizer that prunes unused files and optimizes git resources to prevent bloat during parallel subagent execution.",
+      "allowed_paths": [
+        "magda_agent/isolation/worktree_optimizer_v1.py",
+        "tests/test_worktree_optimizer_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Optimizer detects and prunes unused worktree elements.",
+        "Tests mock git and filesystem interactions to verify pruning logic."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-evaluation-v2-1a2b3c",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Quality Evaluation V2",
+      "description": "Inspired by OpenClaw trends (June 2026): Create an evaluation module to assess the quality of long-running action trajectories and generate reward signals for the RL loop.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_evaluation_v2.py",
+        "tests/test_trajectory_evaluation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator scores action trajectories and outputs reward signals.",
+        "Tests ensure consistent reward values for various mocked trajectories."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_orchestrator.py
+++ b/magda_agent/integration/a2a_orchestrator.py
@@ -125,8 +125,13 @@ class A2AOrchestrator:
         if concurrent:
             if delegation_plan:
                 sub_plans = self.delegator.split_plan(delegation_plan)
-                del_results = await self.dispatch_concurrently(sub_plans)
-                results.update(del_results)
+                try:
+                    del_results = await self.dispatch_concurrently(sub_plans)
+                    results.update(del_results)
+                except Exception as e:
+                    logging.warning(f"Concurrent delegation failed, falling back to sequential: {e}")
+                    res = await self.delegator.execute_plan(delegation_plan)
+                    results.update(res)
             if mcp_tasks:
                 mcp_completed = await asyncio.gather(*mcp_tasks, return_exceptions=True)
                 for res in mcp_completed:

--- a/tests/test_a2a_orchestrator.py
+++ b/tests/test_a2a_orchestrator.py
@@ -204,3 +204,24 @@ async def test_execute_orchestrated_plan_with_mcp_tool_concurrent(a2a_orchestrat
 
     assert results["step_1"] == "MCP Concurrent Success"
     assert results["step_2"] == "Delegation Concurrent Success"
+
+@pytest.mark.asyncio
+async def test_execute_orchestrated_plan_concurrent_fallback(a2a_orchestrator: A2AOrchestrator, caplog: pytest.LogCaptureFixture) -> None:
+    """
+    Tests that execute_orchestrated_plan falls back to sequential execution
+    when concurrent delegation raises an unexpected exception.
+    """
+    plan = [
+        {"id": "step_1", "skill": "delegate_to_agent", "skill_kwargs": {"capability": "coding"}, "description": "code it"}
+    ]
+
+    a2a_orchestrator.dispatch_concurrently = AsyncMock(side_effect=Exception("Simulated network error"))
+    a2a_orchestrator.delegator.split_plan = MagicMock(return_value=[{"capability": "coding", "steps": [plan[0]]}])
+    a2a_orchestrator.delegator.execute_plan = AsyncMock(return_value={"step_1": "Fallback Sequential Success"})
+
+    results = await a2a_orchestrator.execute_orchestrated_plan(plan, concurrent=True)
+
+    a2a_orchestrator.dispatch_concurrently.assert_called_once()
+    a2a_orchestrator.delegator.execute_plan.assert_called_once_with([plan[0]])
+    assert results["step_1"] == "Fallback Sequential Success"
+    assert "Concurrent delegation failed, falling back to sequential: Simulated network error" in caplog.text


### PR DESCRIPTION
This PR addresses the "A2A Orchestrator Fallback Handling" task by implementing a robust sequential fallback mechanism for multi-agent delegation when concurrent execution fails.

Changes:
- Added a `try-except Exception` block in `magda_agent/integration/a2a_orchestrator.py` during concurrent dispatch.
- Upon failure, logs a warning and falls back to `self.delegator.execute_plan(delegation_plan)`.
- Added strict type hints and docstrings to a new async `pytest` in `tests/test_a2a_orchestrator.py` using `AsyncMock`.
- Marked task `a2a-orchestrator-fallback-v1-8b09e06f` as done in `agent_tasks.json`.
- Appended 3 new trend-inspired tasks (MCP Dynamic Capability Negotiation, Claude Worktree Pruning, and OpenClaw RL Trajectory Evaluation) to `agent_tasks.json` with unique task IDs verified by `scripts/validate_agent_tasks.py`.

---
*PR created automatically by Jules for task [14766223362850770445](https://jules.google.com/task/14766223362850770445) started by @kazah4359-lgtm*