### PR TITLE
feat: A2A Peer Discovery Mesh Agent Cards v10

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11434,7 +11434,7 @@
     },
     {
       "id": "a2a-peer-discovery-mesh-agent-cards-v10-572fea3f",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Peer Discovery Mesh Agent Cards v10",
@@ -26238,6 +26238,57 @@
         "Compressor evaluates current working memory against a token threshold.",
         "Delegates summary generation to the LLM mock.",
         "Tests verify the reduced token count prior to spawning subagents."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-optimization-v3-9d8c7b6a",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Trajectory Optimization V3",
+      "description": "Inspired by OpenClaw-RL trends (June 2026): Implement a module to optimize online RL trajectories by extracting quality metrics directly from user interactions.",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_optimization_v3.py",
+        "tests/test_trajectory_optimization_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module tracks and optimizes trajectories based on simulated user interactions.",
+        "Tests use mocks to verify RL weight updates based on interaction signals."
+      ]
+    },
+    {
+      "id": "claude-evaluator-git-conflict-resolver-v2-1f2e3d4c",
+      "status": "todo",
+      "area": "agents",
+      "risk": "high",
+      "title": "Claude Evaluator Git Conflict Auto-Resolver V2",
+      "description": "Inspired by Claude Agent Teams capabilities (June 2026): Create a Git conflict resolver subagent that operates in isolated worktrees to automatically handle simple merge conflicts using semantic understanding.",
+      "allowed_paths": [
+        "magda_agent/agents/git_conflict_resolver_v2.py",
+        "tests/test_git_conflict_resolver_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent uses LLM (mocked in tests) to semantically resolve Git conflicts.",
+        "Tests verify resolution logic over mock git state."
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-export-v2-5a6b7c8d",
+      "status": "todo",
+      "area": "skills",
+      "risk": "low",
+      "title": "Hermes Skill Marketplace Exporter V2",
+      "description": "Inspired by Hermes agentskills.io standard (June 2026): Build a utility to export Magda procedures into the standard agentskills.io JSON manifest format.",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_export_v2.py",
+        "tests/test_marketplace_export_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter correctly formats internal skills to the external agentskills.io schema.",
+        "Tests verify valid JSON generation."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -341,3 +341,4 @@
 * [ ] FEATURE: Claude Worktree Pruning and Resource Optimizer (claude-worktree-pruning-optimizer-v1)
 * [x] FEATURE: OpenClaw Virtual Context Compression Layer (new-openclaw-virtual-context-compression-v1)
 * [x] FEATURE: Hermes Agent Longitudinal Tracking Synchronization (hermes-agent-quality-metric-sync-003)
+* [x] FEATURE: A2A Peer Discovery Mesh Agent Cards v10 (a2a-peer-discovery-mesh-agent-cards-v10)

--- a/magda_agent/integration/a2a_peer_discovery_v10.py
+++ b/magda_agent/integration/a2a_peer_discovery_v10.py
@@ -1,0 +1,57 @@
+from typing import Dict, List, Optional, Any
+import logging
+import httpx
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_orchestrator import A2AOrchestrator
+
+class A2APeerDiscoveryServiceV10:
+    """
+    Service to register, rank, and map tasks to discovered external A2A agents (v10).
+    Inspired by A2A standard from Google/Linux foundation: Implement mesh agent cards discovery.
+    """
+
+    def __init__(self, discovery: A2ADiscovery, orchestrator: A2AOrchestrator) -> None:
+        """
+        Initializes the A2APeerDiscoveryServiceV10.
+        """
+        self.discovery = discovery
+        self.orchestrator = orchestrator
+
+    async def register_and_rank_peers(self, external_cards: List[AgentCard]) -> None:
+        """
+        Registers external Agent Cards and optionally ranks them.
+        """
+        for card in external_cards:
+            self.discovery._register_agent(card)
+        logging.info(f"Registered {len(external_cards)} external peers.")
+
+    def map_task_to_peer(self, task_constraints: Dict[str, Any]) -> Optional[AgentCard]:
+        """
+        Maps task constraints to a discovered peer agent.
+        """
+        required_capability = task_constraints.get("required_capability")
+        if not required_capability:
+            return None
+
+        agents = self.discovery.find_agents_by_capability(required_capability)
+        if not agents:
+            return None
+
+        # Basic ranking: return the first matched agent
+        return agents[0]
+
+    async def discover_peers_via_mdns(self, mdns_endpoint: str) -> List[AgentCard]:
+        """
+        Simulates discovering peers via mDNS/API.
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(mdns_endpoint)
+                response.raise_for_status()
+                data = response.json()
+                cards = [AgentCard.from_json(card_json) for card_json in data.get("cards", [])]
+                await self.register_and_rank_peers(cards)
+                return cards
+        except Exception as e:
+            logging.error(f"Error discovering peers via mDNS: {e}")
+            return []

--- a/tests/test_a2a_peer_discovery_v10.py
+++ b/tests/test_a2a_peer_discovery_v10.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_delegation import A2ADelegator
+from magda_agent.integration.a2a_orchestrator import A2AOrchestrator
+from magda_agent.integration.a2a_peer_discovery_v10 import A2APeerDiscoveryServiceV10
+
+@pytest.fixture
+def a2a_discovery() -> A2ADiscovery:
+    """Provides a mocked A2ADiscovery instance."""
+    local_card = AgentCard("local", "local", "local", [], {})
+    discovery = A2ADiscovery(local_card)
+    return discovery
+
+@pytest.fixture
+def a2a_orchestrator(a2a_discovery: A2ADiscovery) -> A2AOrchestrator:
+    """Provides a mocked A2AOrchestrator instance."""
+    delegator = A2ADelegator(a2a_discovery)
+    return A2AOrchestrator(a2a_discovery, delegator)
+
+@pytest.fixture
+def a2a_peer_discovery_v10_service(a2a_discovery: A2ADiscovery, a2a_orchestrator: A2AOrchestrator) -> A2APeerDiscoveryServiceV10:
+    """Provides an A2APeerDiscoveryServiceV10 instance."""
+    return A2APeerDiscoveryServiceV10(a2a_discovery, a2a_orchestrator)
+
+@pytest.mark.asyncio
+async def test_register_and_rank_peers(a2a_peer_discovery_v10_service: A2APeerDiscoveryServiceV10, a2a_discovery: A2ADiscovery) -> None:
+    """Tests that peers are correctly registered."""
+    cards = [
+        AgentCard("peer1", "Peer 1", "Desc 1", ["cap1"], {"mcp": "url1"}),
+        AgentCard("peer2", "Peer 2", "Desc 2", ["cap2"], {"mcp": "url2"})
+    ]
+    await a2a_peer_discovery_v10_service.register_and_rank_peers(cards)
+
+    assert len(a2a_discovery._discovered_agents) == 2
+    assert "peer1" in a2a_discovery._discovered_agents
+    assert "peer2" in a2a_discovery._discovered_agents
+
+def test_map_task_to_peer(a2a_peer_discovery_v10_service: A2APeerDiscoveryServiceV10, a2a_discovery: A2ADiscovery) -> None:
+    """Tests mapping tasks to peers."""
+    card1 = AgentCard("peer1", "Peer 1", "Desc 1", ["cap1"], {"mcp": "url1"})
+    a2a_discovery._register_agent(card1)
+
+    matched_peer = a2a_peer_discovery_v10_service.map_task_to_peer({"required_capability": "cap1"})
+    assert matched_peer == card1
+
+    unmatched_peer = a2a_peer_discovery_v10_service.map_task_to_peer({"required_capability": "cap2"})
+    assert unmatched_peer is None
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get', new_callable=AsyncMock)
+async def test_discover_peers_via_mdns(mock_get: AsyncMock, a2a_peer_discovery_v10_service: A2APeerDiscoveryServiceV10, a2a_discovery: A2ADiscovery) -> None:
+    """Tests discovering peers via mDNS."""
+    card_json = AgentCard("peer3", "Peer 3", "Desc 3", ["cap3"], {"mcp": "url3"}).to_json()
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"cards": [card_json]}
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    discovered_cards = await a2a_peer_discovery_v10_service.discover_peers_via_mdns("http://mdns-endpoint")
+
+    assert len(discovered_cards) == 1
+    assert discovered_cards[0].agent_id == "peer3"
+    assert "peer3" in a2a_discovery._discovered_agents
+
+@pytest.mark.asyncio
+@patch('httpx.AsyncClient.get', new_callable=AsyncMock)
+async def test_discover_peers_via_mdns_error(mock_get: AsyncMock, a2a_peer_discovery_v10_service: A2APeerDiscoveryServiceV10) -> None:
+    """Tests handling errors when discovering peers via mDNS."""
+    mock_get.side_effect = Exception("Simulated network error")
+
+    discovered_cards = await a2a_peer_discovery_v10_service.discover_peers_via_mdns("http://mdns-endpoint")
+    assert len(discovered_cards) == 0


### PR DESCRIPTION
Implemented the A2A Peer Discovery Mesh Agent Cards v10 feature as outlined in the autonomous loops instructions. Added proper module tracking, complete testing coverage with mocked APIs, updated tracking files `agent_tasks.json` and `backlog.md`.

---
*PR created automatically by Jules for task [13787958264018430464](https://jules.google.com/task/13787958264018430464) started by @kazah4359-lgtm*