### PR TITLE
feat(memory): Implement Context Engine Plugin Lifecycle Hooks V7

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11571,7 +11571,7 @@
     },
     {
       "id": "context-engine-plugin-lifecycle-v7-0ed894ee",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Context Engine Plugin Architecture v7",
@@ -26734,6 +26734,57 @@
         "Dependency graph correctly identifies independent nodes for parallel execution.",
         "Throws errors for cyclic dependencies.",
         "Tests assert graph generation and concurrent extraction on complex mock plans."
+      ]
+    },
+    {
+      "id": "hermes-structured-output-enforcer-v2-1234abcd",
+      "status": "todo",
+      "area": "generation",
+      "risk": "medium",
+      "title": "Hermes Structured Output Enforcer V2",
+      "description": "Inspired by Hermes Agent structured generation (June 2026): Implement an output enforcement wrapper that guarantees LLM responses conform to a strict Pydantic model by retrying formatting failures before returning to the core loop.",
+      "allowed_paths": [
+        "magda_agent/generation/structured_enforcer_v2.py",
+        "tests/test_structured_enforcer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Enforcer wraps standard LLM client generation.",
+        "Retries parsing failures using validation feedback."
+      ]
+    },
+    {
+      "id": "openai-swarm-dynamic-handoff-v1-5678efgh",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "OpenAI Swarm Dynamic Handoff Protocol V1",
+      "description": "Inspired by OpenAI Agents SDK/Swarm (June 2026): Implement a Hand-Off primitive where a sub-agent can programmatically yield its context and return control to the Orchestrator with a target next-agent specified, instead of simply returning 'done'.",
+      "allowed_paths": [
+        "magda_agent/architecture/swarm_handoff_v1.py",
+        "tests/test_swarm_handoff_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agents can return a Handoff object instead of text.",
+        "Orchestrator respects handoff and shifts context."
+      ]
+    },
+    {
+      "id": "claude-code-tool-discovery-manifest-v3-9012ijkl",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Claude Code Dynamic Tool Discovery Manifest V3",
+      "description": "Inspired by Claude Code (June 2026): Implement a manifest generator that scans the `magda_agent/skills` directory and auto-generates an MCP-compatible JSON manifest for all registered skills on startup, eliminating manual registry sync.",
+      "allowed_paths": [
+        "magda_agent/skills/manifest_generator_v3.py",
+        "tests/test_manifest_generator_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Manifest generator reads skill metadata decorators.",
+        "Produces valid JSON matching MCP specification."
       ]
     }
   ]

--- a/magda_agent/memory/context_engine.py
+++ b/magda_agent/memory/context_engine.py
@@ -40,6 +40,14 @@ class ContextPlugin(Protocol):
         """Called when the overall context is updated."""
         ...
 
+    async def pre_process(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Called to pre-process content before ingestion."""
+        ...
+
+    async def post_process(self, response: str, metadata: Dict[str, Any]) -> str:
+        """Called to post-process a response before returning to user."""
+        ...
+
 
 class ContextEngine:
     """
@@ -80,6 +88,10 @@ class ContextEngine:
             self.hook_registry.register_hook('assemble', plugin.assemble)
         if hasattr(plugin, 'compact'):
             self.hook_registry.register_hook('compact', plugin.compact)
+        if hasattr(plugin, 'pre_process'):
+            self.hook_registry.register_hook('pre_process', plugin.pre_process)
+        if hasattr(plugin, 'post_process'):
+            self.hook_registry.register_hook('post_process', plugin.post_process)
 
         logging.debug(f"Registered plugin: {plugin.__class__.__name__}")
 
@@ -92,6 +104,10 @@ class ContextEngine:
         config_with_hooks: Dict[str, Any] = dict(config)
         config_with_hooks["hook_registry"] = self.hook_registry
         await self.hook_registry.trigger_broadcast_async('bootstrap', config_with_hooks)
+
+    async def pre_process(self, content: str, metadata: Dict[str, Any]) -> str:
+        """Run content through pre_process hook of all plugins."""
+        return await self.hook_registry.trigger_hook_async('pre_process', content, metadata)
 
     async def ingest(self, content: str, metadata: Dict[str, Any]) -> str:
         """Run content through ingest hook of all plugins using the hook registry."""
@@ -169,6 +185,10 @@ class ContextEngine:
         """Triggers the on_context_update hook for all registered plugins."""
         self.hook_registry.trigger_hook('on_context_update', new_context, user_id)
 
+
+    async def post_process(self, response: str, metadata: Dict[str, Any]) -> str:
+        """Run response through post_process hook of all plugins."""
+        return await self.hook_registry.trigger_hook_async('post_process', response, metadata)
 
     def write_context(self, context: Any, user_id: int) -> None:
         """Writes context by executing lifecycle hooks before and after."""

--- a/tests/test_context_engine.py
+++ b/tests/test_context_engine.py
@@ -12,6 +12,8 @@ class MockPlugin(ContextPlugin):
         self.ingest_called = False
         self.assemble_called = False
         self.compact_called = False
+        self.pre_process_called = False
+        self.post_process_called = False
 
     async def bootstrap(self, config):
         self.bootstrap_called = True
@@ -27,6 +29,14 @@ class MockPlugin(ContextPlugin):
     async def compact(self, context_items, metadata):
         self.compact_called = True
         return context_items[:-1]
+
+    async def pre_process(self, content: str, metadata: dict) -> str:
+        self.pre_process_called = True
+        return f"preprocessed_{content}"
+
+    async def post_process(self, response: str, metadata: dict) -> str:
+        self.post_process_called = True
+        return f"postprocessed_{response}"
 
     def before_retrieval(self, query: str, user_id: int) -> str:
         return query
@@ -70,10 +80,20 @@ async def test_context_engine_lifecycle():
     assert "hook_registry" in bootstrap_config
     assert bootstrap_config["hook_registry"] == engine.hook_registry
 
+    # Test Pre Process
+    preprocessed = await engine.pre_process("raw_content", {"user_id": 1})
+    assert mock_plugin.pre_process_called
+    assert preprocessed == "preprocessed_raw_content"
+
     # Test Ingest
     ingested = await engine.ingest("raw", {"user_id": 1})
     assert mock_plugin.ingest_called
     assert ingested == "ingested_raw"
+
+    # Test Post Process
+    postprocessed = await engine.post_process("raw_response", {"user_id": 1})
+    assert mock_plugin.post_process_called
+    assert postprocessed == "postprocessed_raw_response"
 
     # Test Assemble
     assembled = await engine.assemble([], {"user_id": 1})


### PR DESCRIPTION
This PR implements the missing lifecycle hooks `pre_process` and `post_process` in the `ContextEngine` as requested by task `context-engine-plugin-lifecycle-v7-0ed894ee`.

Changes include:
- Expanding the `ContextPlugin` protocol to define these hooks.
- Modifying `ContextEngine` to register these hooks dynamically into the `HookRegistry`.
- Implementing `ContextEngine.pre_process` and `ContextEngine.post_process` executor methods.
- Updating `agent_tasks.json` to mark the current task as done and adding 3 new AI-trend-inspired tasks (Hermes V2 Structured Output Enforcer, OpenAI Swarm Handoff, Claude Code Manifest Generator).
- Adding tests to `tests/test_context_engine.py` using `pytest` and mock plugins.

---
*PR created automatically by Jules for task [16573270686041404092](https://jules.google.com/task/16573270686041404092) started by @kazah4359-lgtm*