### PR TITLE
feat: Update ACS guard v5 to recursively validate complex tool arguments

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12525,7 +12525,7 @@
     },
     {
       "id": "acs-runtime-safety-controls-v5",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "ACS runtime safety controls v5",
@@ -29405,6 +29405,57 @@
       "acceptance": [
         "Backup runner uses CronSchedulerV2 to fire off archiving tasks.",
         "Tests mock file archiving."
+      ]
+    },
+    {
+      "id": "openclaw-rl-implicit-reward-v8-unique",
+      "title": "OpenClaw RL Implicit Reward Tracking V8",
+      "description": "Inspired by June 2026 AI Agent trends (OpenClaw-RL). Implement tracking for implicit reward signals (e.g. conversational turn length, user engagement) to tune RL habits.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/learning/implicit_reward_v8.py",
+        "tests/test_implicit_reward_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Implicit reward tracking module collects passive telemetry without explicit feedback.",
+        "Tests verify reward signal processing with mock telemetry data."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-auth-v8-unique",
+      "title": "MCP Dynamic Capability Auth V8",
+      "description": "Inspired by MCP capabilities and enterprise standards (June 2026). Add granular permission scopes and capability authentication limits when negotiating MCP tools.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_capability_auth_v8.py",
+        "tests/test_mcp_capability_auth_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Capability auth module blocks unauthorized scopes.",
+        "Tests verify correct blocking and passing of scoped tool negotiations."
+      ]
+    },
+    {
+      "id": "a2a-discovery-mesh-agent-cards-v18-unique",
+      "title": "A2A Discovery Mesh Agent Cards V18",
+      "description": "Inspired by A2A Protocol standard updates. Extend A2A Agent Cards to support dynamic TTLs and localized caching within peer subnets.",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_agent_cards_v18.py",
+        "tests/test_a2a_agent_cards_v18.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent cards support configurable TTL and cache invalidation logic.",
+        "Tests mock A2A mesh network broadcasts."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -135,6 +135,7 @@
 * [x] FEATURE: MCP Tools Integration Engine (mcp-tools-integration-v2)
 
 - [x] acs-runtime-safety-controls-v4: ACS Runtime Safety Controls v4
+- [x] acs-runtime-safety-controls-v5: ACS Runtime Safety Controls v5
 * [x] FEATURE: A2A Agent Discovery v4 (a2a-agent-discovery-v4)
 * [x] FEATURE: Agent Teams via Git Worktree Isolation (agent-teams-claude-sdk)
 - [x] openclaw-rl-interactive-learning-v3: OpenClaw-RL Interactive Learning

--- a/magda_agent/safety/acs_guard_v5.py
+++ b/magda_agent/safety/acs_guard_v5.py
@@ -53,6 +53,24 @@ class ACSGuardV5:
             if not isinstance(workflow_data[field], str):
                 return False, f"Input validation failed: '{field}' must be a string."
 
+        if "kwargs" in workflow_data:
+            if not isinstance(workflow_data["kwargs"], dict):
+                return False, "Input validation failed: 'kwargs' must be a dictionary."
+
+            # Verify no deeply nested objects are invalid types (e.g. non-serializable objects)
+            def _validate_arg(arg: Any) -> bool:
+                """Recursively validates that the argument only contains serializable types."""
+                if isinstance(arg, (str, int, float, bool, type(None))):
+                    return True
+                if isinstance(arg, dict):
+                    return all(isinstance(k, str) and _validate_arg(v) for k, v in arg.items())
+                if isinstance(arg, list):
+                    return all(_validate_arg(item) for item in arg)
+                return False
+
+            if not _validate_arg(workflow_data["kwargs"]):
+                return False, "Input validation failed: complex tool arguments contain invalid types."
+
         return True, "Input validation Passed."
 
     def checkpoint_2_intent_authorization(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:

--- a/tests/test_acs_guard_v5.py
+++ b/tests/test_acs_guard_v5.py
@@ -43,6 +43,27 @@ def test_checkpoint_1_input_validation(acs_guard: ACSGuardV5) -> None:
     assert not passed
     assert "missing 'action' field" in reason
 
+    # Pass - valid kwargs
+    valid_data_kwargs = {"action": "read", "tool": "ls", "kwargs": {"path": "/", "recursive": True}}
+    passed, reason = acs_guard.checkpoint_1_input_validation(valid_data_kwargs)
+    assert passed
+    assert "Passed" in reason
+
+    # Fail - kwargs not a dict
+    invalid_data_kwargs = {"action": "read", "tool": "ls", "kwargs": "not a dict"}
+    passed, reason = acs_guard.checkpoint_1_input_validation(invalid_data_kwargs)
+    assert not passed
+    assert "'kwargs' must be a dictionary" in reason
+
+    # Fail - complex args with invalid types (e.g. object instance)
+    class DummyObj:
+        pass
+
+    invalid_data_complex = {"action": "read", "tool": "ls", "kwargs": {"nested": {"obj": DummyObj()}}}
+    passed, reason = acs_guard.checkpoint_1_input_validation(invalid_data_complex)
+    assert not passed
+    assert "complex tool arguments contain invalid types" in reason
+
 
 def test_checkpoint_2_intent_authorization(acs_guard: ACSGuardV5) -> None:
     """Tests the intent authorization checkpoint."""


### PR DESCRIPTION
This PR implements the `acs-runtime-safety-controls-v5` task.

- Updates `ACSGuardV5.checkpoint_1_input_validation` to recursively parse and validate `kwargs`.
- Blocks un-serializable objects (e.g. instances) from passing the input validation checkpoint.
- Adds comprehensive pytest cases to `tests/test_acs_guard_v5.py`.
- Updates `agent_tasks.json` to mark the task as done and appends three new trends tasks.
- Updates `backlog.md` appropriately.

---
*PR created automatically by Jules for task [13139873172891388659](https://jules.google.com/task/13139873172891388659) started by @kazah4359-lgtm*