### PR TITLE
feat(learning): implement Hermes Skill Experience Generator V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12028,7 +12028,7 @@
     },
     {
       "id": "hermes-skill-experience-generator-v2-8b627a98",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "Hermes Skill Experience Generator V2",
@@ -28027,6 +28027,57 @@
         "Cron job merges memory traces from A2A subagent interactions.",
         "Successful peer delegations are consolidated into templates.",
         "Tests verify the consolidation weighting logic via mocks."
+      ]
+    },
+    {
+      "id": "openclaw-rl-implicit-reward-v8-3a403ab6",
+      "title": "OpenClaw RL Implicit Reward Optimization V8",
+      "description": "Inspired by OpenClaw trends (June 2026): Implement an optimizer that aggregates and tracks long-term implicit rewards from user interaction sessions to refine agent habit weights asynchronously.",
+      "area": "learning",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/implicit_reward_v8.py",
+        "tests/test_implicit_reward_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Optimizer correctly tracks interaction sessions and calculates rewards.",
+        "Tests mock RL environments and user responses."
+      ]
+    },
+    {
+      "id": "a2a-discovery-capabilities-health-v4-dea9c7e7",
+      "title": "A2A Capabilities Health Tracking V4",
+      "description": "Inspired by A2A Protocol trends: Implement a background monitor that dynamically verifies external agent capability uptime for gossip discovery.",
+      "area": "multi-agent",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_health_tracking_v4.py",
+        "tests/test_a2a_health_tracking_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Monitor evicts agents with unreachable capabilities.",
+        "Tests mock peer nodes and timeout scenarios."
+      ]
+    },
+    {
+      "id": "claude-virtual-context-compression-v2-ac5f02f2",
+      "title": "Claude Virtual Context Recursive Compression V2",
+      "description": "Inspired by Claude Agent SDK context limits: Implement a recursive semantic compressor for episodic chunks, dynamically resizing them before spawning subagents.",
+      "area": "memory",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/memory/recursive_compressor_v2.py",
+        "tests/test_recursive_compressor_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Compressor recursively shrinks long chunks using LLM summaries.",
+        "Tests mock LLM summary outputs."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -363,3 +363,4 @@
 * [x] FEATURE: Add Agent Teams Git Worktree Isolation (claude-agent-teams-isolation-v2-c3dca071)
 * [x] FEATURE: OpenClaw RL Signals Processor (openclaw-rl-signals-v3)
 * [x] FEATURE: MCP Action Tool Registry v6 (mcp-action-tool-registry-v6-1a2b3c4d)
+* [x] FEATURE: Hermes Skill Experience Generator V2 (hermes-skill-experience-generator-v2)

--- a/magda_agent/learning/skills_creation_v2.py
+++ b/magda_agent/learning/skills_creation_v2.py
@@ -1,0 +1,97 @@
+import re
+import json
+import logging
+from typing import Dict, Any, Optional
+
+from magda_agent.llm_client import LLMClient
+from magda_agent.memory.procedural import ProceduralMemory
+
+class ExperienceSkillCreatorV2:
+    """
+    Creates reusable Python skills dynamically from past execution experiences.
+    Inspired by Hermes Agent trend. Extracts skills from raw logs and outputs
+    MCP-compatible JSON-RPC schemas.
+    """
+    def __init__(self, llm_client: LLMClient, procedural_memory: Optional[ProceduralMemory] = None) -> None:
+        """
+        Initializes the ExperienceSkillCreatorV2.
+
+        Args:
+            llm_client: The LLM client used for code generation.
+            procedural_memory: The memory layer used for storing extracted skills.
+        """
+        self.llm_client = llm_client
+        self.procedural_memory = procedural_memory
+        self.created_skills: Dict[str, Dict[str, Any]] = {}
+
+    async def generate_skill_from_logs(self, problem_description: str, raw_logs: str) -> Optional[Dict[str, Any]]:
+        """
+        Analyzes raw execution logs and attempts to generate a Python skill.
+        Also generates an MCP-compatible JSON-RPC schema for the skill.
+
+        Args:
+            problem_description: A description of the problem solved.
+            raw_logs: The raw string of execution logs.
+
+        Returns:
+            A dictionary containing the generated code and MCP-compatible schema, or None if generation failed.
+        """
+        prompt = (
+            "Analyze the following raw execution logs of a solved task.\n"
+            "Generate a Python function (a 'skill') that encapsulates this logic and is highly reusable.\n"
+            "Return the Python code enclosed in ```python\n...\n```.\n"
+            "Also return an MCP-compatible JSON-RPC schema (v6 compliant) enclosed in ```json\n...\n```.\n"
+            "The JSON schema must have 'name', 'description', and 'inputSchema' (JSON Schema dict) keys.\n\n"
+            f"Problem: {problem_description}\n\n"
+            f"Raw Logs:\n{raw_logs}"
+        )
+
+        messages = [{"role": "user", "content": prompt}]
+
+        try:
+            response = await self.llm_client.chat_completion(messages=messages)
+        except Exception as e:
+            logging.error(f"Failed to generate skill from logs: {e}")
+            return None
+
+        # Extract python code
+        code_match = re.search(r"```python\n(.*?)```", response, re.DOTALL)
+        if not code_match:
+            logging.error("No valid Python code found in response.")
+            return None
+        code = code_match.group(1).strip()
+
+        # Extract json schema
+        json_match = re.search(r"```json\n(.*?)```", response, re.DOTALL)
+        if not json_match:
+            logging.error("No valid JSON schema found in response.")
+            return None
+
+        try:
+            schema = json.loads(json_match.group(1).strip())
+        except json.JSONDecodeError as e:
+            logging.error(f"Failed to decode JSON schema: {e}")
+            return None
+
+        skill_name = schema.get("name", "generated_skill")
+
+        skill_data = {
+            "code": code,
+            "schema": schema
+        }
+
+        self.created_skills[skill_name] = skill_data
+
+        if self.procedural_memory:
+            self.procedural_memory.store_procedure(
+                name=skill_name,
+                procedure=code,
+                metadata={
+                    "source_problem": problem_description,
+                    "type": "hermes_experience_skill_v4",
+                    "schema": schema
+                }
+            )
+
+        logging.info(f"Dynamically generated and stored new skill from logs: {skill_name}")
+        return skill_data

--- a/tests/test_skills_creation_v2.py
+++ b/tests/test_skills_creation_v2.py
@@ -1,0 +1,112 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.learning.skills_creation_v2 import ExperienceSkillCreatorV2
+from magda_agent.memory.procedural import ProceduralMemory
+from magda_agent.llm_client import LLMClient
+
+@pytest.fixture
+def mock_llm_client() -> LLMClient:
+    client = MagicMock(spec=LLMClient)
+    client.chat_completion = AsyncMock()
+    return client
+
+@pytest.fixture
+def mock_procedural_memory() -> ProceduralMemory:
+    mem = MagicMock(spec=ProceduralMemory)
+    mem.store_procedure = MagicMock()
+    return mem
+
+@pytest.mark.asyncio
+async def test_generate_skill_from_logs_success(mock_llm_client: LLMClient, mock_procedural_memory: ProceduralMemory) -> None:
+    mock_response = """
+Here is the skill:
+```python
+def extract_ips(logs):
+    import re
+    return re.findall(r'[0-9]+(?:\.[0-9]+){3}', logs)
+```
+And the schema:
+```json
+{
+    "name": "extract_ips",
+    "description": "Extracts IP addresses from logs",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "logs": {"type": "string"}
+        }
+    }
+}
+```
+"""
+    mock_llm_client.chat_completion.return_value = mock_response
+
+    creator = ExperienceSkillCreatorV2(llm_client=mock_llm_client, procedural_memory=mock_procedural_memory)
+
+    raw_logs = "2026-06-15 10:00:00 [INFO] Connection from 192.168.1.1\n2026-06-15 10:05:00 [INFO] Connection from 10.0.0.5"
+    result = await creator.generate_skill_from_logs("Extract IPs from log text", raw_logs)
+
+    assert result is not None
+    assert "def extract_ips" in result["code"]
+    assert result["schema"]["name"] == "extract_ips"
+    assert "extract_ips" in creator.created_skills
+
+    mock_procedural_memory.store_procedure.assert_called_once_with(
+        name="extract_ips",
+        procedure="def extract_ips(logs):\n    import re\n    return re.findall(r'[0-9]+(?:\\.[0-9]+){3}', logs)",
+        metadata={
+            "source_problem": "Extract IPs from log text",
+            "type": "hermes_experience_skill_v4",
+            "schema": result["schema"]
+        }
+    )
+
+@pytest.mark.asyncio
+async def test_generate_skill_from_logs_missing_code(mock_llm_client: LLMClient, mock_procedural_memory: ProceduralMemory) -> None:
+    mock_response = """
+    I generated a schema for you:
+    ```json
+    {
+        "name": "do_something",
+        "description": "Does something"
+    }
+    ```
+    """
+    mock_llm_client.chat_completion.return_value = mock_response
+
+    creator = ExperienceSkillCreatorV2(llm_client=mock_llm_client, procedural_memory=mock_procedural_memory)
+    result = await creator.generate_skill_from_logs("Task", "raw logs")
+
+    assert result is None
+    mock_procedural_memory.store_procedure.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_generate_skill_from_logs_invalid_json(mock_llm_client: LLMClient, mock_procedural_memory: ProceduralMemory) -> None:
+    mock_response = """
+    ```python
+    def foo(): pass
+    ```
+    ```json
+    {
+        "name": "foo",
+        "inputSchema": {
+            "type": "object"
+    ```
+    """
+    mock_llm_client.chat_completion.return_value = mock_response
+
+    creator = ExperienceSkillCreatorV2(llm_client=mock_llm_client, procedural_memory=mock_procedural_memory)
+    result = await creator.generate_skill_from_logs("Task", "raw logs")
+
+    assert result is None
+    mock_procedural_memory.store_procedure.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_generate_skill_from_logs_api_failure(mock_llm_client: LLMClient, mock_procedural_memory: ProceduralMemory) -> None:
+    mock_llm_client.chat_completion.side_effect = Exception("API Error")
+
+    creator = ExperienceSkillCreatorV2(llm_client=mock_llm_client, procedural_memory=mock_procedural_memory)
+    result = await creator.generate_skill_from_logs("Task", "raw logs")
+
+    assert result is None
+    mock_procedural_memory.store_procedure.assert_not_called()


### PR DESCRIPTION
Implements the Hermes Skill Experience Generator V2 task from agent_tasks.json. 

This introduces `ExperienceSkillCreatorV2` in `magda_agent/learning/skills_creation_v2.py` which dynamically reads raw logs, prompts the LLM to extract the underlying repeatable workflow into a Python function, and generates an MCP-compliant JSON-RPC schema.

Includes tests, removes the task from the todo queue, adds three new trend-inspired tasks, and updates the backlog.

---
*PR created automatically by Jules for task [12933231403976444561](https://jules.google.com/task/12933231403976444561) started by @kazah4359-lgtm*