### PR TITLE
feat(integration): Implement background MCP skill marketplace sync

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11844,7 +11844,7 @@
     },
     {
       "id": "mcp-skill-marketplace-sync-v2",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Dynamic Skill Marketplace Sync v2",
@@ -27468,6 +27468,40 @@
       "acceptance": [
         "LRU cache efficiently stores and retrieves valid JSON schemas.",
         "Tests demonstrate validation speedup or correct hit/miss behavior."
+      ]
+    },
+    {
+      "id": "hermes-online-skill-pruning-v2-9affbe28",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Online Skill Pruning V2",
+      "description": "Inspired by Hermes Agent (June 2026): Implement an online pruner that evaluates skill usage metrics from telemetry and unregisters skills that have high failure rates or zero usage over a significant time period to keep the context window optimized.",
+      "allowed_paths": [
+        "magda_agent/learning/skill_pruner_v2.py",
+        "tests/test_skill_pruner_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "SkillPruner can track and unregister underperforming skills.",
+        "Tests verify pruning logic based on mocked telemetry data."
+      ]
+    },
+    {
+      "id": "context-engine-semantic-routing-v3-0464870d",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Context Engine Semantic Routing V3",
+      "description": "Inspired by OpenClaw Context Engine trends (June 2026): Create a pre_process ContextPlugin hook that semantically analyzes incoming user queries via LLMClient and directly routes specific domains to dedicated sub-agents instead of using the main loop.",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_routing_plugin_v3.py",
+        "tests/test_semantic_routing_plugin_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Semantic routing hook intercepts queries and assigns them to sub-agents if applicable.",
+        "Tests use mocked LLM calls and verify correct routing behavior."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -269,6 +269,7 @@
 
 
 ## 📡 A2A mDNS & Self-Improvement Loops (June 2026 Trends)
+* [x] FEATURE: MCP Dynamic Skill Marketplace Sync v2 (mcp-skill-marketplace-sync-v2)
 * [ ] FEATURE: MCP Kernel Sandboxing V2 (mcp-kernel-sandboxing-v2-94a2f1b0)
 * [ ] FEATURE: OpenClaw Virtual Context Lifecycle Manager V3 (openclaw-virtual-context-v3-7d8e9cfa)
 * [ ] FEATURE: Claude SDK Task Dependency Graph V2 (claude-sdk-dependency-graph-v2-b5c6d7e8)

--- a/magda_agent/integration/skill_marketplace.py
+++ b/magda_agent/integration/skill_marketplace.py
@@ -127,3 +127,81 @@ async def fetch_and_register_skills(url: str, registry: SkillRegistry) -> List[s
         logger.error(f"Failed to fetch and register skills from {url}: {e}")
 
     return registered_skills
+
+import asyncio
+from typing import Optional
+
+class MarketplaceBackgroundSync:
+    """
+    Background loop that periodically polls a configured agentskills.io marketplace URL
+    and dynamically registers tools into the local SkillRegistry.
+    """
+
+    def __init__(self, registry: SkillRegistry, marketplace_url: str, sync_interval: int = 3600) -> None:
+        """
+        Initialize the MarketplaceBackgroundSync process.
+
+        Args:
+            registry (SkillRegistry): The local skill registry to update.
+            marketplace_url (str): The URL of the agentskills.io JSON endpoint.
+            sync_interval (int): Time in seconds between polling attempts. Defaults to 3600 (1 hour).
+        """
+        self.registry = registry
+        self.marketplace_url = marketplace_url
+        self.sync_interval = sync_interval
+        self._running = False
+        self._task: Optional[asyncio.Task[None]] = None
+        self.logger = logging.getLogger(__name__)
+
+    async def _sync_loop(self) -> None:
+        """
+        The main background asyncio loop that periodically triggers synchronization.
+        """
+        while self._running:
+            await self.sync_once()
+            if self._running:
+                try:
+                    await asyncio.sleep(self.sync_interval)
+                except asyncio.CancelledError:
+                    break
+
+    async def sync_once(self) -> None:
+        """
+        Performs a single synchronization cycle by fetching from the marketplace.
+        """
+        self.logger.debug(f"Starting marketplace sync cycle with: {self.marketplace_url}")
+        try:
+            registered_skills = await fetch_and_register_skills(self.marketplace_url, self.registry)
+            self.logger.info(f"Marketplace sync completed successfully. Registered {len(registered_skills)} new/updated skills.")
+        except Exception as e:
+            self.logger.error(f"Error during marketplace sync cycle with {self.marketplace_url}: {e}")
+
+    def start(self) -> None:
+        """
+        Starts the background synchronization loop.
+        """
+        if self._running:
+            self.logger.warning("MarketplaceBackgroundSync loop is already running.")
+            return
+
+        self._running = True
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._sync_loop())
+        self.logger.info(f"Started MarketplaceBackgroundSync loop with interval {self.sync_interval}s.")
+
+    async def stop(self) -> None:
+        """
+        Stops the background synchronization loop gracefully.
+        """
+        if not self._running:
+            return
+
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        self.logger.info("Stopped MarketplaceBackgroundSync loop.")

--- a/tests/test_skill_marketplace.py
+++ b/tests/test_skill_marketplace.py
@@ -1,6 +1,7 @@
 import pytest
+import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
-from magda_agent.integration.skill_marketplace import fetch_and_register_skills, AgentSkillsExporter
+from magda_agent.integration.skill_marketplace import fetch_and_register_skills, AgentSkillsExporter, MarketplaceBackgroundSync
 from magda_agent.skills.registry import SkillRegistry
 from magda_agent.skills.marketplace import search_marketplace_skills
 
@@ -106,3 +107,49 @@ def test_agent_skills_exporter():
     assert skills[0]["name"] == "dummy_skill"
     assert skills[0]["description"] == "A dummy skill"
     assert "parameters" in skills[0]
+
+@pytest.mark.asyncio
+async def test_marketplace_background_sync_once():
+    registry = MagicMock(spec=SkillRegistry)
+    url = "https://mock-marketplace.io/skills.json"
+    sync_process = MarketplaceBackgroundSync(registry, url, sync_interval=1)
+
+    with patch('magda_agent.integration.skill_marketplace.fetch_and_register_skills', new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = ["skill1", "skill2"]
+        await sync_process.sync_once()
+
+        mock_fetch.assert_called_once_with(url, registry)
+
+@pytest.mark.asyncio
+async def test_marketplace_background_sync_once_error():
+    registry = MagicMock(spec=SkillRegistry)
+    url = "https://mock-marketplace.io/skills.json"
+    sync_process = MarketplaceBackgroundSync(registry, url, sync_interval=1)
+
+    with patch('magda_agent.integration.skill_marketplace.fetch_and_register_skills', new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.side_effect = Exception("Mock network error")
+
+        # Should not raise exception
+        await sync_process.sync_once()
+        mock_fetch.assert_called_once_with(url, registry)
+
+
+@pytest.mark.asyncio
+async def test_marketplace_background_sync_start_stop():
+    registry = MagicMock(spec=SkillRegistry)
+    url = "https://mock-marketplace.io/skills.json"
+    sync_process = MarketplaceBackgroundSync(registry, url, sync_interval=0.01)
+
+    with patch('magda_agent.integration.skill_marketplace.fetch_and_register_skills', new_callable=AsyncMock) as mock_fetch:
+        sync_process.start()
+        assert sync_process._running is True
+        assert sync_process._task is not None
+
+        # Let the event loop run a bit to trigger the task
+        await asyncio.sleep(0.05)
+
+        assert mock_fetch.called
+
+        await sync_process.stop()
+        assert sync_process._running is False
+        assert sync_process._task is None


### PR DESCRIPTION
This PR completes the `mcp-skill-marketplace-sync-v2` task. It implements a non-blocking `MarketplaceBackgroundSync` asyncio loop inside `magda_agent/integration/skill_marketplace.py` that continuously fetches and registers new tools from the agentskills.io marketplace.

In addition:
- Added comprehensive unit testing for background loop lifecycle (start/stop/sync_once).
- Verified `agent_tasks.json` structure passes standard testing and validation checks.
- Marked task as completed in both `agent_tasks.json` and `backlog.md`.
- Appended two newly generated AI trend-inspired tasks to `agent_tasks.json` (Context Engine Semantic Routing V3, Hermes Online Skill Pruning V2).

---
*PR created automatically by Jules for task [7087743388509907135](https://jules.google.com/task/7087743388509907135) started by @kazah4359-lgtm*