### PR TITLE
feat(security): Implement MCPKernel Tool Taint Isolation V10

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -24834,7 +24834,7 @@
     },
     {
       "id": "mcp-kernel-tool-taint-isolation-v10-482de2b9",
-      "status": "todo",
+      "status": "done",
       "area": "security",
       "risk": "high",
       "title": "MCPKernel Tool Taint Isolation V10",
@@ -27711,6 +27711,59 @@
       "acceptance": [
         "Module successfully delegates tasks using A2A.",
         "Tests mock A2A responses and pass."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-streaming-export-v11-a7501213",
+      "title": "MCP Action Tool Streaming Export V11",
+      "description": "Inspired by MCP standard trends (June 2026): Implement an action tool exporter that streams responses via an async generator compatible with JSON-RPC streaming, enabling real-time feedback for long-running tools.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_streaming_export_v11.py",
+        "tests/test_mcp_streaming_export_v11.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter correctly formats yields from Python generators into MCP streaming payload chunks.",
+        "Tests verify that the chunking mechanism buffers properly.",
+        "Tests verify JSON-RPC serialization."
+      ]
+    },
+    {
+      "id": "a2a-swarm-intelligence-consensus-v4-bb8189c6",
+      "title": "A2A Swarm Intelligence Consensus Protocol V4",
+      "description": "Inspired by Swarm Intelligence and A2A trends (June 2026): Create a consensus protocol for the A2A mesh that allows peer sub-agents to vote on critical task parameters before taking an action.",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_consensus_v4.py",
+        "tests/test_a2a_consensus_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Protocol handles distributed voting from multiple discovered peer agents.",
+        "Consensus requirement prevents execution until a quorum is reached.",
+        "Tests verify voting resolution and quorum conditions."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-lifecycle-manager-v5-ad4c79c2",
+      "title": "OpenClaw Virtual Context Lifecycle Manager V5",
+      "description": "Inspired by OpenClaw trends (June 2026): Implement an intelligent background process that periodically scans and archives idle virtual contexts from subagents to free up memory constraints.",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_lifecycle_v5.py",
+        "tests/test_virtual_context_lifecycle_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lifecycle manager detects idle context boundaries and triggers Episodic Memory archiving.",
+        "Tests mock context engine states and verify cleanup."
       ]
     }
   ]

--- a/magda_agent/security/mcp_taint_isolation_v10.py
+++ b/magda_agent/security/mcp_taint_isolation_v10.py
@@ -1,0 +1,90 @@
+"""
+MCPKernel Tool Taint Isolation V10.
+
+Implements strict process-level network isolation for subprocesses
+that execute external tools utilizing tainted user data.
+"""
+import ctypes
+import os
+import subprocess
+from typing import Any, Dict, List, Optional, Union
+
+from magda_agent.security.mcp_kernel_taint import is_tainted, sanitize
+
+# Linux CLONE_NEWNET flag for unshare syscall
+CLONE_NEWNET = 0x40000000
+
+class IsolationError(Exception):
+    """Exception raised when network isolation cannot be guaranteed."""
+    pass
+
+
+def _drop_network() -> None:
+    """
+    Attempts to drop network access using the Linux unshare syscall.
+    If the system call fails (e.g., due to lack of CAP_SYS_ADMIN privileges
+    or being on a non-Linux platform), it raises an IsolationError to fail securely.
+    """
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+        result = libc.unshare(CLONE_NEWNET)
+        if result != 0:
+            raise IsolationError(f"Failed to drop network access: unshare returned {result}")
+    except OSError as e:
+        raise IsolationError(f"Failed to drop network access: {e}")
+    except AttributeError:
+        raise IsolationError("Failed to drop network access: libc.so.6 not found or unshare not supported")
+
+
+class IsolatedSubprocessProxy:
+    """
+    A proxy for executing subprocesses with network isolation for tainted data.
+    """
+
+    @staticmethod
+    def run(
+        args: Union[str, List[Any]],
+        env: Optional[Dict[str, str]] = None,
+        **kwargs: Any
+    ) -> subprocess.CompletedProcess:
+        """
+        Executes a command. If any arguments or environment variables are tainted,
+        applies strict network isolation.
+
+        Args:
+            args: The command and its arguments.
+            env: Optional environment variables dictionary.
+            **kwargs: Additional keyword arguments for subprocess.run.
+
+        Returns:
+            The CompletedProcess instance resulting from the execution.
+
+        Raises:
+            IsolationError: If tainted data is detected but isolation fails.
+        """
+        has_taint = is_tainted(args) or (env is not None and is_tainted(env))
+
+        # Sanitize arguments and environment to avoid type issues with subprocess.run
+        clean_args = sanitize(args)
+        clean_env = sanitize(env)
+
+        execution_env = clean_env.copy() if clean_env is not None else os.environ.copy()
+
+        # Isolate if tainted
+        preexec_fn = kwargs.get("preexec_fn")
+
+        if has_taint:
+            # Set environment flag for mocked testing or downstream wrappers
+            execution_env["__MCP_ISOLATED_NETWORK"] = "1"
+
+            # Use unshare to drop network access on Linux. Must fail if unsuccessful.
+            def _isolated_preexec() -> None:
+                _drop_network()
+                if preexec_fn is not None:
+                    preexec_fn()
+
+            kwargs["preexec_fn"] = _isolated_preexec
+
+        kwargs["env"] = execution_env
+
+        return subprocess.run(clean_args, **kwargs)

--- a/tests/test_mcp_taint_isolation_v10.py
+++ b/tests/test_mcp_taint_isolation_v10.py
@@ -1,0 +1,116 @@
+"""Tests for MCPKernel Tool Taint Isolation V10."""
+
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magda_agent.security.mcp_kernel_taint import mark_tainted
+from magda_agent.security.mcp_taint_isolation_v10 import IsolatedSubprocessProxy, IsolationError
+
+
+@patch("subprocess.run")
+def test_isolated_subprocess_proxy_clean_args(mock_run: MagicMock) -> None:
+    """Test executing a command with untainted arguments."""
+    mock_run.return_value = subprocess.CompletedProcess(args=["ls", "-la"], returncode=0)
+
+    result = IsolatedSubprocessProxy.run(["ls", "-la"])
+
+    assert result.returncode == 0
+    mock_run.assert_called_once()
+
+    # Verify that the isolation flag is not set
+    call_kwargs = mock_run.call_args.kwargs
+    assert "__MCP_ISOLATED_NETWORK" not in call_kwargs.get("env", {})
+    assert "preexec_fn" not in call_kwargs or call_kwargs["preexec_fn"] is None
+
+
+@patch("subprocess.run")
+@patch("magda_agent.security.mcp_taint_isolation_v10._drop_network")
+def test_isolated_subprocess_proxy_tainted_args(mock_drop_network: MagicMock, mock_run: MagicMock) -> None:
+    """Test executing a command with tainted arguments."""
+    mock_run.return_value = subprocess.CompletedProcess(args=["curl", "http://example.com"], returncode=0)
+
+    tainted_args = mark_tainted(["curl", "http://example.com"])
+    result = IsolatedSubprocessProxy.run(tainted_args)
+
+    assert result.returncode == 0
+    mock_run.assert_called_once()
+
+    # Verify the arguments were sanitized
+    call_args = mock_run.call_args.args[0]
+    assert type(call_args[0]) is str
+    assert type(call_args[1]) is str
+
+    # Verify isolation mechanisms were engaged
+    call_kwargs = mock_run.call_args.kwargs
+    assert call_kwargs["env"]["__MCP_ISOLATED_NETWORK"] == "1"
+    assert call_kwargs["preexec_fn"] is not None
+
+    # Call the preexec_fn to ensure it attempts to drop the network
+    call_kwargs["preexec_fn"]()
+    mock_drop_network.assert_called_once()
+
+
+@patch("subprocess.run")
+@patch("magda_agent.security.mcp_taint_isolation_v10._drop_network")
+def test_isolated_subprocess_proxy_tainted_env(mock_drop_network: MagicMock, mock_run: MagicMock) -> None:
+    """Test executing a command with tainted environment variables."""
+    mock_run.return_value = subprocess.CompletedProcess(args=["env"], returncode=0)
+
+    tainted_env = mark_tainted({"SECRET": "value"})
+    result = IsolatedSubprocessProxy.run(["env"], env=tainted_env)
+
+    assert result.returncode == 0
+    mock_run.assert_called_once()
+
+    # Verify the environment variables were sanitized
+    call_kwargs = mock_run.call_args.kwargs
+    assert type(call_kwargs["env"]["SECRET"]) is str
+    assert call_kwargs["env"]["SECRET"] == "value"
+
+    # Verify isolation mechanisms were engaged
+    assert call_kwargs["env"]["__MCP_ISOLATED_NETWORK"] == "1"
+    assert call_kwargs["preexec_fn"] is not None
+
+    # Call the preexec_fn to ensure it attempts to drop the network
+    call_kwargs["preexec_fn"]()
+    mock_drop_network.assert_called_once()
+
+
+@patch("subprocess.run")
+@patch("magda_agent.security.mcp_taint_isolation_v10._drop_network")
+def test_isolated_subprocess_proxy_existing_preexec(mock_drop_network: MagicMock, mock_run: MagicMock) -> None:
+    """Test executing a tainted command with an existing preexec_fn."""
+    mock_run.return_value = subprocess.CompletedProcess(args=["ls"], returncode=0)
+
+    mock_custom_preexec = MagicMock()
+
+    tainted_args = mark_tainted(["ls"])
+    result = IsolatedSubprocessProxy.run(tainted_args, preexec_fn=mock_custom_preexec)
+
+    assert result.returncode == 0
+
+    # Call the wrapped preexec_fn
+    call_kwargs = mock_run.call_args.kwargs
+    call_kwargs["preexec_fn"]()
+
+    # Both drop_network and the custom preexec_fn should be called
+    mock_drop_network.assert_called_once()
+    mock_custom_preexec.assert_called_once()
+
+
+@patch("subprocess.run")
+@patch("magda_agent.security.mcp_taint_isolation_v10._drop_network", side_effect=IsolationError("Failed"))
+def test_isolated_subprocess_proxy_drop_network_fails(mock_drop_network: MagicMock, mock_run: MagicMock) -> None:
+    """Test that execution fails securely if drop_network raises an IsolationError."""
+    tainted_args = mark_tainted(["curl", "http://example.com"])
+
+    # The run method returns, but the preexec_fn would throw when called
+    IsolatedSubprocessProxy.run(tainted_args)
+
+    call_kwargs = mock_run.call_args.kwargs
+
+    with pytest.raises(IsolationError, match="Failed"):
+        call_kwargs["preexec_fn"]()


### PR DESCRIPTION
This PR implements strict process-level network isolation for subprocesses executing external tools with tainted data, fulfilling the `mcp-kernel-tool-taint-isolation-v10-482de2b9` task.

### Changes
* **`magda_agent/security/mcp_taint_isolation_v10.py`**: A new proxy wrapper around `subprocess.run` that checks input arguments and environment variables for taint. If taint is detected, it sanitizes the inputs and attempts to execute the process with isolated network access. It attempts to drop network via the Linux `unshare` system call (`CLONE_NEWNET`), explicitly raising an `IsolationError` if it fails to fail safely.
* **`tests/test_mcp_taint_isolation_v10.py`**: Unit tests verifying that tainted variables correctly invoke isolation mechanisms and block execution if network isolation fails.
* **`agent_tasks.json`**: Marked the task as done. Appended three new trend-related tasks (MCP streaming exports, A2A consensus, OpenClaw context management).

---
*PR created automatically by Jules for task [8912267150870503692](https://jules.google.com/task/8912267150870503692) started by @kazah4359-lgtm*