### PR TITLE
feat: add A2A Agent Cards v4 discovery support

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11861,7 +11861,7 @@
     },
     {
       "id": "a2a-discovery-agent-cards-v4",
-      "status": "todo",
+      "status": "done",
       "area": "multi-agent",
       "risk": "medium",
       "title": "A2A Discovery Agent Cards v4",

--- a/magda_agent/integration/a2a_cards.py
+++ b/magda_agent/integration/a2a_cards.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 import json
 import logging
 from dataclasses import dataclass, asdict
@@ -130,3 +130,153 @@ class A2ADiscoveryV3:
             if agent.has_capability(capability):
                 matched_agents.append(agent)
         return matched_agents
+
+
+@dataclass
+class AgentCardV4:
+    """
+    Represents the capabilities and identity of an agent in the network, version 4.
+    Supports standardized capability matching, status tracking, and metadata extension.
+    """
+    agent_id: str
+    name: str
+    description: str
+    capabilities: List[str]
+    endpoints: Dict[str, str]
+    protocol_version: str = "v4"
+    metadata: Optional[Dict[str, Any]] = None
+    status: str = "active"
+
+    def to_json(self) -> str:
+        """
+        Serializes the AgentCardV4 to a JSON string.
+        """
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "AgentCardV4":
+        """
+        Deserializes an AgentCardV4 from a JSON string.
+        """
+        data = json.loads(json_str)
+        return cls(**data)
+
+    def has_capability(self, capability: str) -> bool:
+        """
+        Checks if the agent has the specified capability.
+        Supports exact match and prefix match (e.g. 'code' matches 'code_execution').
+        """
+        for cap in self.capabilities:
+            if cap == capability or cap.startswith(f"{capability}_"):
+                return True
+        return False
+
+    def matches_any_capability(self, required_capabilities: List[str]) -> bool:
+        """
+        Checks if the agent matches any of the required capabilities.
+        """
+        return any(self.has_capability(cap) for cap in required_capabilities)
+
+
+class A2ADiscoveryV4:
+    """
+    Handles discovery of other agents in the network and broadcasting
+    the local agent's capabilities using the v4 protocol.
+    """
+    def __init__(self, local_card: AgentCardV4, security_context: Optional[A2ASecurityContext] = None) -> None:
+        """
+        Initializes the discovery module with the local agent's card.
+        """
+        self.local_card = local_card
+        self.security_context = security_context or A2ASecurityContext()
+        self._discovered_agents: Dict[str, AgentCardV4] = {}
+        self._capability_index: Dict[str, List[str]] = {}
+
+    async def broadcast_card(self) -> str:
+        """
+        Broadcasts the local agent's card to the network in a v4 envelope format.
+        """
+        logging.info(f"Broadcasting Agent Card V4: {self.local_card.name}")
+
+        envelope = {
+            "type": "a2a_discovery_broadcast",
+            "version": "4.0",
+            "payload": asdict(self.local_card)
+        }
+        return json.dumps(envelope)
+
+    def parse_envelope(self, envelope_json: str) -> Optional[AgentCardV4]:
+        """
+        Parses a single network envelope JSON and returns an AgentCardV4 if valid.
+        """
+        try:
+            envelope = json.loads(envelope_json)
+            if isinstance(envelope, dict):
+                if envelope.get("type") == "a2a_discovery_broadcast" and envelope.get("version") in ("4.0", "v4"):
+                    payload = envelope.get("payload")
+                    if isinstance(payload, str):
+                        return AgentCardV4.from_json(payload)
+                    elif isinstance(payload, dict):
+                        return AgentCardV4(**payload)
+                elif "agent_id" in envelope and "capabilities" in envelope:
+                    return AgentCardV4(**envelope)
+        except Exception as e:
+            logging.error(f"Failed to parse Agent Card Envelope V4: {e}")
+        return None
+
+    async def fetch_cards(self, network_envelopes: Optional[List[str]] = None, auth_token: Optional[str] = None) -> List[AgentCardV4]:
+        """
+        Fetches Agent Cards from the network envelopes, registers and returns them.
+        """
+        if auth_token and not self.security_context.validate_token(auth_token):
+            logging.error("Invalid auth token for fetch_cards")
+            raise ValueError("Invalid authentication token")
+
+        self.security_context.trace_action("fetch_cards_v4", {"count": len(network_envelopes) if network_envelopes else 0})
+
+        if network_envelopes is None:
+            network_envelopes = []
+
+        registered_cards: List[AgentCardV4] = []
+        for envelope_json in network_envelopes:
+            card = self.parse_envelope(envelope_json)
+            if card:
+                self._register_agent(card)
+                registered_cards.append(card)
+
+        return registered_cards
+
+    def _register_agent(self, card: AgentCardV4) -> None:
+        """
+        Registers a discovered agent internally and updates the capability index.
+        """
+        self._discovered_agents[card.agent_id] = card
+        for capability in card.capabilities:
+            if capability not in self._capability_index:
+                self._capability_index[capability] = []
+            if card.agent_id not in self._capability_index[capability]:
+                self._capability_index[capability].append(card.agent_id)
+        logging.info(f"Discovered Agent V4: {card.name} with capabilities {card.capabilities}")
+
+    def get_agent_by_id(self, agent_id: str) -> Optional[AgentCardV4]:
+        """
+        Retrieves a discovered agent's card by its ID.
+        """
+        return self._discovered_agents.get(agent_id)
+
+    def find_agents_by_capability(self, capability: str) -> List[AgentCardV4]:
+        """
+        Returns a list of Agent Cards that support the given capability.
+        Supports capability matching logic.
+        """
+        matched_agents = []
+        for agent in self._discovered_agents.values():
+            if agent.has_capability(capability):
+                matched_agents.append(agent)
+        return matched_agents
+
+    def get_all_agents(self) -> List[AgentCardV4]:
+        """
+        Returns all discovered AgentCardV4 instances.
+        """
+        return list(self._discovered_agents.values())

--- a/tests/test_a2a_cards.py
+++ b/tests/test_a2a_cards.py
@@ -1,6 +1,7 @@
 import pytest
 import json
-from magda_agent.integration.a2a_cards import AgentCardV3, A2ADiscoveryV3
+from unittest.mock import MagicMock
+from magda_agent.integration.a2a_cards import AgentCardV3, A2ADiscoveryV3, AgentCardV4, A2ADiscoveryV4
 
 
 def test_agent_card_v3_serialization():
@@ -93,3 +94,161 @@ async def test_a2a_discovery_v3():
     # Test no match
     matched_none = discovery.find_agents_by_capability("translation")
     assert len(matched_none) == 0
+
+
+def test_agent_card_v4_serialization():
+    card = AgentCardV4(
+        agent_id="v4-agent-1",
+        name="V4 Agent One",
+        description="A version 4 agent",
+        capabilities=["data_analysis", "ml_inference"],
+        endpoints={"a2a": "http://localhost:9090"},
+        metadata={"region": "us-east-1"},
+        status="active"
+    )
+    json_str = card.to_json()
+    deserialized = AgentCardV4.from_json(json_str)
+    assert deserialized.agent_id == "v4-agent-1"
+    assert deserialized.name == "V4 Agent One"
+    assert deserialized.capabilities == ["data_analysis", "ml_inference"]
+    assert deserialized.protocol_version == "v4"
+    assert deserialized.metadata == {"region": "us-east-1"}
+    assert deserialized.status == "active"
+
+
+def test_agent_card_v4_capability_matching():
+    card = AgentCardV4(
+        agent_id="v4-agent-2",
+        name="V4 Agent Two",
+        description="Capabilities tester",
+        capabilities=["code_refactoring", "data_processing"],
+        endpoints={}
+    )
+    assert card.has_capability("code_refactoring") is True
+    assert card.has_capability("code") is True
+    assert card.has_capability("data") is True
+    assert card.has_capability("nlp") is False
+
+    assert card.matches_any_capability(["nlp", "data"]) is True
+    assert card.matches_any_capability(["nlp", "vision"]) is False
+
+
+@pytest.mark.asyncio
+async def test_a2a_discovery_v4_broadcast_and_parse():
+    local_card = AgentCardV4(
+        agent_id="local-v4",
+        name="Local V4",
+        description="Local V4 discovery agent",
+        capabilities=["orchestration_v4"],
+        endpoints={"http": "http://127.0.0.1:8000"}
+    )
+    discovery = A2ADiscoveryV4(local_card=local_card)
+
+    broadcast_json = await discovery.broadcast_card()
+    broadcast_data = json.loads(broadcast_json)
+    assert broadcast_data["type"] == "a2a_discovery_broadcast"
+    assert broadcast_data["version"] == "4.0"
+    assert broadcast_data["payload"]["agent_id"] == "local-v4"
+
+    # Test parse envelope with string payload
+    peer_card = AgentCardV4(
+        agent_id="peer-v4-1",
+        name="Peer V4 One",
+        description="Peer 1",
+        capabilities=["vision_processing"],
+        endpoints={}
+    )
+    envelope_dict = {
+        "type": "a2a_discovery_broadcast",
+        "version": "4.0",
+        "payload": peer_card.to_json()
+    }
+    parsed = discovery.parse_envelope(json.dumps(envelope_dict))
+    assert parsed is not None
+    assert parsed.agent_id == "peer-v4-1"
+
+    # Test parse envelope with dict payload
+    envelope_dict2 = {
+        "type": "a2a_discovery_broadcast",
+        "version": "4.0",
+        "payload": json.loads(peer_card.to_json())
+    }
+    parsed2 = discovery.parse_envelope(json.dumps(envelope_dict2))
+    assert parsed2 is not None
+    assert parsed2.agent_id == "peer-v4-1"
+
+    # Test parse direct json card format
+    parsed_direct = discovery.parse_envelope(peer_card.to_json())
+    assert parsed_direct is not None
+    assert parsed_direct.agent_id == "peer-v4-1"
+
+    # Test invalid envelope format returns None
+    assert discovery.parse_envelope("invalid json") is None
+    assert discovery.parse_envelope(json.dumps({"unrecognized": True})) is None
+
+
+@pytest.mark.asyncio
+async def test_a2a_discovery_v4_fetch_and_lookup():
+    local_card = AgentCardV4(
+        agent_id="local-v4",
+        name="Local V4",
+        description="Local V4 agent",
+        capabilities=["manager"],
+        endpoints={}
+    )
+    discovery = A2ADiscoveryV4(local_card=local_card)
+
+    peer1 = AgentCardV4(
+        agent_id="peer-v4-a",
+        name="Peer A",
+        description="Peer A desc",
+        capabilities=["sql_query"],
+        endpoints={}
+    )
+    peer2 = AgentCardV4(
+        agent_id="peer-v4-b",
+        name="Peer B",
+        description="Peer B desc",
+        capabilities=["sql_optimization"],
+        endpoints={}
+    )
+
+    env1 = json.dumps({"type": "a2a_discovery_broadcast", "version": "4.0", "payload": json.loads(peer1.to_json())})
+    env2 = json.dumps({"type": "a2a_discovery_broadcast", "version": "4.0", "payload": json.loads(peer2.to_json())})
+
+    fetched = await discovery.fetch_cards(network_envelopes=[env1, env2])
+    assert len(fetched) == 2
+
+    assert discovery.get_agent_by_id("peer-v4-a") is not None
+    assert discovery.get_agent_by_id("peer-v4-b") is not None
+    assert len(discovery.get_all_agents()) == 2
+
+    sql_agents = discovery.find_agents_by_capability("sql")
+    assert len(sql_agents) == 2
+
+    exact_agents = discovery.find_agents_by_capability("sql_query")
+    assert len(exact_agents) == 1
+    assert exact_agents[0].agent_id == "peer-v4-a"
+
+
+@pytest.mark.asyncio
+async def test_a2a_discovery_v4_auth():
+    local_card = AgentCardV4(
+        agent_id="local-v4",
+        name="Local V4",
+        description="Local V4 agent",
+        capabilities=["manager"],
+        endpoints={}
+    )
+    mock_sec_ctx = MagicMock()
+    mock_sec_ctx.validate_token.side_effect = lambda t: t == "valid-token"
+
+    discovery = A2ADiscoveryV4(local_card=local_card, security_context=mock_sec_ctx)
+
+    # Invalid token raises ValueError
+    with pytest.raises(ValueError, match="Invalid authentication token"):
+        await discovery.fetch_cards(network_envelopes=[], auth_token="invalid-token")
+
+    # Valid token succeeds
+    res = await discovery.fetch_cards(network_envelopes=[], auth_token="valid-token")
+    assert res == []


### PR DESCRIPTION
Implemented AgentCardV4 and A2ADiscoveryV4 in magda_agent/integration/a2a_cards.py with capability matching, network envelope broadcasting/parsing, and security token validation. Added comprehensive unit tests in tests/test_a2a_cards.py and updated agent_tasks.json task status to done.

---
*PR created automatically by Jules for task [11714546583549388290](https://jules.google.com/task/11714546583549388290) started by @kazah4359-lgtm*