### PR TITLE
feat: Complete MCP Action Tool Registry v6 and update task lists

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -11960,7 +11960,7 @@
     },
     {
       "id": "mcp-action-tool-registry-v6-1a2b3c4d",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Action Tool Registry v6",
@@ -27923,6 +27923,57 @@
         "Destructive tool executions are halted pending confirmation.",
         "Token validation correctly tracks capability constraints.",
         "Tests simulate user approvals and rejections."
+      ]
+    },
+    {
+      "id": "hermes-skill-synthesis-loop-v2-97f8b038",
+      "title": "Hermes Background Skill Synthesis Loop V2",
+      "description": "Inspired by Hermes Agent trends: Implement a background task that synthesizes new skills from interaction histories, extracting tool usage patterns.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/hermes_skill_synthesis_v2.py",
+        "tests/test_hermes_skill_synthesis_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Skill synthesizer module is implemented.",
+        "Tests verify that tool usage patterns are extracted into skill templates."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-pruning-v6-df2ab201",
+      "title": "OpenClaw Virtual Context Selective Pruning V6",
+      "description": "Inspired by OpenClaw trends: Implement a virtual context pruning layer that selectively discards non-relevant token chunks when memory limits are reached.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/openclaw_context_pruning_v6.py",
+        "tests/test_openclaw_context_pruning_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pruning logic preserves relevant tokens.",
+        "Tests verify selective token removal."
+      ]
+    },
+    {
+      "id": "mcp-taint-tracking-sandbox-v8-7456acb7",
+      "title": "MCP Tool Taint Tracking Sandbox V8",
+      "description": "Inspired by MCP & ACS trends: Implement an execution sandbox that tracks tainted data flows through MCP action tools to prevent sensitive data exfiltration.",
+      "area": "safety",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_taint_sandbox_v8.py",
+        "tests/test_mcp_taint_sandbox_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox tracks data taint and halts exfiltration.",
+        "Tests verify taint violations are caught."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -362,3 +362,4 @@
 * [x] FEATURE: Implement ACS Guardrails for Agent Safety (acs-guardrails-integration-v1-6335a739)
 * [x] FEATURE: Add Agent Teams Git Worktree Isolation (claude-agent-teams-isolation-v2-c3dca071)
 * [x] FEATURE: OpenClaw RL Signals Processor (openclaw-rl-signals-v3)
+* [x] FEATURE: MCP Action Tool Registry v6 (mcp-action-tool-registry-v6-1a2b3c4d)

--- a/magda_agent/skills/mcp_registry_v6.py
+++ b/magda_agent/skills/mcp_registry_v6.py
@@ -137,3 +137,11 @@ class MCPRegistryV6:
 
         logging.info(f"Synchronized {loaded_count} tools from adapters.")
         return loaded_count
+
+    def clear(self) -> None:
+        """
+        Clears all loaded tools and registered adapters from the registry.
+        """
+        self.mcp_tools.clear()
+        self.adapters.clear()
+        logging.info("Cleared all MCP tools and adapters from the registry.")

--- a/tests/test_mcp_registry_v6.py
+++ b/tests/test_mcp_registry_v6.py
@@ -82,3 +82,14 @@ def test_mcp_registry_v6_sync_from_adapters():
     assert "dynamic_tool_2" in registry.mcp_tools
     assert "invalid_dynamic" not in registry.mcp_tools
     mock_adapter.get_tools.assert_called_once()
+
+def test_mcp_registry_v6_clear():
+    registry = MCPRegistryV6()
+    registry.load_tool({"name": "tool1", "description": "First tool"})
+    mock_adapter = MagicMock(spec=MCPAdapter)
+    registry.register_adapter(mock_adapter)
+
+    registry.clear()
+
+    assert len(registry.mcp_tools) == 0
+    assert len(registry.adapters) == 0


### PR DESCRIPTION
This PR implements the missing pieces for the `mcp-action-tool-registry-v6-1a2b3c4d` task and updates the required governance files (`agent_tasks.json` and `backlog.md`). Additionally, it adds 3 new AI-trend-inspired tasks to the backlog as instructed.

---
*PR created automatically by Jules for task [13938167632537612451](https://jules.google.com/task/13938167632537612451) started by @kazah4359-lgtm*