### PR TITLE
feat: OpenClaw Canvas Tool Execution Tracing

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12079,7 +12079,7 @@
     },
     {
       "id": "openclaw-rl-canvas-tool-tracing-0ce2e402",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "medium",
       "title": "OpenClaw Canvas Tool Execution Tracing",
@@ -28182,6 +28182,40 @@
       "acceptance": [
         "Auth negotiation loop is successfully simulated.",
         "Tests mock challenge-response iterations before execution."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-audit-middleware-cf7bdf6318e042728bc44ae95a8ba7f2",
+      "title": "MCP Action Tool Audit Middleware",
+      "description": "Inspired by Prempti (Falco) safety trends: Implement an audit trail middleware layer that logs every executed action tool call and its context to SQLite for forensic tracking before allowing it to proceed.",
+      "area": "safety",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_audit_middleware_v2.py",
+        "tests/test_mcp_audit_middleware_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Middleware successfully intercepts tool calls and logs them.",
+        "Tests verify that tool payloads are recorded accurately using SQLite mocks."
+      ]
+    },
+    {
+      "id": "a2a-subagent-worktree-garbage-collector-7a66b46439054aa7936c31a199eade92",
+      "title": "A2A Subagent Git Worktree Garbage Collector",
+      "description": "Inspired by Claude Agent Teams architectures: Implement a cron-like garbage collection task that scans and purges stalled or orphaned subagent git worktrees to prevent system bloat.",
+      "area": "architecture",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/worktree_gc_v1.py",
+        "tests/test_worktree_gc_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "GC correctly identifies and removes stale git worktrees.",
+        "Tests mock os and shutil methods to verify safe cleanup."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -365,3 +365,4 @@
 * [x] FEATURE: MCP Action Tool Registry v6 (mcp-action-tool-registry-v6-1a2b3c4d)
 * [x] FEATURE: Hermes Skill Experience Generator V2 (hermes-skill-experience-generator-v2)
 * [x] FEATURE: MCP Dynamic Action Registry V7 (mcp-dynamic-action-registry-v7-1edad2b2)
+* [x] FEATURE: OpenClaw Canvas Tool Execution Tracing (openclaw-rl-canvas-tool-tracing-0ce2e402)

--- a/magda_agent/telemetry/a2a_distributed_v7.py
+++ b/magda_agent/telemetry/a2a_distributed_v7.py
@@ -104,6 +104,30 @@ class A2ADistributedTelemetryV7:
         json_payload = json.dumps(payload)
         await self._mock_websocket_emit(json_payload)
 
+    async def broadcast_tool_execution_trace(
+        self, subagent_id: str, tool_name: str, arguments: Dict[str, Any], result: Any, success: bool
+    ) -> None:
+        """
+        Broadcast a tool execution trace to the Canvas UI via WebSocket mock.
+
+        Args:
+            subagent_id (str): The unique identifier for the sub-agent.
+            tool_name (str): The name of the tool executed.
+            arguments (Dict[str, Any]): The arguments passed to the tool.
+            result (Any): The result returned by the tool.
+            success (bool): Whether the tool execution was successful.
+        """
+        payload = {
+            "type": "canvas_tool_trace",
+            "subagent_id": subagent_id,
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "result": result,
+            "success": success
+        }
+        json_payload = json.dumps(payload)
+        await self._mock_websocket_emit(json_payload)
+
     async def _mock_websocket_emit(self, json_payload: str) -> None:
         """
         Mock WebSocket emission for Canvas UI updates.

--- a/tests/test_a2a_distributed_v7.py
+++ b/tests/test_a2a_distributed_v7.py
@@ -100,3 +100,27 @@ async def test_broadcast_rl_reward_to_canvas_no_details(telemetry):
         assert payload["subagent_id"] == "sub_1"
         assert payload["reward_signal"] == reward_signal
         assert payload["details"] == {}
+
+@pytest.mark.asyncio
+async def test_broadcast_tool_execution_trace(telemetry):
+    tool_name = "search_web"
+    arguments = {"query": "OpenClaw AI trends"}
+    result = "Found 10 results"
+    success = True
+
+    with patch.object(telemetry, '_mock_websocket_emit', new_callable=AsyncMock) as mock_emit:
+        await telemetry.broadcast_tool_execution_trace("sub_1", tool_name, arguments, result, success)
+
+        mock_emit.assert_called_once()
+        args, _ = mock_emit.call_args
+        json_payload = args[0]
+
+        import json
+        payload = json.loads(json_payload)
+
+        assert payload["type"] == "canvas_tool_trace"
+        assert payload["subagent_id"] == "sub_1"
+        assert payload["tool_name"] == tool_name
+        assert payload["arguments"] == arguments
+        assert payload["result"] == result
+        assert payload["success"] == success


### PR DESCRIPTION
Resolves task `openclaw-rl-canvas-tool-tracing-0ce2e402`.

Implemented the OpenClaw Canvas live tool execution tracer to emit MCP tool execution details over the simulated WebSocket connection, completing the `A2ADistributedTelemetryV7` payload functionality for action tools visualization.

Also updated backlog and tasks definitions based on June 2026 AI trends for future work items.

---
*PR created automatically by Jules for task [2851594245852187178](https://jules.google.com/task/2851594245852187178) started by @kazah4359-lgtm*