### PR TITLE
feat(skills): Implement MCP Server Prefixed Routing V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12610,7 +12610,7 @@
     },
     {
       "id": "mcp-server-prefixed-routing-v2",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "MCP Server Prefixed Routing V2",
@@ -29644,6 +29644,59 @@
       "acceptance": [
         "Agent cards support configurable TTL and cache invalidation logic.",
         "Tests mock A2A mesh network broadcasts."
+      ]
+    },
+    {
+      "id": "mcp-compatible-skills-export-v2-8a9ef8aa",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP-compatible Skills Export Engine V2",
+      "description": "Inspired by MCP standards trend: Develop an exporter that can bundle Magda's internal skills into a standard MCP tool server.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_exporter_v2.py",
+        "tests/test_mcp_exporter_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP exporter creates a correct JSON-RPC schema for skills.",
+        "Test coverage is sufficient and mocked."
+      ]
+    },
+    {
+      "id": "openclaw-online-rl-v2-01e0f0d6",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Online Learning Integration V2",
+      "description": "Inspired by OpenClaw trends: Implement an online RL module that uses next-state signals (user replies) to adjust agent parameters in real-time.",
+      "allowed_paths": [
+        "magda_agent/learning/online_rl_v2.py",
+        "tests/test_online_rl_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module calculates reward from user signals.",
+        "Module adjusts user model parameters without storing real state.",
+        "Mocked tests pass."
+      ]
+    },
+    {
+      "id": "canvas-live-websockets-v4-937a95a3",
+      "status": "todo",
+      "area": "gateway",
+      "risk": "medium",
+      "title": "Canvas Live WebSockets Telemetry V4",
+      "description": "Inspired by OpenClaw Canvas visualization trend: Implement a websocket server telemetry module that broadcasts agent tool execution state to connected clients.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_live_v4.py",
+        "tests/test_canvas_live_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket server accepts connections.",
+        "State broadcasts are formatted correctly.",
+        "Tests mock websockets properly."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_engine.py
+++ b/magda_agent/skills/mcp_engine.py
@@ -38,7 +38,7 @@ class MCPEngine:
 
         if server_name:
             # 1a. Register the remote server routing with the MCPClient
-            tool_name = f"{server_name}__{tool_name}"
+            tool_name = f"{server_name}.{tool_name}"
             self.mcp_client.register_mcp_server(server_name, connection_info)
         else:
             # 1b. Register the remote tool routing directly with the MCPClient
@@ -89,7 +89,7 @@ class MCPEngine:
         if not tool_name:
             raise ValueError("MCP tool definition must include a 'name'.")
 
-        effective_name = f"{server_name}__{tool_name}" if server_name else tool_name
+        effective_name = f"{server_name}.{tool_name}" if server_name else tool_name
 
         if self.registry.has_skill(effective_name):
             logging.info(f"Reloading existing MCP tool '{effective_name}'.")

--- a/tests/test_mcp_engine.py
+++ b/tests/test_mcp_engine.py
@@ -66,3 +66,46 @@ def test_mcp_engine_invalid_tool_def() -> None:
 
     with pytest.raises(ValueError, match="must include a 'name'"):
         engine.import_mcp_tool({"description": "No name tool"}, {})
+
+def test_mcp_engine_import_with_server_name() -> None:
+    """Verify MCPEngine handles server_name prefixing correctly."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_client.register_mcp_server = MagicMock()
+
+    engine = MCPEngine(registry, mcp_client)
+
+    tool_def = {
+        "name": "get_files",
+        "description": "Get files from server.",
+        "inputSchema": {}
+    }
+    connection_info = {"url": "http://localhost:8001/mcp"}
+
+    engine.import_mcp_tool(tool_def, connection_info, server_name="filesystem")
+
+    # Verify server routing is registered
+    mcp_client.register_mcp_server.assert_called_once_with("filesystem", connection_info)
+
+    # Verify skill is dynamically registered in Magda with the prefix
+    assert registry.has_skill("filesystem.get_files")
+    assert registry.descriptions["filesystem.get_files"] == "Get files from server."
+
+@pytest.mark.asyncio
+async def test_mcp_engine_wrapper_execution_with_server_name() -> None:
+    """Verify the dynamically wrapped skill executes correctly with a server_name prefix."""
+    registry = SkillRegistry()
+    mcp_client = MCPClient()
+    mcp_client.execute_tool = AsyncMock(return_value="file_content.txt")
+
+    engine = MCPEngine(registry, mcp_client)
+
+    tool_def = {"name": "get_files"}
+    connection_info = {"url": "mock"}
+
+    engine.import_mcp_tool(tool_def, connection_info, server_name="filesystem")
+
+    result = await registry.execute_skill("filesystem.get_files", path="/home/user")
+
+    assert result == "file_content.txt"
+    mcp_client.execute_tool.assert_awaited_once_with("filesystem.get_files", path="/home/user")

--- a/tests/test_mcp_engine_prefixes.py
+++ b/tests/test_mcp_engine_prefixes.py
@@ -37,9 +37,9 @@ def test_import_mcp_tool_with_server_prefix():
     # Verify registry registered the prefixed tool
     mock_registry.register_skill.assert_called_once()
     registered_kwargs = mock_registry.register_skill.call_args.kwargs
-    assert registered_kwargs["name"] == "docs_server__search_docs"
+    assert registered_kwargs["name"] == "docs_server.search_docs"
     assert registered_kwargs["description"] == "Searches documentation."
-    assert registered_kwargs["func"].__name__ == "docs_server__search_docs"
+    assert registered_kwargs["func"].__name__ == "docs_server.search_docs"
     assert getattr(registered_kwargs["func"], "__mcp_schema__") == {}
 
 
@@ -113,4 +113,4 @@ async def test_imported_prefixed_tool_execution():
     result = await registered_func(location="London")
 
     assert result == "success result"
-    mock_mcp_client.execute_tool.assert_called_once_with("weather_station__get_weather", location="London")
+    mock_mcp_client.execute_tool.assert_called_once_with("weather_station.get_weather", location="London")

--- a/tests/test_mcp_hot_reload.py
+++ b/tests/test_mcp_hot_reload.py
@@ -95,7 +95,7 @@ def test_mcp_engine_reload_tool_with_server():
 
     # Import initially
     mcp_engine.import_mcp_tool(initial_def, connection_info, server_name="test_server")
-    effective_name = "test_server__server_tool"
+    effective_name = "test_server.server_tool"
     assert skill_registry.has_skill(effective_name)
     assert skill_registry.descriptions[effective_name] == "Server initial"
     assert mcp_client.registered_servers["test_server"] == {"url": "http://server:8000"}


### PR DESCRIPTION
Resolves task `mcp-server-prefixed-routing-v2`.

Replaces the legacy double-underscore (`__`) routing delimiter with a dot-separated (`.`) routing strategy inside the `MCPEngine` class methods for consistency with modern SDK tools format.
Added missing test logic mapping into the `test_mcp_engine.py` and converted existing ones.

Includes updates to the backlog queue per trend requests.
Tested correctly across all components without regressions.

---
*PR created automatically by Jules for task [17628333182369990610](https://jules.google.com/task/17628333182369990610) started by @kazah4359-lgtm*