### PR TITLE
feat: Add CanvasSkillsTelemetry for SkillRegistry

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11277,7 +11277,7 @@
     },
     {
       "id": "canvas-telemetry-skills-d25e2200",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "Canvas Telemetry for Skills execution",
@@ -25789,6 +25789,60 @@
       "acceptance": [
         "Lifecycle manager detects idle context boundaries and triggers Episodic Memory archiving.",
         "Tests mock context engine states and verify cleanup."
+      ]
+    },
+    {
+      "id": "a2a-distributed-consensus-voting-v1",
+      "title": "A2A Distributed Consensus Voting V1",
+      "description": "Inspired by A2A Protocol and Swarm Intelligence trends (June 2026): Implement a distributed consensus voting mechanism that allows peer A2A agents to vote on the validity of an execution plan before it is enacted.",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_consensus_voting_v1.py",
+        "tests/test_a2a_consensus_voting_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Consensus module correctly aggregates votes from mock peer agents.",
+        "Execution is blocked if the required quorum is not reached.",
+        "Tests verify quorum logic and network event mocking."
+      ]
+    },
+    {
+      "id": "context-engine-semantic-deduplication-v1",
+      "title": "Context Engine Semantic Deduplication Plugin V1",
+      "description": "Inspired by Context Engine virtual memory management trends: Create a plugin that scans working memory for semantically duplicate entries during the compression phase and merges them into single unified representations to save context space.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_dedup_plugin_v1.py",
+        "tests/test_semantic_dedup_plugin_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin hooks into the Context Engine lifecycle correctly.",
+        "Semantically duplicate memories are merged effectively using mock embeddings.",
+        "Tests verify that context token length is reduced after deduplication."
+      ]
+    },
+    {
+      "id": "agent-teams-fault-tolerant-orchestrator-v1",
+      "title": "Agent Teams Fault-tolerant Orchestrator V1",
+      "description": "Inspired by Claude Agent SDK multi-agent orchestration trends: Implement a fault-tolerant orchestrator that automatically respawns subagents in new isolated Git worktrees if their original execution crashes or times out.",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/architecture/fault_tolerant_orchestrator_v1.py",
+        "tests/test_fault_tolerant_orchestrator_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Orchestrator detects crashed or timed-out subagents.",
+        "Failing subagents are safely respawned in fresh worktrees up to a maximum retry limit.",
+        "Tests verify retry logic and worktree replacement using mock crashes."
       ]
     }
   ]

--- a/magda_agent/skills/registry.py
+++ b/magda_agent/skills/registry.py
@@ -2,6 +2,7 @@ from typing import Dict, Callable, Any, Optional, Tuple, TYPE_CHECKING
 import logging
 import time
 from magda_agent.skills.telemetry_export import SkillTelemetryTracker
+from magda_agent.telemetry.canvas_skills_telemetry import CanvasSkillsTelemetry
 
 if TYPE_CHECKING:
     from magda_agent.safety.policy import PolicyLayer
@@ -10,11 +11,12 @@ class SkillRegistry:
     """
     Registry to manage and trigger available skills for the AGI agent.
     """
-    def __init__(self, policy_layer: Optional["PolicyLayer"] = None):
+    def __init__(self, policy_layer: Optional["PolicyLayer"] = None, canvas_telemetry: Optional["CanvasSkillsTelemetry"] = None):
         self.skills: Dict[str, Callable] = {}
         self.descriptions: Dict[str, str] = {}
         self.policy_layer = policy_layer
         self.telemetry_tracker = SkillTelemetryTracker()
+        self.canvas_telemetry = canvas_telemetry or CanvasSkillsTelemetry()
 
         # Initialize AgentGuard if policy_layer is provided
         from magda_agent.safety.agent_guard import AgentGuard
@@ -71,6 +73,25 @@ class SkillRegistry:
     def execute_skill(self, name: str, **kwargs) -> Any:
         if name not in self.skills:
             return f"Error: Skill '{name}' not found."
+
+        # Emit skill start event asynchronously via a new event loop if needed, or by dispatching it
+        # Since execute_skill might be called synchronously, we will use a fire-and-forget approach
+        def _dispatch_telemetry(coro):
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(coro)
+            except RuntimeError:
+                # Fallback to run a single task without replacing the loop,
+                # though usually if no loop is running we can create one
+                try:
+                    new_loop = asyncio.new_event_loop()
+                    new_loop.run_until_complete(coro)
+                finally:
+                    new_loop.close()
+
+        if self.canvas_telemetry:
+            _dispatch_telemetry(self.canvas_telemetry.broadcast_skill_start(name, kwargs))
 
         try:
             if hasattr(self, 'mcp_enforcer') and self.mcp_enforcer and self.policy_layer:
@@ -176,6 +197,8 @@ class SkillRegistry:
                                     duration=duration_async
                                 )
                                 from magda_agent.safety.acs_guard_v2 import SecurityViolationError
+                                if self.canvas_telemetry:
+                                    _dispatch_telemetry(self.canvas_telemetry.broadcast_skill_fail(name, f"Action blocked by ACS checkpoint 5: {reason}", duration_async * 1000))
                                 raise SecurityViolationError(f"Action blocked by ACS checkpoint 5: {reason}")
                             self.acs_guard.audit_logger.log_call(
                                 tool_name=name,
@@ -184,6 +207,8 @@ class SkillRegistry:
                                 result=actual_result,
                                 duration=duration_async
                             )
+                        if self.canvas_telemetry:
+                            _dispatch_telemetry(self.canvas_telemetry.broadcast_skill_success(name, actual_result, duration_async * 1000))
                         return actual_result
                     except Exception as ea:
                         duration_async = time.time() - start_time
@@ -196,6 +221,8 @@ class SkillRegistry:
                                 duration=duration_async
                             )
                         logging.error(f"Error executing skill {name}: {ea}")
+                        if self.canvas_telemetry:
+                            _dispatch_telemetry(self.canvas_telemetry.broadcast_skill_fail(name, str(ea), duration_async * 1000))
                         raise
                 return async_audit_wrapper(result)
 
@@ -213,6 +240,8 @@ class SkillRegistry:
                         duration=duration
                     )
                     from magda_agent.safety.acs_guard_v2 import SecurityViolationError
+                    if self.canvas_telemetry:
+                        _dispatch_telemetry(self.canvas_telemetry.broadcast_skill_fail(name, f"Action blocked by ACS checkpoint 5: {reason}", duration * 1000))
                     raise SecurityViolationError(f"Action blocked by ACS checkpoint 5: {reason}")
 
                 # Successful execution audit
@@ -225,6 +254,8 @@ class SkillRegistry:
                 )
 
             self.telemetry_tracker.record_usage(name, success=True, execution_time_ms=duration * 1000)
+            if self.canvas_telemetry:
+                _dispatch_telemetry(self.canvas_telemetry.broadcast_skill_success(name, result, duration * 1000))
 
             return result
         except Exception as e:
@@ -235,6 +266,8 @@ class SkillRegistry:
 
             self.telemetry_tracker.record_usage(name, success=False, execution_time_ms=exec_time)
             logging.error(f"Error executing skill {name}: {e}")
+            if self.canvas_telemetry:
+                _dispatch_telemetry(self.canvas_telemetry.broadcast_skill_fail(name, str(e), exec_time))
             return f"Error executing skill {name}: {e}"
 
 

--- a/magda_agent/telemetry/canvas_skills_telemetry.py
+++ b/magda_agent/telemetry/canvas_skills_telemetry.py
@@ -1,0 +1,92 @@
+import json
+import logging
+from typing import Any, Dict, Optional
+
+class CanvasSkillsTelemetry:
+    """
+    A telemetry streamer that broadcasts skill execution lifecycle events
+    (start, success, fail) to an external Canvas client via WebSockets.
+    """
+
+    def __init__(self, websocket: Optional[Any] = None) -> None:
+        """
+        Initialize the CanvasSkillsTelemetry.
+
+        Args:
+            websocket (Optional[Any]): An open asynchronous websocket connection.
+        """
+        self.websocket = websocket
+        self.logger = logging.getLogger(__name__)
+
+    async def broadcast_skill_start(self, skill_name: str, kwargs: Dict[str, Any]) -> None:
+        """
+        Broadcast that a skill execution has started.
+
+        Args:
+            skill_name (str): The name of the skill.
+            kwargs (Dict[str, Any]): The arguments passed to the skill.
+        """
+        payload = {
+            "skill_name": skill_name,
+            "kwargs": kwargs,
+            "status": "start"
+        }
+        await self._broadcast_event("skill_start", payload)
+
+    async def broadcast_skill_success(self, skill_name: str, result: Any, duration_ms: float) -> None:
+        """
+        Broadcast that a skill execution was successful.
+
+        Args:
+            skill_name (str): The name of the skill.
+            result (Any): The result returned by the skill.
+            duration_ms (float): Execution duration in milliseconds.
+        """
+        payload = {
+            "skill_name": skill_name,
+            "result": str(result),  # convert to string to ensure json serialization
+            "duration_ms": duration_ms,
+            "status": "success"
+        }
+        await self._broadcast_event("skill_success", payload)
+
+    async def broadcast_skill_fail(self, skill_name: str, error: str, duration_ms: float) -> None:
+        """
+        Broadcast that a skill execution has failed.
+
+        Args:
+            skill_name (str): The name of the skill.
+            error (str): The error message.
+            duration_ms (float): Execution duration in milliseconds before failure.
+        """
+        payload = {
+            "skill_name": skill_name,
+            "error": error,
+            "duration_ms": duration_ms,
+            "status": "fail"
+        }
+        await self._broadcast_event("skill_fail", payload)
+
+    async def _broadcast_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        """
+        Helper method to format and send events over the websocket.
+
+        Args:
+            event_type (str): The type of the event.
+            data (Dict[str, Any]): The payload of the event.
+        """
+        if self.websocket is None:
+            self.logger.debug(f"Skipping broadcast for {event_type} - no websocket connected.")
+            return
+
+        payload = {
+            "type": event_type,
+            "data": data
+        }
+
+        try:
+            message = json.dumps(payload)
+            await self.websocket.send_text(message)
+            self.logger.debug(f"Successfully broadcasted {event_type} event.")
+        except Exception as e:
+            self.logger.error(f"Failed to broadcast {event_type} event: {e}")

--- a/tests/test_canvas_skills_telemetry.py
+++ b/tests/test_canvas_skills_telemetry.py
@@ -1,0 +1,91 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import MagicMock, AsyncMock
+
+from magda_agent.telemetry.canvas_skills_telemetry import CanvasSkillsTelemetry
+from magda_agent.skills.registry import SkillRegistry
+
+@pytest.mark.asyncio
+async def test_canvas_skills_telemetry_broadcasts():
+    websocket = AsyncMock()
+    telemetry = CanvasSkillsTelemetry(websocket)
+
+    # Test skill start
+    await telemetry.broadcast_skill_start("test_skill", {"arg1": "value1"})
+    websocket.send_text.assert_called_once()
+    payload = json.loads(websocket.send_text.call_args[0][0])
+    assert payload["type"] == "skill_start"
+    assert payload["data"]["skill_name"] == "test_skill"
+    assert payload["data"]["kwargs"] == {"arg1": "value1"}
+    assert payload["data"]["status"] == "start"
+    websocket.reset_mock()
+
+    # Test skill success
+    await telemetry.broadcast_skill_success("test_skill", {"result": "success"}, 150.0)
+    websocket.send_text.assert_called_once()
+    payload = json.loads(websocket.send_text.call_args[0][0])
+    assert payload["type"] == "skill_success"
+    assert payload["data"]["skill_name"] == "test_skill"
+    assert payload["data"]["result"] == str({"result": "success"})
+    assert payload["data"]["duration_ms"] == 150.0
+    assert payload["data"]["status"] == "success"
+    websocket.reset_mock()
+
+    # Test skill fail
+    await telemetry.broadcast_skill_fail("test_skill", "An error occurred", 50.0)
+    websocket.send_text.assert_called_once()
+    payload = json.loads(websocket.send_text.call_args[0][0])
+    assert payload["type"] == "skill_fail"
+    assert payload["data"]["skill_name"] == "test_skill"
+    assert payload["data"]["error"] == "An error occurred"
+    assert payload["data"]["duration_ms"] == 50.0
+    assert payload["data"]["status"] == "fail"
+
+def test_registry_integration():
+    telemetry = CanvasSkillsTelemetry(websocket=AsyncMock())
+    registry = SkillRegistry(canvas_telemetry=telemetry)
+
+    # Register a simple skill
+    def simple_skill(x, y):
+        return x + y
+
+    registry.register_skill("add", simple_skill, "Adds two numbers")
+
+    telemetry.broadcast_skill_start = AsyncMock()
+    telemetry.broadcast_skill_success = AsyncMock()
+    telemetry.broadcast_skill_fail = AsyncMock()
+
+    # Execute skill
+    result = registry.execute_skill("add", x=5, y=3)
+
+    assert result == 8
+    telemetry.broadcast_skill_start.assert_called_once_with("add", {"x": 5, "y": 3})
+    telemetry.broadcast_skill_success.assert_called_once()
+    assert telemetry.broadcast_skill_success.call_args[0][0] == "add"
+    assert telemetry.broadcast_skill_success.call_args[0][1] == 8
+
+def test_registry_integration_error():
+    telemetry = CanvasSkillsTelemetry(websocket=AsyncMock())
+    registry = SkillRegistry(canvas_telemetry=telemetry)
+
+    def failing_skill():
+        raise ValueError("Intentional fail")
+
+    registry.register_skill("fail_skill", failing_skill, "Fails intentionally")
+
+    telemetry.broadcast_skill_start = AsyncMock()
+    telemetry.broadcast_skill_success = AsyncMock()
+    telemetry.broadcast_skill_fail = AsyncMock()
+
+    # Execute skill that fails
+    try:
+        registry.execute_skill("fail_skill")
+    except Exception:
+        pass
+
+    telemetry.broadcast_skill_start.assert_called_once_with("fail_skill", {})
+    telemetry.broadcast_skill_success.assert_not_called()
+    telemetry.broadcast_skill_fail.assert_called_once()
+    assert telemetry.broadcast_skill_fail.call_args[0][0] == "fail_skill"
+    assert "Intentional fail" in telemetry.broadcast_skill_fail.call_args[0][1]


### PR DESCRIPTION
Implements task `canvas-telemetry-skills-d25e2200` to broadcast skill lifecycle events to Canvas WebSockets. Adds 3 new trending tasks to the project.

---
*PR created automatically by Jules for task [17345986473348065497](https://jules.google.com/task/17345986473348065497) started by @kazah4359-lgtm*