### PR TITLE
feat: Implement A2A Enterprise Tracing V5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12643,7 +12643,7 @@
     },
     {
       "id": "a2a-enterprise-tracing-v5",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Enterprise Tracing V5",
@@ -29749,6 +29749,57 @@
       "acceptance": [
         "Pruning logic preserves relevant tokens.",
         "Tests verify selective token removal and paging."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-hooks-v10-unique",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Plugin Hooks V10",
+      "description": "Inspired by OpenClaw trends: Implement Context Engine plugin interface with lifecycle hooks for better virtual context management.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_hooks_v10.py",
+        "tests/test_context_engine_hooks_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context Engine supports plugin lifecycle hooks.",
+        "Tests mock plugin executions and verify hook invocations."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-governance-v9-unique",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Action Tool Governance Policy V9",
+      "description": "Inspired by MCP standards: Enhance the ActionToolGovernance layer to include dynamic policy rules for MCP tool executions.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_governance_v9.py",
+        "tests/test_mcp_governance_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Governance layer correctly enforces dynamic MCP policy rules.",
+        "Tests verify policy enforcement and tool interception."
+      ]
+    },
+    {
+      "id": "a2a-mdns-discovery-cache-v3-unique",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "A2A mDNS Discovery Cache V3",
+      "description": "Inspired by A2A Protocol trends: Add localized caching for A2A mDNS discovery to reduce network broadcast overhead.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mdns_cache_v3.py",
+        "tests/test_a2a_mdns_cache_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "mDNS discovery utilizes localized caching.",
+        "Tests mock network broadcasts and verify cache hits/misses."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_tracing_v5.py
+++ b/magda_agent/integration/a2a_tracing_v5.py
@@ -1,0 +1,110 @@
+import uuid
+import time
+from typing import Dict, Any, List, Optional
+import json
+
+class A2ATracerV5:
+    """
+    Enterprise tracing and monitoring support for A2A delegated tasks.
+
+    This module provides tracing capabilities by generating trace IDs, span IDs,
+    and recording events with their start and end times to monitor A2A delegations.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the A2ATracerV5 with an empty dictionary of traces.
+        """
+        self.traces: Dict[str, Dict[str, Any]] = {}
+
+    def start_trace(self, task_name: str) -> str:
+        """
+        Starts a new trace for a given task.
+
+        Args:
+            task_name: The name of the task being traced.
+
+        Returns:
+            The generated trace ID.
+        """
+        trace_id = str(uuid.uuid4())
+        self.traces[trace_id] = {
+            "task_name": task_name,
+            "start_time": time.time(),
+            "end_time": None,
+            "status": "in_progress",
+            "spans": []
+        }
+        return trace_id
+
+    def end_trace(self, trace_id: str, status: str = "completed") -> None:
+        """
+        Ends an existing trace.
+
+        Args:
+            trace_id: The ID of the trace to end.
+            status: The final status of the trace (e.g., 'completed', 'failed').
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        self.traces[trace_id]["end_time"] = time.time()
+        self.traces[trace_id]["status"] = status
+
+    def add_span(self, trace_id: str, span_name: str, duration_ms: float) -> str:
+        """
+        Adds a span to an existing trace.
+
+        Args:
+            trace_id: The ID of the trace.
+            span_name: The name of the span or operation.
+            duration_ms: The duration of the operation in milliseconds.
+
+        Returns:
+            The generated span ID.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        span_id = str(uuid.uuid4())
+        span = {
+            "span_id": span_id,
+            "span_name": span_name,
+            "duration_ms": duration_ms,
+            "timestamp": time.time()
+        }
+        self.traces[trace_id]["spans"].append(span)
+        return span_id
+
+    def get_trace(self, trace_id: str) -> Dict[str, Any]:
+        """
+        Retrieves the details of a trace.
+
+        Args:
+            trace_id: The ID of the trace.
+
+        Returns:
+            A dictionary containing the trace details.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        return self.traces[trace_id]
+
+    def export_traces(self) -> str:
+        """
+        Exports all traces as a JSON string.
+
+        Returns:
+            A JSON string representing all traces.
+        """
+        return json.dumps(self.traces)

--- a/tests/test_a2a_tracing_v5.py
+++ b/tests/test_a2a_tracing_v5.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from magda_agent.integration.a2a_tracing_v5 import A2ATracerV5
+import json
+
+@pytest.fixture
+def tracer():
+    return A2ATracerV5()
+
+@patch('magda_agent.integration.a2a_tracing_v5.time.time')
+@patch('magda_agent.integration.a2a_tracing_v5.uuid.uuid4')
+def test_start_trace(mock_uuid, mock_time, tracer):
+    mock_uuid.return_value = "fake-uuid-1"
+    mock_time.return_value = 1000.0
+
+    trace_id = tracer.start_trace("test_task")
+
+    assert trace_id == "fake-uuid-1"
+    assert "fake-uuid-1" in tracer.traces
+    assert tracer.traces["fake-uuid-1"] == {
+        "task_name": "test_task",
+        "start_time": 1000.0,
+        "end_time": None,
+        "status": "in_progress",
+        "spans": []
+    }
+
+@patch('magda_agent.integration.a2a_tracing_v5.time.time')
+def test_end_trace(mock_time, tracer):
+    mock_time.return_value = 1005.0
+    tracer.traces["fake-trace-id"] = {
+        "task_name": "test_task",
+        "start_time": 1000.0,
+        "end_time": None,
+        "status": "in_progress",
+        "spans": []
+    }
+
+    tracer.end_trace("fake-trace-id", status="success")
+
+    assert tracer.traces["fake-trace-id"]["end_time"] == 1005.0
+    assert tracer.traces["fake-trace-id"]["status"] == "success"
+
+def test_end_trace_not_found(tracer):
+    with pytest.raises(KeyError, match="Trace ID fake-trace-id not found."):
+        tracer.end_trace("fake-trace-id")
+
+@patch('magda_agent.integration.a2a_tracing_v5.time.time')
+@patch('magda_agent.integration.a2a_tracing_v5.uuid.uuid4')
+def test_add_span(mock_uuid, mock_time, tracer):
+    mock_uuid.return_value = "fake-span-id"
+    mock_time.return_value = 1002.0
+    tracer.traces["fake-trace-id"] = {
+        "task_name": "test_task",
+        "start_time": 1000.0,
+        "end_time": None,
+        "status": "in_progress",
+        "spans": []
+    }
+
+    span_id = tracer.add_span("fake-trace-id", "test_span", 150.0)
+
+    assert span_id == "fake-span-id"
+    assert len(tracer.traces["fake-trace-id"]["spans"]) == 1
+    assert tracer.traces["fake-trace-id"]["spans"][0] == {
+        "span_id": "fake-span-id",
+        "span_name": "test_span",
+        "duration_ms": 150.0,
+        "timestamp": 1002.0
+    }
+
+def test_add_span_not_found(tracer):
+    with pytest.raises(KeyError, match="Trace ID fake-trace-id not found."):
+        tracer.add_span("fake-trace-id", "test_span", 150.0)
+
+def test_get_trace(tracer):
+    tracer.traces["fake-trace-id"] = {
+        "task_name": "test_task"
+    }
+    trace = tracer.get_trace("fake-trace-id")
+    assert trace == {"task_name": "test_task"}
+
+def test_get_trace_not_found(tracer):
+    with pytest.raises(KeyError, match="Trace ID fake-trace-id not found."):
+        tracer.get_trace("fake-trace-id")
+
+def test_export_traces(tracer):
+    tracer.traces["fake-trace-id"] = {
+        "task_name": "test_task"
+    }
+    exported = tracer.export_traces()
+    assert json.loads(exported) == {"fake-trace-id": {"task_name": "test_task"}}


### PR DESCRIPTION
This PR implements the `a2a-enterprise-tracing-v5` task.

### Changes:
- `magda_agent/integration/a2a_tracing_v5.py`: Provides enterprise tracing and monitoring support for A2A delegated tasks by generating trace IDs, span IDs, and recording event timings.
- `tests/test_a2a_tracing_v5.py`: Pytest suite using `unittest.mock` for time and UUIDs, ensuring correct logic.
- `agent_tasks.json`: Updated the status of `a2a-enterprise-tracing-v5` to `done` and added three new tasks based on June 2026 AI Agent trends:
  - `openclaw-context-engine-hooks-v10-unique`
  - `mcp-action-tool-governance-v9-unique`
  - `a2a-mdns-discovery-cache-v3-unique`

---
*PR created automatically by Jules for task [2607796939078155106](https://jules.google.com/task/2607796939078155106) started by @kazah4359-lgtm*