### PR TITLE
feat(learning): implement SkillPrunerV2 and add new trend-inspired tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -27472,7 +27472,7 @@
     },
     {
       "id": "hermes-online-skill-pruning-v2-9affbe28",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Hermes Online Skill Pruning V2",
@@ -27677,6 +27677,40 @@
       "acceptance": [
         "Sync manager successfully aggregates records based on user id across platforms.",
         "Tests mock memory stores and verify the consolidated output."
+      ]
+    },
+    {
+      "id": "mcp-tool-exporter-v2-c8687eba",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Tool Exporter V2",
+      "description": "Inspired by June 2026 AI Agent Trends (MCP-совместимость): Implement a skill exporter that formats Magda skills as MCP tools according to the latest specification.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_exporter_v2.py",
+        "tests/test_mcp_exporter_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter properly formats skills as MCP tools.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-v2-0441d397",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A Task Delegation V2",
+      "description": "Inspired by June 2026 AI Agent Trends (A2A поддержка): Implement an A2A task delegation module that discovers agents via Agent Cards and delegates subtasks to them.",
+      "allowed_paths": [
+        "magda_agent/multi_agent/a2a_delegation_v2.py",
+        "tests/test_a2a_delegation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module successfully delegates tasks using A2A.",
+        "Tests mock A2A responses and pass."
       ]
     }
   ]

--- a/magda_agent/learning/skill_pruner_v2.py
+++ b/magda_agent/learning/skill_pruner_v2.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Optional
+from magda_agent.skills.registry import SkillRegistry
+
+class SkillPrunerV2:
+    """
+    SkillPrunerV2 evaluates skill usage metrics from telemetry and unregisters
+    skills that have high failure rates or zero usage over a significant time period.
+    This helps keep the context window optimized.
+    """
+
+    def __init__(self, registry: SkillRegistry) -> None:
+        """
+        Initializes the SkillPrunerV2.
+
+        Args:
+            registry (SkillRegistry): The registry containing skills to prune.
+        """
+        self.logger = logging.getLogger(__name__)
+        self.registry = registry
+
+    def evaluate_and_prune(
+        self,
+        min_calls: int = 5,
+        failure_threshold: float = 0.5,
+        prune_zero_usage: bool = True
+    ) -> None:
+        """
+        Evaluates current telemetry metrics and prunes underperforming skills
+        from the SkillRegistry.
+
+        Args:
+            min_calls (int): The minimum number of calls a skill must have before
+                             its failure rate is evaluated.
+            failure_threshold (float): The maximum allowed failure rate. Skills with
+                                       a failure rate above this threshold are pruned.
+            prune_zero_usage (bool): Whether to prune skills that have zero calls.
+        """
+        if not hasattr(self.registry, 'telemetry_tracker'):
+            self.logger.warning("SkillRegistry does not have a telemetry_tracker. Skipping pruning.")
+            return
+
+        tracker = self.registry.telemetry_tracker
+        metrics = tracker.get_aggregated_metrics()
+
+        min_success_rate = 1.0 - failure_threshold
+        skills_to_remove = []
+
+        for skill_name, data in metrics.items():
+            if skill_name not in self.registry.skills:
+                continue
+
+            total_calls = data.get("total_calls", 0)
+            success_rate = data.get("success_rate", 0.0)
+
+            if total_calls == 0 and prune_zero_usage:
+                self.logger.info(f"Pruning skill '{skill_name}' due to zero usage.")
+                skills_to_remove.append(skill_name)
+            elif total_calls >= min_calls and success_rate < min_success_rate:
+                self.logger.info(
+                    f"Pruning skill '{skill_name}' due to high failure rate "
+                    f"(success_rate: {success_rate:.2f}, calls: {total_calls})."
+                )
+                skills_to_remove.append(skill_name)
+
+        # Apply pruning
+        for skill_name in skills_to_remove:
+            if skill_name in self.registry.skills:
+                del self.registry.skills[skill_name]
+            if skill_name in self.registry.descriptions:
+                del self.registry.descriptions[skill_name]

--- a/tests/test_skill_pruner_v2.py
+++ b/tests/test_skill_pruner_v2.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import MagicMock
+from magda_agent.learning.skill_pruner_v2 import SkillPrunerV2
+
+@pytest.fixture
+def mock_registry() -> MagicMock:
+    """Fixture providing a mock SkillRegistry populated with fake skills and telemetry data."""
+    registry = MagicMock()
+    # Populate mock skills and descriptions
+    registry.skills = {
+        "good_skill": lambda x: x,
+        "bad_skill": lambda x: x,
+        "new_skill": lambda x: x,
+        "unused_skill": lambda x: x
+    }
+    registry.descriptions = {
+        "good_skill": "A good skill",
+        "bad_skill": "A bad skill",
+        "new_skill": "A new skill with few calls",
+        "unused_skill": "A skill with zero calls"
+    }
+
+    # Setup telemetry tracker mock
+    tracker = MagicMock()
+
+    # Mock get_aggregated_metrics to return predefined test data
+    def mock_get_metrics():
+        return {
+            "good_skill": {"total_calls": 10, "success_rate": 0.9, "total_execution_time_ms": 100},
+            "bad_skill": {"total_calls": 6, "success_rate": 0.3, "total_execution_time_ms": 100},
+            "new_skill": {"total_calls": 2, "success_rate": 0.0, "total_execution_time_ms": 100},
+            "unused_skill": {"total_calls": 0, "success_rate": 0.0, "total_execution_time_ms": 0}
+        }
+
+    tracker.get_aggregated_metrics.side_effect = mock_get_metrics
+    registry.telemetry_tracker = tracker
+
+    return registry
+
+def test_skill_pruner_high_failure(mock_registry: MagicMock) -> None:
+    """Test that skills with high failure rates and zero usage are pruned when prune_zero_usage is True."""
+    pruner = SkillPrunerV2(mock_registry)
+    pruner.evaluate_and_prune(min_calls=5, failure_threshold=0.5, prune_zero_usage=True)
+
+    assert "good_skill" in mock_registry.skills
+    assert "good_skill" in mock_registry.descriptions
+
+    assert "new_skill" in mock_registry.skills
+    assert "new_skill" in mock_registry.descriptions
+
+    assert "bad_skill" not in mock_registry.skills
+    assert "bad_skill" not in mock_registry.descriptions
+
+    assert "unused_skill" not in mock_registry.skills
+    assert "unused_skill" not in mock_registry.descriptions
+
+def test_skill_pruner_keep_zero_usage(mock_registry: MagicMock) -> None:
+    """Test that unused skills are kept when prune_zero_usage is False."""
+    pruner = SkillPrunerV2(mock_registry)
+    pruner.evaluate_and_prune(min_calls=5, failure_threshold=0.5, prune_zero_usage=False)
+
+    assert "unused_skill" in mock_registry.skills
+    assert "unused_skill" in mock_registry.descriptions
+
+    assert "bad_skill" not in mock_registry.skills
+    assert "bad_skill" not in mock_registry.descriptions
+
+def test_skill_pruner_no_telemetry_tracker() -> None:
+    """Test that pruning is skipped safely if the registry lacks a telemetry tracker."""
+    registry = MagicMock()
+    del registry.telemetry_tracker
+    registry.skills = {"skill1": lambda x: x}
+
+    pruner = SkillPrunerV2(registry)
+    pruner.evaluate_and_prune()
+
+    assert "skill1" in registry.skills


### PR DESCRIPTION
Closes `hermes-online-skill-pruning-v2-9affbe28` by implementing the `SkillPrunerV2` module and updating tasks. Tests have been written to mock telemetry and ensure proper pruning.

---
*PR created automatically by Jules for task [4730857658022026163](https://jules.google.com/task/4730857658022026163) started by @kazah4359-lgtm*

----
## Summary by Gitar

- **New tasks:**
    - Added new trend-inspired tasks `mcp-tool-exporter-v2-c8687eba` and `a2a-task-delegation-v2-0441d397` to `agent_tasks.json`

<sub>This will update automatically on new commits.</sub>