### PR TITLE
Implement OpenClaw RL Live Telemetry Streaming V5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11810,7 +11810,7 @@
     },
     {
       "id": "openclaw-rl-canvas-metrics-v5-unique-4b6157db",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw-RL Live Telemetry Streaming V5",
@@ -27363,6 +27363,60 @@
       "acceptance": [
         "Manager offloads memory blocks based on token overflow.",
         "Tests mock tokens and context limits."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-exporter-d543b064",
+      "title": "MCP Action Tool Exporter V2",
+      "description": "Inspired by the rising MCP (Model Context Protocol) trend (where action tools grew to 65%): Implement an integration layer extending MCPSkillExporter to accurately register Magda's internal actions directly into an external MCP action tool registry.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_action_exporter.py",
+        "tests/test_mcp_action_exporter.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter can construct valid MCP tool JSON schemas for registered skills.",
+        "Exporter gracefully handles missing parameter schemas.",
+        "Tests verify the output matches expected MCP JSON-RPC standards."
+      ]
+    },
+    {
+      "id": "a2a-agent-discovery-mesh-e1e10f95",
+      "title": "A2A Agent Discovery Mesh Expansion V2",
+      "description": "Inspired by A2A Protocol and Agent Cards trends: Build an advanced mesh-based discovery service where peer agents can gossip about available capabilities over local channels, allowing highly resilient peer-to-peer discovery without a central registry.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_mesh.py",
+        "tests/test_a2a_discovery_mesh.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Discovery mesh service can aggregate and broadcast Agent Cards.",
+        "Agents dynamically learn about indirect peers via gossip propagation.",
+        "Tests verify gossip propagation logic with mock network endpoints."
+      ]
+    },
+    {
+      "id": "context-engine-compression-plugin-159236a1",
+      "title": "Context Engine Semantic Compression Plugin V2",
+      "description": "Inspired by Context Engine virtual memory management trends: Create a plugin that scans working memory for semantically duplicate or older entries during the compression phase, merging them into single unified representations or archiving them to save context space.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_compression_plugin.py",
+        "tests/test_semantic_compression_plugin.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin hooks into the Context Engine lifecycle correctly.",
+        "Semantically duplicate memories are merged effectively using mock embeddings.",
+        "Tests verify that context token length is reduced after compression."
       ]
     }
   ]

--- a/magda_agent/telemetry/a2a_distributed_v7.py
+++ b/magda_agent/telemetry/a2a_distributed_v7.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict, Any, List
 
@@ -65,4 +66,29 @@ class A2ADistributedTelemetryV7:
             payload (Dict[str, Any]): The payload to broadcast.
         """
         # Mock network call delay could be simulated here, but we pass for now.
+        pass
+
+    async def broadcast_pad_shift_to_canvas(self, subagent_id: str, pad_shift: Dict[str, float]) -> None:
+        """
+        Broadcast a PAD shift event to the Canvas UI via WebSocket mock.
+
+        Args:
+            subagent_id (str): The unique identifier for the sub-agent.
+            pad_shift (Dict[str, float]): The PAD shift data to broadcast.
+        """
+        payload = {
+            "type": "canvas_pad_shift",
+            "subagent_id": subagent_id,
+            "pad_shift": pad_shift
+        }
+        json_payload = json.dumps(payload)
+        await self._mock_websocket_emit(json_payload)
+
+    async def _mock_websocket_emit(self, json_payload: str) -> None:
+        """
+        Mock WebSocket emission for Canvas UI updates.
+
+        Args:
+            json_payload (str): The JSON string payload to emit.
+        """
         pass

--- a/tests/test_a2a_distributed_v7.py
+++ b/tests/test_a2a_distributed_v7.py
@@ -43,3 +43,21 @@ async def test_broadcast_events(telemetry):
 
         # Verify events list is cleared
         assert len(telemetry.events) == 0
+
+@pytest.mark.asyncio
+async def test_broadcast_pad_shift_to_canvas(telemetry):
+    pad_shift = {"P": 0.5, "A": -0.2, "D": 0.1}
+
+    with patch.object(telemetry, '_mock_websocket_emit', new_callable=AsyncMock) as mock_emit:
+        await telemetry.broadcast_pad_shift_to_canvas("sub_1", pad_shift)
+
+        mock_emit.assert_called_once()
+        args, _ = mock_emit.call_args
+        json_payload = args[0]
+
+        import json
+        payload = json.loads(json_payload)
+
+        assert payload["type"] == "canvas_pad_shift"
+        assert payload["subagent_id"] == "sub_1"
+        assert payload["pad_shift"] == pad_shift


### PR DESCRIPTION
Implemented RL telemetry mapping PAD shifts in real-time to the OpenClaw canvas as specified by task `openclaw-rl-canvas-metrics-v5-unique-4b6157db`. Added tests to verify the JSON output. Also appended three new todo tasks to `agent_tasks.json` inspired by docs/trends.md (MCP Action tool exporter, A2A Discovery mesh expansion, Context Engine compression plugin).

---
*PR created automatically by Jules for task [16374298914638028306](https://jules.google.com/task/16374298914638028306) started by @kazah4359-lgtm*