### PR TITLE
feat(planning): implement DependencyGraphV9 for DAG task planning

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11383,7 +11383,7 @@
     },
     {
       "id": "claude-sdk-dependency-graph-planner-v9-f356f47e",
-      "status": "todo",
+      "status": "done",
       "area": "planning",
       "risk": "medium",
       "title": "Claude SDK Dependency Graph Planner v9",
@@ -26094,6 +26094,60 @@
         "Pipeline successfully extracts reward scalars from all modalities.",
         "Habit weights correctly reflect multimodal inputs.",
         "Tests mock multi-turn responses."
+      ]
+    },
+    {
+      "id": "hermes-agent-chain-of-thought-optimizer-a68596f7",
+      "status": "todo",
+      "area": "planning",
+      "risk": "medium",
+      "title": "Hermes Agent Chain of Thought Optimizer",
+      "description": "Inspired by Hermes Agent chain of thought optimization: Implement a module that dynamically prunes redundant reasoning steps from the planner DAG to optimize token usage before execution.",
+      "allowed_paths": [
+        "magda_agent/planning/cot_optimizer.py",
+        "tests/test_cot_optimizer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Optimizer removes redundant sequential steps from the DAG.",
+        "Tests verify that pruning reduces step count without altering dependencies.",
+        "Topological order remains valid."
+      ]
+    },
+    {
+      "id": "openclaw-agent-canvas-dag-viewer-v2-8862c2b2",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas DAG Viewer V2",
+      "description": "Inspired by OpenClaw Canvas visualization trends: Create a WebSocket exporter that streams the planner DAG state updates to the Canvas dashboard.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_dag_viewer_v2.py",
+        "tests/test_canvas_dag_viewer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter converts DAG into node/edge format.",
+        "Updates are broadcast via mock WebSockets.",
+        "Tests verify WebSocket payload formats."
+      ]
+    },
+    {
+      "id": "claude-code-parallel-execution-tracker-348ff059",
+      "status": "todo",
+      "area": "execution",
+      "risk": "high",
+      "title": "Claude Code Parallel Execution Tracker",
+      "description": "Inspired by Claude Agent SDK execution graphs: Implement an execution tracker that coordinates the parallel resolution of independent steps in a DAG, reporting status changes.",
+      "allowed_paths": [
+        "magda_agent/execution/dag_tracker.py",
+        "tests/test_dag_tracker.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tracker identifies executable layers.",
+        "State transitions (pending -> running -> done) are tracked correctly.",
+        "Tests verify coordination of mock tasks."
       ]
     }
   ]

--- a/magda_agent/planning/dependency_graph_v9.py
+++ b/magda_agent/planning/dependency_graph_v9.py
@@ -1,0 +1,133 @@
+import logging
+from typing import List, Dict, Any, Set, Optional
+
+class DependencyGraphV9:
+    """
+    Utility class for resolving task dependencies and computing topological sorts
+    for execution plans. Implements the dependency graph task system for Claude multi-agent orchestration.
+    """
+
+    @staticmethod
+    def get_executable_steps(plan_steps: List[Dict[str, Any]], completed_step_ids: Set[str]) -> List[Dict[str, Any]]:
+        """
+        Returns a list of steps that have all their dependencies met and are not yet completed.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries. Each should have 'id' and 'dependencies'.
+            completed_step_ids (Set[str]): A set of IDs of steps that have already been completed.
+
+        Returns:
+            List[Dict[str, Any]]: A list of steps ready for execution.
+        """
+        executable_steps: List[Dict[str, Any]] = []
+        for step in plan_steps:
+            step_id: Optional[str] = step.get("id")
+            if not step_id or step_id in completed_step_ids:
+                continue
+
+            dependencies: List[str] = step.get("dependencies", [])
+            # A step is executable if all its dependencies are in completed_step_ids
+            all_met: bool = all(dep in completed_step_ids for dep in dependencies)
+            if all_met:
+                executable_steps.append(step)
+
+        return executable_steps
+
+    @staticmethod
+    def topological_sort(plan_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Returns a topologically sorted list of steps using Kahn's algorithm.
+        Raises ValueError if a cycle is detected.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries.
+
+        Returns:
+            List[Dict[str, Any]]: The sorted steps.
+        """
+        # Build adjacency list
+        adj: Dict[str, List[str]] = {step.get("id", ""): [] for step in plan_steps if step.get("id")}
+        in_degree: Dict[str, int] = {step.get("id", ""): 0 for step in plan_steps if step.get("id")}
+
+        step_map: Dict[str, Dict[str, Any]] = {step.get("id", ""): step for step in plan_steps if step.get("id")}
+
+        for step in plan_steps:
+            step_id: Optional[str] = step.get("id")
+            if not step_id:
+                continue
+            dependencies: List[str] = step.get("dependencies", [])
+            for dep in dependencies:
+                if dep in adj:
+                    adj[dep].append(step_id)
+                    in_degree[step_id] += 1
+                else:
+                    logging.warning(f"Dependency {dep} for step {step_id} not found in plan steps.")
+
+        # Kahn's algorithm
+        queue: List[str] = [node for node, deg in in_degree.items() if deg == 0]
+        sorted_ids: List[str] = []
+
+        while queue:
+            node: str = queue.pop(0)
+            sorted_ids.append(node)
+            neighbors: List[str] = adj.get(node, [])
+            for neighbor in neighbors:
+                in_degree[neighbor] -= 1
+                if in_degree[neighbor] == 0:
+                    queue.append(neighbor)
+
+        if len(sorted_ids) != len(adj):
+            raise ValueError("Cycle detected in plan dependencies")
+
+        return [step_map[node] for node in sorted_ids]
+
+    @staticmethod
+    def get_execution_layers(plan_steps: List[Dict[str, Any]]) -> List[List[Dict[str, Any]]]:
+        """
+        Computes the execution layers of the task graph. Each layer contains tasks that can be
+        executed in parallel (i.e. all their dependencies are in previous layers).
+        Raises ValueError if a cycle is detected.
+
+        Args:
+            plan_steps (List[Dict[str, Any]]): The list of step dictionaries.
+
+        Returns:
+            List[List[Dict[str, Any]]]: A list of layers, where each layer is a list of steps.
+        """
+        adj: Dict[str, List[str]] = {step.get("id", ""): [] for step in plan_steps if step.get("id")}
+        in_degree: Dict[str, int] = {step.get("id", ""): 0 for step in plan_steps if step.get("id")}
+        step_map: Dict[str, Dict[str, Any]] = {step.get("id", ""): step for step in plan_steps if step.get("id")}
+
+        for step in plan_steps:
+            step_id: Optional[str] = step.get("id")
+            if not step_id:
+                continue
+            dependencies: List[str] = step.get("dependencies", [])
+            for dep in dependencies:
+                if dep in adj:
+                    adj[dep].append(step_id)
+                    in_degree[step_id] += 1
+                else:
+                    logging.warning(f"Dependency {dep} for step {step_id} not found in plan steps.")
+
+        layers: List[List[Dict[str, Any]]] = []
+        queue: List[str] = [node for node, deg in in_degree.items() if deg == 0]
+        processed_count = 0
+
+        while queue:
+            current_layer_nodes = list(queue)
+            current_layer = [step_map[node] for node in current_layer_nodes]
+            layers.append(current_layer)
+            queue = []
+
+            for node in current_layer_nodes:
+                processed_count += 1
+                for neighbor in adj.get(node, []):
+                    in_degree[neighbor] -= 1
+                    if in_degree[neighbor] == 0:
+                        queue.append(neighbor)
+
+        if processed_count != len(adj):
+            raise ValueError("Cycle detected in plan dependencies")
+
+        return layers

--- a/tests/test_dependency_graph_v9.py
+++ b/tests/test_dependency_graph_v9.py
@@ -1,0 +1,82 @@
+import pytest
+from magda_agent.planning.dependency_graph_v9 import DependencyGraphV9
+
+def test_get_executable_steps() -> None:
+    """Tests that executable steps are correctly identified based on completed dependencies."""
+    plan_steps = [
+        {"id": "task1", "dependencies": []},
+        {"id": "task2", "dependencies": ["task1"]},
+        {"id": "task3", "dependencies": ["task1"]},
+        {"id": "task4", "dependencies": ["task2", "task3"]}
+    ]
+
+    # Initially only task1 is executable
+    completed: set[str] = set()
+    executable = DependencyGraphV9.get_executable_steps(plan_steps, completed)
+    assert len(executable) == 1
+    assert executable[0]["id"] == "task1"
+
+    # After task1 is completed, task2 and task3 are executable
+    completed = {"task1"}
+    executable = DependencyGraphV9.get_executable_steps(plan_steps, completed)
+    assert len(executable) == 2
+    ids = {step["id"] for step in executable}
+    assert ids == {"task2", "task3"}
+
+    # After task1 and task2, task3 is executable
+    completed = {"task1", "task2"}
+    executable = DependencyGraphV9.get_executable_steps(plan_steps, completed)
+    assert len(executable) == 1
+    assert executable[0]["id"] == "task3"
+
+    # After task1, task2, and task3, task4 is executable
+    completed = {"task1", "task2", "task3"}
+    executable = DependencyGraphV9.get_executable_steps(plan_steps, completed)
+    assert len(executable) == 1
+    assert executable[0]["id"] == "task4"
+
+def test_topological_sort() -> None:
+    """Tests the topological sorting of plan steps."""
+    plan_steps = [
+        {"id": "task4", "dependencies": ["task2", "task3"]},
+        {"id": "task2", "dependencies": ["task1"]},
+        {"id": "task3", "dependencies": ["task1"]},
+        {"id": "task1", "dependencies": []}
+    ]
+
+    sorted_steps = DependencyGraphV9.topological_sort(plan_steps)
+    assert len(sorted_steps) == 4
+    assert sorted_steps[0]["id"] == "task1"
+    assert sorted_steps[3]["id"] == "task4"
+
+    # Check cycle detection
+    cyclic_steps = [
+        {"id": "task1", "dependencies": ["task2"]},
+        {"id": "task2", "dependencies": ["task1"]}
+    ]
+    with pytest.raises(ValueError, match="Cycle detected"):
+        DependencyGraphV9.topological_sort(cyclic_steps)
+
+def test_get_execution_layers() -> None:
+    """Tests the calculation of execution layers for parallel execution boundaries."""
+    plan_steps = [
+        {"id": "task1", "dependencies": []},
+        {"id": "task2", "dependencies": ["task1"]},
+        {"id": "task3", "dependencies": ["task1"]},
+        {"id": "task4", "dependencies": ["task2", "task3"]}
+    ]
+
+    layers = DependencyGraphV9.get_execution_layers(plan_steps)
+    assert len(layers) == 3
+    assert len(layers[0]) == 1 and layers[0][0]["id"] == "task1"
+    assert len(layers[1]) == 2
+    assert {"task2", "task3"} == {step["id"] for step in layers[1]}
+    assert len(layers[2]) == 1 and layers[2][0]["id"] == "task4"
+
+    # Cycle detection
+    cyclic_steps = [
+        {"id": "task1", "dependencies": ["task2"]},
+        {"id": "task2", "dependencies": ["task1"]}
+    ]
+    with pytest.raises(ValueError, match="Cycle detected"):
+        DependencyGraphV9.get_execution_layers(cyclic_steps)


### PR DESCRIPTION
Implemented `DependencyGraphV9` utility class for Claude SDK style multi-agent planning. Added robust Kahn's algorithm-based dependency resolution to compute topological sorts and execution layers for parallelizing agent tasks. Also appended 3 new trending agent tasks to `agent_tasks.json`.

---
*PR created automatically by Jules for task [10118616227978849083](https://jules.google.com/task/10118616227978849083) started by @kazah4359-lgtm*