### PR TITLE
Add MCP Action Tool Preflight Validation Layer

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11330,7 +11330,7 @@
     },
     {
       "id": "mcp-action-tool-preflight-validation-cc9ee9dd",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Action Tool Preflight Validation",

--- a/magda_agent/safety/mcp_preflight_validation.py
+++ b/magda_agent/safety/mcp_preflight_validation.py
@@ -1,0 +1,223 @@
+"""MCP Action Tool Preflight Validation Layer.
+
+Provides strict JSON schema argument type-checking for MCP JSON-RPC action tools
+before policy evaluation or tool execution.
+"""
+
+import json
+import logging
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+import jsonschema
+
+logger = logging.getLogger(__name__)
+
+
+class MCPActionToolPreflightValidator:
+    """
+    Preflight validator specifically for MCP action tools.
+    Enforces strict JSON schema argument validation on incoming action tool calls
+    before passing them to the policy layer or tool execution layer.
+    """
+
+    def __init__(
+        self,
+        schemas: Optional[Dict[str, Dict[str, Any]]] = None,
+        policy_layer: Optional[Any] = None,
+        executor: Optional[Callable[[str, Dict[str, Any]], Any]] = None,
+    ) -> None:
+        """
+        Initialize the MCPActionToolPreflightValidator.
+
+        Args:
+            schemas: Optional dictionary mapping tool names to their JSON schema definitions.
+            policy_layer: Optional policy layer instance for evaluation after preflight schema checks.
+            executor: Optional tool execution function/callable.
+        """
+        self.schemas: Dict[str, Dict[str, Any]] = schemas or {}
+        self.policy_layer = policy_layer
+        self.executor = executor
+
+    def register_tool_schema(self, tool_name: str, schema: Dict[str, Any]) -> None:
+        """
+        Registers a JSON schema for a specific tool name.
+
+        Args:
+            tool_name: The name of the action tool.
+            schema: The JSON schema or MCP tool definition containing an 'inputSchema'.
+        """
+        if "inputSchema" in schema and isinstance(schema["inputSchema"], dict):
+            input_schema = schema["inputSchema"]
+        else:
+            input_schema = schema
+
+        try:
+            jsonschema.Draft7Validator.check_schema(input_schema)
+        except jsonschema.exceptions.SchemaError as e:
+            raise ValueError(f"Invalid JSON Schema for tool '{tool_name}': {e}") from e
+
+        self.schemas[tool_name] = input_schema
+        logger.info(f"Registered preflight schema for tool: {tool_name}")
+
+    def validate_args(self, tool_name: str, arguments: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Validates arguments against the registered JSON schema for tool_name.
+
+        Args:
+            tool_name: Name of the action tool.
+            arguments: Dictionary of arguments supplied for the tool.
+
+        Returns:
+            Tuple[bool, str]: (is_valid, error_message)
+        """
+        if tool_name not in self.schemas:
+            return False, f"Tool '{tool_name}' is not registered in preflight schema registry."
+
+        input_schema = self.schemas[tool_name]
+        try:
+            jsonschema.validate(instance=arguments, schema=input_schema)
+            return True, ""
+        except jsonschema.exceptions.ValidationError as e:
+            return False, f"Schema validation error for tool '{tool_name}': {e.message}"
+
+    def validate_preflight_call(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Tuple[bool, int, str]:
+        """
+        Performs full preflight checks: strict schema validation first, then policy evaluation if provided.
+
+        Args:
+            tool_name: Name of the tool to execute.
+            arguments: Tool call arguments.
+
+        Returns:
+            Tuple[bool, int, str]: (is_allowed, error_code, error_message)
+                JSON-RPC error codes:
+                -32601: Method/Tool not found
+                -32602: Invalid params (Schema validation failure)
+                -32000: Policy blocked / Preflight failure
+        """
+        if tool_name not in self.schemas:
+            return False, -32601, f"Method or tool not found: '{tool_name}'."
+
+        is_schema_valid, schema_err = self.validate_args(tool_name, arguments)
+        if not is_schema_valid:
+            logger.warning(f"Preflight schema validation blocked tool '{tool_name}': {schema_err}")
+            return False, -32602, f"Invalid params: {schema_err}"
+
+        # If strict schema validation passes, proceed to policy evaluation if available
+        if self.policy_layer is not None:
+            try:
+                allowed, reason = self.policy_layer.evaluate(tool_name, arguments)
+                if not allowed:
+                    logger.warning(f"Policy evaluation blocked tool '{tool_name}': {reason}")
+                    return False, -32000, f"Policy evaluation blocked execution: {reason}"
+            except Exception as e:
+                logger.error(f"Error evaluating policy layer for tool '{tool_name}': {e}")
+                return False, -32000, f"Policy evaluation failed: {str(e)}"
+
+        return True, 0, ""
+
+    def process_jsonrpc_request(
+        self, request: Union[str, Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """
+        Intercepts and processes a JSON-RPC request, applying preflight schema validation before policy and execution.
+
+        Args:
+            request: JSON string or dictionary representing the JSON-RPC call.
+
+        Returns:
+            Dict[str, Any]: Standardized JSON-RPC 2.0 response dictionary.
+        """
+        if isinstance(request, str):
+            try:
+                req_dict = json.loads(request)
+            except json.JSONDecodeError:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32700, "message": "Parse error: Invalid JSON string."},
+                }
+        elif isinstance(request, dict):
+            req_dict = request
+        else:
+            return {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request: Payload must be object or JSON string."},
+            }
+
+        req_id = req_dict.get("id")
+        if req_dict.get("jsonrpc") != "2.0":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32600, "message": "Invalid Request: jsonrpc version must be '2.0'."},
+            }
+
+        method = req_dict.get("method")
+        if not method or not isinstance(method, str):
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32600, "message": "Invalid Request: 'method' must be a non-empty string."},
+            }
+
+        params = req_dict.get("params", {})
+
+        # Distinguish between standard MCP tool calls ("tools/call" or "call_tool") and direct method calls
+        if method in ("tools/call", "call_tool"):
+            if not isinstance(params, dict):
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": "Invalid params: 'params' must be an object."},
+                }
+            tool_name = params.get("name")
+            if not tool_name or not isinstance(tool_name, str):
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": "Invalid params: 'name' is required for tool calls."},
+                }
+            arguments = params.get("arguments", {})
+            if not isinstance(arguments, dict):
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": "Invalid params: 'arguments' must be an object."},
+                }
+        else:
+            tool_name = method
+            arguments = params if isinstance(params, dict) else {}
+
+        is_valid, err_code, err_msg = self.validate_preflight_call(tool_name, arguments)
+        if not is_valid:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": err_code, "message": err_msg},
+            }
+
+        # If preflight checks pass and an executor is provided, execute the tool
+        if self.executor is not None:
+            try:
+                result = self.executor(tool_name, arguments)
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": result,
+                }
+            except Exception as e:
+                logger.error(f"Error executing tool '{tool_name}': {e}")
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32603, "message": f"Internal error during execution: {str(e)}"},
+                }
+
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"status": "validated", "tool": tool_name, "arguments": arguments},
+        }

--- a/tests/test_mcp_preflight_validation.py
+++ b/tests/test_mcp_preflight_validation.py
@@ -1,0 +1,191 @@
+import json
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.safety.mcp_preflight_validation import MCPActionToolPreflightValidator
+
+
+@pytest.fixture
+def weather_tool_schema():
+    return {
+        "name": "get_weather",
+        "description": "Get weather for a location",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"},
+                "units": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+            },
+            "required": ["location"]
+        }
+    }
+
+
+@pytest.fixture
+def mock_policy():
+    policy = MagicMock()
+    policy.evaluate.return_value = (True, "Allowed")
+    return policy
+
+
+@pytest.fixture
+def mock_executor():
+    def _executor(tool_name, arguments):
+        if tool_name == "get_weather":
+            loc = arguments.get("location")
+            return {"temperature": 22, "location": loc, "units": arguments.get("units", "celsius")}
+        if tool_name == "failing_tool":
+            raise RuntimeError("Execution catastrophic failure")
+        return {"status": "success"}
+
+    return MagicMock(side_effect=_executor)
+
+
+@pytest.fixture
+def validator(weather_tool_schema, mock_policy, mock_executor):
+    val = MCPActionToolPreflightValidator(policy_layer=mock_policy, executor=mock_executor)
+    val.register_tool_schema("get_weather", weather_tool_schema)
+    return val
+
+
+def test_register_invalid_schema():
+    val = MCPActionToolPreflightValidator()
+    invalid_schema = {"type": "invalid_type_name"}
+    with pytest.raises(ValueError, match="Invalid JSON Schema"):
+        val.register_tool_schema("bad_tool", invalid_schema)
+
+
+def test_validate_args_unregistered_tool(validator):
+    is_valid, err = validator.validate_args("unknown_tool", {"param": 1})
+    assert is_valid is False
+    assert "not registered" in err
+
+
+def test_validate_args_success(validator):
+    is_valid, err = validator.validate_args("get_weather", {"location": "London", "units": "celsius"})
+    assert is_valid is True
+    assert err == ""
+
+
+def test_validate_args_missing_required(validator):
+    is_valid, err = validator.validate_args("get_weather", {"units": "celsius"})
+    assert is_valid is False
+    assert "location" in err
+
+
+def test_validate_args_invalid_type(validator):
+    is_valid, err = validator.validate_args("get_weather", {"location": 12345})
+    assert is_valid is False
+    assert "12345 is not of type 'string'" in err
+
+
+def test_validate_args_invalid_enum(validator):
+    is_valid, err = validator.validate_args("get_weather", {"location": "Paris", "units": "kelvin"})
+    assert is_valid is False
+    assert "'kelvin' is not one of" in err
+
+
+def test_validate_preflight_call_unregistered_tool(validator):
+    is_allowed, code, msg = validator.validate_preflight_call("unknown_tool", {})
+    assert is_allowed is False
+    assert code == -32601
+    assert "Method or tool not found" in msg
+
+
+def test_validate_preflight_call_schema_failure(validator, mock_policy):
+    is_allowed, code, msg = validator.validate_preflight_call("get_weather", {"units": "celsius"})
+    assert is_allowed is False
+    assert code == -32602
+    assert "Invalid params" in msg
+    mock_policy.evaluate.assert_not_called()
+
+
+def test_validate_preflight_call_policy_blocked(validator, mock_policy):
+    mock_policy.evaluate.return_value = (False, "Location restricted")
+    is_allowed, code, msg = validator.validate_preflight_call("get_weather", {"location": "RestrictedCity"})
+    assert is_allowed is False
+    assert code == -32000
+    assert "Policy evaluation blocked execution" in msg
+
+
+def test_validate_preflight_call_success(validator, mock_policy):
+    is_allowed, code, msg = validator.validate_preflight_call("get_weather", {"location": "Tokyo"})
+    assert is_allowed is True
+    assert code == 0
+    assert msg == ""
+    mock_policy.evaluate.assert_called_once_with("get_weather", {"location": "Tokyo"})
+
+
+def test_process_jsonrpc_request_parse_error(validator):
+    resp = validator.process_jsonrpc_request("invalid json payload{")
+    assert resp["error"]["code"] == -32700
+
+
+def test_process_jsonrpc_request_invalid_version(validator):
+    resp = validator.process_jsonrpc_request({"jsonrpc": "1.0", "method": "get_weather", "id": 1})
+    assert resp["error"]["code"] == -32600
+
+
+def test_process_jsonrpc_request_missing_method(validator):
+    resp = validator.process_jsonrpc_request({"jsonrpc": "2.0", "id": 1})
+    assert resp["error"]["code"] == -32600
+
+
+def test_process_jsonrpc_request_tools_call_format_success(validator, mock_executor):
+    req = {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+            "name": "get_weather",
+            "arguments": {"location": "Berlin", "units": "celsius"}
+        },
+        "id": 100
+    }
+    resp = validator.process_jsonrpc_request(req)
+    assert resp["id"] == 100
+    assert "result" in resp
+    assert resp["result"]["location"] == "Berlin"
+    mock_executor.assert_called_once_with("get_weather", {"location": "Berlin", "units": "celsius"})
+
+
+def test_process_jsonrpc_request_call_tool_format_schema_error(validator, mock_executor, mock_policy):
+    req = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "call_tool",
+        "params": {
+            "name": "get_weather",
+            "arguments": {"units": "celsius"}  # missing location
+        },
+        "id": 101
+    })
+    resp = validator.process_jsonrpc_request(req)
+    assert resp["id"] == 101
+    assert resp["error"]["code"] == -32602
+    assert "Invalid params" in resp["error"]["message"]
+    mock_policy.evaluate.assert_not_called()
+    mock_executor.assert_not_called()
+
+
+def test_process_jsonrpc_request_direct_method_format(validator):
+    req = {
+        "jsonrpc": "2.0",
+        "method": "get_weather",
+        "params": {"location": "Madrid"},
+        "id": 102
+    }
+    resp = validator.process_jsonrpc_request(req)
+    assert resp["id"] == 102
+    assert resp["result"]["location"] == "Madrid"
+
+
+def test_process_jsonrpc_request_execution_exception(validator):
+    validator.register_tool_schema("failing_tool", {"type": "object"})
+    req = {
+        "jsonrpc": "2.0",
+        "method": "failing_tool",
+        "params": {},
+        "id": 103
+    }
+    resp = validator.process_jsonrpc_request(req)
+    assert resp["id"] == 103
+    assert resp["error"]["code"] == -32603
+    assert "Execution catastrophic failure" in resp["error"]["message"]


### PR DESCRIPTION
Implemented a pre-flight validation layer specific to MCP JSON-RPC action tools (`MCPActionToolPreflightValidator`). It enforces strict JSON schema typing on arguments before policy evaluation or tool execution, handling both MCP payload formats (`tools/call`, `call_tool`) and direct method invocations. Included comprehensive unit tests and updated `agent_tasks.json`.

---
*PR created automatically by Jules for task [17727121781040275809](https://jules.google.com/task/17727121781040275809) started by @kazah4359-lgtm*