### PR TITLE
feat: A2A Agent Discovery Mesh Expansion V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -27389,7 +27389,7 @@
       "description": "Inspired by A2A Protocol and Agent Cards trends: Build an advanced mesh-based discovery service where peer agents can gossip about available capabilities over local channels, allowing highly resilient peer-to-peer discovery without a central registry.",
       "area": "integration",
       "risk": "medium",
-      "status": "todo",
+      "status": "done",
       "allowed_paths": [
         "magda_agent/integration/a2a_discovery_mesh.py",
         "tests/test_a2a_discovery_mesh.py",
@@ -27590,6 +27590,42 @@
         "Cron scheduler registers the task successfully.",
         "Task correctly exports a subset of ChromaDB to a mock JSON file.",
         "Tests use a mocked ChromaDB instance."
+      ]
+    },
+    {
+      "id": "mcp-tool-execution-audit-trail-v1-1ad39c71",
+      "title": "MCP Tool Execution Audit Trail V1",
+      "description": "Inspired by Agent Guard / Prempti Pattern trends (June 2026): Implement an interception layer that logs and creates an audit trail of all MCP tool executions, recording tool names, inputs, outputs, and the executing agent for security monitoring.",
+      "area": "safety",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_audit_trail_v1.py",
+        "tests/test_mcp_audit_trail_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Interceptor successfully logs tool execution details.",
+        "Audit trail is saved to an episodic memory equivalent or mock log.",
+        "Tests verify that tool parameters and outputs are recorded correctly without blocking execution."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-selection-v1-54e7d2dc",
+      "title": "OpenClaw Virtual Context Selection V1",
+      "description": "Inspired by Context Engine / MemGPT Virtual Context trends (June 2026): Implement a virtual context selection plugin that dynamically queries episodic memory for relevant previous interactions and automatically loads them into the working memory context prior to generation.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_selection_v1.py",
+        "tests/test_virtual_context_selection_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin hooks into Context Engine to intercept context generation.",
+        "Semantic similarity search is mocked to select relevant prior context.",
+        "Tests verify working memory contains retrieved context based on a given query."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -357,3 +357,4 @@
 * [x] FEATURE: Claude Subagent Token Context Optimizer V2 (claude-subagent-token-context-optimizer-v2-ec3a412d)
 * [x] FEATURE: MCP Dynamic Skill Marketplace Poller (mcp-dynamic-skill-marketplace-poller-1d28f431)
 * [x] FEATURE: ACS Validation Checkpoints V5 (acs-validation-checkpoints-v5-unique-bc81b2a5)
+* [x] FEATURE: A2A Agent Discovery Mesh Expansion V2 (a2a-discovery-mesh-expansion-v2-1e10f95)

--- a/magda_agent/integration/a2a_discovery_mesh.py
+++ b/magda_agent/integration/a2a_discovery_mesh.py
@@ -1,0 +1,73 @@
+from typing import List, Dict, Any
+import logging
+import httpx
+from dataclasses import asdict
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+
+class A2ADiscoveryMesh:
+    """
+    Manages an A2A discovery mesh based on the A2A Protocol trend.
+    It facilitates finding peers with required capabilities using AgentCards,
+    and propagates gossip about known peers to other nodes.
+    """
+
+    def __init__(self, discovery: A2ADiscovery) -> None:
+        """
+        Initializes the A2ADiscoveryMesh.
+
+        Args:
+            discovery: The core A2ADiscovery instance containing local_card and _discovered_agents.
+        """
+        self.discovery = discovery
+
+    def aggregate_cards(self) -> List[AgentCard]:
+        """
+        Aggregates the local agent's card and all discovered peer cards.
+
+        Returns:
+            A list of AgentCard instances known to this mesh node.
+        """
+        cards = [self.discovery.local_card]
+        cards.extend(list(self.discovery._discovered_agents.values()))
+        return cards
+
+    async def broadcast_gossip(self, endpoint_urls: List[str]) -> None:
+        """
+        Broadcasts all known agent cards (gossip) to the specified endpoints.
+
+        Args:
+            endpoint_urls: A list of HTTP endpoints (e.g., 'http://192.168.1.10:8000/gossip') to send the cards to.
+        """
+        aggregated_cards = self.aggregate_cards()
+        cards_data = [asdict(card) for card in aggregated_cards]
+
+        async with httpx.AsyncClient() as client:
+            for url in endpoint_urls:
+                try:
+                    response = await client.post(url, json=cards_data)
+                    response.raise_for_status()
+                    logging.info(f"Successfully gossiped {len(aggregated_cards)} cards to {url}")
+                except Exception as e:
+                    logging.error(f"Failed to gossip cards to {url}: {e}")
+
+    def receive_gossip(self, cards_data: List[Dict[str, Any]]) -> None:
+        """
+        Receives gossip data (a list of agent card dictionaries) and registers
+        new or updated agents into the discovery service.
+
+        Args:
+            cards_data: A list of dictionaries, each representing an AgentCard.
+        """
+        registered_count = 0
+        for card_dict in cards_data:
+            try:
+                card = AgentCard(**card_dict)
+                # Don't register ourselves if we receive our own card back
+                if card.agent_id != self.discovery.local_card.agent_id:
+                    self.discovery._register_agent(card)
+                    registered_count += 1
+            except Exception as e:
+                logging.error(f"Failed to parse or register agent card from gossip: {e}")
+
+        logging.info(f"Registered {registered_count} cards from gossip.")

--- a/tests/test_a2a_discovery_mesh.py
+++ b/tests/test_a2a_discovery_mesh.py
@@ -1,0 +1,130 @@
+import pytest
+import httpx
+from unittest.mock import AsyncMock, patch
+from dataclasses import asdict
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_discovery_mesh import A2ADiscoveryMesh
+
+
+@pytest.fixture
+def local_card():
+    return AgentCard(
+        agent_id="agent-local-1",
+        name="Local Agent",
+        description="I am the local agent",
+        capabilities=["chat", "planning"],
+        endpoints={"gossip": "http://localhost:8000/gossip"}
+    )
+
+
+@pytest.fixture
+def peer_card():
+    return AgentCard(
+        agent_id="agent-peer-2",
+        name="Peer Agent",
+        description="I am a remote peer",
+        capabilities=["coding"],
+        endpoints={"gossip": "http://192.168.1.10:8000/gossip"}
+    )
+
+
+@pytest.fixture
+def discovery_service(local_card, peer_card):
+    service = A2ADiscovery(local_card=local_card)
+    service._register_agent(peer_card)
+    return service
+
+
+@pytest.fixture
+def mesh(discovery_service):
+    return A2ADiscoveryMesh(discovery=discovery_service)
+
+
+def test_aggregate_cards(mesh, local_card, peer_card):
+    cards = mesh.aggregate_cards()
+    assert len(cards) == 2
+    assert local_card in cards
+    assert peer_card in cards
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+async def test_broadcast_gossip_success(mock_post, mesh, local_card, peer_card):
+    # Setup mock response
+    mock_post.return_value.raise_for_status = AsyncMock()
+
+    endpoints = ["http://192.168.1.10:8000/gossip", "http://192.168.1.11:8000/gossip"]
+    await mesh.broadcast_gossip(endpoints)
+
+    assert mock_post.call_count == 2
+
+    # Check what was sent
+    expected_data = [asdict(local_card), asdict(peer_card)]
+
+    # First call args
+    first_call_args, first_call_kwargs = mock_post.call_args_list[0]
+    assert first_call_args[0] == "http://192.168.1.10:8000/gossip"
+    assert first_call_kwargs["json"] == expected_data
+
+    # Second call args
+    second_call_args, second_call_kwargs = mock_post.call_args_list[1]
+    assert second_call_args[0] == "http://192.168.1.11:8000/gossip"
+    assert second_call_kwargs["json"] == expected_data
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+async def test_broadcast_gossip_failure(mock_post, mesh):
+    # Setup mock to simulate a network error
+    mock_post.side_effect = httpx.RequestError("Network error", request=AsyncMock())
+
+    endpoints = ["http://192.168.1.10:8000/gossip"]
+    # Should not raise an exception, just log the error
+    await mesh.broadcast_gossip(endpoints)
+
+    mock_post.assert_called_once()
+
+
+def test_receive_gossip_new_peer(mesh):
+    new_peer_data = {
+        "agent_id": "agent-peer-3",
+        "name": "New Peer",
+        "description": "Just joined the mesh",
+        "capabilities": ["search"],
+        "endpoints": {"gossip": "http://192.168.1.12:8000/gossip"},
+        "protocol_version": "2.0"
+    }
+
+    mesh.receive_gossip([new_peer_data])
+
+    # Verify it was registered in the discovery service
+    discovered_agent = mesh.discovery.get_agent_by_id("agent-peer-3")
+    assert discovered_agent is not None
+    assert discovered_agent.name == "New Peer"
+    assert "search" in discovered_agent.capabilities
+
+
+def test_receive_gossip_ignores_local_card(mesh, local_card):
+    # Receive gossip containing our own card
+    gossip_data = [asdict(local_card)]
+
+    # To check if it was ignored, we can monitor the call to _register_agent
+    # However, since _register_agent is a simple method, we just verify the state doesn't break
+    with patch.object(mesh.discovery, '_register_agent') as mock_register:
+        mesh.receive_gossip(gossip_data)
+
+        # Should not have called register for our own card
+        mock_register.assert_not_called()
+
+
+def test_receive_gossip_invalid_data(mesh):
+    invalid_data = [
+        {"not_an_agent_id": "missing_required_fields"}
+    ]
+
+    # Should handle the exception internally and not raise
+    mesh.receive_gossip(invalid_data)
+
+    # Should still just have the initial 1 peer registered during fixture setup
+    assert len(mesh.discovery._discovered_agents) == 1


### PR DESCRIPTION
Implemented the "A2A Agent Discovery Mesh Expansion V2" task by creating `magda_agent/integration/a2a_discovery_mesh.py`. This class leverages `httpx` to broadcast known AgentCards (gossip) to other endpoints, and correctly parses received gossip to dynamically register indirect peers into the `A2ADiscovery` module. Provided full test coverage in `tests/test_a2a_discovery_mesh.py` utilizing `AsyncMock` and `patch`. 

Also successfully added two new relevant trending tasks ("MCP Tool Execution Audit Trail V1" and "OpenClaw Virtual Context Selection V1") to `agent_tasks.json` and updated the backlog.

---
*PR created automatically by Jules for task [5559156223617195461](https://jules.google.com/task/5559156223617195461) started by @kazah4359-lgtm*