### PR TITLE
feat: OpenClaw-RL Live Telemetry Streaming V3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11759,7 +11759,7 @@
     },
     {
       "id": "openclaw-rl-live-telemetry-v3-3a5f2175",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw-RL Live Telemetry Streaming V3",
@@ -27243,6 +27243,40 @@
       "acceptance": [
         "mDNS discovery requires a valid secure token for agent registration.",
         "Tests simulate authorized and unauthorized discovery."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v8-1485f109",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V8",
+      "description": "Inspired by June 2026 AI agent trends (MCP tools): Implement multi-turn capability negotiation for MCP tools between agents.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_negotiation_v8.py",
+        "tests/test_mcp_negotiation_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Capability negotiation module created.",
+        "Tests mock tool negotiation correctly."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-v4-8658210e",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Context Lifecycle Manager V4",
+      "description": "Inspired by MemGPT/Letta pattern and OpenClaw 2026 trends: Implement a lifecycle manager for working memory to page least relevant memory blocks in and out of a secondary store based on token overflow.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_v4.py",
+        "tests/test_virtual_context_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lifecycle manager can offload memory blocks transparently.",
+        "Tests verify that context overflow is handled properly."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -352,3 +352,4 @@
 * [x] FEATURE: Claude Agent SDK Trend: Agent Teams with Git Worktree Isolation (agent-teams-git-worktree-isolation-ecc2d6cf)
 * [x] FEATURE: OpenClaw Context Engine Plugin V8 (openclaw-context-engine-plugin-v8-a1b2c3d4)
 * [x] FEATURE: MCP Action Tool Registry v5 (mcp-action-tool-registry-v5-e5f6g7h8)
+* [x] FEATURE: OpenClaw-RL Live Telemetry Streaming V3 (openclaw-rl-live-telemetry-v3-3a5f2175)

--- a/magda_agent/telemetry/live_rl_v3.py
+++ b/magda_agent/telemetry/live_rl_v3.py
@@ -1,0 +1,54 @@
+import logging
+import time
+from typing import Any, Dict, Optional
+from magda_agent.emotions.engine import PADState
+from magda_agent.telemetry.live_event_emitter import LiveEventEmitter
+
+class LiveRLTelemetryV3(LiveEventEmitter):
+    """
+    Live telemetry streamer for OpenClaw-RL.
+    Extends LiveEventEmitter to broadcast PAD shifts via WebSocket.
+    """
+    def __init__(self, websocket: Optional[Any] = None) -> None:
+        """
+        Initialize the LiveRLTelemetryV3 with an optional websocket.
+        """
+        super().__init__(websocket)
+        self.logger = logging.getLogger(__name__)
+
+    async def emit_pad_shift(
+        self,
+        old_pad: PADState,
+        new_pad: PADState,
+        emotion_label: str,
+        user_id: Optional[int] = None,
+        habit_weights: Optional[Dict[str, float]] = None
+    ) -> None:
+        """
+        Emit a real-time PAD state shift event over the websocket.
+
+        Args:
+            old_pad: The previous PADState.
+            new_pad: The updated PADState.
+            emotion_label: The human-readable emotion label for the new state.
+            user_id: Optional identifier for the user.
+            habit_weights: Optional current habit weights of the agent.
+        """
+        delta_pad = {
+            "pleasure": new_pad.pleasure - old_pad.pleasure,
+            "arousal": new_pad.arousal - old_pad.arousal,
+            "dominance": new_pad.dominance - old_pad.dominance
+        }
+
+        data = {
+            "user_id": user_id,
+            "old_pad": old_pad.to_dict(),
+            "new_pad": new_pad.to_dict(),
+            "delta": delta_pad,
+            "emotion_label": emotion_label,
+        }
+
+        if habit_weights is not None:
+            data["habit_weights"] = habit_weights
+
+        await self.emit_state_change("pad_shift", data)

--- a/tests/test_live_rl_v3.py
+++ b/tests/test_live_rl_v3.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from magda_agent.emotions.engine import PADState
+from magda_agent.telemetry.live_rl_v3 import LiveRLTelemetryV3
+
+@pytest.fixture
+def mock_websocket():
+    ws = AsyncMock()
+    ws.send_text = AsyncMock()
+    return ws
+
+@pytest.mark.asyncio
+async def test_live_rl_telemetry_emit_pad_shift(mock_websocket):
+    telemetry = LiveRLTelemetryV3(websocket=mock_websocket)
+
+    old_pad = PADState(pleasure=0.1, arousal=0.2, dominance=0.3)
+    new_pad = PADState(pleasure=0.5, arousal=0.6, dominance=0.7)
+    emotion_label = "Excited/Happy"
+    user_id = 42
+    habit_weights = {"greet": 0.8}
+
+    with patch("time.time", return_value=12345.678):
+        await telemetry.emit_pad_shift(
+            old_pad=old_pad,
+            new_pad=new_pad,
+            emotion_label=emotion_label,
+            user_id=user_id,
+            habit_weights=habit_weights
+        )
+
+    mock_websocket.send_text.assert_called_once()
+
+    # Extract the JSON payload
+    call_args = mock_websocket.send_text.call_args
+    message_json = call_args[0][0]
+    payload = json.loads(message_json)
+
+    # Verify top-level structure from LiveEventEmitter
+    assert payload["type"] == "pad_shift_change"
+    assert payload["category"] == "pad_shift"
+    assert payload["timestamp"] == 12345.678
+
+    # Verify nested data structure
+    data = payload["data"]
+    assert data["user_id"] == 42
+
+    assert data["old_pad"]["pleasure"] == pytest.approx(0.1)
+    assert data["old_pad"]["arousal"] == pytest.approx(0.2)
+    assert data["old_pad"]["dominance"] == pytest.approx(0.3)
+
+    assert data["new_pad"]["pleasure"] == pytest.approx(0.5)
+    assert data["new_pad"]["arousal"] == pytest.approx(0.6)
+    assert data["new_pad"]["dominance"] == pytest.approx(0.7)
+
+    assert data["delta"]["pleasure"] == pytest.approx(0.4)
+    assert data["delta"]["arousal"] == pytest.approx(0.4)
+    assert data["delta"]["dominance"] == pytest.approx(0.4)
+
+    assert data["emotion_label"] == "Excited/Happy"
+    assert data["habit_weights"] == {"greet": 0.8}
+
+@pytest.mark.asyncio
+async def test_live_rl_telemetry_no_websocket():
+    telemetry = LiveRLTelemetryV3(websocket=None)
+
+    old_pad = PADState()
+    new_pad = PADState()
+
+    # Should not raise exception
+    await telemetry.emit_pad_shift(
+        old_pad=old_pad,
+        new_pad=new_pad,
+        emotion_label="Neutral"
+    )


### PR DESCRIPTION
Implements the `openclaw-rl-live-telemetry-v3-3a5f2175` task by creating the `LiveRLTelemetryV3` class that formats and broadcasts PAD shifts over WebSocket, supporting real-time emotion telemetry for OpenClaw-RL. Added comprehensive pytest coverage, updated `agent_tasks.json` indicating completion while spawning two new trend-inspired tasks, and kept `backlog.md` in sync.

---
*PR created automatically by Jules for task [8431897835753472427](https://jules.google.com/task/8431897835753472427) started by @kazah4359-lgtm*