### PR TITLE
Implement Magentic-One Orchestration Router v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11485,7 +11485,7 @@
     },
     {
       "id": "magentic-one-orchestration-router-v2-944692d0",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "medium",
       "title": "Magentic-One Orchestration Router v2",
@@ -26380,6 +26380,60 @@
         "Evaluator scores action trajectories and outputs reward signals.",
         "Evaluator identifies points of context fragmentation.",
         "Tests ensure consistent reward values for various mocked trajectories."
+      ]
+    },
+    {
+      "id": "a2a-mesh-subagent-telemetry-v4-abcd1234",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "A2A Mesh Sub-agent Telemetry Aggregation V4",
+      "description": "Inspired by A2A Protocol and multi-agent orchestration trends: Implement a background module to aggregate and broadcast sub-agent tracing telemetry (e.g. latency, token usage) over an A2A distributed mesh network.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_mesh_telemetry_v4.py",
+        "tests/test_a2a_mesh_telemetry_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry module successfully intercepts trace logs.",
+        "Module emits telemetry payloads via mock network interface.",
+        "Tests mock telemetry tracing and verify payload formatting."
+      ]
+    },
+    {
+      "id": "mcp-action-guardrail-circuit-breaker-v1-efgh5678",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Action Guardrail Circuit Breaker V1",
+      "description": "Inspired by ACS security trends (June 2026): Implement a circuit breaker logic in the MCP execution guardrail layer that temporarily stops all external MCP action tool executions if the failure or taint violation threshold is exceeded rapidly.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_circuit_breaker_v1.py",
+        "tests/test_mcp_circuit_breaker_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Circuit breaker tracks consecutive policy failures.",
+        "Blocks all execution if the threshold is surpassed, returning a specific error payload.",
+        "Tests mock policy violations and verify the breaker opens."
+      ]
+    },
+    {
+      "id": "contextual-reflection-loop-v1-ijkl9012",
+      "status": "todo",
+      "area": "reflection",
+      "risk": "medium",
+      "title": "Contextual Reflection Loop V1",
+      "description": "Inspired by Online Learning and Self-improvement loops: Implement an offline contextual reflection service that evaluates recent sub-agent conversational exchanges and condenses them into semantic procedural templates if they meet success heuristic thresholds.",
+      "allowed_paths": [
+        "magda_agent/learning/contextual_reflection_v1.py",
+        "tests/test_contextual_reflection_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Service fetches mock sub-agent conversational logs.",
+        "Service filters logs according to mock success thresholds.",
+        "Tests verify successful processing and memory persistence logic."
       ]
     }
   ]

--- a/magda_agent/architecture/magentic_one_router_v2.py
+++ b/magda_agent/architecture/magentic_one_router_v2.py
@@ -1,0 +1,75 @@
+import logging
+import json
+from typing import List, Optional
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.architecture.magentic_one_v2 import MagenticOneWorkerV2
+
+
+class MagenticOneOrchestrationRouterV2:
+    """
+    Implements a hierarchical orchestration router based on Microsoft's Magentic-One pattern.
+    Routes tasks to the most appropriate active sub-agent (worker).
+    """
+
+    def __init__(self, llm: LLMClient, workers: List[MagenticOneWorkerV2]) -> None:
+        """
+        Initializes the MagenticOneOrchestrationRouterV2.
+
+        Args:
+            llm (LLMClient): The language model client.
+            workers (List[MagenticOneWorkerV2]): The list of available workers.
+        """
+        self.llm = llm
+        self.workers = workers
+
+    async def route(self, task: str, context: List[str]) -> str:
+        """
+        Routes the task to the most appropriate worker based on the task description
+        and the available workers' specialties.
+
+        Args:
+            task (str): The task to be executed.
+            context (List[str]): Context strings for the current run.
+
+        Returns:
+            str: The output of the task execution by the selected worker.
+        """
+        if not self.workers:
+            logging.error("No workers available for routing.")
+            return "Error: No workers available."
+
+        worker_descriptions = "\n".join(
+            [f"- {worker.name}: {worker.description}" for worker in self.workers]
+        )
+
+        prompt = (
+            f"Task: {task}\n"
+            f"Context: {context}\n"
+            f"Available workers:\n{worker_descriptions}\n"
+            "Analyze the task and select the best worker to execute it. "
+            "Return ONLY the exact name of the selected worker. Do not include any other text."
+        )
+
+        try:
+            response = await self.llm.chat_completion([{"role": "user", "content": prompt}])
+            selected_worker_name = response.strip()
+
+            selected_worker = self._find_worker(selected_worker_name)
+
+            if not selected_worker:
+                logging.warning(f"Worker '{selected_worker_name}' not found. Falling back to the first available worker.")
+                selected_worker = self.workers[0]
+
+            logging.info(f"Routing task to worker: {selected_worker.name}")
+            return await selected_worker.execute_subtask(task, context)
+
+        except Exception as e:
+            logging.error(f"Routing failed: {e}")
+            return f"Routing error: {e}"
+
+    def _find_worker(self, name: str) -> Optional[MagenticOneWorkerV2]:
+        for worker in self.workers:
+            if worker.name == name:
+                return worker
+        return None

--- a/tests/test_magentic_one_router_v2.py
+++ b/tests/test_magentic_one_router_v2.py
@@ -1,0 +1,74 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.architecture.magentic_one_v2 import MagenticOneWorkerV2
+from magda_agent.architecture.magentic_one_router_v2 import MagenticOneOrchestrationRouterV2
+
+
+class MockLLMClient(LLMClient):
+    def __init__(self):
+        self.chat_completion = AsyncMock()
+
+
+def test_route_successful():
+    llm = MockLLMClient()
+    llm.chat_completion.side_effect = [
+        "WorkerB",  # First call selects worker
+        "WorkerB executed the task"  # Call from inside WorkerB's execute_subtask
+    ]
+
+    worker_a = MagenticOneWorkerV2("WorkerA", "Does A things", llm)
+    worker_b = MagenticOneWorkerV2("WorkerB", "Does B things", llm)
+    workers = [worker_a, worker_b]
+
+    router = MagenticOneOrchestrationRouterV2(llm, workers)
+
+    result = asyncio.run(router.route("Do a B thing", []))
+
+    assert "WorkerB executed the task" in result
+    assert llm.chat_completion.call_count == 2
+    # First call is router selecting worker
+    assert "WorkerB" in llm.chat_completion.call_args_list[0][0][0][0]["content"] or "Available workers" in llm.chat_completion.call_args_list[0][0][0][0]["content"]
+    # Second call is the worker executing
+    assert "WorkerB" in llm.chat_completion.call_args_list[1][0][0][0]["content"]
+
+
+def test_route_fallback_when_worker_not_found():
+    llm = MockLLMClient()
+    llm.chat_completion.side_effect = [
+        "NonExistentWorker",  # Router selects unknown worker
+        "WorkerA executed the task"  # Fallback to WorkerA
+    ]
+
+    worker_a = MagenticOneWorkerV2("WorkerA", "Does A things", llm)
+    workers = [worker_a]
+
+    router = MagenticOneOrchestrationRouterV2(llm, workers)
+
+    result = asyncio.run(router.route("Do something", []))
+
+    assert "WorkerA executed the task" in result
+
+
+def test_route_no_workers():
+    llm = MockLLMClient()
+    router = MagenticOneOrchestrationRouterV2(llm, [])
+
+    result = asyncio.run(router.route("Do something", []))
+
+    assert "Error: No workers available." in result
+
+
+def test_route_exception_handling():
+    llm = MockLLMClient()
+    llm.chat_completion.side_effect = Exception("LLM connection failed")
+
+    worker_a = MagenticOneWorkerV2("WorkerA", "Does A things", llm)
+    router = MagenticOneOrchestrationRouterV2(llm, [worker_a])
+
+    result = asyncio.run(router.route("Do something", []))
+
+    assert "Routing error" in result
+    assert "LLM connection failed" in result


### PR DESCRIPTION
This PR implements the "Magentic-One Orchestration Router v2" task.
It introduces `MagenticOneOrchestrationRouterV2` which routes subtasks to appropriate workers based on descriptions using the LLM. It includes comprehensive tests mocking the LLM calls and properly handles worker selection failures. The `agent_tasks.json` has been updated with 3 new "todo" tasks related to AI trends.

---
*PR created automatically by Jules for task [4245032245589725973](https://jules.google.com/task/4245032245589725973) started by @kazah4359-lgtm*