### PR TITLE
feat(skills): implement MCP Dynamic Action Registry V7

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12045,7 +12045,7 @@
     },
     {
       "id": "mcp-dynamic-action-registry-v7-1edad2b2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Dynamic Action Registry V7",
@@ -28078,6 +28078,59 @@
       "acceptance": [
         "Compressor recursively shrinks long chunks using LLM summaries.",
         "Tests mock LLM summary outputs."
+      ]
+    },
+    {
+      "id": "a2a-distributed-tracer-mesh-v9-7d8d998c",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "medium",
+      "title": "A2A Distributed Tracer Mesh V9",
+      "description": "Inspired by A2A Protocol and enterprise tracing trends: Implement a distributed telemetry tracer for mesh networks that propagates span IDs between independent peer agents to trace multi-agent execution paths.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_mesh_tracer_v9.py",
+        "tests/test_a2a_mesh_tracer_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tracer propagates span IDs across mock A2A network boundaries.",
+        "Tests verify traces correctly link parent and child execution contexts."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-semantic-dedup-v8-5d11d79d",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Context Semantic Deduplication V8",
+      "description": "Inspired by MemGPT/Letta patterns and Context Engine plugins: Create a working memory compression hook that dynamically merges semantically duplicate facts before paging them out to Episodic Memory.",
+      "allowed_paths": [
+        "magda_agent/memory/semantic_dedup_v8.py",
+        "tests/test_semantic_dedup_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Deduplication hook intercepts context compression lifecycle.",
+        "Semantically duplicate memories are merged using mock embeddings.",
+        "Tests verify the reduced token usage after deduplication."
+      ]
+    },
+    {
+      "id": "claude-worktree-isolation-fault-tolerance-v3-59e743a0",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Worktree Isolation Fault Tolerance V3",
+      "description": "Inspired by Claude Agent Teams multi-agent architectures: Build a fault-tolerant spawner that detects crashed subagent git worktrees and automatically respawns the task in a clean isolated state without parent process disruption.",
+      "allowed_paths": [
+        "magda_agent/architecture/worktree_fault_tolerance_v3.py",
+        "tests/test_worktree_fault_tolerance_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Spawner tracks active subagent statuses.",
+        "Crashed worktrees are cleaned and respawned seamlessly.",
+        "Tests mock subprocess crashes and verify the respawn logic."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -364,3 +364,4 @@
 * [x] FEATURE: OpenClaw RL Signals Processor (openclaw-rl-signals-v3)
 * [x] FEATURE: MCP Action Tool Registry v6 (mcp-action-tool-registry-v6-1a2b3c4d)
 * [x] FEATURE: Hermes Skill Experience Generator V2 (hermes-skill-experience-generator-v2)
+* [x] FEATURE: MCP Dynamic Action Registry V7 (mcp-dynamic-action-registry-v7-1edad2b2)

--- a/magda_agent/skills/mcp_registry_v7.py
+++ b/magda_agent/skills/mcp_registry_v7.py
@@ -1,39 +1,126 @@
 import logging
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Protocol, runtime_checkable
+
+@runtime_checkable
+class MCPActionAdapter(Protocol):
+    """
+    Protocol for dynamically providing external MCP action tools to the registry.
+    """
+    async def fetch_action_tools(self) -> List[Dict[str, Any]]:
+        """
+        Retrieves a list of MCP action tool schemas from an external source asynchronously.
+
+        Returns:
+            List[Dict[str, Any]]: A list of action tool schemas.
+        """
+        ...
 
 class MCPRegistryV7:
     """
-    Registry specialized in handling tools exported via the Model Context Protocol (MCP) version 7.
-    Allows for dynamic registration and unregistration of tools at runtime.
+    Registry specialized in handling action tools exported via the Model Context Protocol (MCP) version 7.
+    Allows for dynamic synchronization of action tools from registered adapters.
+    """
+
+    """
+    Registry specialized in handling action tools exported via the Model Context Protocol (MCP) version 7.
+    Allows for dynamic synchronization of action tools from registered adapters.
     """
 
     def __init__(self) -> None:
-        """Initialize the MCP Registry V7."""
+        """Initialize the MCP Registry V7 for action tools."""
         self.mcp_tools: Dict[str, Dict[str, Any]] = {}
+        self.adapters: List[MCPActionAdapter] = []
 
-    def register_tool(self, tool_schema: Dict[str, Any]) -> bool:
+    def register_tool(self, schema: Dict[str, Any]) -> bool:
         """
-        Dynamically registers and verifies an external MCP tool schema.
+        Alias for load_action_tool for backward compatibility.
+
+        Args:
+            schema (Dict[str, Any]): The MCP tool schema dictionary.
+
+        Returns:
+            bool: True if loaded successfully, False otherwise.
+        """
+        return self.load_action_tool(schema)
+
+    def list_tools(self) -> List[str]:
+        """
+        Alias for list_action_tools for backward compatibility.
+
+        Returns:
+            List[str]: A list of tool names.
+        """
+        return self.list_action_tools()
+
+    def unload_tool(self, name: str) -> bool:
+        """
+        Alias for unload_action_tool for backward compatibility.
+
+        Args:
+            name (str): The name of the MCP tool to unload.
+
+        Returns:
+            bool: True if the tool was successfully unloaded, False if not found.
+        """
+        return self.unload_action_tool(name)
+
+    def get_tools(self) -> List[Dict[str, Any]]:
+        """
+        Returns a list of all tools for backward compatibility.
+
+        Returns:
+            List[Dict[str, Any]]: A list of all registered tool schemas.
+        """
+        return [self.mcp_tools[k] for k in self.mcp_tools]
+
+    def get_tool(self, name: str) -> Dict[str, Any]:
+        """
+        Alias for get_action_tool for backward compatibility.
+
+        Args:
+            name (str): The name of the MCP action tool.
+
+        Returns:
+            Dict[str, Any]: The tool schema, or an empty dictionary if not found.
+        """
+        return self.get_action_tool(name)
+
+    def unregister_tool(self, name: str) -> bool:
+        """
+        Alias for unload_action_tool for backward compatibility.
+
+        Args:
+            name (str): The name of the MCP action tool.
+
+        Returns:
+            bool: True if the tool was successfully unloaded, False if not found.
+        """
+        return self.unload_action_tool(name)
+
+
+    def load_action_tool(self, tool_schema: Dict[str, Any]) -> bool:
+        """
+        Dynamically loads and verifies an external MCP action tool schema.
 
         Args:
             tool_schema (Dict[str, Any]): The MCP tool schema dictionary.
 
         Returns:
-            bool: True if registered successfully, False otherwise.
+            bool: True if loaded successfully, False otherwise.
         """
-        if not self._is_valid_schema(tool_schema):
-            logging.error(f"Failed to register MCP tool: Invalid schema {tool_schema}")
+        if not self._is_valid_action_schema(tool_schema):
+            logging.error(f"Failed to load MCP action tool: Invalid schema {tool_schema}")
             return False
 
         name: str = tool_schema["name"]
         self.mcp_tools[name] = tool_schema
-        logging.info(f"Successfully registered MCP tool: {name}")
+        logging.info(f"Successfully loaded MCP action tool: {name}")
         return True
 
-    def _is_valid_schema(self, schema: Dict[str, Any]) -> bool:
+    def _is_valid_action_schema(self, schema: Dict[str, Any]) -> bool:
         """
-        Verifies if the schema complies with MCP tool standards.
-        Also validates that 'inputSchema' is a dictionary if provided.
+        Verifies if the schema complies with MCP tool standards for action tools.
+        Expects basic MCP fields and possibly action-specific metadata.
 
         Args:
             schema (Dict[str, Any]): The MCP tool schema.
@@ -55,40 +142,78 @@ class MCPRegistryV7:
 
         return True
 
-    def get_tool(self, name: str) -> Dict[str, Any]:
+    def get_action_tool(self, name: str) -> Dict[str, Any]:
         """
-        Retrieve a registered MCP tool by name.
+        Retrieve a loaded MCP action tool by name.
 
         Args:
-            name (str): The name of the MCP tool.
+            name (str): The name of the MCP action tool.
 
         Returns:
             Dict[str, Any]: The tool schema, or an empty dictionary if not found.
         """
         return self.mcp_tools.get(name, {})
 
-    def list_tools(self) -> List[str]:
+    def list_action_tools(self) -> List[str]:
         """
-        List all available registered MCP tools.
+        List all available MCP action tools.
 
         Returns:
             List[str]: A list of tool names.
         """
         return list(self.mcp_tools.keys())
 
-    def unregister_tool(self, name: str) -> bool:
+    def unload_action_tool(self, name: str) -> bool:
         """
-        Dynamically unregisters and removes an MCP tool from the registry.
+        Dynamically unregisters and removes an MCP action tool from the registry.
 
         Args:
-            name (str): The name of the MCP tool to unregister.
+            name (str): The name of the MCP action tool to unload.
 
         Returns:
-            bool: True if the tool was successfully unregistered, False if not found.
+            bool: True if the tool was successfully unloaded, False if not found.
         """
         if name in self.mcp_tools:
             del self.mcp_tools[name]
-            logging.info(f"Successfully unregistered MCP tool: {name}")
+            logging.info(f"Successfully unloaded MCP action tool: {name}")
             return True
-        logging.warning(f"Failed to unregister MCP tool: {name} not found in registry.")
+        logging.warning(f"Failed to unload MCP action tool: {name} not found in registry.")
         return False
+
+    def register_adapter(self, adapter: MCPActionAdapter) -> None:
+        """
+        Registers an adapter to dynamically fetch external action tools.
+
+        Args:
+            adapter (MCPActionAdapter): The adapter instance providing action tools.
+        """
+        self.adapters.append(adapter)
+        logging.info(f"Registered MCP action adapter: {adapter}")
+
+    async def sync_from_adapters(self) -> int:
+        """
+        Synchronizes action tools from all registered adapters asynchronously.
+
+        Returns:
+            int: The total number of action tools successfully synced and loaded.
+        """
+        loaded_count = 0
+        for adapter in self.adapters:
+            try:
+                tools = await adapter.fetch_action_tools()
+                for tool in tools:
+                    if self.load_action_tool(tool):
+                        loaded_count += 1
+            except Exception as e:
+                logging.error(f"Error syncing from action adapter {adapter}: {e}")
+
+        logging.info(f"Synchronized {loaded_count} action tools from adapters.")
+        return loaded_count
+
+    def clear(self) -> None:
+        """
+        Clears all loaded action tools and registered adapters from the registry.
+        """
+        self.mcp_tools.clear()
+        self.adapters.clear()
+        logging.info("Cleared all MCP action tools and adapters from the registry.")

--- a/tests/test_mcp_registry_v7.py
+++ b/tests/test_mcp_registry_v7.py
@@ -1,64 +1,105 @@
 import pytest
-from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7
+from unittest.mock import AsyncMock
+from magda_agent.skills.mcp_registry_v7 import MCPRegistryV7, MCPActionAdapter
 
 @pytest.fixture
 def registry():
     return MCPRegistryV7()
 
-def test_register_tool_valid(registry):
+def test_load_action_tool_valid(registry):
     tool_schema = {
-        "name": "test_tool",
-        "description": "A test tool",
+        "name": "create_file",
+        "description": "Creates a file",
         "inputSchema": {
             "type": "object",
-            "properties": {}
+            "properties": {
+                "filename": {"type": "string"}
+            }
         }
     }
-    assert registry.register_tool(tool_schema) is True
-    assert "test_tool" in registry.list_tools()
-    assert registry.get_tool("test_tool") == tool_schema
+    assert registry.load_action_tool(tool_schema) is True
+    assert "create_file" in registry.list_action_tools()
+    assert registry.get_action_tool("create_file") == tool_schema
 
-def test_register_tool_invalid_missing_name(registry):
+def test_load_action_tool_invalid(registry):
     tool_schema = {
-        "description": "A test tool"
+        "name": "create_file",
+        # Missing description
     }
-    assert registry.register_tool(tool_schema) is False
-    assert len(registry.list_tools()) == 0
+    assert registry.load_action_tool(tool_schema) is False
+    assert "create_file" not in registry.list_action_tools()
 
-def test_register_tool_invalid_missing_description(registry):
+    tool_schema_invalid_input = {
+        "name": "create_file",
+        "description": "Creates a file",
+        "inputSchema": "invalid_string"
+    }
+    assert registry.load_action_tool(tool_schema_invalid_input) is False
+
+def test_unload_action_tool(registry):
     tool_schema = {
-        "name": "test_tool"
+        "name": "create_file",
+        "description": "Creates a file"
     }
-    assert registry.register_tool(tool_schema) is False
+    registry.load_action_tool(tool_schema)
+    assert registry.unload_action_tool("create_file") is True
+    assert "create_file" not in registry.list_action_tools()
+    assert registry.unload_action_tool("nonexistent") is False
 
-def test_register_tool_invalid_wrong_input_schema(registry):
+def test_clear_registry(registry):
     tool_schema = {
-        "name": "test_tool",
-        "description": "A test tool",
-        "inputSchema": "not a dictionary"
+        "name": "create_file",
+        "description": "Creates a file"
     }
-    assert registry.register_tool(tool_schema) is False
+    registry.load_action_tool(tool_schema)
+    mock_adapter = AsyncMock(spec=MCPActionAdapter)
+    registry.register_adapter(mock_adapter)
 
-def test_unregister_tool(registry):
-    tool_schema = {
-        "name": "test_tool",
-        "description": "A test tool"
-    }
-    registry.register_tool(tool_schema)
-    assert registry.unregister_tool("test_tool") is True
-    assert "test_tool" not in registry.list_tools()
+    assert len(registry.list_action_tools()) == 1
+    assert len(registry.adapters) == 1
 
-def test_unregister_tool_not_found(registry):
-    assert registry.unregister_tool("nonexistent") is False
+    registry.clear()
 
-def test_list_tools(registry):
-    assert registry.list_tools() == []
-    registry.register_tool({"name": "tool1", "description": "desc1"})
-    registry.register_tool({"name": "tool2", "description": "desc2"})
-    tools = registry.list_tools()
-    assert "tool1" in tools
-    assert "tool2" in tools
-    assert len(tools) == 2
+    assert len(registry.list_action_tools()) == 0
+    assert len(registry.adapters) == 0
 
-def test_get_tool_not_found(registry):
-    assert registry.get_tool("nonexistent") == {}
+@pytest.mark.asyncio
+async def test_sync_from_adapters(registry):
+    mock_adapter = AsyncMock(spec=MCPActionAdapter)
+    mock_adapter.fetch_action_tools.return_value = [
+        {"name": "tool1", "description": "Action Tool 1"},
+        {"name": "tool2", "description": "Action Tool 2"}
+    ]
+
+    registry.register_adapter(mock_adapter)
+
+    count = await registry.sync_from_adapters()
+    assert count == 2
+    assert "tool1" in registry.list_action_tools()
+    assert "tool2" in registry.list_action_tools()
+
+@pytest.mark.asyncio
+async def test_sync_from_adapters_with_invalid_tool(registry):
+    mock_adapter = AsyncMock(spec=MCPActionAdapter)
+    mock_adapter.fetch_action_tools.return_value = [
+        {"name": "valid_tool", "description": "Valid Tool"},
+        {"name": "invalid_tool"} # Missing description
+    ]
+
+    registry.register_adapter(mock_adapter)
+
+    count = await registry.sync_from_adapters()
+    assert count == 1
+    assert "valid_tool" in registry.list_action_tools()
+    assert "invalid_tool" not in registry.list_action_tools()
+
+@pytest.mark.asyncio
+async def test_sync_from_adapters_exception(registry):
+    mock_adapter = AsyncMock(spec=MCPActionAdapter)
+    mock_adapter.fetch_action_tools.side_effect = Exception("Network error")
+
+    registry.register_adapter(mock_adapter)
+
+    count = await registry.sync_from_adapters()
+    assert count == 0
+    assert len(registry.list_action_tools()) == 0


### PR DESCRIPTION
This PR implements the requested `mcp-dynamic-action-registry-v7-1edad2b2` task, building out the `MCPRegistryV7` class to dynamically fetch and register action tools via the newly introduced `MCPActionAdapter`. 

It includes backwards compatibility aliases to seamlessly slot in where prior versions of the registry were used. It also updates `agent_tasks.json` (marking the current task done and appending 3 new trend tasks generated autonomously based on the AI Agent Trends markdown) and updates `backlog.md`. All local tests, including `test_mcp_registry_v7.py` and the broader application suite, pass without regressions.

---
*PR created automatically by Jules for task [10468610531723894905](https://jules.google.com/task/10468610531723894905) started by @kazah4359-lgtm*