### PR TITLE
Implement Claude Evaluator Subagent Teams

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12593,7 +12593,7 @@
     },
     {
       "id": "claude-evaluator-subagent-teams",
-      "status": "todo",
+      "status": "done",
       "area": "architecture",
       "risk": "high",
       "title": "Claude Evaluator Subagent Teams",
@@ -29593,6 +29593,57 @@
       "acceptance": [
         "Guardrail intercepts policy violations.",
         "Tests verify that failed policies raise exceptions properly."
+      ]
+    },
+    {
+      "id": "openclaw-rl-implicit-reward-v8-unique-new",
+      "title": "OpenClaw RL Implicit Reward Tracking V8",
+      "description": "Inspired by June 2026 AI Agent trends (OpenClaw-RL). Implement tracking for implicit reward signals (e.g. conversational turn length, user engagement) to tune RL habits.",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/learning/implicit_reward_v8.py",
+        "tests/test_implicit_reward_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Implicit reward tracking module collects passive telemetry without explicit feedback.",
+        "Tests verify reward signal processing with mock telemetry data."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-auth-v8-unique-new",
+      "title": "MCP Dynamic Capability Auth V8",
+      "description": "Inspired by MCP capabilities and enterprise standards (June 2026). Add granular permission scopes and capability authentication limits when negotiating MCP tools.",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_capability_auth_v8.py",
+        "tests/test_mcp_capability_auth_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Capability auth module blocks unauthorized scopes.",
+        "Tests verify correct blocking and passing of scoped tool negotiations."
+      ]
+    },
+    {
+      "id": "a2a-discovery-mesh-agent-cards-v18-unique-new",
+      "title": "A2A Discovery Mesh Agent Cards V18",
+      "description": "Inspired by A2A Protocol standard updates. Extend A2A Agent Cards to support dynamic TTLs and localized caching within peer subnets.",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_agent_cards_v18.py",
+        "tests/test_a2a_agent_cards_v18.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent cards support configurable TTL and cache invalidation logic.",
+        "Tests mock A2A mesh network broadcasts."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -99,6 +99,7 @@
 - [x] hermes-whatsapp-gateway-v2-e8512f68: Hermes WhatsApp Channel Gateway v2
 - [x] mcp-tool-concurrency-integration-e80b41b0: MCP Tool Concurrency Integration v3
 - [x] claude-evaluator-multi-agent-teams-v2: Claude SDK Teams Orchestration Evaluator (2026-06-XX)
+* [x] FEATURE: Claude Evaluator Subagent Teams (claude-evaluator-subagent-teams)
 * [x] FEATURE: Export Skills to MCP Tool Server (mcp-tool-export-skills) (2026-06-XX)
 * [x] FEATURE: Agent Guard ACS Checkpoints v6 (agent-guard-acs-checkpoints-v6)
 * [x] FEATURE: Online RL from User Feedback v6 (online-rl-user-feedback-v6)

--- a/magda_agent/architecture/agent_teams_v3.py
+++ b/magda_agent/architecture/agent_teams_v3.py
@@ -3,7 +3,7 @@ import logging
 import os
 import shutil
 import uuid
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Any
 
 class GitWorktreeError(Exception):
     """Exception raised for errors during git worktree operations."""
@@ -176,3 +176,49 @@ class AgentTeamManagerV3:
         if agent_id not in self.agents:
             return None
         return self.isolation_manager.active_worktrees.get(agent_id)
+
+class AgentEvaluatorTeam:
+    """
+    Subagent evaluator pool that can test generator team code iteratively.
+    Inspired by Claude Agent SDK trend.
+    """
+    def __init__(self, evaluators: List[str]):
+        """
+        Initialize the evaluator team.
+        """
+        self.evaluators = evaluators
+
+    async def evaluate_code(self, code: str, context: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Evaluate generator code iteratively.
+        """
+        results = []
+        for evaluator in self.evaluators:
+            result = await self._call_llm_evaluator(evaluator, code, context)
+            results.append(result)
+
+        passed = all(r.get("passed", False) for r in results)
+
+        return {
+            "passed": passed,
+            "results": results,
+            "overall_score": sum(r.get("score", 0) for r in results) / len(results) if results else 0
+        }
+
+    async def _call_llm_evaluator(self, evaluator_id: str, code: str, context: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Call the LLM for evaluation.
+        """
+        from magda_agent.llm_client import LLMClient
+        client = LLMClient()
+        prompt = f"Evaluate this code:\n{code}\nContext: {context}\nEvaluator ID: {evaluator_id}"
+
+        response = await client.generate(prompt=prompt, system_prompt="You are a code evaluator.")
+
+        # Simplified response parsing
+        return {
+            "evaluator_id": evaluator_id,
+            "passed": "PASSED" in response,
+            "score": 100 if "PASSED" in response else 50,
+            "feedback": response
+        }

--- a/tests/test_agent_teams_v3.py
+++ b/tests/test_agent_teams_v3.py
@@ -146,3 +146,24 @@ async def test_agent_team_manager_getters(base_dir):
         assert manager.get_worktree_path("agentA") == path1
         assert manager.get_worktree_path("agentB") == path2
         assert manager.get_worktree_path("nonexistent") is None
+
+@pytest.mark.asyncio
+async def test_agent_evaluator_team():
+    """
+    Test the AgentEvaluatorTeam class.
+    """
+    from magda_agent.architecture.agent_teams_v3 import AgentEvaluatorTeam
+    team = AgentEvaluatorTeam(evaluators=["eval1", "eval2"])
+
+    with patch("magda_agent.llm_client.LLMClient.generate", new_callable=AsyncMock) as mock_generate:
+        mock_generate.side_effect = [
+            "PASSED: Code is solid",
+            "PASSED: Looks excellent"
+        ]
+
+        result = await team.evaluate_code("def foo(): pass", {"context": "test"})
+
+        assert result["passed"] is True
+        assert result["overall_score"] == 100
+        assert len(result["results"]) == 2
+        assert mock_generate.call_count == 2


### PR DESCRIPTION
Implement Claude Evaluator Subagent Teams

- Add AgentEvaluatorTeam class to test generator team code iteratively.
- Update agent_tasks.json and backlog.md.
- Add three new trend-inspired tasks to agent_tasks.json.

---
*PR created automatically by Jules for task [16448456168121955839](https://jules.google.com/task/16448456168121955839) started by @kazah4359-lgtm*