### PR TITLE
feat: OpenClaw-RL canvas metrics streaming v6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11878,7 +11878,7 @@
     },
     {
       "id": "openclaw-rl-canvas-metrics-v6",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw-RL Live Telemetry Streaming V6",
@@ -27502,6 +27502,41 @@
       "acceptance": [
         "Semantic routing hook intercepts queries and assigns them to sub-agents if applicable.",
         "Tests use mocked LLM calls and verify correct routing behavior."
+      ]
+    },
+    {
+      "id": "hermes-skill-market-exporter-v1-5497465c",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "Hermes agentskills.io Market Exporter V1",
+      "description": "Inspired by Hermes Agent (June 2026): Implement an exporter that takes local Magda skills from SkillRegistry and formats them according to the open agentskills.io standard for potential external discovery.",
+      "allowed_paths": [
+        "magda_agent/integration/agentskills_exporter_v1.py",
+        "tests/test_agentskills_exporter_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "AgentskillsExporter can serialize a Magda tool into agentskills.io compliant JSON.",
+        "Tests verify that parameters, descriptions, and metadata map correctly."
+      ]
+    },
+    {
+      "id": "claude-team-evaluator-v1-fe845ed5",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude Agent Teams Evaluator Subagent V1",
+      "description": "Inspired by Claude Agent Teams (June 2026): Implement a dedicated Evaluator Subagent that receives the Plan output from a Generator subagent and returns a pass/fail assessment against the original goal before continuing execution.",
+      "allowed_paths": [
+        "magda_agent/multi_agent/evaluator_subagent_v1.py",
+        "tests/test_evaluator_subagent_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "EvaluatorSubagent correctly parses plan steps and invokes LLMClient for semantic validation.",
+        "If plan is poor, subagent returns a clear failure reason.",
+        "Tests mock LLM calls and verify evaluator logic."
       ]
     }
   ]

--- a/magda_agent/telemetry/a2a_distributed_v7.py
+++ b/magda_agent/telemetry/a2a_distributed_v7.py
@@ -84,6 +84,26 @@ class A2ADistributedTelemetryV7:
         json_payload = json.dumps(payload)
         await self._mock_websocket_emit(json_payload)
 
+    async def broadcast_rl_reward_to_canvas(
+        self, subagent_id: str, reward_signal: float, details: Dict[str, Any] = None
+    ) -> None:
+        """
+        Broadcast an RL reward signal to the Canvas UI via WebSocket mock.
+
+        Args:
+            subagent_id (str): The unique identifier for the sub-agent.
+            reward_signal (float): The reinforcement learning reward signal.
+            details (Dict[str, Any], optional): Additional details regarding the reward. Defaults to None.
+        """
+        payload = {
+            "type": "canvas_rl_reward",
+            "subagent_id": subagent_id,
+            "reward_signal": reward_signal,
+            "details": details or {}
+        }
+        json_payload = json.dumps(payload)
+        await self._mock_websocket_emit(json_payload)
+
     async def _mock_websocket_emit(self, json_payload: str) -> None:
         """
         Mock WebSocket emission for Canvas UI updates.

--- a/tests/test_a2a_distributed_v7.py
+++ b/tests/test_a2a_distributed_v7.py
@@ -61,3 +61,42 @@ async def test_broadcast_pad_shift_to_canvas(telemetry):
         assert payload["type"] == "canvas_pad_shift"
         assert payload["subagent_id"] == "sub_1"
         assert payload["pad_shift"] == pad_shift
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_reward_to_canvas(telemetry):
+    reward_signal = 0.85
+    details = {"action": "clarify_intent", "reason": "user_positive"}
+
+    with patch.object(telemetry, '_mock_websocket_emit', new_callable=AsyncMock) as mock_emit:
+        await telemetry.broadcast_rl_reward_to_canvas("sub_1", reward_signal, details)
+
+        mock_emit.assert_called_once()
+        args, _ = mock_emit.call_args
+        json_payload = args[0]
+
+        import json
+        payload = json.loads(json_payload)
+
+        assert payload["type"] == "canvas_rl_reward"
+        assert payload["subagent_id"] == "sub_1"
+        assert payload["reward_signal"] == reward_signal
+        assert payload["details"] == details
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_reward_to_canvas_no_details(telemetry):
+    reward_signal = 0.85
+
+    with patch.object(telemetry, '_mock_websocket_emit', new_callable=AsyncMock) as mock_emit:
+        await telemetry.broadcast_rl_reward_to_canvas("sub_1", reward_signal)
+
+        mock_emit.assert_called_once()
+        args, _ = mock_emit.call_args
+        json_payload = args[0]
+
+        import json
+        payload = json.loads(json_payload)
+
+        assert payload["type"] == "canvas_rl_reward"
+        assert payload["subagent_id"] == "sub_1"
+        assert payload["reward_signal"] == reward_signal
+        assert payload["details"] == {}


### PR DESCRIPTION
Implemented the OpenClaw-RL Canvas Metrics V6 task from the backlog by adding `broadcast_rl_reward_to_canvas` allowing asynchronous streaming of reward signal metric payloads for UI canvas rendering. Provided matching unit tests and managed the backlog tasks by rotating the completed objective and deriving 2 future objectives from the June 2026 AI Agent market trends.

---
*PR created automatically by Jules for task [6161001157947408148](https://jules.google.com/task/6161001157947408148) started by @kazah4359-lgtm*