### PR TITLE
feat: Implement Episodic and Semantic Memory Separation

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11622,7 +11622,7 @@
     },
     {
       "id": "memory-episodic-semantic-separation-c4ade337",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Episodic and Semantic Memory Separation",
@@ -26875,6 +26875,60 @@
         "OpenClawRL class parses user feedback (positive/negative) and updates action weights.",
         "Weights are persisted in memory.",
         "Tests mock memory updates and verify weight adjustments."
+      ]
+    },
+    {
+      "id": "mcp-tool-policy-guard-v5-9a8b7c6d",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Tool Policy Guard V5",
+      "description": "Inspired by MCPKernel Taint Tracking Sandbox trends (June 2026): Implement an execution wrapper that intercepts MCP tool execution, checking inputs against a strict policy matrix before proceeding, effectively sandboxing dynamic actions.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_policy_guard_v5.py",
+        "tests/test_mcp_policy_guard_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox intercepts MCP tool executions.",
+        "Validates arguments against policies before execution.",
+        "Tests mock valid and invalid tool calls to verify interception."
+      ]
+    },
+    {
+      "id": "a2a-subagent-team-delegator-1b2c3d4e",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Subagent Team Delegator",
+      "description": "Inspired by Claude Agent Teams multi-agent pattern (June 2026): Delegate task steps to specialized subagents using A2A protocol. Allows spawning isolated agents for concurrent steps.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_team_delegator.py",
+        "tests/test_a2a_team_delegator.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Delegator can dispatch a plan step to a peer agent.",
+        "Supports async/await for parallel execution.",
+        "Tests mock A2A network responses."
+      ]
+    },
+    {
+      "id": "openclaw-habit-learning-v5-5f6g7h8i",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw Habit Learning V5",
+      "description": "Inspired by OpenClaw-RL (June 2026): Implement online reinforcement learning from tool usage success and user replies. Track tool outputs and adjust habit weights in real-time.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_habit_v5.py",
+        "tests/test_openclaw_habit_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "OpenClawHabitLearner class parses user feedback and tool success.",
+        "Weights are adjusted and persisted.",
+        "Tests verify weight adjustments through mocks."
       ]
     }
   ]

--- a/magda_agent/memory/episodic_semantic_v2.py
+++ b/magda_agent/memory/episodic_semantic_v2.py
@@ -1,0 +1,108 @@
+import logging
+from typing import Optional, Dict, Any, List
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.memory.semantic import SemanticMemory
+from magda_agent.llm_client import LLMClient
+
+class EpisodicSemanticMemoryManagerV2:
+    """
+    EpisodicSemanticMemoryManagerV2 handles routing information to strict separation between Episodic
+    (event-based) and Semantic (knowledge-based) memory stores.
+    """
+
+    def __init__(self, episodic: EpisodicMemory, semantic: SemanticMemory, llm_client: Optional[LLMClient] = None) -> None:
+        """
+        Initialize the memory manager.
+
+        Args:
+            episodic: The episodic memory instance.
+            semantic: The semantic memory instance.
+            llm_client: Optional LLMClient to help route memories accurately.
+        """
+        self.episodic = episodic
+        self.semantic = semantic
+        self.llm_client = llm_client
+        logging.info("Initialized EpisodicSemanticMemoryManagerV2")
+
+    async def route_and_store(self, text: str, metadata: Optional[Dict[str, Any]] = None, user_id: Optional[int] = None) -> str:
+        """
+        Route the text to either episodic or semantic memory based on its content, and store it.
+
+        Args:
+            text: The information to be stored.
+            metadata: Optional metadata to attach to the memory.
+            user_id: Optional user identifier.
+
+        Returns:
+            str: The name of the store used ('episodic' or 'semantic').
+        """
+        store_type = await self._determine_store(text)
+
+        if store_type == "semantic":
+            self.semantic.store_fact(text=text, metadata=metadata, user_id=user_id)
+            logging.debug(f"Routed to Semantic memory: {text[:30]}...")
+            return "semantic"
+        else:
+            self.episodic.store_event(text=text, metadata=metadata, user_id=user_id)
+            logging.debug(f"Routed to Episodic memory: {text[:30]}...")
+            return "episodic"
+
+    async def _determine_store(self, text: str) -> str:
+        """
+        Internal method to determine if a text is an event (episodic) or a fact (semantic).
+
+        Args:
+            text: The text to classify.
+
+        Returns:
+            str: 'episodic' or 'semantic'.
+        """
+        if self.llm_client:
+            prompt = f"Determine if the following text is a specific event (return 'episodic') or a stable fact/knowledge (return 'semantic'). Respond with only one word: 'episodic' or 'semantic'.\n\nText: {text}"
+            try:
+                response = await self.llm_client.generate(prompt)
+                response = response.strip().lower()
+                if "semantic" in response:
+                    return "semantic"
+                return "episodic"
+            except Exception as e:
+                logging.error(f"LLM routing failed, falling back to heuristics: {e}")
+
+        # Simple heuristics fallback
+        text_lower = text.lower()
+        if "yesterday" in text_lower or "today" in text_lower or "just now" in text_lower or "happened" in text_lower or "said" in text_lower or "did" in text_lower:
+            return "episodic"
+
+        if "is a" in text_lower or "are" in text_lower or "fact" in text_lower or "always" in text_lower or "means" in text_lower or "prefer" in text_lower:
+             return "semantic"
+
+        # Default to episodic if ambiguous
+        return "episodic"
+
+    def retrieve_episodic(self, query: str, top_k: int = 5, user_id: Optional[int] = None) -> List[str]:
+        """
+        Retrieve relevant events from the episodic memory store.
+
+        Args:
+            query: The semantic search query.
+            top_k: Number of results to return.
+            user_id: Optional user identifier to filter by.
+
+        Returns:
+            List[str]: A list of relevant events.
+        """
+        return self.episodic.recall_events(query=query, top_k=top_k, user_id=user_id)
+
+    def retrieve_semantic(self, query: str, top_k: int = 5, user_id: Optional[int] = None) -> List[str]:
+        """
+        Retrieve relevant facts from the semantic memory store.
+
+        Args:
+            query: The semantic search query.
+            top_k: Number of results to return.
+            user_id: Optional user identifier to filter by.
+
+        Returns:
+            List[str]: A list of relevant facts.
+        """
+        return self.semantic.recall_facts(query=query, top_k=top_k, user_id=user_id)

--- a/tests/test_episodic_semantic_v2.py
+++ b/tests/test_episodic_semantic_v2.py
@@ -1,0 +1,104 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.memory.episodic_semantic_v2 import EpisodicSemanticMemoryManagerV2
+from magda_agent.memory.episodic import EpisodicMemory
+from magda_agent.memory.semantic import SemanticMemory
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_episodic():
+    episodic = MagicMock(spec=EpisodicMemory)
+    episodic.store_event = MagicMock()
+    episodic.recall_events = MagicMock(return_value=["event 1", "event 2"])
+    return episodic
+
+@pytest.fixture
+def mock_semantic():
+    semantic = MagicMock(spec=SemanticMemory)
+    semantic.store_fact = MagicMock()
+    semantic.recall_facts = MagicMock(return_value=["fact 1"])
+    return semantic
+
+@pytest.fixture
+def mock_llm_client():
+    llm_client = MagicMock(spec=LLMClient)
+    llm_client.generate = AsyncMock()
+    return llm_client
+
+@pytest.mark.asyncio
+async def test_route_and_store_semantic_llm(mock_episodic, mock_semantic, mock_llm_client):
+    manager = EpisodicSemanticMemoryManagerV2(mock_episodic, mock_semantic, mock_llm_client)
+
+    mock_llm_client.generate.return_value = " semantic \n"
+
+    store_used = await manager.route_and_store("The sky is blue.", metadata={"key": "value"}, user_id=1)
+
+    assert store_used == "semantic"
+    mock_semantic.store_fact.assert_called_once_with(text="The sky is blue.", metadata={"key": "value"}, user_id=1)
+    mock_episodic.store_event.assert_not_called()
+    mock_llm_client.generate.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_route_and_store_episodic_llm(mock_episodic, mock_semantic, mock_llm_client):
+    manager = EpisodicSemanticMemoryManagerV2(mock_episodic, mock_semantic, mock_llm_client)
+
+    mock_llm_client.generate.return_value = "episodic"
+
+    store_used = await manager.route_and_store("Yesterday I went to the store.", metadata={"key": "value"}, user_id=2)
+
+    assert store_used == "episodic"
+    mock_episodic.store_event.assert_called_once_with(text="Yesterday I went to the store.", metadata={"key": "value"}, user_id=2)
+    mock_semantic.store_fact.assert_not_called()
+    mock_llm_client.generate.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_route_and_store_semantic_heuristic(mock_episodic, mock_semantic):
+    # No LLM client provided, relies on heuristics
+    manager = EpisodicSemanticMemoryManagerV2(mock_episodic, mock_semantic)
+
+    store_used = await manager.route_and_store("Water is a liquid.", user_id=3)
+
+    assert store_used == "semantic"
+    mock_semantic.store_fact.assert_called_once_with(text="Water is a liquid.", metadata=None, user_id=3)
+    mock_episodic.store_event.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_route_and_store_episodic_heuristic(mock_episodic, mock_semantic):
+    # No LLM client provided, relies on heuristics
+    manager = EpisodicSemanticMemoryManagerV2(mock_episodic, mock_semantic)
+
+    store_used = await manager.route_and_store("I did my homework today.", user_id=4)
+
+    assert store_used == "episodic"
+    mock_episodic.store_event.assert_called_once_with(text="I did my homework today.", metadata=None, user_id=4)
+    mock_semantic.store_fact.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_route_and_store_llm_failure_fallback(mock_episodic, mock_semantic, mock_llm_client):
+    manager = EpisodicSemanticMemoryManagerV2(mock_episodic, mock_semantic, mock_llm_client)
+
+    # Simulate LLM failure
+    mock_llm_client.generate.side_effect = Exception("API error")
+
+    # "is a" triggers semantic heuristic
+    store_used = await manager.route_and_store("A dog is a mammal.", user_id=5)
+
+    assert store_used == "semantic"
+    mock_semantic.store_fact.assert_called_once_with(text="A dog is a mammal.", metadata=None, user_id=5)
+    mock_episodic.store_event.assert_not_called()
+
+def test_retrieve_episodic(mock_episodic, mock_semantic):
+    manager = EpisodicSemanticMemoryManagerV2(mock_episodic, mock_semantic)
+
+    results = manager.retrieve_episodic("went to store", top_k=2, user_id=1)
+
+    assert results == ["event 1", "event 2"]
+    mock_episodic.recall_events.assert_called_once_with(query="went to store", top_k=2, user_id=1)
+
+def test_retrieve_semantic(mock_episodic, mock_semantic):
+    manager = EpisodicSemanticMemoryManagerV2(mock_episodic, mock_semantic)
+
+    results = manager.retrieve_semantic("what is water", top_k=1, user_id=2)
+
+    assert results == ["fact 1"]
+    mock_semantic.recall_facts.assert_called_once_with(query="what is water", top_k=1, user_id=2)


### PR DESCRIPTION
This PR implements the `memory-episodic-semantic-separation-c4ade337` task to separate episodic (event) and semantic (fact) memory routing.

- **`magda_agent/memory/episodic_semantic_v2.py`**: Added the `EpisodicSemanticMemoryManagerV2` class which takes an LLM client and determines whether incoming knowledge is an episodic event or a semantic fact.
- **`tests/test_episodic_semantic_v2.py`**: Fully mocked tests using `AsyncMock` to ensure no live API calls occur.
- **`agent_tasks.json`**: Marked the task as completed and generated 3 new trend-inspired backlog tasks based on AI Agent trends (June 2026).

**Note:** Integration into the main `MemorySystem` or `__init__.py` was avoided to strictly comply with the allowed_paths constraint declared in `agent_tasks.json`.

---
*PR created automatically by Jules for task [8024575912574193213](https://jules.google.com/task/8024575912574193213) started by @kazah4359-lgtm*