### PR TITLE
feat(memory): implement selective retrieval context plugin

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11294,7 +11294,7 @@
     },
     {
       "id": "context-engine-selective-retrieval-b8bfa454",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine Selective Retrieval Hook",
@@ -25843,6 +25843,60 @@
         "Orchestrator detects crashed or timed-out subagents.",
         "Failing subagents are safely respawned in fresh worktrees up to a maximum retry limit.",
         "Tests verify retry logic and worktree replacement using mock crashes."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-telemetry-ea325e36",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "MCP Dynamic Tool Telemetry Integration",
+      "description": "Inspired by MCP standard trends: Implement a background module to track telemetry of dynamically registered MCP tools and emit latency and usage metrics over the A2A network.",
+      "allowed_paths": [
+        "magda_agent/telemetry/mcp_dynamic_telemetry.py",
+        "tests/test_mcp_dynamic_telemetry.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry module logs MCP tool execution duration.",
+        "Module emits usage metrics to a mock A2A network interface.",
+        "Tests mock execution and verify metric payloads."
+      ]
+    },
+    {
+      "id": "a2a-swarm-discovery-mesh-512f2139",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Swarm Discovery Mesh Service",
+      "description": "Inspired by A2A standard trend: Implement an advanced mesh-based discovery service where peer agents can gossip about available capabilities over mDNS, allowing highly resilient peer-to-peer discovery.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_swarm_mesh.py",
+        "tests/test_a2a_swarm_mesh.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Swarm mesh service can aggregate and broadcast Agent Cards.",
+        "Agents dynamically learn about indirect peers via gossip propagation.",
+        "Tests verify gossip propagation logic with mock network endpoints."
+      ]
+    },
+    {
+      "id": "claude-agent-hierarchical-delegation-2e4db966",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Claude Agent Hierarchical Delegation",
+      "description": "Inspired by Claude Agent multi-agent orchestration trends: Implement a hierarchical delegation module where a lead Planner agent can spawn Sub-planners with constrained scopes and isolated Git worktrees.",
+      "allowed_paths": [
+        "magda_agent/agents/hierarchical_planner.py",
+        "tests/test_hierarchical_planner.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lead planner can dynamically spawn isolated sub-planners.",
+        "Sub-planners run with restricted scopes.",
+        "Tests verify successful delegation and scope containment."
       ]
     }
   ]

--- a/magda_agent/memory/selective_retrieval_hook.py
+++ b/magda_agent/memory/selective_retrieval_hook.py
@@ -1,0 +1,55 @@
+from typing import List, Any
+from magda_agent.memory.selective_retrieval import SelectiveMemoryRetriever
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+class SelectiveRetrievalHook:
+    """
+    A plugin for the ContextEngine that hooks into after_retrieval
+    to fetch contextually relevant episodic memories based on the planner's
+    current subgoal (the query) and append them to the working memory context.
+    """
+    def __init__(self, retriever: SelectiveMemoryRetriever, top_k: int = 5):
+        """
+        Initializes the SelectiveRetrievalHook.
+
+        Args:
+            retriever: The SelectiveMemoryRetriever instance to use for finding episodes.
+            top_k: The maximum number of episodic memories to retrieve.
+        """
+        self.retriever = retriever
+        self.top_k = top_k
+
+    def after_retrieval(self, context: List[Any], query: str, user_id: int) -> List[Any]:
+        """
+        Lifecycle hook called after context is retrieved.
+        Retrieves top_k episodic memories relevant to the query and appends them
+        to the context.
+
+        Args:
+            context: The initially retrieved context (from WorkingMemory).
+            query: The search query, typically the planner's current task/subgoal.
+            user_id: The ID of the user requesting context.
+
+        Returns:
+            The augmented list of context items.
+        """
+        # Ensure we don't modify the original list in place unexpectedly if passed by reference
+        updated_context = list(context)
+
+        episodes = self.retriever.get_relevant_episodes(current_task=query, user_id=user_id, top_k=self.top_k)
+
+        for ep in episodes:
+            # Wrap string episode in a MemoryEntry if needed,
+            # ContextEngine can usually handle strings or MemoryEntries.
+            # We'll use MemoryEntry to be consistent with working memory.
+            entry = MemoryEntry(
+                content=ep,
+                importance=0.5,
+                emotional_state=PADState(0.0, 0.0, 0.0),
+                tags=["episodic_recall"],
+                user_id=user_id
+            )
+            updated_context.append(entry)
+
+        return updated_context

--- a/tests/test_selective_retrieval_hook.py
+++ b/tests/test_selective_retrieval_hook.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.memory.selective_retrieval_hook import SelectiveRetrievalHook
+from magda_agent.memory.working import MemoryEntry
+from magda_agent.emotions.engine import PADState
+
+def test_selective_retrieval_hook_after_retrieval():
+    """
+    Tests that SelectiveRetrievalHook's after_retrieval method correctly calls
+    SelectiveMemoryRetriever and appends the returned episodes as MemoryEntry objects.
+    """
+    # Mock the retriever
+    mock_retriever = MagicMock()
+    mock_retriever.get_relevant_episodes.return_value = ["episode 1", "episode 2"]
+
+    # Initialize the hook
+    hook = SelectiveRetrievalHook(retriever=mock_retriever, top_k=3)
+
+    # Initial context (e.g., from working memory)
+    pad_state = PADState(0.0, 0.0, 0.0)
+    initial_context = [
+        MemoryEntry(content="working memory item 1", importance=0.8, emotional_state=pad_state, tags=["wm"], user_id=42)
+    ]
+
+    # Call the hook
+    query = "test task query"
+    user_id = 42
+    updated_context = hook.after_retrieval(context=initial_context, query=query, user_id=user_id)
+
+    # Assert retriever was called correctly
+    mock_retriever.get_relevant_episodes.assert_called_once_with(current_task=query, user_id=user_id, top_k=3)
+
+    # Assert context is properly updated
+    assert len(updated_context) == 3
+    assert updated_context[0].content == "working memory item 1"
+
+    # Assert episodes were appended as MemoryEntry objects
+    assert updated_context[1].content == "episode 1"
+    assert "episodic_recall" in updated_context[1].tags
+    assert updated_context[1].user_id == user_id
+
+    assert updated_context[2].content == "episode 2"
+    assert "episodic_recall" in updated_context[2].tags
+    assert updated_context[2].user_id == user_id


### PR DESCRIPTION
Implemented the `SelectiveRetrievalHook` context engine plugin to selectively retrieve contextually relevant episodic memories based on the planner's current task/subgoal. It integrates directly into the `after_retrieval` lifecycle hook of the `ContextEngine` and uses the existing `SelectiveMemoryRetriever`. Also added tests, updated the task status, and appended 3 new trend-inspired tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [3956211984706846865](https://jules.google.com/task/3956211984706846865) started by @kazah4359-lgtm*