### PR TITLE
feat: implement MCP Dynamic Skill Marketplace Poller

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11793,7 +11793,7 @@
     },
     {
       "id": "mcp-dynamic-skill-marketplace-poller-1d28f431",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Dynamic Skill Marketplace Poller",
@@ -27329,6 +27329,40 @@
       "acceptance": [
         "HabitTracker updates tool usage weights implicitly based on positive user next-state replies.",
         "Tests verify that weights shift appropriately after simulated interactions."
+      ]
+    },
+    {
+      "id": "a2a-peer-capability-discovery-v5-2cbaf360",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Peer Capability Discovery V5",
+      "description": "Inspired by June 2026 AI Agent trends: Implement A2A capabilities discovery for multi-agent network. Nodes should broadcast available tools and schema.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_capability_discovery_v5.py",
+        "tests/test_a2a_capability_discovery_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Node can broadcast capability via A2A mesh network.",
+        "Tests mock network and verify format."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-paging-v6-ccb5348a",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "title": "OpenClaw Virtual Context Paging V6",
+      "description": "Inspired by June 2026 AI Agent trends (OpenClaw memory paging): Swap least-relevant working memory into a secondary store when limits are exceeded.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_paging_v6.py",
+        "tests/test_virtual_context_paging_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Manager offloads memory blocks based on token overflow.",
+        "Tests mock tokens and context limits."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -354,3 +354,4 @@
 * [x] FEATURE: MCP Action Tool Registry v5 (mcp-action-tool-registry-v5-e5f6g7h8)
 * [x] FEATURE: OpenClaw-RL Live Telemetry Streaming V3 (openclaw-rl-live-telemetry-v3-3a5f2175)
 * [x] FEATURE: Claude Subagent Token Context Optimizer V2 (claude-subagent-token-context-optimizer-v2-ec3a412d)
+* [x] FEATURE: MCP Dynamic Skill Marketplace Poller (mcp-dynamic-skill-marketplace-poller-1d28f431)

--- a/magda_agent/integration/mcp_marketplace_poller.py
+++ b/magda_agent/integration/mcp_marketplace_poller.py
@@ -1,0 +1,74 @@
+import asyncio
+import logging
+import httpx
+
+from magda_agent.skills.mcp_registry_v5 import MCPRegistryV5
+from magda_agent.scheduler.cron_scheduler_v2 import CronSchedulerV2
+
+
+logger = logging.getLogger(__name__)
+
+
+class MCPMarketplacePoller:
+    """
+    A background job that periodically syncs with an agentskills.io-like
+    marketplace to dynamically register external MCP tools.
+    """
+
+    def __init__(self, registry: MCPRegistryV5, scheduler: CronSchedulerV2, marketplace_url: str = "https://api.agentskills.io/v1/tools", cron_expr: str = "0 * * * *") -> None:
+        """
+        Initialize the MCPMarketplacePoller.
+
+        Args:
+            registry: The MCPRegistryV5 instance to register valid tools into.
+            scheduler: The CronSchedulerV2 instance to schedule the polling job.
+            marketplace_url: The URL to fetch MCP tools from.
+            cron_expr: Cron expression for how often to sync. Default is hourly ("0 * * * *").
+        """
+        self.registry = registry
+        self.scheduler = scheduler
+        self.marketplace_url = marketplace_url
+        self.cron_expr = cron_expr
+        self.client = httpx.AsyncClient()
+
+    def schedule_sync(self) -> None:
+        """
+        Registers the sync job with the scheduler.
+        """
+        self.scheduler.add_task("mcp_marketplace_sync", self.cron_expr, self.sync_marketplace)
+        logger.info(f"Scheduled MCP Marketplace sync for {self.marketplace_url} with cron {self.cron_expr}")
+
+    async def sync_marketplace(self) -> None:
+        """
+        Fetches tools from the marketplace and registers them in the local registry.
+        """
+        logger.info(f"Starting MCP Marketplace sync from {self.marketplace_url}...")
+        try:
+            response = await self.client.get(self.marketplace_url, timeout=10.0)
+            response.raise_for_status()
+
+            data = response.json()
+            if not isinstance(data, list):
+                logger.warning(f"Marketplace sync failed: Expected JSON list, got {type(data)}")
+                return
+
+            registered_count = 0
+            for item in data:
+                if isinstance(item, dict) and "name" in item and "description" in item and "parameters" in item:
+                    # Attempt to register tool
+                    success = self.registry.load_tool(item)
+                    if success:
+                        registered_count += 1
+                else:
+                    logger.debug(f"Skipping malformed item: {item}")
+
+            logger.info(f"MCP Marketplace sync complete. Registered {registered_count} tools.")
+
+        except httpx.HTTPError as e:
+            logger.error(f"Network error during MCP Marketplace sync: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error during MCP Marketplace sync: {e}", exc_info=True)
+
+    async def close(self) -> None:
+        """Close the internal HTTP client."""
+        await self.client.aclose()

--- a/tests/test_mcp_marketplace_poller.py
+++ b/tests/test_mcp_marketplace_poller.py
@@ -1,0 +1,104 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from magda_agent.integration.mcp_marketplace_poller import MCPMarketplacePoller
+from magda_agent.skills.mcp_registry_v5 import MCPRegistryV5
+from magda_agent.scheduler.cron_scheduler_v2 import CronSchedulerV2
+
+@pytest.fixture
+def registry():
+    return MagicMock(spec=MCPRegistryV5)
+
+@pytest.fixture
+def scheduler():
+    return MagicMock(spec=CronSchedulerV2)
+
+@pytest.mark.asyncio
+async def test_schedule_sync(registry, scheduler):
+    """Test that the poller correctly schedules the task with the cron scheduler."""
+    poller = MCPMarketplacePoller(registry, scheduler, cron_expr="*/5 * * * *")
+    poller.schedule_sync()
+
+    scheduler.add_task.assert_called_once_with(
+        "mcp_marketplace_sync",
+        "*/5 * * * *",
+        poller.sync_marketplace
+    )
+    await poller.close()
+
+@pytest.mark.asyncio
+@patch("magda_agent.integration.mcp_marketplace_poller.httpx.AsyncClient.get")
+async def test_sync_marketplace_success(mock_get, registry, scheduler):
+    """Test successful fetching and registration of valid tools."""
+    poller = MCPMarketplacePoller(registry, scheduler)
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+
+    # In httpx, response.json() is NOT async. So we just need a MagicMock that returns our list.
+    mock_response.json = MagicMock(return_value=[
+        {
+            "name": "valid_tool",
+            "description": "Does something",
+            "parameters": {"type": "object", "properties": {}}
+        },
+        {
+            "name": "invalid_tool",
+            "description": "Missing parameters"
+        }
+    ])
+
+    mock_get.return_value = mock_response
+
+    # Simulate registry success for the valid tool
+    registry.load_tool.return_value = True
+
+    await poller.sync_marketplace()
+
+    # Verify the network call was made
+    mock_get.assert_called_once_with(poller.marketplace_url, timeout=10.0)
+    mock_response.raise_for_status.assert_called_once()
+
+    # Verify the registry was called ONLY for the valid tool
+    registry.load_tool.assert_called_once_with(mock_response.json()[0])
+
+    await poller.close()
+
+
+@pytest.mark.asyncio
+@patch("magda_agent.integration.mcp_marketplace_poller.httpx.AsyncClient.get")
+async def test_sync_marketplace_network_error(mock_get, registry, scheduler):
+    """Test that network errors are caught gracefully."""
+    poller = MCPMarketplacePoller(registry, scheduler)
+
+    # Simulate a network error
+    mock_get.side_effect = httpx.RequestError("Network unreachable", request=MagicMock())
+
+    await poller.sync_marketplace()
+
+    # Verify no tools were registered
+    registry.load_tool.assert_not_called()
+
+    await poller.close()
+
+
+@pytest.mark.asyncio
+@patch("magda_agent.integration.mcp_marketplace_poller.httpx.AsyncClient.get")
+async def test_sync_marketplace_invalid_json_format(mock_get, registry, scheduler):
+    """Test when API returns dict instead of list."""
+    poller = MCPMarketplacePoller(registry, scheduler)
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    # Provide a dict instead of a list, fix json() to be a regular mock
+    mock_response.json = MagicMock(return_value={"error": "Not found"})
+    mock_get.return_value = mock_response
+
+    await poller.sync_marketplace()
+
+    # Verify no tools were registered
+    registry.load_tool.assert_not_called()
+
+    await poller.close()


### PR DESCRIPTION
This PR implements the MCP Dynamic Skill Marketplace Poller background job as described in the task `mcp-dynamic-skill-marketplace-poller-1d28f431`.

### Changes made
1. **Created `MCPMarketplacePoller` (`magda_agent/integration/mcp_marketplace_poller.py`)**: A background cron job that fetches MCP-compatible tools from a marketplace endpoint (e.g. agentskills.io) using `httpx` and dynamically registers them via `MCPRegistryV5`.
2. **Added comprehensive tests (`tests/test_mcp_marketplace_poller.py`)**: Covers cron scheduling and network mock assertions for both successful tool validation (testing for required JSON schema: `name`, `description`, `parameters`) and graceful failure cases (network unreachable, malformed payloads).
3. **Updated the task queue (`agent_tasks.json` and `backlog.md`)**:
   - Marked the poller task as `done`.
   - Appended two new `todo` tasks inspired by current trends: `a2a-peer-capability-discovery` and `openclaw-virtual-context-paging`.
   - Appended the resolved task to `backlog.md`.

---
*PR created automatically by Jules for task [14772674681634635636](https://jules.google.com/task/14772674681634635636) started by @kazah4359-lgtm*