### PR TITLE
feat(security): implement MCPKernel taint tracking

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -25687,7 +25687,7 @@
       "id": "mcp-kernel-taint-tracking-v1-9bc7dfd3",
       "title": "MCPKernel Taint Tracking V1",
       "description": "Inspired by MCPKernel (June 2026 trend): Implement a taint tracking mechanism that monitors data flow from external MCP tools to prevent prompt injection and unauthorized state mutation.",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "high",
       "allowed_paths": [
@@ -25897,6 +25897,60 @@
         "Lead planner can dynamically spawn isolated sub-planners.",
         "Sub-planners run with restricted scopes.",
         "Tests verify successful delegation and scope containment."
+      ]
+    },
+    {
+      "id": "hermes-cron-daily-report-v1-976e2ca8",
+      "title": "Hermes Cron Daily Report Skill V1",
+      "description": "Inspired by Hermes Agent cron scheduler trends (June 2026): Implement a background cron skill that generates a daily summary report of agent activities, errors, and memory consolidation.",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/skills/cron_daily_report.py",
+        "tests/test_cron_daily_report.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill triggers on a cron schedule.",
+        "Report aggregates activity from mock telemetry/memory sources.",
+        "Tests verify cron scheduling and report generation using mocks."
+      ]
+    },
+    {
+      "id": "openclaw-live-canvas-virtual-memory-v1-823816b7",
+      "title": "OpenClaw Live Canvas Virtual Memory Sync V1",
+      "description": "Inspired by OpenClaw Canvas trends (June 2026): Implement an exporter that streams Virtual Context memory blocks to a live dashboard via WebSockets.",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_virtual_memory.py",
+        "tests/test_canvas_virtual_memory.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter listens for Virtual Context updates.",
+        "Updates are broadcast to the mock Canvas WebSocket endpoint.",
+        "Tests verify WebSocket payload structure and broadcasting logic."
+      ]
+    },
+    {
+      "id": "claude-agent-subagent-memory-isolation-v1-616f6775",
+      "title": "Claude Agent Subagent Memory Isolation V1",
+      "description": "Inspired by Claude Agent multi-agent orchestration trends (June 2026): Implement a context partitioner that ensures spawned Sub-planners cannot access the full parent working memory, receiving only a constrained subset.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/memory/subagent_partitioner.py",
+        "tests/test_subagent_partitioner.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Partitioner filters parent memory based on sub-agent scope.",
+        "Sub-agents only receive context relevant to their assigned task.",
+        "Tests mock parent context and verify correct partitioning rules."
       ]
     }
   ]

--- a/magda_agent/security/mcp_taint_tracker.py
+++ b/magda_agent/security/mcp_taint_tracker.py
@@ -1,0 +1,136 @@
+"""
+MCPKernel Taint Tracking Module.
+Implements a mechanism to track data flow from external MCP tools to prevent
+prompt injection and unauthorized state mutation.
+"""
+from typing import Any, List, Union, Tuple, Set
+
+
+class TaintError(Exception):
+    """Exception raised when a taint violation occurs."""
+    pass
+
+
+class TaintedString(str):
+    """
+    A string wrapper that carries taint information.
+    """
+
+    def __new__(cls, value: str, taints: Set[str] = None) -> 'TaintedString':
+        """Creates a new TaintedString instance."""
+        obj = str.__new__(cls, value)
+        obj.taints = set(taints) if taints else set()
+        return obj
+
+    def __add__(self, other: Union[str, 'TaintedString']) -> 'TaintedString':
+        """Adds another string to this one, combining taints."""
+        combined_taints = set(self.taints)
+        if isinstance(other, TaintedString):
+            combined_taints.update(other.taints)
+        return TaintedString(str(self) + str(other), combined_taints)
+
+    def __radd__(self, other: Union[str, 'TaintedString']) -> 'TaintedString':
+        """Right-adds another string to this one, combining taints."""
+        combined_taints = set(self.taints)
+        if isinstance(other, TaintedString):
+            combined_taints.update(other.taints)
+        return TaintedString(str(other) + str(self), combined_taints)
+
+    def __mul__(self, count: int) -> 'TaintedString':
+        """Multiplies the string, propagating taints."""
+        return TaintedString(str(self) * count, self.taints)
+
+    def __rmul__(self, count: int) -> 'TaintedString':
+        """Right-multiplies the string, propagating taints."""
+        return TaintedString(str(self) * count, self.taints)
+
+    def join(self, iterable: Any) -> 'TaintedString':
+        """Joins an iterable of strings, collecting all taints."""
+        result_str = str(self).join(str(item) for item in iterable)
+        combined_taints = set(self.taints)
+        for item in iterable:
+            if isinstance(item, TaintedString):
+                combined_taints.update(item.taints)
+        return TaintedString(result_str, combined_taints)
+
+    def replace(self, old: str, new: str, count: int = -1) -> 'TaintedString':
+        """Replaces a substring, collecting taints from the arguments."""
+        combined_taints = set(self.taints)
+        if isinstance(old, TaintedString):
+            combined_taints.update(old.taints)
+        if isinstance(new, TaintedString):
+            combined_taints.update(new.taints)
+        return TaintedString(str(self).replace(str(old), str(new), count), combined_taints)
+
+    def format(self, *args: Any, **kwargs: Any) -> 'TaintedString':
+        """Formats the string, collecting taints from the formatting arguments."""
+        combined_taints = set(self.taints)
+        for arg in args:
+            if isinstance(arg, TaintedString):
+                combined_taints.update(arg.taints)
+        for val in kwargs.values():
+            if isinstance(val, TaintedString):
+                combined_taints.update(val.taints)
+
+        # Clean arguments for the actual formatting to avoid recursive taint checks
+        # or formatting issues with subclasses of str
+        clean_args = [str(arg) if isinstance(arg, TaintedString) else arg for arg in args]
+        clean_kwargs = {k: str(v) if isinstance(v, TaintedString) else v for k, v in kwargs.items()}
+
+        return TaintedString(str(self).format(*clean_args, **clean_kwargs), combined_taints)
+
+    # Additional string methods can be overridden to propagate taints
+
+
+class MCPTaintTracker:
+    """
+    Tracks and manages data originating from external MCP tools.
+    """
+    def __init__(self) -> None:
+        """Initializes the Taint Tracker."""
+        self._sensitive_endpoints = set()
+
+    def register_sensitive_endpoint(self, endpoint_name: str) -> None:
+        """
+        Registers an endpoint as sensitive.
+
+        Args:
+            endpoint_name: The name of the endpoint to protect.
+        """
+        self._sensitive_endpoints.add(endpoint_name)
+
+    def label_data(self, data: str, source: str) -> TaintedString:
+        """
+        Labels data with a taint source.
+
+        Args:
+            data: The string data to taint.
+            source: The source of the taint (e.g., 'mcp_tool_x').
+
+        Returns:
+            A TaintedString with the specified source.
+        """
+        return TaintedString(data, taints={source})
+
+    def check_execution(self, endpoint_name: str, data: Any) -> None:
+        """
+        Checks if tainted data is attempting to reach a sensitive endpoint.
+
+        Args:
+            endpoint_name: The name of the endpoint being accessed.
+            data: The data being passed to the endpoint.
+
+        Raises:
+            TaintError: If tainted data reaches a sensitive endpoint.
+        """
+        if endpoint_name in self._sensitive_endpoints:
+            if isinstance(data, TaintedString) and data.taints:
+                raise TaintError(f"Tainted data from {data.taints} attempted to access sensitive endpoint '{endpoint_name}'")
+            # If data is a dictionary, list, etc., we would recursively check for TaintedString
+            elif isinstance(data, (list, tuple, set)):
+                for item in data:
+                    self.check_execution(endpoint_name, item)
+            elif isinstance(data, dict):
+                for key, value in data.items():
+                    self.check_execution(endpoint_name, key)
+                    self.check_execution(endpoint_name, value)

--- a/tests/test_mcp_taint_tracker.py
+++ b/tests/test_mcp_taint_tracker.py
@@ -1,0 +1,114 @@
+"""
+Tests for the MCPTaintTracker module.
+"""
+import pytest
+from magda_agent.security.mcp_taint_tracker import MCPTaintTracker, TaintError, TaintedString
+
+
+def test_taint_labeling() -> None:
+    """Test that data is correctly labeled with a taint."""
+    tracker = MCPTaintTracker()
+    data = tracker.label_data("mcp_output", "tool_a")
+
+    assert isinstance(data, TaintedString)
+    assert data == "mcp_output"
+    assert "tool_a" in data.taints
+
+
+def test_taint_propagation_add() -> None:
+    """Test that taint propagates through string concatenation."""
+    tracker = MCPTaintTracker()
+    tainted = tracker.label_data("hello", "tool_a")
+
+    result = tainted + " world"
+    assert isinstance(result, TaintedString)
+    assert result == "hello world"
+    assert "tool_a" in result.taints
+
+    result2 = "say " + tainted
+    assert isinstance(result2, TaintedString)
+    assert result2 == "say hello"
+    assert "tool_a" in result2.taints
+
+    tainted2 = tracker.label_data(" world", "tool_b")
+    result3 = tainted + tainted2
+    assert isinstance(result3, TaintedString)
+    assert result3 == "hello world"
+    assert "tool_a" in result3.taints
+    assert "tool_b" in result3.taints
+
+
+def test_taint_propagation_join() -> None:
+    """Test that taint propagates through string join."""
+    tracker = MCPTaintTracker()
+    tainted = tracker.label_data("hello", "tool_a")
+
+    # We can only track join when called ON a TaintedString
+    tainted_sep = tracker.label_data("-", "tool_sep")
+    result = tainted_sep.join([tainted, "world"])
+    assert isinstance(result, TaintedString)
+    assert result == "hello-world"
+    assert "tool_sep" in result.taints
+    assert "tool_a" in result.taints
+
+
+def test_taint_propagation_replace() -> None:
+    """Test that taint propagates through string replacement."""
+    tracker = MCPTaintTracker()
+    tainted = tracker.label_data("hello world", "tool_a")
+
+    result = tainted.replace("world", "there")
+    assert isinstance(result, TaintedString)
+    assert result == "hello there"
+    assert "tool_a" in result.taints
+
+
+def test_taint_propagation_format() -> None:
+    """Test that taint propagates through string formatting."""
+    tracker = MCPTaintTracker()
+    tainted_format = tracker.label_data("hello {}", "tool_format")
+
+    result = tainted_format.format("world")
+    assert isinstance(result, TaintedString)
+    assert result == "hello world"
+    assert "tool_format" in result.taints
+
+    tainted_arg = tracker.label_data("world", "tool_arg")
+    result2 = "hello {}".format(tainted_arg)
+    # The normal str.format doesn't know about TaintedString, it will call str()
+    # So we can't easily track this without overriding str (which is not possible)
+    # However, if we call format ON the TaintedString:
+    result3 = TaintedString("hello {}").format(tainted_arg)
+    assert isinstance(result3, TaintedString)
+    assert result3 == "hello world"
+    assert "tool_arg" in result3.taints
+
+
+def test_blocking_execution() -> None:
+    """Test that execution is blocked when tainted data reaches sensitive endpoints."""
+    tracker = MCPTaintTracker()
+    tracker.register_sensitive_endpoint("system.execute")
+
+    tainted = tracker.label_data("rm -rf /", "tool_a")
+
+    # Execution should be blocked
+    with pytest.raises(TaintError, match="Tainted data from {'tool_a'} attempted to access sensitive endpoint 'system.execute'"):
+        tracker.check_execution("system.execute", tainted)
+
+    # Should not block non-sensitive endpoints
+    tracker.check_execution("logger.log", tainted)
+
+    # Should block if tainted data is nested in a list
+    with pytest.raises(TaintError):
+        tracker.check_execution("system.execute", ["echo", tainted])
+
+    # Should block if tainted data is nested in a dict
+    with pytest.raises(TaintError):
+        tracker.check_execution("system.execute", {"cmd": tainted})
+
+    # Should block if key is tainted
+    with pytest.raises(TaintError):
+        tracker.check_execution("system.execute", {tainted: "value"})
+
+    # Should NOT block untainted data even on sensitive endpoints
+    tracker.check_execution("system.execute", "ls -la")


### PR DESCRIPTION
Implements the `mcp-kernel-taint-tracking-v1-9bc7dfd3` task. It includes the `MCPTaintTracker` class that allows monitoring data flow originating from external MCP tools to prevent unauthorized state mutation or prompt injections on sensitive endpoints. It uses a custom `TaintedString` class to carry taint metadata through standard string operations (`+`, `join`, `replace`, `format`). It updates `agent_tasks.json` with 3 new AI trend tasks from June 2026.

---
*PR created automatically by Jules for task [7665450528767977491](https://jules.google.com/task/7665450528767977491) started by @kazah4359-lgtm*