### PR TITLE
feat: implement MCP Action Tool Registry v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11742,7 +11742,7 @@
     },
     {
       "id": "mcp-action-tool-registry-v5-e5f6g7h8",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Action Tool Registry v5",
@@ -27192,6 +27192,57 @@
       "acceptance": [
         "Manager spawns subagents concurrently.",
         "Tests verify that multiple agents run simultaneously using mocks."
+      ]
+    },
+    {
+      "id": "openclaw-context-hooks-v6-12345678",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Hooks V6",
+      "description": "Inspired by OpenClaw trends: Implement a Context Engine plugin interface with lifecycle hooks for managing working memory during agent execution.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_v6.py",
+        "tests/test_context_engine_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context Engine supports plugin interface and lifecycle hooks.",
+        "Tests verify correct execution of hooks using mocks."
+      ]
+    },
+    {
+      "id": "hermes-online-skill-pruning-v1-87654321",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Online Skill Pruning V1",
+      "description": "Inspired by Hermes trends: Implement online skill pruning to remove rarely used or poorly performing skills based on usage metrics.",
+      "allowed_paths": [
+        "magda_agent/skills/skill_pruning_v1.py",
+        "tests/test_skill_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pruning algorithm identifies and removes low-usage skills.",
+        "Tests pass with mock usage metrics."
+      ]
+    },
+    {
+      "id": "a2a-mdns-security-token-v1-abcdef12",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A mDNS Discovery Secure Token Authentication",
+      "description": "Inspired by A2A trends: Implement secure token authentication for mDNS peer discovery in local agent networks to prevent unauthorized agent pairing.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mdns_secure.py",
+        "tests/test_a2a_mdns_secure.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "mDNS discovery requires a valid secure token for agent registration.",
+        "Tests simulate authorized and unauthorized discovery."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -351,3 +351,4 @@
 * [x] FEATURE: Multi-agent workflows support (multi-agent-workflows-51100812)
 * [x] FEATURE: Claude Agent SDK Trend: Agent Teams with Git Worktree Isolation (agent-teams-git-worktree-isolation-ecc2d6cf)
 * [x] FEATURE: OpenClaw Context Engine Plugin V8 (openclaw-context-engine-plugin-v8-a1b2c3d4)
+* [x] FEATURE: MCP Action Tool Registry v5 (mcp-action-tool-registry-v5-e5f6g7h8)

--- a/magda_agent/skills/mcp_registry_v5.py
+++ b/magda_agent/skills/mcp_registry_v5.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 class MCPRegistryV5:
     """
@@ -42,12 +42,38 @@ class MCPRegistryV5:
         if not isinstance(schema, dict):
             return False
 
-        required_fields = ["name", "description"]
+        required_fields = ["name", "description", "parameters"]
         for field in required_fields:
-            if field not in schema or not isinstance(schema[field], str) or not schema[field]:
+            if field not in schema:
+                return False
+            if field in ["name", "description"] and (not isinstance(schema[field], str) or not schema[field]):
+                return False
+            if field == "parameters" and not isinstance(schema[field], dict):
                 return False
 
         return True
+
+    def get_tool(self, name: str) -> Optional[Dict[str, Any]]:
+        """
+        Retrieves a tool schema by name.
+
+        Args:
+            name (str): The name of the MCP tool to retrieve.
+
+        Returns:
+            Optional[Dict[str, Any]]: The tool schema if found, None otherwise.
+        """
+        return self.mcp_tools.get(name)
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """
+        Lists all registered MCP tool schemas.
+
+        Returns:
+            List[Dict[str, Any]]: A list of all registered tool schemas.
+        """
+        return list(self.mcp_tools.values())
+
 
     def unload_tool(self, name: str) -> bool:
         """

--- a/tests/test_mcp_registry_v5.py
+++ b/tests/test_mcp_registry_v5.py
@@ -8,7 +8,7 @@ def test_mcp_registry_v5_init():
 
 def test_mcp_registry_v5_load_tool_success():
     registry = MCPRegistryV5()
-    tool_schema = {"name": "test_tool", "description": "A test tool."}
+    tool_schema = {"name": "test_tool", "description": "A test tool.", "parameters": {}}
 
     # We do not use LLMs directly in this registry, but if we did, we'd mock it here
     mock_llm = MagicMock()
@@ -20,20 +20,49 @@ def test_mcp_registry_v5_load_tool_invalid_schema():
     registry = MCPRegistryV5()
 
     # Missing description
-    invalid_schema = {"name": "test_tool"}
+    invalid_schema = {"name": "test_tool", "parameters": {}}
     assert registry.load_tool(invalid_schema) is False
     assert "test_tool" not in registry.mcp_tools
 
     # Missing name
-    invalid_schema2 = {"description": "test"}
+    invalid_schema2 = {"description": "test", "parameters": {}}
     assert registry.load_tool(invalid_schema2) is False
+
+    # Missing parameters
+    invalid_schema3 = {"name": "test", "description": "test"}
+    assert registry.load_tool(invalid_schema3) is False
+
+    # Invalid parameters type
+    invalid_schema4 = {"name": "test", "description": "test", "parameters": []}
+    assert registry.load_tool(invalid_schema4) is False
 
     # Not a dict
     assert registry.load_tool("not a dict") is False # type: ignore
 
+def test_mcp_registry_v5_get_tool():
+    registry = MCPRegistryV5()
+    tool_schema = {"name": "test_tool", "description": "A test tool.", "parameters": {}}
+    registry.load_tool(tool_schema)
+
+    assert registry.get_tool("test_tool") == tool_schema
+    assert registry.get_tool("nonexistent") is None
+
+def test_mcp_registry_v5_list_tools():
+    registry = MCPRegistryV5()
+    tool_schema1 = {"name": "test_tool1", "description": "A test tool.", "parameters": {}}
+    tool_schema2 = {"name": "test_tool2", "description": "A test tool.", "parameters": {}}
+
+    registry.load_tool(tool_schema1)
+    registry.load_tool(tool_schema2)
+
+    tools = registry.list_tools()
+    assert len(tools) == 2
+    assert tool_schema1 in tools
+    assert tool_schema2 in tools
+
 def test_mcp_registry_v5_unload_tool_success():
     registry = MCPRegistryV5()
-    tool_schema = {"name": "test_tool", "description": "A test tool."}
+    tool_schema = {"name": "test_tool", "description": "A test tool.", "parameters": {}}
     registry.load_tool(tool_schema)
 
     assert registry.unload_tool("test_tool") is True


### PR DESCRIPTION
This PR implements the MCP Action Tool Registry v5 based on the task queue.

**Changes:**
- `magda_agent/skills/mcp_registry_v5.py`: Added strict validation for `parameters`, and standard dictionary retrieval (`get_tool`, `list_tools`).
- `tests/test_mcp_registry_v5.py`: Updated to test new schema validations and retrieval logic.
- `agent_tasks.json`: Marked the completed task as `done` and added 3 new tasks (`openclaw-context-hooks-v6-12345678`, `hermes-online-skill-pruning-v1-87654321`, `a2a-mdns-security-token-v1-abcdef12`) inspired by June 2026 AI Agent trends.
- `backlog.md`: Synced to reflect completion.

---
*PR created automatically by Jules for task [17475098837750229885](https://jules.google.com/task/17475098837750229885) started by @kazah4359-lgtm*