### PR TITLE
feat: implement OpenClaw-RL online reinforcement learning from next-state signals

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11708,7 +11708,7 @@
     },
     {
       "id": "openclaw-rl-next-state-signals-v1-c9a5b60a",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL: Online Reinforcement Learning from Next-State Signals",
@@ -27106,6 +27106,58 @@
         "Middleware intercepts workflow steps at 5 distinct checkpoints.",
         "Validates state against defined ACS policy controls.",
         "Tests use mock policies to ensure robust checkpoint validation."
+      ]
+    },
+    {
+      "id": "mcp-skill-registry-exporter-v1-187c3745",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Skill Registry Exporter",
+      "description": "Inspired by MCP standards (June 2026): Implement an exporter that converts Magda skills into MCP-compatible JSON-RPC action tools so they can be discovered and used by external agents.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_exporter_v1.py",
+        "tests/test_mcp_exporter_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill representations are converted to strict JSON-RPC structures.",
+        "Tests mock skill registry and assert correctly formatted MCP export."
+      ]
+    },
+    {
+      "id": "virtual-context-paging-v1-b6d3a240",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "title": "Virtual Context Paging for Working Memory",
+      "description": "Inspired by MemGPT/Letta patterns (June 2026): Implement dynamic context paging to swap least-relevant working memory into a secondary store when token limits are exceeded.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_pager.py",
+        "tests/test_virtual_context_pager.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context pager detects token overflow and safely offloads oldest blocks.",
+        "Tests mock token counts and verify that memory state shrinks transparently."
+      ]
+    },
+    {
+      "id": "agent-guard-runtime-policy-layer-v1-05bb0192",
+      "status": "todo",
+      "area": "safety",
+      "risk": "critical",
+      "title": "Agent Guard Runtime Policy Layer",
+      "description": "Inspired by Agent Guard and Falco Prempti patterns (June 2026): Implement a runtime governance layer that intercepts all tool calls mutating external state to check against a strict policy matrix.",
+      "allowed_paths": [
+        "magda_agent/safety/agent_guard_policy_layer.py",
+        "tests/test_agent_guard_policy_layer.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool calls are intercepted by the governance layer.",
+        "Unsafe state mutations are blocked by the policy engine.",
+        "Tests mock mutating tools and verify they are correctly dropped."
       ]
     }
   ]

--- a/magda_agent/learning/openclaw_rl_v6.py
+++ b/magda_agent/learning/openclaw_rl_v6.py
@@ -1,0 +1,92 @@
+import logging
+from typing import Optional, List
+
+from magda_agent.learning.habits import HabitTracker
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+class OpenClawRLV6:
+    """
+    OpenClaw-RL Online Reinforcement Learning V6.
+    Implements online learning from next-state signals (such as user replies
+    and tool outputs) without explicit labeling. The agent learns from talking.
+    """
+
+    def __init__(
+        self,
+        habit_tracker: HabitTracker,
+        mirror_neurons: MirrorNeurons,
+    ) -> None:
+        """
+        Initializes the learner with its dependencies.
+
+        Args:
+            habit_tracker: The system for tracking habit/skill usage.
+            mirror_neurons: The sentiment and empathy processor for implicit feedback.
+        """
+        self.habit_tracker = habit_tracker
+        self.mirror_neurons = mirror_neurons
+
+    def _calculate_reward(self, p_shift: float, tool_output: Optional[str]) -> float:
+        """
+        Calculates the reward score based on empathy shift and tool output.
+
+        Args:
+            p_shift: The positive shift in empathy.
+            tool_output: The output from the executed tool.
+
+        Returns:
+            A calculated reward float between 0.0 and 10.0.
+        """
+        # Base reward transformation
+        base_reward = (p_shift + 1.0) * 5.0
+
+        # Give bonus if there's a valid tool output and positive empathy shift
+        if tool_output and p_shift > 0.0:
+            base_reward += 2.0
+
+        return max(0.0, min(10.0, base_reward))
+
+    async def process_next_state_signal(
+        self,
+        user_reply: str,
+        action_context: str,
+        user_id: int,
+        tool_output: Optional[str] = None,
+        skills_used: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Analyzes the user's reply as a next-state signal, and reinforces habits.
+
+        Args:
+            user_reply (str): The user's reply string.
+            action_context (str): A description of the action taken.
+            user_id (int): The ID of the current user.
+            tool_output (Optional[str], optional): The output from the executed tool. Defaults to None.
+            skills_used (Optional[List[str]], optional): A list of skill names used. Defaults to None.
+        """
+        if not user_reply or not action_context:
+            return
+
+        signal_text = user_reply
+        if tool_output:
+            signal_text += f" [Tool Output: {tool_output}]"
+
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(signal_text)
+
+        skills = skills_used or ["rl_skill_v6"]
+
+        reward = self._calculate_reward(p_shift, tool_output)
+
+        if reward > 5.0:
+            # Positive signal, reinforce habits
+            for skill in skills:
+                self.habit_tracker.record_usage(
+                    input_text=action_context,
+                    skill_used=skill,
+                    evaluation_score=reward,
+                    user_id=user_id
+                )
+            logging.info(f"OpenClawRLV6: Positive signal received (reward={reward:.2f}). Reinforced skills: {skills}")
+        else:
+            # Negative or low neutral signal
+            logging.info(f"OpenClawRLV6: Low/Negative signal (reward={reward:.2f}). No usage recorded.")

--- a/tests/test_openclaw_rl_v6.py
+++ b/tests/test_openclaw_rl_v6.py
@@ -1,0 +1,119 @@
+import pytest
+from unittest.mock import MagicMock
+
+from magda_agent.learning.openclaw_rl_v6 import OpenClawRLV6
+
+@pytest.fixture
+def mock_habit_tracker() -> MagicMock:
+    """Mocks the HabitTracker."""
+    return MagicMock()
+
+@pytest.fixture
+def mock_mirror_neurons() -> MagicMock:
+    """Mocks the MirrorNeurons."""
+    return MagicMock()
+
+@pytest.fixture
+def learner(mock_habit_tracker: MagicMock, mock_mirror_neurons: MagicMock) -> OpenClawRLV6:
+    """Provides a fresh OpenClawRLV6 instance."""
+    return OpenClawRLV6(
+        habit_tracker=mock_habit_tracker,
+        mirror_neurons=mock_mirror_neurons
+    )
+
+def test_calculate_reward(learner: OpenClawRLV6) -> None:
+    """Tests the reward calculation logic directly."""
+    # Positive empathy shift, with tool output
+    # base = (0.5 + 1.0) * 5.0 = 7.5
+    # bonus = 2.0 (since p_shift > 0 and tool_output is given)
+    # total = 9.5
+    assert learner._calculate_reward(0.5, "Some output") == 9.5
+
+    # Negative empathy shift, with tool output
+    # base = (-0.5 + 1.0) * 5.0 = 2.5
+    # no bonus since p_shift <= 0
+    assert learner._calculate_reward(-0.5, "Some output") == 2.5
+
+    # Capped at 10.0
+    assert learner._calculate_reward(1.0, "output") == 10.0
+
+    # Capped at 0.0
+    assert learner._calculate_reward(-1.5, None) == 0.0
+
+@pytest.mark.asyncio
+async def test_process_positive_signal(
+    learner: OpenClawRLV6,
+    mock_habit_tracker: MagicMock,
+    mock_mirror_neurons: MagicMock
+) -> None:
+    """Tests positive signal reinforces habits."""
+    # Arrange
+    user_id = 42
+    user_reply = "This is very helpful!"
+    action_context = "Executed search"
+    tool_output = "Search results found"
+
+    mock_mirror_neurons.empathize.return_value = (0.5, 0.1, 0.0) # p_shift = 0.5
+
+    # Act
+    await learner.process_next_state_signal(
+        user_reply=user_reply,
+        action_context=action_context,
+        user_id=user_id,
+        tool_output=tool_output,
+        skills_used=["search_skill"]
+    )
+
+    # Assert
+    mock_mirror_neurons.empathize.assert_called_once_with(f"{user_reply} [Tool Output: {tool_output}]")
+    mock_habit_tracker.record_usage.assert_called_once_with(
+        input_text=action_context,
+        skill_used="search_skill",
+        evaluation_score=9.5,
+        user_id=user_id
+    )
+
+@pytest.mark.asyncio
+async def test_process_negative_signal(
+    learner: OpenClawRLV6,
+    mock_habit_tracker: MagicMock,
+    mock_mirror_neurons: MagicMock
+) -> None:
+    """Tests negative signal does not reinforce habits."""
+    # Arrange
+    user_id = 42
+    user_reply = "That's wrong."
+    action_context = "Executed search"
+    tool_output = "Search results"
+
+    mock_mirror_neurons.empathize.return_value = (-0.8, -0.2, 0.0) # p_shift = -0.8
+
+    # Act
+    await learner.process_next_state_signal(
+        user_reply=user_reply,
+        action_context=action_context,
+        user_id=user_id,
+        tool_output=tool_output
+    )
+
+    # Assert
+    mock_mirror_neurons.empathize.assert_called_once_with(f"{user_reply} [Tool Output: {tool_output}]")
+    mock_habit_tracker.record_usage.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_empty_signals(
+    learner: OpenClawRLV6,
+    mock_habit_tracker: MagicMock,
+    mock_mirror_neurons: MagicMock
+) -> None:
+    """Tests empty signals do not process anything."""
+    # Act
+    await learner.process_next_state_signal(
+        user_reply="",
+        action_context="Something",
+        user_id=1
+    )
+
+    # Assert
+    mock_mirror_neurons.empathize.assert_not_called()
+    mock_habit_tracker.record_usage.assert_not_called()


### PR DESCRIPTION
This PR implements the OpenClaw-RL Online Reinforcement Learning V6 task. 

It defines a new module at `magda_agent/learning/openclaw_rl_v6.py` and provides full test coverage at `tests/test_openclaw_rl_v6.py`. The agent now implicitly adjusts and rewards habit tracking based on next-state signals (like user dialogue) utilizing the `MirrorNeurons` pad shift.

Additionally, this PR marks task `openclaw-rl-next-state-signals-v1-c9a5b60a` as done, updates `backlog.md`, and introduces 3 new trend-focused tasks to the queue:
- MCP Skill Registry Exporter
- Virtual Context Paging for Working Memory
- Agent Guard Runtime Policy Layer

---
*PR created automatically by Jules for task [6950622391879919473](https://jules.google.com/task/6950622391879919473) started by @kazah4359-lgtm*