### PR TITLE
feat: implement MCP tool registry sync v9

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11348,7 +11348,7 @@
     },
     {
       "id": "mcp-action-tool-registry-sync-v9-fe20c694",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Tool Registry Sync v9",
@@ -25987,6 +25987,60 @@
         "Agents randomly pick peers to exchange new Agent Cards.",
         "Gossip loop limits TTL (time-to-live) of forwarded cards to prevent infinite loops.",
         "Tests simulate a fragmented mesh and verify cards reach all nodes."
+      ]
+    },
+    {
+      "id": "openclaw-context-compressor-v5-8f4b2a9e",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Context Compressor V5",
+      "description": "Inspired by OpenClaw trends (June 2026): Implement a background process that continuously monitors working memory limits and applies semantic compression to older contexts before archiving them as Episodic Memories.",
+      "allowed_paths": [
+        "magda_agent/memory/context_compressor_v5.py",
+        "tests/test_context_compressor_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Background compressor monitors token count thresholds.",
+        "Compression mock summarizes token lists effectively.",
+        "Tests verify token thresholding and mock summary outputs."
+      ]
+    },
+    {
+      "id": "a2a-swarm-agent-discovery-v5-e7a9b3d1",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Swarm Agent Discovery v5",
+      "description": "Inspired by A2A Protocol and Swarm Intelligence trends (June 2026): Implement an mDNS-based local discovery module for peer agents to advertise and discover capabilities via standard Agent Cards.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mdns_discovery_v5.py",
+        "tests/test_a2a_mdns_discovery_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Service can broadcast its own Agent Card over mock mDNS.",
+        "Service can discover other agents publishing Agent Cards.",
+        "Tests verify discovery lifecycle and mock parsing of mDNS payloads."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backup-v2-4c6e9f1a",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Cron Nightly Backup Skill V2",
+      "description": "Inspired by Hermes Agent cron scheduler trends (June 2026): Implement a scheduled skill that exports the current state of SQLite databases to an archive format nightly.",
+      "allowed_paths": [
+        "magda_agent/skills/cron_nightly_backup.py",
+        "tests/test_cron_nightly_backup.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill operates on a cron schedule (e.g., nightly).",
+        "Skill correctly copies mock database files to an archive path.",
+        "Tests mock file I/O and verify cron scheduling."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_registry_sync_v9.py
+++ b/magda_agent/skills/mcp_registry_sync_v9.py
@@ -1,0 +1,131 @@
+import asyncio
+import logging
+from typing import Dict, Any, Optional
+
+import httpx
+
+from magda_agent.skills.mcp_registry import MCPRegistry
+
+
+class MCPRegistrySyncV9:
+    """
+    Background loop that periodically polls a configured MCP server URL
+    and dynamically registers or unregisters tools in the local MCPRegistry.
+    """
+
+    def __init__(self, registry: MCPRegistry, mcp_server_url: str, sync_interval: int = 60) -> None:
+        """
+        Initialize the MCPRegistrySyncV9.
+
+        Args:
+            registry (MCPRegistry): The local registry to keep synchronized.
+            mcp_server_url (str): The remote MCP server URL to poll for tools.
+            sync_interval (int): Time in seconds between polling attempts. Defaults to 60.
+        """
+        self.registry = registry
+        self.mcp_server_url = mcp_server_url
+        self.sync_interval = sync_interval
+        self._running = False
+        self._task: Optional[asyncio.Task[None]] = None
+        self.logger = logging.getLogger(__name__)
+
+    async def _sync_loop(self) -> None:
+        """
+        The main background loop that periodically synchronizes the registry.
+        """
+        while self._running:
+            await self.sync_once()
+            if self._running:
+                try:
+                    await asyncio.sleep(self.sync_interval)
+                except asyncio.CancelledError:
+                    break
+
+    async def sync_once(self) -> None:
+        """
+        Performs a single synchronization cycle by querying the remote MCP server.
+        """
+        self.logger.debug(f"Starting sync cycle with MCP server: {self.mcp_server_url}")
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{self.mcp_server_url}/tools")
+                response.raise_for_status()
+                data = response.json()
+        except httpx.RequestError as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: Network error: {e}")
+            return
+        except httpx.HTTPStatusError as e:
+             self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: HTTP error {e.response.status_code}")
+             return
+        except Exception as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: {e}")
+            return
+
+        if not isinstance(data, dict) or "tools" not in data or not isinstance(data["tools"], list):
+            self.logger.error(f"Invalid response format from MCP server {self.mcp_server_url}: 'tools' list not found.")
+            return
+
+        remote_tools: Dict[str, Dict[str, Any]] = {}
+        for tool in data["tools"]:
+            if isinstance(tool, dict) and "name" in tool:
+                remote_tools[tool["name"]] = tool
+
+        local_tools_names = set(self.registry.list_tools())
+        remote_tools_names = set(remote_tools.keys())
+
+        # Tools to add or update
+        for name, tool_schema in remote_tools.items():
+            if name not in local_tools_names:
+                # Add new tool
+                try:
+                    success = self.registry.load_tool(tool_schema)
+                    if not success:
+                        self.logger.warning(f"Failed to load new MCP tool: {name}")
+                except Exception as e:
+                     self.logger.error(f"Error loading new MCP tool {name}: {e}")
+            else:
+                # Tool already exists, reload it to ensure we have the latest schema
+                try:
+                     self.registry.reload_tool(tool_schema)
+                except Exception as e:
+                     self.logger.error(f"Error reloading existing MCP tool {name}: {e}")
+
+        # Tools to remove
+        tools_to_remove = local_tools_names - remote_tools_names
+        for name in tools_to_remove:
+             try:
+                 self.registry.unload_tool(name)
+                 self.logger.info(f"Unloaded MCP tool {name} as it is no longer present on the remote server.")
+             except Exception as e:
+                 self.logger.error(f"Error unloading MCP tool {name}: {e}")
+
+    def start(self) -> None:
+        """
+        Starts the background synchronization loop.
+        """
+        if self._running:
+            self.logger.warning("Sync loop is already running.")
+            return
+
+        self._running = True
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._sync_loop())
+        self.logger.info(f"Started MCPRegistrySyncV9 loop with interval {self.sync_interval}s.")
+
+    async def stop(self) -> None:
+        """
+        Stops the background synchronization loop.
+        """
+        if not self._running:
+            return
+
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        self.logger.info("Stopped MCPRegistrySyncV9 loop.")

--- a/tests/test_mcp_registry_sync_v9.py
+++ b/tests/test_mcp_registry_sync_v9.py
@@ -1,0 +1,165 @@
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+import pytest
+
+from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.skills.mcp_registry_sync_v9 import MCPRegistrySyncV9
+
+@pytest.fixture
+def registry() -> MCPRegistry:
+    return MCPRegistry()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_add_tool(registry: MCPRegistry) -> None:
+    sync = MCPRegistrySyncV9(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "tools": [
+            {
+                "name": "test_tool_1",
+                "description": "A test tool"
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert "test_tool_1" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_remove_tool(registry: MCPRegistry) -> None:
+    # Pre-load a tool
+    registry.load_tool({
+        "name": "test_tool_to_remove",
+        "description": "Will be removed"
+    })
+    assert "test_tool_to_remove" in registry.list_tools()
+
+    sync = MCPRegistrySyncV9(registry, "http://mock-mcp-server", sync_interval=60)
+
+    # Remote server returns empty list of tools
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"tools": []}
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert "test_tool_to_remove" not in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_update_tool(registry: MCPRegistry) -> None:
+    # Pre-load a tool
+    registry.load_tool({
+        "name": "test_tool_to_update",
+        "description": "Old description"
+    })
+
+    sync = MCPRegistrySyncV9(registry, "http://mock-mcp-server", sync_interval=60)
+
+    # Remote server returns updated tool
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "tools": [
+            {
+                "name": "test_tool_to_update",
+                "description": "New description"
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    tool = registry.get_tool("test_tool_to_update")
+    assert tool["description"] == "New description"
+
+@pytest.mark.asyncio
+async def test_sync_once_http_request_error(registry: MCPRegistry) -> None:
+    registry.load_tool({
+        "name": "test_tool",
+        "description": "Should remain"
+    })
+
+    sync = MCPRegistrySyncV9(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.side_effect = httpx.RequestError("Network error", request=MagicMock())
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    # Tool should still be there because sync failed
+    assert "test_tool" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_http_status_error(registry: MCPRegistry) -> None:
+    registry.load_tool({
+        "name": "test_tool",
+        "description": "Should remain"
+    })
+
+    sync = MCPRegistrySyncV9(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("404 Not Found", request=MagicMock(), response=mock_response)
+    mock_response.status_code = 404
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    # Tool should still be there because sync failed
+    assert "test_tool" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_invalid_json(registry: MCPRegistry) -> None:
+    sync = MCPRegistrySyncV9(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = ["not", "a", "dict"]
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert len(registry.list_tools()) == 0
+
+@pytest.mark.asyncio
+async def test_start_stop() -> None:
+    registry = MCPRegistry()
+    sync = MCPRegistrySyncV9(registry, "http://mock-mcp-server", sync_interval=1)
+
+    with patch.object(sync, 'sync_once', new_callable=AsyncMock) as mock_sync_once:
+        sync.start()
+        assert sync._running is True
+        assert sync._task is not None
+
+        # let it run one cycle
+        await asyncio.sleep(0.1)
+
+        await sync.stop()
+        assert sync._running is False
+        assert sync._task is None
+
+        mock_sync_once.assert_called()


### PR DESCRIPTION
Implemented the MCP Tool Registry Sync v9 background task that polls a remote MCP server using `httpx.AsyncClient` and dynamically synchronizes its schema with the local `MCPRegistry`. The PR features full type safety, comprehensive error handling, async test coverage using `unittest.mock`, and pipeline fulfillment for task `mcp-action-tool-registry-sync-v9-fe20c694`. Furthermore, the task backlog has been organically expanded with 3 new architecture design tasks inspired by June 2026 AI agent patterns.

---
*PR created automatically by Jules for task [1148657583744240087](https://jules.google.com/task/1148657583744240087) started by @kazah4359-lgtm*