### PR TITLE
feat(integration): implement A2A discovery mesh v11

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11451,7 +11451,7 @@
     },
     {
       "id": "a2a-protocol-discovery-mesh-v11-0f46c26a",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Protocol Discovery Mesh v11",
@@ -26289,6 +26289,60 @@
       "acceptance": [
         "Exporter correctly formats internal skills to the external agentskills.io schema.",
         "Tests verify valid JSON generation."
+      ]
+    },
+    {
+      "id": "mcp-policy-layer-guard-v5-aef893d7",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Policy Layer Guard V5",
+      "description": "Inspired by 2026 trends for runtime safety (e.g. MCPKernel, Agent Guard): Implement a policy enforcement layer that intercepts every MCP tool call before execution to enforce explicit rule-based constraints.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_policy_layer_v5.py",
+        "tests/test_mcp_policy_layer_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Policy layer successfully blocks unapproved tool calls.",
+        "Policy layer successfully permits approved tool calls.",
+        "Tests use mocks to verify interception logic."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugin-v4-8edcf10a",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Plugin V4",
+      "description": "Inspired by OpenClaw's Context Engine standard: Create a virtual context management plugin that manages memory splitting (Working vs Episodic) dynamically for new conversations.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_plugin_v4.py",
+        "tests/test_context_engine_plugin_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin intercepts context requests and appends episodic memory chunks appropriately.",
+        "Limits context window usage correctly.",
+        "Tests use mocks to verify context assembly."
+      ]
+    },
+    {
+      "id": "hermes-cron-scheduler-tasks-v2-9a749752",
+      "status": "todo",
+      "area": "execution",
+      "risk": "low",
+      "title": "Hermes Cron Scheduler Background Tasks V2",
+      "description": "Inspired by Hermes Agent's background operations: Implement an asynchronous cron-like scheduler to handle scheduled background operations without user prompting, like daily summaries.",
+      "allowed_paths": [
+        "magda_agent/execution/cron_scheduler_v2.py",
+        "tests/test_cron_scheduler_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler correctly initiates background tasks at specified intervals.",
+        "Main application loop is not blocked.",
+        "Tests use AsyncMock to verify time-based task triggering."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_discovery_mesh_v11.py
+++ b/magda_agent/integration/a2a_discovery_mesh_v11.py
@@ -1,0 +1,84 @@
+from typing import Dict, List, Optional, Any
+import logging
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+
+class A2ADiscoveryMeshV11:
+    """
+    Manages an A2A discovery mesh based on the A2A Protocol trend.
+    It tracks the state of peers, allows registering new peers, and facilitates finding
+    peers with required capabilities using AgentCards.
+    """
+
+    def __init__(self, discovery: A2ADiscovery) -> None:
+        """
+        Initializes the A2ADiscoveryMeshV11.
+
+        Args:
+            discovery: The core A2ADiscovery instance.
+        """
+        self.discovery = discovery
+        self.peer_states: Dict[str, str] = {}
+
+    def register_peers(self, cards: List[AgentCard]) -> None:
+        """
+        Registers multiple external Agent Cards into the mesh.
+
+        Args:
+            cards: A list of AgentCard instances to register.
+        """
+        for card in cards:
+            self.discovery._register_agent(card)
+            self.peer_states[card.agent_id] = "active"
+            logging.info(f"Registered peer in mesh: {card.agent_id}")
+
+    def update_peer_state(self, agent_id: str, state: str) -> None:
+        """
+        Updates the state of a registered peer in the mesh.
+
+        Args:
+            agent_id: The ID of the agent whose state to update.
+            state: The new state (e.g., 'active', 'offline', 'busy').
+        """
+        if agent_id in self.peer_states:
+            self.peer_states[agent_id] = state
+            logging.info(f"Updated peer state for {agent_id} to {state}")
+        else:
+            logging.warning(f"Attempted to update state for unknown peer: {agent_id}")
+
+    def get_peer_state(self, agent_id: str) -> Optional[str]:
+        """
+        Retrieves the state of a registered peer.
+
+        Args:
+            agent_id: The ID of the agent.
+
+        Returns:
+            The state of the agent if it exists, otherwise None.
+        """
+        return self.peer_states.get(agent_id)
+
+    def find_best_peer_for_capability(self, capability: str) -> Optional[AgentCard]:
+        """
+        Finds the most suitable active peer for a required capability.
+
+        Args:
+            capability: The required capability.
+
+        Returns:
+            The AgentCard of the selected peer, or None if no active peer is found.
+        """
+        agents = self.discovery.find_agents_by_capability(capability)
+        if not agents:
+            return None
+
+        # Filter for only active agents
+        active_agents = [
+            agent for agent in agents
+            if self.peer_states.get(agent.agent_id) == "active"
+        ]
+
+        if not active_agents:
+            return None
+
+        # Return the first active agent as a simple strategy
+        return active_agents[0]

--- a/tests/test_a2a_discovery_mesh_v11.py
+++ b/tests/test_a2a_discovery_mesh_v11.py
@@ -1,0 +1,70 @@
+import pytest
+from typing import List
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_discovery_mesh_v11 import A2ADiscoveryMeshV11
+
+@pytest.fixture
+def a2a_discovery() -> A2ADiscovery:
+    """Provides a mocked A2ADiscovery instance."""
+    local_card = AgentCard("local", "local", "local", [], {})
+    discovery = A2ADiscovery(local_card)
+    return discovery
+
+@pytest.fixture
+def a2a_discovery_mesh(a2a_discovery: A2ADiscovery) -> A2ADiscoveryMeshV11:
+    """Provides an A2ADiscoveryMeshV11 instance."""
+    return A2ADiscoveryMeshV11(a2a_discovery)
+
+def test_register_peers(a2a_discovery_mesh: A2ADiscoveryMeshV11, a2a_discovery: A2ADiscovery) -> None:
+    """Tests registering peers into the mesh."""
+    cards = [
+        AgentCard("peer1", "Peer 1", "Desc 1", ["cap1"], {"mcp": "url1"}),
+        AgentCard("peer2", "Peer 2", "Desc 2", ["cap2"], {"mcp": "url2"})
+    ]
+    a2a_discovery_mesh.register_peers(cards)
+
+    assert "peer1" in a2a_discovery._discovered_agents
+    assert "peer2" in a2a_discovery._discovered_agents
+    assert a2a_discovery_mesh.get_peer_state("peer1") == "active"
+    assert a2a_discovery_mesh.get_peer_state("peer2") == "active"
+
+def test_update_peer_state(a2a_discovery_mesh: A2ADiscoveryMeshV11) -> None:
+    """Tests updating the state of a registered peer."""
+    card = AgentCard("peer1", "Peer 1", "Desc 1", ["cap1"], {"mcp": "url1"})
+    a2a_discovery_mesh.register_peers([card])
+
+    assert a2a_discovery_mesh.get_peer_state("peer1") == "active"
+
+    a2a_discovery_mesh.update_peer_state("peer1", "offline")
+    assert a2a_discovery_mesh.get_peer_state("peer1") == "offline"
+
+    # Should not raise exception for unknown peer
+    a2a_discovery_mesh.update_peer_state("unknown_peer", "active")
+    assert a2a_discovery_mesh.get_peer_state("unknown_peer") is None
+
+def test_find_best_peer_for_capability(a2a_discovery_mesh: A2ADiscoveryMeshV11) -> None:
+    """Tests finding the best active peer for a capability."""
+    cards = [
+        AgentCard("peer1", "Peer 1", "Desc 1", ["cap1"], {"mcp": "url1"}),
+        AgentCard("peer2", "Peer 2", "Desc 2", ["cap1"], {"mcp": "url2"}),
+        AgentCard("peer3", "Peer 3", "Desc 3", ["cap2"], {"mcp": "url3"})
+    ]
+    a2a_discovery_mesh.register_peers(cards)
+
+    # All active initially
+    best_peer = a2a_discovery_mesh.find_best_peer_for_capability("cap1")
+    assert best_peer is not None
+    assert best_peer.agent_id in ["peer1", "peer2"]
+
+    # Make peer1 offline, so it should return peer2
+    a2a_discovery_mesh.update_peer_state("peer1", "offline")
+    best_peer_after_update = a2a_discovery_mesh.find_best_peer_for_capability("cap1")
+    assert best_peer_after_update is not None
+    assert best_peer_after_update.agent_id == "peer2"
+
+    # Capability with only offline peers
+    a2a_discovery_mesh.update_peer_state("peer2", "offline")
+    assert a2a_discovery_mesh.find_best_peer_for_capability("cap1") is None
+
+    # Capability that doesn't exist
+    assert a2a_discovery_mesh.find_best_peer_for_capability("unknown_cap") is None


### PR DESCRIPTION
This PR implements the `A2ADiscoveryMeshV11` task based on recent AI agent trends. It introduces a discovery mesh that manages peer states (e.g. active, offline) and routes capability requests to the correct `AgentCard`.

Tests are provided and the task backlog in `agent_tasks.json` has been updated and appended with 3 new actionable, trend-inspired (June 2026) tasks.

---
*PR created automatically by Jules for task [11740616882189430295](https://jules.google.com/task/11740616882189430295) started by @kazah4359-lgtm*