### PR TITLE
feat(skills): Add MCP Dynamic Tools Registration Pipeline

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11243,7 +11243,7 @@
     },
     {
       "id": "mcp-dynamic-tools-registration-86f72b11",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Tools Registration Pipeline",
@@ -25681,6 +25681,61 @@
       "acceptance": [
         "Evaluator scores action trajectories and outputs reward signals.",
         "Tests ensure consistent reward values for various mocked trajectories."
+      ]
+    },
+    {
+      "id": "mcp-kernel-taint-tracking-v1-9bc7dfd3",
+      "title": "MCPKernel Taint Tracking V1",
+      "description": "Inspired by MCPKernel (June 2026 trend): Implement a taint tracking mechanism that monitors data flow from external MCP tools to prevent prompt injection and unauthorized state mutation.",
+      "status": "todo",
+      "area": "security",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/security/mcp_taint_tracker.py",
+        "tests/test_mcp_taint_tracker.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tracker correctly labels data originating from MCP tools.",
+        "Taint propagates through string operations.",
+        "Execution is blocked if tainted data reaches sensitive endpoints.",
+        "Pytest tests verify correct taint propagation and blocking."
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-sync-v1-acf4e663",
+      "title": "Hermes Skill Marketplace Sync V1",
+      "description": "Inspired by agentskills.io (June 2026 trend): Implement a background task that syncs local procedural skills with a remote skill marketplace API.",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_sync_api.py",
+        "tests/test_marketplace_sync_api.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Service fetches available skills from a mock marketplace API.",
+        "Service registers fetched skills via the SkillRegistry.",
+        "Pytest mock tests confirm API interaction and registration."
+      ]
+    },
+    {
+      "id": "acs-runtime-governance-layer-v1-980a3da5",
+      "title": "ACS Runtime Governance Layer V1",
+      "description": "Inspired by Agent Control Specification (ACS) trend (June 2026): Implement a 5-checkpoint runtime governance layer to validate agentic workflows.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/acs_governance_layer.py",
+        "tests/test_acs_governance_layer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Implements 5 ACS validation checkpoints.",
+        "Integrates checkpoints into tool execution.",
+        "Pytest mock tests confirm validation blocks unsafe actions."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_dynamic_registration.py
+++ b/magda_agent/skills/mcp_dynamic_registration.py
@@ -1,0 +1,102 @@
+import asyncio
+import logging
+from typing import Dict, Any, List, Optional, Callable
+
+import httpx
+
+from magda_agent.skills.registry import SkillRegistry
+
+class MCPDynamicRegistrationPipeline:
+    """
+    Pipeline for fetching remote MCP server schemas and registering them
+    as native functions dynamically into the local SkillRegistry.
+    """
+
+    def __init__(self, registry: SkillRegistry) -> None:
+        """
+        Initialize the MCPDynamicRegistrationPipeline.
+
+        Args:
+            registry (SkillRegistry): The local SkillRegistry to register tools into.
+        """
+        self.registry = registry
+        self.logger = logging.getLogger(__name__)
+
+    def _create_native_proxy(self, mcp_server_url: str, tool_name: str) -> Callable[..., Any]:
+        """
+        Creates an asynchronous native function proxy that forwards calls to the remote MCP server.
+
+        Args:
+            mcp_server_url (str): The base URL of the remote MCP server.
+            tool_name (str): The name of the remote tool to call.
+
+        Returns:
+            Callable[..., Any]: The native proxy function.
+        """
+        async def proxy_func(**kwargs: Any) -> Any:
+            """
+            Native proxy function that forwards execution to the remote MCP server.
+
+            Args:
+                **kwargs: The arguments to pass to the remote tool.
+
+            Returns:
+                Any: The result from the remote tool execution.
+            """
+            url = f"{mcp_server_url}/tools/{tool_name}/execute"
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.post(url, json={"arguments": kwargs})
+                    response.raise_for_status()
+                    data = response.json()
+                    return data.get("result", data)
+            except Exception as e:
+                self.logger.error(f"Error executing remote MCP tool {tool_name} at {mcp_server_url}: {e}")
+                return f"Error executing remote MCP tool {tool_name}: {e}"
+
+        # Optionally, one could attach the original signature here, but SkillRegistry
+        # normally executes via kwargs unpacking.
+        proxy_func.__name__ = tool_name
+        return proxy_func
+
+    async def fetch_and_register(self, mcp_server_url: str) -> bool:
+        """
+        Fetches tools from a remote MCP server and registers them as native skills.
+
+        Args:
+            mcp_server_url (str): The base URL of the remote MCP server.
+
+        Returns:
+            bool: True if tools were fetched and registered successfully, False otherwise.
+        """
+        self.logger.info(f"Fetching MCP schemas from {mcp_server_url}")
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{mcp_server_url}/tools")
+                response.raise_for_status()
+                data = response.json()
+        except Exception as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {mcp_server_url}: {e}")
+            return False
+
+        if not isinstance(data, dict) or "tools" not in data or not isinstance(data["tools"], list):
+            self.logger.error(f"Invalid response format from MCP server {mcp_server_url}: 'tools' list not found.")
+            return False
+
+        success_count = 0
+        for tool in data["tools"]:
+            if isinstance(tool, dict) and "name" in tool:
+                name = tool["name"]
+                description = tool.get("description", f"Remote MCP tool: {name}")
+
+                # Create a proxy native function that will call the HTTP endpoint
+                proxy_func = self._create_native_proxy(mcp_server_url, name)
+
+                try:
+                    self.registry.register_skill(name, proxy_func, description)
+                    success_count += 1
+                    self.logger.info(f"Registered remote MCP tool {name} as a native skill.")
+                except Exception as e:
+                    self.logger.error(f"Error registering MCP tool {name}: {e}")
+
+        return success_count > 0

--- a/tests/test_mcp_dynamic_registration.py
+++ b/tests/test_mcp_dynamic_registration.py
@@ -1,0 +1,79 @@
+import pytest
+import respx
+import httpx
+from typing import Any
+
+from magda_agent.skills.mcp_dynamic_registration import MCPDynamicRegistrationPipeline
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.fixture
+def mock_registry() -> SkillRegistry:
+    """Provides a mocked SkillRegistry instance."""
+    return SkillRegistry()
+
+@pytest.fixture
+def pipeline(mock_registry: SkillRegistry) -> MCPDynamicRegistrationPipeline:
+    """Provides an MCPDynamicRegistrationPipeline instance."""
+    return MCPDynamicRegistrationPipeline(registry=mock_registry)
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_and_register_success(pipeline: MCPDynamicRegistrationPipeline, mock_registry: SkillRegistry) -> None:
+    """Tests successful fetching and registration of remote MCP tools."""
+    server_url = "http://mock-mcp-server.local"
+
+    # Mock the /tools endpoint
+    mock_tools_response = {
+        "tools": [
+            {"name": "remote_tool_1", "description": "First remote tool"},
+            {"name": "remote_tool_2", "description": "Second remote tool"}
+        ]
+    }
+    respx.get(f"{server_url}/tools").respond(json=mock_tools_response, status_code=200)
+
+    success = await pipeline.fetch_and_register(server_url)
+
+    assert success is True
+    assert mock_registry.has_skill("remote_tool_1")
+    assert mock_registry.has_skill("remote_tool_2")
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_and_register_failure(pipeline: MCPDynamicRegistrationPipeline) -> None:
+    """Tests failure handling when fetching remote MCP tools."""
+    server_url = "http://mock-mcp-server.local"
+
+    # Mock a server error
+    respx.get(f"{server_url}/tools").respond(status_code=500)
+
+    success = await pipeline.fetch_and_register(server_url)
+
+    assert success is False
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_native_proxy_execution(pipeline: MCPDynamicRegistrationPipeline, mock_registry: SkillRegistry) -> None:
+    """Tests execution of the registered native proxy function."""
+    server_url = "http://mock-mcp-server.local"
+
+    # Mock the /tools endpoint to register one tool
+    mock_tools_response = {
+        "tools": [
+            {"name": "remote_math_add"}
+        ]
+    }
+    respx.get(f"{server_url}/tools").respond(json=mock_tools_response, status_code=200)
+
+    await pipeline.fetch_and_register(server_url)
+
+    assert mock_registry.has_skill("remote_math_add")
+
+    # Mock the tool execution endpoint
+    mock_execute_response = {"result": 42}
+    respx.post(f"{server_url}/tools/remote_math_add/execute").respond(json=mock_execute_response, status_code=200)
+
+    # Call the registered native skill
+    # SkillRegistry executes tools through its execute_skill method
+    result = await mock_registry.execute_skill("remote_math_add", a=20, b=22)
+
+    assert result == 42


### PR DESCRIPTION
This PR implements the MCP Dynamic Tools Registration Pipeline as requested in the task `mcp-dynamic-tools-registration-86f72b11`.

It includes:
- `MCPDynamicRegistrationPipeline` which uses `httpx` to dynamically fetch and register tools from remote MCP servers as native proxy functions.
- `tests/test_mcp_dynamic_registration.py` which thoroughly tests the pipeline using `respx` to mock HTTP endpoints.
- Updates to `agent_tasks.json` marking the current task as done and adding 3 new trend-inspired tasks.
- Appropriate type hints and docstrings for all added code.

---
*PR created automatically by Jules for task [6349335421880346642](https://jules.google.com/task/6349335421880346642) started by @kazah4359-lgtm*