### PR TITLE
feat(safety): implement ASSERT policy evaluation framework

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11605,7 +11605,7 @@
     },
     {
       "id": "assert-policy-evaluation-framework-99612579",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "ASSERT Policy Evaluation Framework",
@@ -26839,6 +26839,42 @@
         "Dependency graph correctly identifies conditional branching paths.",
         "Supports dynamic re-evaluation of the graph upon step completion.",
         "Tests assert graph generation and branch evaluation on complex mock plans."
+      ]
+    },
+    {
+      "id": "agent-guard-runtime-governance-38491a34",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Agent Guard Runtime Governance Layer",
+      "description": "Implement an Agent Guard runtime governance layer that sits between the agent and external actions, using the newly created AssertEvaluator to validate actions against explicit safety policies before execution, similar to Microsoft's ACS.",
+      "allowed_paths": [
+        "magda_agent/safety/agent_guard.py",
+        "tests/test_agent_guard.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "AgentGuard intercepts actions and calls AssertEvaluator.",
+        "If AssertEvaluator returns non-compliant, the action is blocked and a fallback is executed.",
+        "Tests verify block and allow paths using mock evaluators."
+      ]
+    },
+    {
+      "id": "openclaw-online-rl-skills-b8392f11",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw Online RL from Feedback",
+      "description": "Implement OpenClaw-inspired online reinforcement learning from user feedback and next-state signals. Track tool output successes and user corrections to adjust habit weights in the dialogue online learner.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_v6.py",
+        "tests/test_openclaw_rl_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "OpenClawRL class parses user feedback (positive/negative) and updates action weights.",
+        "Weights are persisted in memory.",
+        "Tests mock memory updates and verify weight adjustments."
       ]
     }
   ]

--- a/magda_agent/safety/assert_evaluation.py
+++ b/magda_agent/safety/assert_evaluation.py
@@ -1,0 +1,85 @@
+import json
+import logging
+from typing import Any, Dict, List
+
+from magda_agent.llm_client import LLMClient
+
+
+class AssertEvaluator:
+    """
+    ASSERT Policy Evaluation Framework.
+
+    This class implements a policy-driven evaluation framework to validate
+    inputs, such as tool calls, against explicit safety policies.
+    """
+
+    def __init__(self, llm: LLMClient) -> None:
+        """
+        Initialize the AssertEvaluator.
+
+        Args:
+            llm (LLMClient): The LLM client used to evaluate policies.
+        """
+        self.llm = llm
+
+    async def evaluate_input(self, input_data: Dict[str, Any], policies: List[str]) -> Dict[str, Any]:
+        """
+        Evaluate an input, such as a tool call, against a list of explicit safety policies.
+
+        Args:
+            input_data (Dict[str, Any]): The input data to evaluate.
+            policies (List[str]): A list of policies to evaluate against.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing the evaluation result with
+                            keys 'is_compliant' (bool) and 'violations' (List[str]).
+        """
+        formatted_policies = "\n".join([f"- {policy}" for policy in policies])
+        input_json = json.dumps(input_data, indent=2)
+
+        prompt = (
+            "Evaluate the following input against the provided safety policies.\n"
+            "Determine if the input violates ANY of these policies.\n\n"
+            f"Policies:\n{formatted_policies}\n\n"
+            f"Input:\n{input_json}\n\n"
+            "Respond ONLY with a JSON object in this exact format:\n"
+            "{\n"
+            '  "is_compliant": true,\n'
+            '  "violations": ["Policy description if violated, else empty"]\n'
+            "}"
+        )
+
+        messages = [{"role": "system", "content": prompt}]
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            try:
+                evaluation_text = await self.llm.chat_completion(messages, temperature=0.1)
+
+                if "```" in evaluation_text:
+                    evaluation_text = evaluation_text.split("```")[1]
+                    if evaluation_text.startswith("json"):
+                        evaluation_text = evaluation_text[4:]
+
+                evaluation = json.loads(evaluation_text.strip())
+                is_compliant = bool(evaluation.get("is_compliant", False))
+                violations = evaluation.get("violations", [])
+
+                if not is_compliant and violations:
+                    logging.warning(f"ASSERT Framework: Input violation detected! Violations: {violations}")
+
+                return {
+                    "is_compliant": is_compliant,
+                    "violations": violations
+                }
+
+            except json.JSONDecodeError as e:
+                logging.warning(f"ASSERT Framework JSON decoding error attempt {attempt + 1}/{max_retries}: {e}")
+                if attempt == max_retries - 1:
+                    logging.error("ASSERT Framework reached max retries. Failing closed (is_compliant=False).")
+                    return {"is_compliant": False, "violations": ["Evaluation failed due to JSON decoding error."]}
+            except Exception as e:
+                logging.error(f"ASSERT Framework failed: {e}")
+                return {"is_compliant": False, "violations": [f"Evaluation failed: {str(e)}"]}
+
+        return {"is_compliant": False, "violations": ["Unknown error"]}

--- a/tests/test_assert_evaluation.py
+++ b/tests/test_assert_evaluation.py
@@ -1,0 +1,100 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.safety.assert_evaluation import AssertEvaluator
+
+
+@pytest.fixture
+def mock_llm_client():
+    mock = AsyncMock(spec=LLMClient)
+    return mock
+
+
+@pytest.fixture
+def evaluator(mock_llm_client):
+    return AssertEvaluator(llm=mock_llm_client)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_input_compliant(evaluator, mock_llm_client):
+    mock_json_response = '''
+    ```json
+    {
+      "is_compliant": true,
+      "violations": []
+    }
+    ```
+    '''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    input_data = {"tool_name": "get_weather", "arguments": {"location": "London"}}
+    policies = ["Do not access local files"]
+
+    result = await evaluator.evaluate_input(input_data, policies)
+
+    mock_llm_client.chat_completion.assert_called_once()
+    call_args = mock_llm_client.chat_completion.call_args[0][0]
+    assert "- Do not access local files" in call_args[0]["content"]
+    assert "get_weather" in call_args[0]["content"]
+
+    assert result is not None
+    assert result["is_compliant"] is True
+    assert result["violations"] == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_input_violation(evaluator, mock_llm_client):
+    mock_json_response = '''
+    {
+      "is_compliant": false,
+      "violations": ["Do not access local files"]
+    }
+    '''
+    mock_llm_client.chat_completion.return_value = mock_json_response
+
+    input_data = {"tool_name": "read_file", "arguments": {"filepath": "/etc/passwd"}}
+    policies = ["Do not access local files"]
+
+    result = await evaluator.evaluate_input(input_data, policies)
+
+    assert result is not None
+    assert result["is_compliant"] is False
+    assert result["violations"] == ["Do not access local files"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_input_json_decode_error_retry(evaluator, mock_llm_client):
+    invalid_json = "this is not valid json"
+    valid_json = '''
+    {
+      "is_compliant": true,
+      "violations": []
+    }
+    '''
+    mock_llm_client.chat_completion.side_effect = [invalid_json, valid_json]
+
+    input_data = {"tool_name": "get_weather"}
+    policies = ["Policy 1"]
+
+    result = await evaluator.evaluate_input(input_data, policies)
+
+    assert result is not None
+    assert result["is_compliant"] is True
+    assert mock_llm_client.chat_completion.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_evaluate_input_exception_failing_closed(evaluator, mock_llm_client):
+    mock_llm_client.chat_completion.side_effect = Exception("API error")
+
+    input_data = {"tool_name": "get_weather"}
+    policies = ["Policy 1"]
+
+    result = await evaluator.evaluate_input(input_data, policies)
+
+    assert result is not None
+    assert result["is_compliant"] is False
+    assert "API error" in result["violations"][0]


### PR DESCRIPTION
This PR implements the ASSERT Policy Evaluation Framework as requested in task `assert-policy-evaluation-framework-99612579`.

It introduces `AssertEvaluator` to evaluate inputs against policies using an LLM. It includes complete unit tests and keeps the scope strictly within `allowed_paths`. Two new tasks inspired by Agent Guard and OpenClaw RL were appended to `agent_tasks.json`.

---
*PR created automatically by Jules for task [2499437630712733149](https://jules.google.com/task/2499437630712733149) started by @kazah4359-lgtm*