### PR TITLE
feat: implement acs validation checkpoints v5 and update tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11827,7 +11827,7 @@
     },
     {
       "id": "acs-validation-checkpoints-v5-unique-bc81b2a5",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "ACS Validation Checkpoints V5",
@@ -27417,6 +27417,57 @@
         "Plugin hooks into the Context Engine lifecycle correctly.",
         "Semantically duplicate memories are merged effectively using mock embeddings.",
         "Tests verify that context token length is reduced after compression."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-benchmark-v2-8af5da74",
+      "status": "todo",
+      "area": "evaluation",
+      "risk": "medium",
+      "title": "Hermes Cron Nightly Benchmark V2",
+      "description": "Inspired by Hermes trends (June 2026): Implement a background cron job to run nightly benchmarks (e.g., SWE-bench, AgentBench subset) against the agent to track longitudinal performance metrics and prevent regressions.",
+      "allowed_paths": [
+        "magda_agent/evaluation/nightly_benchmark_v2.py",
+        "tests/test_nightly_benchmark_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Nightly benchmark cron job is registered successfully.",
+        "Mock benchmarks execute and record results properly in tests."
+      ]
+    },
+    {
+      "id": "claude-evaluator-semantic-diff-check-v2-a41d0bbc",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Claude Evaluator Semantic Diff Check V2",
+      "description": "Inspired by Claude Agent Teams (June 2026): Implement an Evaluator Subagent that semantically checks git diffs prior to submission, halting execution if large or destructive context changes are detected.",
+      "allowed_paths": [
+        "magda_agent/safety/evaluator_semantic_diff_v2.py",
+        "tests/test_evaluator_semantic_diff_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagent can parse diffs and assess their semantic risk.",
+        "Tests mock diffs and verify that destructive changes are blocked."
+      ]
+    },
+    {
+      "id": "openai-agents-schema-caching-v2-2afdfab7",
+      "status": "todo",
+      "area": "performance",
+      "risk": "low",
+      "title": "OpenAI Agents SDK Tool Schema Caching V2",
+      "description": "Inspired by OpenAI Agents SDK and MCP (June 2026): Implement an LRU cache layer for storing JSON schema evaluations of MCP tools to reduce repeated validation overhead during concurrent multi-agent operations.",
+      "allowed_paths": [
+        "magda_agent/performance/tool_schema_cache_v2.py",
+        "tests/test_tool_schema_cache_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "LRU cache efficiently stores and retrieves valid JSON schemas.",
+        "Tests demonstrate validation speedup or correct hit/miss behavior."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -355,3 +355,4 @@
 * [x] FEATURE: OpenClaw-RL Live Telemetry Streaming V3 (openclaw-rl-live-telemetry-v3-3a5f2175)
 * [x] FEATURE: Claude Subagent Token Context Optimizer V2 (claude-subagent-token-context-optimizer-v2-ec3a412d)
 * [x] FEATURE: MCP Dynamic Skill Marketplace Poller (mcp-dynamic-skill-marketplace-poller-1d28f431)
+* [x] FEATURE: ACS Validation Checkpoints V5 (acs-validation-checkpoints-v5-unique-bc81b2a5)

--- a/magda_agent/safety/acs_checkpoints_v3.py
+++ b/magda_agent/safety/acs_checkpoints_v3.py
@@ -1,15 +1,23 @@
 import logging
-from typing import Dict, Any, Tuple
+from typing import Dict, Any, Tuple, Optional
+from magda_agent.llm_client import LLMClient
 
 class ACSCheckpointsV3:
     """
     Implements 5 ACS validation checkpoints for agentic workflows (v3).
     Ensures all actions pass through 5 checks before execution.
     """
-    def __init__(self) -> None:
-        self.logger = logging.getLogger(__name__)
+    def __init__(self, llm_client: Optional[LLMClient] = None) -> None:
+        """
+        Initialize the ACS Checkpoints V3 validator.
 
-    def checkpoint_1_input_validation(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
+        Args:
+            llm_client (Optional[LLMClient]): LLM Client for semantic validation.
+        """
+        self.logger = logging.getLogger(__name__)
+        self.llm_client = llm_client
+
+    async def checkpoint_1_input_validation(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Validates raw input data for actions.
 
@@ -25,7 +33,7 @@ class ACSCheckpointsV3:
             return False, "Checkpoint 1 Failed: missing 'action_name'."
         return True, "Checkpoint 1 Passed."
 
-    def checkpoint_2_intent_authorization(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
+    async def checkpoint_2_intent_authorization(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Verifies if the intent is authorized.
 
@@ -37,9 +45,16 @@ class ACSCheckpointsV3:
         """
         if action_data.get("action_name") == "unauthorized_action":
             return False, "Checkpoint 2 Failed: unauthorized action intent."
+
+        if self.llm_client:
+            intent = str(action_data.get("intent", ""))
+            if intent:
+                response = await self.llm_client.generate(f"Is this intent safe? {intent}")
+                if "unsafe" in response.lower():
+                    return False, "Checkpoint 2 Failed: LLM determined intent is unsafe."
         return True, "Checkpoint 2 Passed."
 
-    def checkpoint_3_tool_policy(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
+    async def checkpoint_3_tool_policy(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Checks compliance with tool policies.
 
@@ -53,7 +68,7 @@ class ACSCheckpointsV3:
             return False, "Checkpoint 3 Failed: tool is forbidden."
         return True, "Checkpoint 3 Passed."
 
-    def checkpoint_4_state_transition(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
+    async def checkpoint_4_state_transition(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Ensures the state transition is valid.
 
@@ -67,7 +82,7 @@ class ACSCheckpointsV3:
             return False, "Checkpoint 4 Failed: invalid state transition from error."
         return True, "Checkpoint 4 Passed."
 
-    def checkpoint_5_output_sanitization(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
+    async def checkpoint_5_output_sanitization(self, action_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Sanitizes output data.
 
@@ -81,7 +96,7 @@ class ACSCheckpointsV3:
             return False, "Checkpoint 5 Failed: sensitive data found in output."
         return True, "Checkpoint 5 Passed."
 
-    def validate_action(self, action_data: Dict[str, Any]) -> bool:
+    async def validate_action(self, action_data: Dict[str, Any]) -> bool:
         """
         Runs all 5 checkpoints and returns True if all pass.
 
@@ -100,7 +115,7 @@ class ACSCheckpointsV3:
         ]
 
         for checkpoint in checkpoints:
-            passed, reason = checkpoint(action_data)
+            passed, reason = await checkpoint(action_data)
             if not passed:
                 self.logger.warning(reason)
                 return False

--- a/tests/test_acs_checkpoints_v3.py
+++ b/tests/test_acs_checkpoints_v3.py
@@ -1,8 +1,10 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 from magda_agent.safety.acs_checkpoints_v3 import ACSCheckpointsV3
+from magda_agent.llm_client import LLMClient
 
-def test_acs_checkpoints_v3_pass():
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_pass():
     checkpoints = ACSCheckpointsV3()
     valid_data = {
         "action_name": "test_action",
@@ -10,55 +12,95 @@ def test_acs_checkpoints_v3_pass():
         "state": "active",
         "output": "public result"
     }
-    assert checkpoints.validate_action(valid_data) is True
+    assert await checkpoints.validate_action(valid_data) is True
 
-def test_acs_checkpoints_v3_fail_1():
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_fail_1():
     checkpoints = ACSCheckpointsV3()
-    assert checkpoints.validate_action({}) is False
-    assert checkpoints.validate_action({"tool_name": "test"}) is False
+    assert await checkpoints.validate_action({}) is False
+    assert await checkpoints.validate_action({"tool_name": "test"}) is False
 
-    passed, reason = checkpoints.checkpoint_1_input_validation({})
+    passed, reason = await checkpoints.checkpoint_1_input_validation({})
     assert not passed
     assert "Checkpoint 1 Failed: empty action data." in reason
 
-    passed, reason = checkpoints.checkpoint_1_input_validation({"tool_name": "test"})
+    passed, reason = await checkpoints.checkpoint_1_input_validation({"tool_name": "test"})
     assert not passed
     assert "Checkpoint 1 Failed: missing 'action_name'." in reason
 
-def test_acs_checkpoints_v3_fail_2():
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_fail_2():
     checkpoints = ACSCheckpointsV3()
-    assert checkpoints.validate_action({"action_name": "unauthorized_action"}) is False
+    assert await checkpoints.validate_action({"action_name": "unauthorized_action"}) is False
 
-    passed, reason = checkpoints.checkpoint_2_intent_authorization({"action_name": "unauthorized_action"})
+    passed, reason = await checkpoints.checkpoint_2_intent_authorization({"action_name": "unauthorized_action"})
     assert not passed
     assert "Checkpoint 2 Failed: unauthorized action intent." in reason
 
-def test_acs_checkpoints_v3_fail_3():
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_fail_3():
     checkpoints = ACSCheckpointsV3()
-    assert checkpoints.validate_action({"action_name": "test", "tool_name": "forbidden_tool"}) is False
+    assert await checkpoints.validate_action({"action_name": "test", "tool_name": "forbidden_tool"}) is False
 
-    passed, reason = checkpoints.checkpoint_3_tool_policy({"action_name": "test", "tool_name": "forbidden_tool"})
+    passed, reason = await checkpoints.checkpoint_3_tool_policy({"action_name": "test", "tool_name": "forbidden_tool"})
     assert not passed
     assert "Checkpoint 3 Failed: tool is forbidden." in reason
 
-def test_acs_checkpoints_v3_fail_4():
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_fail_4():
     checkpoints = ACSCheckpointsV3()
-    assert checkpoints.validate_action({"action_name": "test", "state": "error"}) is False
+    assert await checkpoints.validate_action({"action_name": "test", "state": "error"}) is False
 
-    passed, reason = checkpoints.checkpoint_4_state_transition({"action_name": "test", "state": "error"})
+    passed, reason = await checkpoints.checkpoint_4_state_transition({"action_name": "test", "state": "error"})
     assert not passed
     assert "Checkpoint 4 Failed: invalid state transition from error." in reason
 
-def test_acs_checkpoints_v3_fail_5():
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_fail_5():
     checkpoints = ACSCheckpointsV3()
-    assert checkpoints.validate_action({"action_name": "test", "output": "my secret_key is hidden"}) is False
+    assert await checkpoints.validate_action({"action_name": "test", "output": "my secret_key is hidden"}) is False
 
-    passed, reason = checkpoints.checkpoint_5_output_sanitization({"action_name": "test", "output": "my secret_key is hidden"})
+    passed, reason = await checkpoints.checkpoint_5_output_sanitization({"action_name": "test", "output": "my secret_key is hidden"})
     assert not passed
     assert "Checkpoint 5 Failed: sensitive data found in output." in reason
 
+@pytest.mark.asyncio
 @patch('magda_agent.safety.acs_checkpoints_v3.logging.Logger.warning')
-def test_acs_checkpoints_v3_logging(mock_warning):
+async def test_acs_checkpoints_v3_logging(mock_warning):
     checkpoints = ACSCheckpointsV3()
-    assert checkpoints.validate_action({}) is False
+    assert await checkpoints.validate_action({}) is False
     mock_warning.assert_called_once_with("Checkpoint 1 Failed: empty action data.")
+
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_llm_integration_safe():
+    mock_llm = AsyncMock(spec=LLMClient)
+    mock_llm.generate.return_value = "This intent is completely safe and fine."
+
+    checkpoints = ACSCheckpointsV3(llm_client=mock_llm)
+
+    valid_data = {
+        "action_name": "test_action",
+        "intent": "do some action",
+        "tool_name": "allowed_tool",
+        "state": "active",
+        "output": "public result"
+    }
+    assert await checkpoints.validate_action(valid_data) is True
+    mock_llm.generate.assert_called_once_with("Is this intent safe? do some action")
+
+@pytest.mark.asyncio
+async def test_acs_checkpoints_v3_llm_integration_unsafe():
+    mock_llm = AsyncMock(spec=LLMClient)
+    mock_llm.generate.return_value = "This intent is UNSAFE."
+
+    checkpoints = ACSCheckpointsV3(llm_client=mock_llm)
+
+    invalid_data = {
+        "action_name": "test_action",
+        "intent": "delete database",
+        "tool_name": "allowed_tool",
+        "state": "active",
+        "output": "public result"
+    }
+    assert await checkpoints.validate_action(invalid_data) is False
+    mock_llm.generate.assert_called_once_with("Is this intent safe? delete database")


### PR DESCRIPTION
This PR fully implements the "ACS Validation Checkpoints V5" task by refactoring the `ACSCheckpointsV3` validator to act as an asynchronous framework. It integrates `LLMClient` for intelligent semantic authorization of agent intents (e.g. checkpoint 2). Tests have been migrated to `@pytest.mark.asyncio` and `AsyncMock` is used to safely stub the LLM interaction. It also marks the task as done, adds new tasks to `agent_tasks.json`, and updates `backlog.md`.

---
*PR created automatically by Jules for task [9606865058567704198](https://jules.google.com/task/9606865058567704198) started by @kazah4359-lgtm*