### PR TITLE
A2A Peer Task Delegation Discovery

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11312,7 +11312,7 @@
     },
     {
       "id": "a2a-peer-delegation-discovery-94f536ca",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Peer Task Delegation Discovery",
@@ -25951,6 +25951,42 @@
         "Partitioner filters parent memory based on sub-agent scope.",
         "Sub-agents only receive context relevant to their assigned task.",
         "Tests mock parent context and verify correct partitioning rules."
+      ]
+    },
+    {
+      "id": "magda-trend-27331408",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "A2A Mesh Health Telemetry Sync",
+      "description": "Inspired by A2A standard trends: Implement a background task that continuously streams heartbeats and routing latency metrics of discovered peer agents to the central Canvas dashboard.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_mesh_health.py",
+        "tests/test_a2a_mesh_health.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Background task polls discovered agents for heartbeat latency.",
+        "Health metrics are broadcast via WebSocket to the OpenClaw Canvas.",
+        "Tests mock HTTP latency calls and verify payload formats."
+      ]
+    },
+    {
+      "id": "magda-trend-96ee96ee",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "A2A Mesh Gossip Protocol v4",
+      "description": "Inspired by decentralized A2A protocols: Extend A2A discovery with a gossip protocol allowing agents to forward unseen Agent Cards to known peers, ensuring robust network connectivity without a central registry.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_gossip_v4.py",
+        "tests/test_a2a_gossip_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agents randomly pick peers to exchange new Agent Cards.",
+        "Gossip loop limits TTL (time-to-live) of forwarded cards to prevent infinite loops.",
+        "Tests simulate a fragmented mesh and verify cards reach all nodes."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_peer_discovery.py
+++ b/magda_agent/integration/a2a_peer_discovery.py
@@ -1,0 +1,56 @@
+from typing import Dict, List, Optional, Any
+import logging
+import httpx
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_orchestrator import A2AOrchestrator
+
+class A2APeerDiscoveryService:
+    """
+    Service to register, rank, and map tasks to discovered external A2A agents.
+    """
+
+    def __init__(self, discovery: A2ADiscovery, orchestrator: A2AOrchestrator) -> None:
+        """
+        Initializes the A2APeerDiscoveryService.
+        """
+        self.discovery = discovery
+        self.orchestrator = orchestrator
+
+    async def register_and_rank_peers(self, external_cards: List[AgentCard]) -> None:
+        """
+        Registers external Agent Cards and optionally ranks them.
+        """
+        for card in external_cards:
+            self.discovery._register_agent(card)
+        logging.info(f"Registered {len(external_cards)} external peers.")
+
+    def map_task_to_peer(self, task_constraints: Dict[str, Any]) -> Optional[AgentCard]:
+        """
+        Maps task constraints to a discovered peer agent.
+        """
+        required_capability = task_constraints.get("required_capability")
+        if not required_capability:
+            return None
+
+        agents = self.discovery.find_agents_by_capability(required_capability)
+        if not agents:
+            return None
+
+        # Basic ranking: return the first matched agent
+        return agents[0]
+
+    async def discover_peers_via_mdns(self, mdns_endpoint: str) -> List[AgentCard]:
+        """
+        Simulates discovering peers via mDNS/API.
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(mdns_endpoint)
+                response.raise_for_status()
+                data = response.json()
+                cards = [AgentCard.from_json(card_json) for card_json in data.get("cards", [])]
+                await self.register_and_rank_peers(cards)
+                return cards
+        except Exception as e:
+            logging.error(f"Error discovering peers via mDNS: {e}")
+            return []

--- a/tests/test_a2a_peer_discovery.py
+++ b/tests/test_a2a_peer_discovery.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_delegation import A2ADelegator
+from magda_agent.integration.a2a_orchestrator import A2AOrchestrator
+from magda_agent.integration.a2a_peer_discovery import A2APeerDiscoveryService
+
+@pytest.fixture
+def a2a_discovery() -> A2ADiscovery:
+    """Provides a mocked A2ADiscovery instance."""
+    local_card = AgentCard("local", "local", "local", [], {})
+    discovery = A2ADiscovery(local_card)
+    return discovery
+
+@pytest.fixture
+def a2a_orchestrator(a2a_discovery: A2ADiscovery) -> A2AOrchestrator:
+    """Provides a mocked A2AOrchestrator instance."""
+    delegator = A2ADelegator(a2a_discovery)
+    return A2AOrchestrator(a2a_discovery, delegator)
+
+@pytest.fixture
+def a2a_peer_discovery_service(a2a_discovery: A2ADiscovery, a2a_orchestrator: A2AOrchestrator) -> A2APeerDiscoveryService:
+    """Provides an A2APeerDiscoveryService instance."""
+    return A2APeerDiscoveryService(a2a_discovery, a2a_orchestrator)
+
+@pytest.mark.asyncio
+async def test_register_and_rank_peers(a2a_peer_discovery_service: A2APeerDiscoveryService, a2a_discovery: A2ADiscovery) -> None:
+    """Tests that peers are correctly registered."""
+    cards = [
+        AgentCard("peer1", "Peer 1", "Desc 1", ["cap1"], {"mcp": "url1"}),
+        AgentCard("peer2", "Peer 2", "Desc 2", ["cap2"], {"mcp": "url2"})
+    ]
+    await a2a_peer_discovery_service.register_and_rank_peers(cards)
+
+    assert len(a2a_discovery._discovered_agents) == 2
+    assert "peer1" in a2a_discovery._discovered_agents
+    assert "peer2" in a2a_discovery._discovered_agents
+
+def test_map_task_to_peer(a2a_peer_discovery_service: A2APeerDiscoveryService, a2a_discovery: A2ADiscovery) -> None:
+    """Tests mapping tasks to peers."""
+    card1 = AgentCard("peer1", "Peer 1", "Desc 1", ["cap1"], {"mcp": "url1"})
+    a2a_discovery._register_agent(card1)
+
+    matched_peer = a2a_peer_discovery_service.map_task_to_peer({"required_capability": "cap1"})
+    assert matched_peer == card1
+
+    unmatched_peer = a2a_peer_discovery_service.map_task_to_peer({"required_capability": "cap2"})
+    assert unmatched_peer is None
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get', new_callable=AsyncMock)
+async def test_discover_peers_via_mdns(mock_get: AsyncMock, a2a_peer_discovery_service: A2APeerDiscoveryService, a2a_discovery: A2ADiscovery) -> None:
+    """Tests discovering peers via mDNS."""
+    card_json = AgentCard("peer3", "Peer 3", "Desc 3", ["cap3"], {"mcp": "url3"}).to_json()
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"cards": [card_json]}
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    discovered_cards = await a2a_peer_discovery_service.discover_peers_via_mdns("http://mdns-endpoint")
+
+    assert len(discovered_cards) == 1
+    assert discovered_cards[0].agent_id == "peer3"
+    assert "peer3" in a2a_discovery._discovered_agents
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get', new_callable=AsyncMock)
+async def test_discover_peers_via_mdns_error(mock_get: AsyncMock, a2a_peer_discovery_service: A2APeerDiscoveryService) -> None:
+    """Tests handling errors when discovering peers via mDNS."""
+    mock_get.side_effect = Exception("Simulated network error")
+
+    discovered_cards = await a2a_peer_discovery_service.discover_peers_via_mdns("http://mdns-endpoint")
+    assert len(discovered_cards) == 0


### PR DESCRIPTION
Implements A2APeerDiscoveryService module along with proper mocking in pytest to verify peer discovery functionality, satisfying task `a2a-peer-delegation-discovery-94f536ca`. Added two new tasks to backlog based on the June 2026 trending AI landscape.

---
*PR created automatically by Jules for task [16447532538880400769](https://jules.google.com/task/16447532538880400769) started by @kazah4359-lgtm*