### PR TITLE
Implement Claude Tri-Agent Orchestration

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12252,7 +12252,7 @@
     },
     {
       "id": "claude-planner-generator-evaluator-54bfa2b6-new3",
-      "status": "todo",
+      "status": "done",
       "area": "orchestration",
       "risk": "high",
       "title": "Implement Claude Tri-Agent Orchestration",

--- a/magda_agent/architecture/tri_agent_orchestrator_v1.py
+++ b/magda_agent/architecture/tri_agent_orchestrator_v1.py
@@ -1,0 +1,266 @@
+"""
+Tri-Agent Orchestration V1.
+
+This module implements a tri-agent architecture (Planner, Generator, Evaluator)
+for task execution using dependency graphs, inspired by the Claude Agent SDK.
+"""
+
+import logging
+from typing import List, Dict, Any, Optional, Set, Callable, Union
+
+from magda_agent.architecture.dependency_graph import DependencyGraph
+
+
+class PlannerComponent:
+    """
+    Planner component responsible for decomposing tasks into dependency graph steps.
+    """
+
+    def __init__(self, plan_fn: Optional[Union[Callable[..., Any], Any]] = None) -> None:
+        self.plan_fn = plan_fn
+
+    async def create_plan(
+        self,
+        task_description: str,
+        context: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Creates a list of plan steps with dependency metadata.
+
+        Args:
+            task_description: High-level goal or task to decompose.
+            context: Additional contextual information.
+
+        Returns:
+            List of plan step dictionaries containing 'id', 'description', and 'dependencies'.
+        """
+        if self.plan_fn:
+            if hasattr(self.plan_fn, "create_plan") and callable(self.plan_fn.create_plan):
+                result = self.plan_fn.create_plan(task_description, context)
+                if hasattr(result, "__await__"):
+                    result = await result
+            elif callable(self.plan_fn):
+                result = self.plan_fn(task_description, context)
+                if hasattr(result, "__await__"):
+                    result = await result
+            else:
+                raise TypeError("plan_fn must be callable or have a create_plan method")
+            return result
+
+        # Default single-step fallback plan if no plan_fn provided
+        return [
+            {
+                "id": "step_1",
+                "description": task_description,
+                "dependencies": []
+            }
+        ]
+
+
+class GeneratorComponent:
+    """
+    Generator component responsible for executing plan steps to produce proposals/results.
+    """
+
+    def __init__(self, execute_fn: Optional[Union[Callable[..., Any], Any]] = None) -> None:
+        self.execute_fn = execute_fn
+
+    async def execute_step(
+        self,
+        step: Dict[str, Any],
+        context: Dict[str, Any],
+        feedback: Optional[str] = None
+    ) -> Any:
+        """
+        Executes a single step.
+
+        Args:
+            step: Step specification dictionary.
+            context: Execution context containing outputs of previous steps.
+            feedback: Optional evaluator feedback for retry attempts.
+
+        Returns:
+            Output/result of step execution.
+        """
+        if self.execute_fn:
+            if hasattr(self.execute_fn, "execute_step") and callable(self.execute_fn.execute_step):
+                result = self.execute_fn.execute_step(step, context, feedback)
+                if hasattr(result, "__await__"):
+                    result = await result
+            elif callable(self.execute_fn):
+                result = self.execute_fn(step, context, feedback)
+                if hasattr(result, "__await__"):
+                    result = await result
+            else:
+                raise TypeError("execute_fn must be callable or have an execute_step method")
+            return result
+
+        return f"Completed step: {step.get('description', step.get('id'))}"
+
+
+class EvaluatorComponent:
+    """
+    Evaluator component responsible for reviewing generated step outputs against acceptance criteria.
+    """
+
+    def __init__(self, evaluate_fn: Optional[Union[Callable[..., Any], Any]] = None) -> None:
+        self.evaluate_fn = evaluate_fn
+
+    async def evaluate_step(
+        self,
+        step: Dict[str, Any],
+        proposal: Any,
+        context: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Evaluates a step proposal.
+
+        Args:
+            step: Step specification dictionary.
+            proposal: Result produced by GeneratorComponent.
+            context: Accumulated execution context.
+
+        Returns:
+            Dictionary with 'approved' (bool) and 'feedback' (str).
+        """
+        if self.evaluate_fn:
+            if hasattr(self.evaluate_fn, "evaluate_step") and callable(self.evaluate_fn.evaluate_step):
+                result = self.evaluate_fn.evaluate_step(step, proposal, context)
+                if hasattr(result, "__await__"):
+                    result = await result
+            elif callable(self.evaluate_fn):
+                result = self.evaluate_fn(step, proposal, context)
+                if hasattr(result, "__await__"):
+                    result = await result
+            else:
+                raise TypeError("evaluate_fn must be callable or have an evaluate_step method")
+            return result
+
+        # Default evaluation approves proposal
+        return {
+            "approved": True,
+            "feedback": "Step output meets requirements"
+        }
+
+
+class TriAgentOrchestratorV1:
+    """
+    Manages the orchestration loop between Planner, Generator, and Evaluator components
+    resolving step dependencies via DependencyGraph.
+    """
+
+    def __init__(
+        self,
+        planner: Optional[PlannerComponent] = None,
+        generator: Optional[GeneratorComponent] = None,
+        evaluator: Optional[EvaluatorComponent] = None,
+        max_retries: int = 3
+    ) -> None:
+        self.planner = planner or PlannerComponent()
+        self.generator = generator or GeneratorComponent()
+        self.evaluator = evaluator or EvaluatorComponent()
+        self.max_retries = max_retries
+
+    async def execute_task(
+        self,
+        task_description: str,
+        initial_context: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """
+        Executes a task by planning, resolving dependencies, generating outputs, and evaluating steps.
+
+        Args:
+            task_description: The goal or problem statement.
+            initial_context: Initial context data.
+
+        Returns:
+            Execution summary dictionary with status, outputs, and completed steps.
+        """
+        context: Dict[str, Any] = dict(initial_context or {})
+        plan_steps = await self.planner.create_plan(task_description, context)
+
+        if not plan_steps:
+            return {
+                "status": "failed",
+                "error": "Planner generated an empty plan",
+                "completed_steps": [],
+                "step_outputs": {}
+            }
+
+        # Validate DAG topology (raises ValueError if cyclic)
+        try:
+            sorted_steps = DependencyGraph.topological_sort(plan_steps)
+        except ValueError as exc:
+            logging.error(f"Cycle detected in plan dependencies: {exc}")
+            return {
+                "status": "failed",
+                "error": str(exc),
+                "completed_steps": [],
+                "step_outputs": {}
+            }
+
+        completed_step_ids: Set[str] = set()
+        completed_steps_order: List[str] = []
+        step_outputs: Dict[str, Any] = {}
+
+        while len(completed_step_ids) < len(plan_steps):
+            executable_steps = DependencyGraph.get_executable_steps(plan_steps, completed_step_ids)
+            if not executable_steps:
+                logging.error("No executable steps remaining; unresolvable dependencies exist.")
+                return {
+                    "status": "failed",
+                    "error": "Unresolvable step dependencies",
+                    "completed_steps": list(completed_steps_order),
+                    "step_outputs": step_outputs
+                }
+
+            for step in executable_steps:
+                step_id = step["id"]
+                step_context = {
+                    "task_description": task_description,
+                    "initial_context": context,
+                    "completed_outputs": step_outputs
+                }
+
+                approved = False
+                feedback: Optional[str] = None
+                last_proposal: Any = None
+
+                for attempt in range(1, self.max_retries + 1):
+                    logging.info(f"Orchestrator: Executing step '{step_id}' attempt {attempt}/{self.max_retries}")
+                    proposal = await self.generator.execute_step(step, step_context, feedback)
+                    last_proposal = proposal
+
+                    eval_res = await self.evaluator.evaluate_step(step, proposal, step_context)
+                    if not isinstance(eval_res, dict):
+                        eval_res = {"approved": False, "feedback": "Evaluation result was not a dict"}
+
+                    if eval_res.get("approved"):
+                        approved = True
+                        step_outputs[step_id] = proposal
+                        completed_step_ids.add(step_id)
+                        completed_steps_order.append(step_id)
+                        logging.info(f"Step '{step_id}' approved on attempt {attempt}")
+                        break
+                    else:
+                        feedback = eval_res.get("feedback", "No feedback provided")
+                        logging.warning(f"Step '{step_id}' rejected on attempt {attempt}: {feedback}")
+
+                if not approved:
+                    return {
+                        "status": "failed",
+                        "error": f"Step '{step_id}' failed evaluation after {self.max_retries} attempts",
+                        "failed_step": step_id,
+                        "last_feedback": feedback,
+                        "last_proposal": last_proposal,
+                        "completed_steps": list(completed_steps_order),
+                        "step_outputs": step_outputs
+                    }
+
+        return {
+            "status": "success",
+            "task_description": task_description,
+            "plan": plan_steps,
+            "completed_steps": completed_steps_order,
+            "step_outputs": step_outputs
+        }

--- a/tests/test_tri_agent_orchestrator_v1.py
+++ b/tests/test_tri_agent_orchestrator_v1.py
@@ -1,0 +1,127 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from magda_agent.architecture.tri_agent_orchestrator_v1 import (
+    PlannerComponent,
+    GeneratorComponent,
+    EvaluatorComponent,
+    TriAgentOrchestratorV1,
+)
+
+
+@pytest.mark.asyncio
+async def test_default_components_execution():
+    orchestrator = TriAgentOrchestratorV1()
+    res = await orchestrator.execute_task("Simple task")
+
+    assert res["status"] == "success"
+    assert res["completed_steps"] == ["step_1"]
+    assert "step_1" in res["step_outputs"]
+    assert res["step_outputs"]["step_1"] == "Completed step: Simple task"
+
+
+@pytest.mark.asyncio
+async def test_multi_step_dag_execution():
+    async def mock_plan(task_description, context):
+        return [
+            {"id": "step_1", "description": "Fetch data", "dependencies": []},
+            {"id": "step_2", "description": "Process data", "dependencies": ["step_1"]},
+            {"id": "step_3", "description": "Format output", "dependencies": ["step_2"]},
+        ]
+
+    executed_steps = []
+
+    async def mock_execute(step, context, feedback=None):
+        executed_steps.append(step["id"])
+        # Check context propagation
+        if step["id"] == "step_2":
+            assert "step_1" in context["completed_outputs"]
+        return f"Output of {step['id']}"
+
+    async def mock_evaluate(step, proposal, context):
+        return {"approved": True, "feedback": "Good job"}
+
+    planner = PlannerComponent(plan_fn=mock_plan)
+    generator = GeneratorComponent(execute_fn=mock_execute)
+    evaluator = EvaluatorComponent(evaluate_fn=mock_evaluate)
+
+    orchestrator = TriAgentOrchestratorV1(planner=planner, generator=generator, evaluator=evaluator)
+    res = await orchestrator.execute_task("Pipeline task")
+
+    assert res["status"] == "success"
+    assert res["completed_steps"] == ["step_1", "step_2", "step_3"]
+    assert executed_steps == ["step_1", "step_2", "step_3"]
+    assert res["step_outputs"]["step_3"] == "Output of step_3"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_rejection_and_retry():
+    attempts = {"count": 0}
+    received_feedbacks = []
+
+    async def mock_execute(step, context, feedback=None):
+        attempts["count"] += 1
+        received_feedbacks.append(feedback)
+        if attempts["count"] == 1:
+            return "Initial faulty output"
+        return "Fixed output"
+
+    async def mock_evaluate(step, proposal, context):
+        if proposal == "Initial faulty output":
+            return {"approved": False, "feedback": "Needs fix: syntax error"}
+        return {"approved": True, "feedback": "Approved"}
+
+    generator = GeneratorComponent(execute_fn=mock_execute)
+    evaluator = EvaluatorComponent(evaluate_fn=mock_evaluate)
+
+    orchestrator = TriAgentOrchestratorV1(generator=generator, evaluator=evaluator, max_retries=3)
+    res = await orchestrator.execute_task("Task needing revision")
+
+    assert res["status"] == "success"
+    assert attempts["count"] == 2
+    assert received_feedbacks == [None, "Needs fix: syntax error"]
+    assert res["step_outputs"]["step_1"] == "Fixed output"
+
+
+@pytest.mark.asyncio
+async def test_evaluator_max_retries_exceeded():
+    async def mock_evaluate(step, proposal, context):
+        return {"approved": False, "feedback": "Always rejected"}
+
+    evaluator = EvaluatorComponent(evaluate_fn=mock_evaluate)
+    orchestrator = TriAgentOrchestratorV1(evaluator=evaluator, max_retries=2)
+    res = await orchestrator.execute_task("Failing task")
+
+    assert res["status"] == "failed"
+    assert "failed evaluation after 2 attempts" in res["error"]
+    assert res["failed_step"] == "step_1"
+    assert res["last_feedback"] == "Always rejected"
+
+
+@pytest.mark.asyncio
+async def test_cyclic_plan_detection():
+    async def mock_plan(task_description, context):
+        return [
+            {"id": "step_A", "description": "Step A", "dependencies": ["step_B"]},
+            {"id": "step_B", "description": "Step B", "dependencies": ["step_A"]},
+        ]
+
+    planner = PlannerComponent(plan_fn=mock_plan)
+    orchestrator = TriAgentOrchestratorV1(planner=planner)
+    res = await orchestrator.execute_task("Cyclic task")
+
+    assert res["status"] == "failed"
+    assert "Cycle detected" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_empty_plan_handling():
+    async def mock_plan(task_description, context):
+        return []
+
+    planner = PlannerComponent(plan_fn=mock_plan)
+    orchestrator = TriAgentOrchestratorV1(planner=planner)
+    res = await orchestrator.execute_task("Empty task")
+
+    assert res["status"] == "failed"
+    assert "empty plan" in res["error"]


### PR DESCRIPTION
Implement a tri-agent architecture (Planner, Generator, Evaluator) in `magda_agent/architecture/tri_agent_orchestrator_v1.py` for task execution with dependency graphs, inspired by Claude Agent SDK. Include unit tests in `tests/test_tri_agent_orchestrator_v1.py` and update `agent_tasks.json`.

---
*PR created automatically by Jules for task [7709221847178800843](https://jules.google.com/task/7709221847178800843) started by @kazah4359-lgtm*