### PR TITLE
feat: Implement Habit Decay logic

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12627,7 +12627,7 @@
     },
     {
       "id": "openclaw-rl-habit-decay-v3",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL Habit Decay V3",
@@ -29697,6 +29697,58 @@
         "WebSocket server accepts connections.",
         "State broadcasts are formatted correctly.",
         "Tests mock websockets properly."
+      ]
+    },
+    {
+      "id": "claude-team-evaluator-semantic-diff-v4",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude Team Evaluator Semantic Diff Check V4",
+      "description": "Inspired by Claude Agent Teams capabilities (June 2026): Implement an Evaluator Subagent that semantically checks git diffs prior to submission, halting execution if large or destructive context changes are detected.",
+      "allowed_paths": [
+        "magda_agent/multi_agent/evaluator_semantic_diff_v4.py",
+        "tests/test_evaluator_semantic_diff_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator subagent can parse diffs and assess their semantic risk.",
+        "Tests mock diffs and verify that destructive changes are blocked."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-permissions-v5",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Dynamic Tool Permissions V5",
+      "description": "Inspired by MCP & ACS trends: Implement a permission manager for exported MCP tools that requires explicit user confirmation for destructive actions using dynamically granted capability tokens.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_permissions_v5.py",
+        "tests/test_mcp_permissions_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Destructive tool executions are halted pending confirmation.",
+        "Token validation correctly tracks capability constraints.",
+        "Tests simulate user approvals and rejections."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-paging-v7",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Virtual Context Selective Paging V7",
+      "description": "Inspired by MemGPT/OpenClaw trends: Implement a virtual context pruning layer that selectively discards non-relevant token chunks out to episodic memory when active memory limits are reached.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_paging_v7.py",
+        "tests/test_virtual_context_paging_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Pruning logic preserves relevant tokens.",
+        "Tests verify selective token removal and paging."
       ]
     }
   ]

--- a/magda_agent/learning/habits.py
+++ b/magda_agent/learning/habits.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+import time
 import chromadb
 from typing import Optional, Dict
 from collections import Counter
@@ -44,7 +45,10 @@ class HabitTracker:
         if evaluation_score >= 8.0:
             try:
                 habit_id = str(uuid.uuid4())
-                metadata = {"skill_used": skill_used}
+                metadata = {
+                    "skill_used": skill_used,
+                    "timestamp": time.time()
+                }
                 if user_id is not None:
                     metadata["user_id"] = user_id
                 self.collection.add(
@@ -111,3 +115,40 @@ class HabitTracker:
         except Exception as e:
             logging.error(f"Failed to suggest strategy: {e}")
             return None
+
+    def decay_habits(self, days: float = 30.0) -> int:
+        """
+        Removes habit records older than the specified number of days to simulate
+        decay over time.
+
+        Args:
+            days (float): Threshold in days. Records older than this will be deleted.
+
+        Returns:
+            int: The number of decayed records removed.
+        """
+        try:
+            current_time = time.time()
+            threshold_seconds = current_time - (days * 24 * 3600)
+
+            # Get all records with timestamp metadata to filter and delete
+            results = self.collection.get(include=["metadatas"])
+            if not results or not results.get("ids"):
+                return 0
+
+            ids_to_delete = []
+            for i, meta in enumerate(results["metadatas"]):
+                if meta and "timestamp" in meta:
+                    record_time = meta["timestamp"]
+                    if record_time < threshold_seconds:
+                        ids_to_delete.append(results["ids"][i])
+
+            if ids_to_delete:
+                self.collection.delete(ids=ids_to_delete)
+                logging.info(f"Decayed {len(ids_to_delete)} old habit records.")
+
+            return len(ids_to_delete)
+
+        except Exception as e:
+            logging.error(f"Failed to decay habits: {e}")
+            return 0

--- a/tests/test_habit_decay_v3.py
+++ b/tests/test_habit_decay_v3.py
@@ -1,0 +1,56 @@
+import pytest
+import time
+from unittest.mock import patch
+from magda_agent.learning.habits import HabitTracker
+
+
+@pytest.fixture
+def habit_tracker(tmp_path):
+    persist_dir = str(tmp_path / "test_habit_decay_db")
+    return HabitTracker(persist_directory=persist_dir)
+
+
+def test_habit_decay(habit_tracker: HabitTracker):
+    """Test that older habits decay appropriately."""
+    current_time = time.time()
+    one_day = 24 * 3600
+
+    # Store records with mocked time
+    with patch("time.time", return_value=current_time - (40 * one_day)):
+        # 40 days old (should decay)
+        habit_tracker.record_usage("how do I deploy?", "deploy_skill", 9.0)
+        habit_tracker.record_usage("how do I deploy?", "deploy_skill", 9.0)
+
+    with patch("time.time", return_value=current_time - (10 * one_day)):
+        # 10 days old (should not decay)
+        habit_tracker.record_usage("find files", "search_skill", 9.0)
+        habit_tracker.record_usage("find files", "search_skill", 9.0)
+
+    # Initially we have 4 records in the collection
+    assert habit_tracker.collection.count() == 4
+
+    # Decay habits older than 30 days
+    # The first two records (deploy_skill) are 40 days old, they should be deleted.
+    with patch("time.time", return_value=current_time):
+        decayed_count = habit_tracker.decay_habits(days=30.0)
+
+    assert decayed_count == 2
+    assert habit_tracker.collection.count() == 2
+
+    # Let's verify suggest_strategy
+    # The old habit (deploy_skill) has been decayed and shouldn't be suggested
+    # Note: ChromaDB might return empty or not depending on what's left. Let's see what suggest_strategy returns.
+    # We didn't leave any 'deploy_skill' records, so suggestion should fail to find 2 occurrences.
+    assert habit_tracker.suggest_strategy("how do I deploy?") is None
+
+    # The new habit (search_skill) should still be suggested
+    assert habit_tracker.suggest_strategy("find files") == "search_skill"
+
+    # Decay remaining records (using days=5)
+    with patch("time.time", return_value=current_time):
+        decayed_count = habit_tracker.decay_habits(days=5.0)
+
+    assert decayed_count == 2
+    assert habit_tracker.collection.count() == 0
+
+    assert habit_tracker.suggest_strategy("find files") is None


### PR DESCRIPTION
This PR implements the OpenClaw-RL Habit Decay task (openclaw-rl-habit-decay-v3).

1. Added `timestamp` generation in `magda_agent/learning/habits.py` to allow chronologically pruning the database.
2. Added `decay_habits` which purges records older than `days`.
3. Created a comprehensive Pytest (`tests/test_habit_decay_v3.py`) leveraging mocks to fast-forward time and confirm older habits decay properly while preserving new ones.
4. Finalized changes by successfully running tests, evaluating tasks via JSON schema validation, requesting an automated code review, and appending 3 new trend-inspired tasks to the manifest.

---
*PR created automatically by Jules for task [6270294631588434831](https://jules.google.com/task/6270294631588434831) started by @kazah4359-lgtm*