### PR TITLE
Implement OpenClaw Live Canvas Telemetry v9

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11366,7 +11366,7 @@
     },
     {
       "id": "openclaw-live-canvas-telemetry-v9-5946331c",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw Live Canvas Telemetry v9",
@@ -26041,6 +26041,59 @@
         "Skill operates on a cron schedule (e.g., nightly).",
         "Skill correctly copies mock database files to an archive path.",
         "Tests mock file I/O and verify cron scheduling."
+      ]
+    },
+    {
+      "id": "agent-guard-runtime-governance-audit-v12",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Agent Guard Runtime Governance Audit v12",
+      "description": "Inspired by Agent Guard / ACS trends (June 2026): Develop an advanced audit trail component that captures policy evaluations and execution parameters of MCP action tools for compliance monitoring.",
+      "allowed_paths": [
+        "magda_agent/safety/audit_v12.py",
+        "tests/test_audit_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audit component records structured logs of policy evaluations.",
+        "Logs contain execution contexts without leaking sensitive secrets.",
+        "Tests verify accurate recording of mock tool executions."
+      ]
+    },
+    {
+      "id": "claude-code-dependency-graph-visualizer-v1",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "Claude Code Dependency Graph Visualizer",
+      "description": "Inspired by Claude Agent SDK (June 2026): Implement an endpoint that exports the planner's DAG into a standard graph representation (e.g., DOT format) that can be visualized in an external dashboard.",
+      "allowed_paths": [
+        "magda_agent/visualization/dag_visualizer.py",
+        "tests/test_dag_visualizer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Visualizer generates correct DOT representation from the Planner DAG.",
+        "Tests mock DAGs and verify the output format."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-user-feedback-v7",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Multimodal User Feedback v7",
+      "description": "Inspired by OpenClaw RL trends: Automatically extract RL rewards from multimodal feedback signals including explicit textual sentiment and implicit interaction length.",
+      "allowed_paths": [
+        "magda_agent/learning/multimodal_feedback_v7.py",
+        "tests/test_multimodal_feedback_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pipeline successfully extracts reward scalars from all modalities.",
+        "Habit weights correctly reflect multimodal inputs.",
+        "Tests mock multi-turn responses."
       ]
     }
   ]

--- a/magda_agent/agents/generator_agent.py
+++ b/magda_agent/agents/generator_agent.py
@@ -67,9 +67,20 @@ class GeneratorAgent:
                 batch_tasks = []
                 step_metadatas = []
 
+
+
                 for step in executable_steps:
                     if steps_executed >= MAX_STEPS:
                         break
+
+                    try:
+                        from magda_agent.api import app
+                        import asyncio
+                        if hasattr(app, 'state') and hasattr(app.state, 'telemetry_streamers') and app.state.telemetry_streamers:
+                            for streamer in app.state.telemetry_streamers:
+                                asyncio.create_task(streamer.broadcast_planner_step(step))
+                    except ImportError:
+                        pass
 
                     skill_name = step.get('skill')
                     kwargs = step.get('skill_kwargs') or {}

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 from fastapi.responses import JSONResponse
 from magda_agent.visualization.server import CanvasServer
 from magda_agent.visualization.canvas_streamer import CanvasMemoryStreamer
+from magda_agent.telemetry.canvas_stream_v9 import CanvasTelemetryStreamerV9
 from magda_agent.memory.canvas_viz import MemoryCanvasVisualizer
 
 from magda_agent.architecture.gateway import LocalFirstGateway
@@ -457,3 +458,25 @@ async def websocket_canvas_episodic(websocket: WebSocket, user_id: Optional[int]
             await websocket.receive_text()
     except WebSocketDisconnect:
         pass
+
+@app.websocket("/ws/canvas/telemetry_v9")
+async def websocket_canvas_telemetry_v9(websocket: WebSocket):
+    token = websocket.query_params.get("token")
+    if not _configured_api_token() or not hmac.compare_digest(token or "", _configured_api_token() or ""):
+        await websocket.close(code=1008)
+        return
+
+    await websocket.accept()
+    streamer = CanvasTelemetryStreamerV9(websocket=websocket)
+
+    # We store the streamer in app state so the main loop can access it
+    if not hasattr(app.state, 'telemetry_streamers'):
+        app.state.telemetry_streamers = []
+    app.state.telemetry_streamers.append(streamer)
+
+    try:
+        while True:
+            # Keep connection open, wait for client messages if any
+            _ = await websocket.receive_text()
+    except WebSocketDisconnect:
+        app.state.telemetry_streamers.remove(streamer)

--- a/magda_agent/consciousness/core.py
+++ b/magda_agent/consciousness/core.py
@@ -356,6 +356,20 @@ class Consciousness:
         from magda_agent.agents.triad_coordinator import TriadCoordinator
         coordinator = TriadCoordinator(planner_agent, generator_agent, evaluator_agent)
 
+
+        try:
+            from magda_agent.api import app
+            import asyncio
+            if hasattr(app, 'state') and hasattr(app.state, 'telemetry_streamers') and app.state.telemetry_streamers:
+                memory_state = {
+                    "working_memory": [m.content for m in relevant_memories],
+                    "context": context_str
+                }
+                for streamer in app.state.telemetry_streamers:
+                    asyncio.create_task(streamer.broadcast_memory_state(memory_state))
+        except ImportError:
+            pass
+
         _mem_context_str = context_str
 
         def message_builder(plan_str: str) -> list:

--- a/magda_agent/telemetry/canvas_stream_v9.py
+++ b/magda_agent/telemetry/canvas_stream_v9.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional
+
+
+class CanvasTelemetryStreamerV9:
+    """
+    A websocket telemetry streamer that broadcasts agent memory state
+    and planner steps in real-time to an external Canvas client.
+    """
+
+    def __init__(self, websocket: Optional[Any] = None) -> None:
+        """
+        Initialize the CanvasTelemetryStreamerV9.
+
+        Args:
+            websocket (Optional[Any]): An open asynchronous websocket connection.
+        """
+        self.websocket = websocket
+        self.logger = logging.getLogger(__name__)
+
+    async def broadcast_memory_state(self, memory_state: Dict[str, Any]) -> None:
+        """
+        Broadcast the agent's memory state to the connected Canvas client.
+
+        Args:
+            memory_state (Dict[str, Any]): The memory state to broadcast.
+        """
+        await self._broadcast_event("memory_state_update", memory_state)
+
+    async def broadcast_planner_step(self, planner_step: Dict[str, Any]) -> None:
+        """
+        Broadcast a planner step to the connected Canvas client.
+
+        Args:
+            planner_step (Dict[str, Any]): The planner step to broadcast.
+        """
+        await self._broadcast_event("planner_step_update", planner_step)
+
+    async def _broadcast_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        """
+        Helper method to format and send events over the websocket.
+
+        Args:
+            event_type (str): The type of the event.
+            data (Dict[str, Any]): The payload of the event.
+        """
+        if self.websocket is None:
+            self.logger.debug(f"Skipping broadcast for {event_type} - no websocket connected.")
+            return
+
+        payload = {
+            "type": event_type,
+            "data": data
+        }
+
+        try:
+            message = json.dumps(payload)
+            await self.websocket.send_text(message)
+            self.logger.debug(f"Successfully broadcasted {event_type} event.")
+        except Exception as e:
+            self.logger.error(f"Failed to broadcast {event_type} event: {e}")

--- a/tests/test_canvas_stream_v9.py
+++ b/tests/test_canvas_stream_v9.py
@@ -1,0 +1,66 @@
+import asyncio
+import json
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from magda_agent.telemetry.canvas_stream_v9 import CanvasTelemetryStreamerV9
+
+
+@pytest.mark.asyncio
+async def test_broadcast_memory_state() -> None:
+    """Tests broadcasting memory state via websocket."""
+    mock_websocket = AsyncMock()
+    streamer = CanvasTelemetryStreamerV9(websocket=mock_websocket)
+
+    memory_state = {"working_memory": ["item1"], "episodic_memory": ["episode1"]}
+    await streamer.broadcast_memory_state(memory_state)
+
+    expected_payload = {
+        "type": "memory_state_update",
+        "data": memory_state
+    }
+
+    # Verify send_text was called with the correct JSON string
+    mock_websocket.send_text.assert_called_once_with(json.dumps(expected_payload))
+
+
+@pytest.mark.asyncio
+async def test_broadcast_planner_step() -> None:
+    """Tests broadcasting a planner step via websocket."""
+    mock_websocket = AsyncMock()
+    streamer = CanvasTelemetryStreamerV9(websocket=mock_websocket)
+
+    planner_step = {"step_id": 1, "description": "Do something"}
+    await streamer.broadcast_planner_step(planner_step)
+
+    expected_payload = {
+        "type": "planner_step_update",
+        "data": planner_step
+    }
+
+    # Verify send_text was called with the correct JSON string
+    mock_websocket.send_text.assert_called_once_with(json.dumps(expected_payload))
+
+
+@pytest.mark.asyncio
+async def test_no_websocket_connected() -> None:
+    """Tests that broadcast gracefully handles missing websocket."""
+    streamer = CanvasTelemetryStreamerV9(websocket=None)
+
+    with patch.object(streamer.logger, "debug") as mock_debug:
+        await streamer.broadcast_memory_state({"data": "test"})
+        mock_debug.assert_called_with("Skipping broadcast for memory_state_update - no websocket connected.")
+
+
+@pytest.mark.asyncio
+async def test_websocket_send_failure() -> None:
+    """Tests that broadcast gracefully handles a send exception."""
+    mock_websocket = AsyncMock()
+    mock_websocket.send_text.side_effect = Exception("Connection closed")
+    streamer = CanvasTelemetryStreamerV9(websocket=mock_websocket)
+
+    with patch.object(streamer.logger, "error") as mock_error:
+        await streamer.broadcast_memory_state({"data": "test"})
+        mock_error.assert_called_with("Failed to broadcast memory_state_update event: Connection closed")


### PR DESCRIPTION
Implemented `CanvasTelemetryStreamerV9` to broadcast the agent's memory state and planner steps in real time via a WebSocket endpoint (`/ws/canvas/telemetry_v9`). This helps visualize the agent's internal state on a dashboard. Additionally, updated `agent_tasks.json` to keep the autonomous improvement loop running by adding new trend-inspired tasks.

---
*PR created automatically by Jules for task [9501682234733473041](https://jules.google.com/task/9501682234733473041) started by @kazah4359-lgtm*