### PR TITLE
feat: Canvas Live Visualizer V4 implementation and task backlog update

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12321,7 +12321,7 @@
     },
     {
       "id": "openclaw-canvas-live-v4-5e8a3dfa",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "medium",
       "title": "OpenClaw Canvas Live WebSockets V4",
@@ -28827,6 +28827,60 @@
         "Optimizer removes redundant sequential steps and creates macro-steps based on mocked historical success in the DAG.",
         "Tests verify that pruning reduces step count without altering end-goal dependencies.",
         "Topological order remains valid."
+      ]
+    },
+    {
+      "id": "hermes-skill-marketplace-importer-v2-7745ebdf",
+      "title": "Hermes Skill Marketplace Importer V2",
+      "description": "Inspired by Hermes trends (June 2026): Create a utility to dynamically import and sandbox skills from the standard agentskills.io format directly into Magda's procedural memory.",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/skills/marketplace_importer_v2.py",
+        "tests/test_marketplace_importer_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Importer parses agentskills.io JSON manifests accurately.",
+        "Imported skills are sandboxed and added to procedural memory.",
+        "Tests mock the downloading of skills and verify safe import."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-pruning-v1-7916d44c",
+      "title": "OpenClaw RL Trajectory Quality Evaluation V2",
+      "description": "Inspired by OpenClaw-RL trends (June 2026): Add a trajectory evaluator that assesses past dialogue steps for low reward and prunes them from episodic memory to optimize context retrieval.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_evaluation_v2.py",
+        "tests/test_trajectory_evaluation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator calculates cumulative reward across dialogue trajectories.",
+        "Prunes trajectories falling below a dynamic quality threshold.",
+        "Tests verify memory pruning accurately reflects reward tracking."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruner-v1-cb86fa9d",
+      "title": "Claude Worktree Pruning and Resource Optimizer V1",
+      "description": "Inspired by Claude Agent Teams capabilities (June 2026): Build a subagent utility that actively scans isolated git worktrees created for tasks and automatically prunes stale/failed branches and worktrees.",
+      "status": "todo",
+      "area": "agents",
+      "risk": "low",
+      "allowed_paths": [
+        "magda_agent/agents/worktree_pruning_v1.py",
+        "tests/test_worktree_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent successfully identifies stale worktrees based on a TTL policy.",
+        "Safely removes git worktree state and associated branches.",
+        "Tests mock git operations and verify TTL-based cleanup."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -371,3 +371,7 @@
 * [ ] FEATURE: Implement OpenClaw-style Canvas Live Visualization (openclaw-rl-canvas-live-viz-ec761ed7-new1)
 * [ ] FEATURE: Implement Hermes-style Cron Daily Reports (hermes-cron-daily-reports-24f6ff77-new2)
 * [ ] FEATURE: Implement Claude Tri-Agent Orchestration (claude-planner-generator-evaluator-54bfa2b6-new3)
+
+* [ ] SKILLS: Hermes Skill Marketplace Importer V2 (hermes-skill-marketplace-importer-v2-7745ebdf)
+* [ ] LEARNING: OpenClaw RL Trajectory Quality Evaluation V2 (openclaw-rl-trajectory-pruning-v1-7916d44c)
+* [ ] AGENTS: Claude Worktree Pruning and Resource Optimizer V1 (claude-worktree-pruner-v1-cb86fa9d)

--- a/magda_agent/visualization/canvas_live_v4.py
+++ b/magda_agent/visualization/canvas_live_v4.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import logging
+from typing import Set, Any, Dict, Optional
+
+import websockets
+from websockets.server import WebSocketServerProtocol, serve
+
+logger = logging.getLogger(__name__)
+
+class CanvasLiveVisualizerV4:
+    """
+    Inspired by OpenClaw trends: Implement a CanvasLiveVisualizerV4 to stream agent states via websockets for live OpenClaw Canvas visualization.
+    """
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8765):
+        """
+        Initializes the CanvasLiveVisualizerV4.
+
+        Args:
+            host: The host address to bind the WebSocket server to.
+            port: The port to bind the WebSocket server to.
+        """
+        self.host = host
+        self.port = port
+        self.clients: Set[WebSocketServerProtocol] = set()
+        self._server: Optional[Any] = None
+
+    async def _handler(self, websocket: WebSocketServerProtocol) -> None:
+        """
+        Handles incoming WebSocket connections and registers them.
+
+        Args:
+            websocket: The connected WebSocket client.
+        """
+        self.clients.add(websocket)
+        logger.info(f"Client connected: {websocket.remote_address}")
+        try:
+            # Keep connection open and wait for it to close
+            await websocket.wait_closed()
+        finally:
+            self.clients.remove(websocket)
+            logger.info(f"Client disconnected: {websocket.remote_address}")
+
+    async def start(self) -> None:
+        """
+        Starts the WebSocket server.
+        """
+        logger.info(f"Starting CanvasLiveVisualizerV4 server on {self.host}:{self.port}")
+        self._server = await serve(self._handler, self.host, self.port)
+
+    async def stop(self) -> None:
+        """
+        Stops the WebSocket server.
+        """
+        if self._server:
+            logger.info("Stopping CanvasLiveVisualizerV4 server")
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        # Close all active client connections
+        if self.clients:
+            await asyncio.gather(*(client.close() for client in self.clients))
+            self.clients.clear()
+
+    async def broadcast_state(self, state: Dict[str, Any]) -> None:
+        """
+        Broadcasts the agent state to all connected clients.
+
+        Args:
+            state: A dictionary representing the agent's current state.
+        """
+        if not self.clients:
+            return
+
+        payload = {
+            "type": "state_update",
+            "data": {
+                "state": state
+            }
+        }
+
+        try:
+            message = json.dumps(payload)
+        except TypeError as e:
+            logger.error(f"Failed to serialize broadcast payload: {e}")
+            return
+
+        # Broadcast the message to all connected clients
+        tasks = [
+            asyncio.create_task(client.send(message))
+            for client in self.clients
+            if not client.closed
+        ]
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_canvas_live_v4.py
+++ b/tests/test_canvas_live_v4.py
@@ -1,0 +1,102 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+import pytest
+from magda_agent.visualization.canvas_live_v4 import CanvasLiveVisualizerV4
+
+@pytest.fixture
+def visualizer():
+    return CanvasLiveVisualizerV4(host="127.0.0.1", port=9999)
+
+@pytest.mark.asyncio
+async def test_start_and_stop(visualizer):
+    with patch("magda_agent.visualization.canvas_live_v4.serve", new_callable=AsyncMock) as mock_serve:
+        mock_server = AsyncMock()
+        mock_serve.return_value = mock_server
+
+        await visualizer.start()
+
+        mock_serve.assert_called_once_with(visualizer._handler, "127.0.0.1", 9999)
+        assert visualizer._server == mock_server
+
+        await visualizer.stop()
+
+        mock_server.close.assert_called_once()
+        mock_server.wait_closed.assert_awaited_once()
+        assert visualizer._server is None
+
+@pytest.mark.asyncio
+async def test_handler_registers_client(visualizer):
+    mock_websocket = AsyncMock()
+    mock_websocket.remote_address = ("127.0.0.1", 54321)
+
+    async def mock_wait_closed():
+        fut = asyncio.Future()
+        mock_websocket.close_fut = fut
+        await fut
+        return
+
+    mock_websocket.wait_closed = mock_wait_closed
+
+    # Run the handler as a task so we can check the state before it closes
+    handler_task = asyncio.create_task(visualizer._handler(mock_websocket))
+
+    # Yield to event loop to let handler run
+    await asyncio.sleep(0.01)
+
+    assert mock_websocket in visualizer.clients
+
+    # Close the websocket to complete the handler by setting the future result
+    mock_websocket.close_fut.set_result(None)
+
+    # Wait for the handler task to finish
+    await handler_task
+
+    assert mock_websocket not in visualizer.clients
+
+@pytest.mark.asyncio
+async def test_broadcast_state_sends_to_clients(visualizer):
+    mock_websocket1 = AsyncMock()
+    mock_websocket1.closed = False
+    mock_websocket2 = AsyncMock()
+    mock_websocket2.closed = False
+
+    visualizer.clients.add(mock_websocket1)
+    visualizer.clients.add(mock_websocket2)
+
+    state = {"execution_step": "planning", "status": "active"}
+
+    await visualizer.broadcast_state(state)
+
+    expected_payload = json.dumps({
+        "type": "state_update",
+        "data": {
+            "state": state
+        }
+    })
+
+    mock_websocket1.send.assert_awaited_once_with(expected_payload)
+    mock_websocket2.send.assert_awaited_once_with(expected_payload)
+
+@pytest.mark.asyncio
+async def test_broadcast_state_ignores_closed_clients(visualizer):
+    mock_websocket1 = AsyncMock()
+    mock_websocket1.closed = False
+    mock_websocket2 = AsyncMock()
+    mock_websocket2.closed = True
+
+    visualizer.clients.add(mock_websocket1)
+    visualizer.clients.add(mock_websocket2)
+
+    state = {"execution_step": "planning"}
+
+    await visualizer.broadcast_state(state)
+
+    mock_websocket1.send.assert_awaited_once()
+    mock_websocket2.send.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_broadcast_state_no_clients(visualizer):
+    # Should return early without errors
+    state = {"execution_step": "planning"}
+    await visualizer.broadcast_state(state)


### PR DESCRIPTION
Implemented the `CanvasLiveVisualizerV4` module within `magda_agent/visualization/canvas_live_v4.py` designed to utilize WebSockets for streaming agent states, mimicking OpenClaw Canvas Live trends. Unit tests have been provided under `tests/test_canvas_live_v4.py` validating websocket logic with `AsyncMock`. The `agent_tasks.json` backlog has been updated, marking the relevant task completed and accurately appending 3 new actionable tasks based on AI trends from June 2026, alongside synchronizing these new tasks to `backlog.md`.

---
*PR created automatically by Jules for task [15826707986337717014](https://jules.google.com/task/15826707986337717014) started by @kazah4359-lgtm*