### PR TITLE
Implement A2A Peer Task Delegation V3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12062,7 +12062,7 @@
     },
     {
       "id": "a2a-peer-task-delegation-v3-d601c251",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Peer Task Delegation V3",
@@ -28131,6 +28131,57 @@
         "Spawner tracks active subagent statuses.",
         "Crashed worktrees are cleaned and respawned seamlessly.",
         "Tests mock subprocess crashes and verify the respawn logic."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-v3-7b870cf0",
+      "title": "OpenClaw Canvas Metrics Exporter V3",
+      "description": "Inspired by OpenClaw trends: Implement an exporter to stream RL interaction metrics (PAD shifts, implicit rewards) to the visual canvas UI in real-time.",
+      "area": "telemetry",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/telemetry/canvas_metrics_exporter_v3.py",
+        "tests/test_canvas_metrics_exporter_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter properly aggregates and formats metrics for the canvas.",
+        "Tests use mocks to verify payload structures."
+      ]
+    },
+    {
+      "id": "hermes-skill-sandbox-isolation-v2-193dbb3e",
+      "title": "Hermes Skill Sandbox Isolation Layer V2",
+      "description": "Inspired by Hermes Agent trends: Implement a local sandbox isolation wrapper for dynamically created skills to limit execution time and memory footprint during testing.",
+      "area": "safety",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/skill_sandbox_isolation_v2.py",
+        "tests/test_skill_sandbox_isolation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sandbox wrapper restricts execution time and memory (mocked).",
+        "Tests verify exception handling when limits are exceeded."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-auth-negotiation-v4-ce5e0dc2",
+      "title": "MCP Action Tool Auth Negotiation V4",
+      "description": "Inspired by MCP capability negotiation trends: Build a protocol extension to allow client and server to negotiate multi-turn authentication steps before an action tool executes.",
+      "area": "integration",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_auth_negotiation_v4.py",
+        "tests/test_mcp_auth_negotiation_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Auth negotiation loop is successfully simulated.",
+        "Tests mock challenge-response iterations before execution."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -139,7 +139,7 @@
 * [x] FEATURE: Agent Teams via Git Worktree Isolation (agent-teams-claude-sdk)
 - [x] openclaw-rl-interactive-learning-v3: OpenClaw-RL Interactive Learning
 * [x] FEATURE: MCP Action Tools Expansion (mcp-action-tools-v3)
-* [x] FEATURE: A2A Task Delegation (v3)
+* [x] FEATURE: A2A Task Delegation (v3) (a2a-peer-task-delegation-v3-d601c251)
 * [x] FEATURE: Longitudinal Quality Metrics CLI
 * [x] FEATURE: Agent Skills MCP Export Enhancements (agent-skills-mcp-export)
 * [x] FEATURE: MCP Export of Internal Skills v2 (mcp-skill-export-v2)

--- a/magda_agent/integration/a2a_delegation_v3.py
+++ b/magda_agent/integration/a2a_delegation_v3.py
@@ -1,0 +1,98 @@
+from typing import Dict, Any, List, Optional
+import logging
+import httpx
+from magda_agent.integration.a2a_discovery_v3_unique import A2ADiscoveryServiceV3Unique
+
+logger = logging.getLogger(__name__)
+
+class A2ADelegatorV3:
+    """
+    A2A Task Delegation Protocol v3.
+    Handles discovering peers using a discovery service and formatting
+    task payloads for peer-to-peer delegation via API requests.
+    Supports asynchronous task delegation to a specific peer or discovering
+    a peer based on required capabilities.
+    """
+
+    def __init__(self, discovery_service: Optional[A2ADiscoveryServiceV3Unique] = None) -> None:
+        """
+        Initializes the A2ADelegatorV3.
+
+        Args:
+            discovery_service: An optional discovery service to use for finding peers.
+                               Defaults to A2ADiscoveryServiceV3Unique if none is provided.
+        """
+        self.discovery_service = discovery_service or A2ADiscoveryServiceV3Unique()
+
+    def discover_peers(self, raw_cards: List[str]) -> None:
+        """
+        Discovers peers from raw agent card JSON strings and registers them.
+
+        Args:
+            raw_cards: A list of JSON strings representing AgentCards.
+        """
+        self.discovery_service.parse_and_register_cards(raw_cards)
+
+    def format_task_payload(self, task_id: str, capability: str, task_parameters: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Formats a task into a structured JSON-RPC style payload.
+
+        Args:
+            task_id: A unique identifier for the task.
+            capability: The capability required to execute the task.
+            task_parameters: A dictionary of parameters for the task.
+
+        Returns:
+            A structured dictionary payload.
+        """
+        return {
+            "jsonrpc": "2.0",
+            "id": task_id,
+            "method": "execute_task",
+            "params": {
+                "capability": capability,
+                "task_parameters": task_parameters
+            }
+        }
+
+    async def delegate_task(self, task_id: str, capability: str, task_parameters: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Discovers an appropriate peer and delegates a formatted task to it.
+
+        Args:
+            task_id: A unique identifier for the task.
+            capability: The capability required to execute the task.
+            task_parameters: A dictionary of parameters for the task.
+
+        Returns:
+            A dictionary containing the response from the peer or an error structure.
+        """
+        agents = self.discovery_service.find_agents_by_capability(capability)
+
+        if not agents:
+            logger.warning(f"No agents found for capability: {capability}")
+            return {"error": f"No agent found for capability: {capability}", "status": "failed"}
+
+        # Select the first available agent
+        target_agent = agents[0]
+
+        rpc_endpoint = target_agent.endpoints.get("rpc")
+        if not rpc_endpoint:
+            logger.error(f"Agent {target_agent.name} is missing an RPC endpoint.")
+            return {"error": f"Agent {target_agent.name} missing RPC endpoint", "status": "failed"}
+
+        payload = self.format_task_payload(task_id, capability, task_parameters)
+
+        logger.info(f"Delegating task {task_id} to Agent {target_agent.name} at {rpc_endpoint}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(rpc_endpoint, json=payload, timeout=10.0)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPError as e:
+            logger.error(f"Delegation to {target_agent.name} failed due to network error: {e}")
+            return {"error": f"Network error: {str(e)}", "status": "failed"}
+        except Exception as e:
+            logger.error(f"Delegation to {target_agent.name} failed: {e}")
+            return {"error": f"Internal error: {str(e)}", "status": "failed"}

--- a/tests/test_a2a_delegation_v3.py
+++ b/tests/test_a2a_delegation_v3.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from magda_agent.integration.a2a_delegation_v3 import A2ADelegatorV3
+from magda_agent.integration.a2a_cards import AgentCardV3
+
+@pytest.mark.asyncio
+async def test_delegate_task_success():
+    """Test successful task delegation to a discovered peer."""
+    delegator = A2ADelegatorV3()
+
+    mock_agent = MagicMock(spec=AgentCardV3)
+    mock_agent.name = "TestAgent"
+    mock_agent.endpoints = {"rpc": "http://test-agent:8000/rpc"}
+
+    with patch.object(delegator.discovery_service, 'find_agents_by_capability', return_value=[mock_agent]):
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"status": "success", "result": "task completed"}
+            mock_response.raise_for_status.return_value = None
+            mock_post.return_value = mock_response
+
+            result = await delegator.delegate_task("task-123", "data_analysis", {"data": [1, 2, 3]})
+
+            assert result == {"status": "success", "result": "task completed"}
+            mock_post.assert_called_once()
+            args, kwargs = mock_post.call_args
+            assert args[0] == "http://test-agent:8000/rpc"
+            assert kwargs["json"]["id"] == "task-123"
+            assert kwargs["json"]["params"]["capability"] == "data_analysis"
+
+@pytest.mark.asyncio
+async def test_delegate_task_no_agents():
+    """Test task delegation when no agents are found."""
+    delegator = A2ADelegatorV3()
+
+    with patch.object(delegator.discovery_service, 'find_agents_by_capability', return_value=[]):
+        result = await delegator.delegate_task("task-123", "data_analysis", {"data": [1, 2, 3]})
+
+        assert result == {"error": "No agent found for capability: data_analysis", "status": "failed"}
+
+@pytest.mark.asyncio
+async def test_delegate_task_no_rpc_endpoint():
+    """Test task delegation when the agent is missing an RPC endpoint."""
+    delegator = A2ADelegatorV3()
+
+    mock_agent = MagicMock(spec=AgentCardV3)
+    mock_agent.name = "TestAgent"
+    mock_agent.endpoints = {}  # Missing RPC endpoint
+
+    with patch.object(delegator.discovery_service, 'find_agents_by_capability', return_value=[mock_agent]):
+        result = await delegator.delegate_task("task-123", "data_analysis", {"data": [1, 2, 3]})
+
+        assert result == {"error": "Agent TestAgent missing RPC endpoint", "status": "failed"}
+
+@pytest.mark.asyncio
+async def test_delegate_task_network_error():
+    """Test task delegation handling network errors."""
+    delegator = A2ADelegatorV3()
+
+    mock_agent = MagicMock(spec=AgentCardV3)
+    mock_agent.name = "TestAgent"
+    mock_agent.endpoints = {"rpc": "http://test-agent:8000/rpc"}
+
+    with patch.object(delegator.discovery_service, 'find_agents_by_capability', return_value=[mock_agent]):
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_request = MagicMock(spec=httpx.Request)
+            mock_post.side_effect = httpx.RequestError("Connection timeout", request=mock_request)
+
+            result = await delegator.delegate_task("task-123", "data_analysis", {"data": [1, 2, 3]})
+
+            assert result == {"error": "Network error: Connection timeout", "status": "failed"}
+
+def test_format_task_payload():
+    """Test that the payload is formatted correctly."""
+    delegator = A2ADelegatorV3()
+    payload = delegator.format_task_payload("task-123", "data_analysis", {"data": [1, 2, 3]})
+
+    assert payload == {
+        "jsonrpc": "2.0",
+        "id": "task-123",
+        "method": "execute_task",
+        "params": {
+            "capability": "data_analysis",
+            "task_parameters": {"data": [1, 2, 3]}
+        }
+    }
+
+def test_discover_peers():
+    """Test discover peers registers cards via discovery service."""
+    delegator = A2ADelegatorV3()
+    raw_cards = ['{"name": "Agent1"}', '{"name": "Agent2"}']
+
+    with patch.object(delegator.discovery_service, 'parse_and_register_cards') as mock_register:
+        delegator.discover_peers(raw_cards)
+        mock_register.assert_called_once_with(raw_cards)


### PR DESCRIPTION
Implemented A2A task delegation v3 which dynamically discovers agents via AgentCardV3 capabilities and correctly sends formatted JSON-RPC task payloads over HTTP. Handled edge cases for missing agents, missing RPC endpoints, and timeout network errors natively. Includes a fully mocked comprehensive test suite. Backlog.md is updated mapping the implementation, and new trending tasks are scheduled.

---
*PR created automatically by Jules for task [7155462633426564848](https://jules.google.com/task/7155462633426564848) started by @kazah4359-lgtm*