### PR TITLE
feat(a2a): add delegation circuit breaker v7 v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12711,7 +12711,7 @@
     },
     {
       "id": "a2a-delegation-circuit-breaker-v7-bc9e8aae",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Delegation Circuit Breaker V7 v2",
@@ -29920,6 +29920,40 @@
       "acceptance": [
         "Review subagent processes git diffs and returns structured feedback.",
         "Tests verify mock diff processing and LLM prompt generation."
+      ]
+    },
+    {
+      "id": "hermes-cron-nightly-backups-v1-019b7c8f",
+      "status": "todo",
+      "area": "maintenance",
+      "risk": "medium",
+      "title": "Hermes Cron Nightly Backups V1",
+      "description": "Inspired by Hermes Agent trend: Implement a cron-based scheduled task for nightly memory/state backups.",
+      "allowed_paths": [
+        "magda_agent/maintenance/nightly_backups_v1.py",
+        "tests/test_nightly_backups_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Cron job successfully schedules the backup function.",
+        "Tests verify backup logic executes correctly."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-hooks-v6-83d2e4bd",
+      "status": "todo",
+      "area": "memory",
+      "risk": "low",
+      "title": "OpenClaw Context Engine Hooks V6",
+      "description": "Inspired by OpenClaw trend: Implement the V6 Context Engine plugin interface with full lifecycle hooks for memory management.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_hooks_v6.py",
+        "tests/test_context_engine_hooks_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Plugin interface supports init, compress, and destroy hooks.",
+        "Tests pass verifying hook invocation."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -383,3 +383,7 @@
 * [ ] FEATURE: OpenClaw Context Engine Plugin V8 (openclaw-context-engine-plugin-v8-unique-new)
 * [ ] FEATURE: MCP Dynamic Capability Negotiation V5 (mcp-dynamic-capability-negotiation-v5-unique-new)
 * [ ] FEATURE: Claude Worktree Pruning and Resource Optimizer V1 (claude-worktree-pruning-optimizer-v1-unique-new)
+
+* [ ] FEATURE: Hermes Cron Nightly Backups V1 (hermes-cron-nightly-backups-v1)
+* [ ] FEATURE: OpenClaw Context Engine Hooks V6 (openclaw-context-engine-hooks-v6)
+* [x] FEATURE: A2A Delegation Circuit Breaker V7 v2 (a2a-delegation-circuit-breaker-v7-bc9e8aae)

--- a/magda_agent/integration/a2a_circuit_breaker_v7_v2.py
+++ b/magda_agent/integration/a2a_circuit_breaker_v7_v2.py
@@ -1,0 +1,65 @@
+import asyncio
+import time
+from enum import Enum
+from typing import Callable, Any, TypeVar, Awaitable
+
+T = TypeVar('T')
+
+class CircuitBreakerState(Enum):
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+class CircuitBreakerOpenException(Exception):
+    """Exception raised when the circuit breaker is OPEN."""
+    pass
+
+class A2ACircuitBreaker:
+    """
+    A circuit breaker for A2A delegation to prevent continuous failures to unresponsive peer agents.
+    """
+    def __init__(self, failure_threshold: int = 3, reset_timeout: float = 60.0) -> None:
+        self.failure_threshold = failure_threshold
+        self.reset_timeout = reset_timeout
+        self.state = CircuitBreakerState.CLOSED
+        self.failure_count = 0
+        self.last_failure_time = 0.0
+
+    async def call(self, func: Callable[..., Awaitable[T]], *args: Any, **kwargs: Any) -> T:
+        """
+        Executes the given async function subject to circuit breaker rules.
+        """
+        if self.state == CircuitBreakerState.OPEN:
+            if time.time() - self.last_failure_time >= self.reset_timeout:
+                self.state = CircuitBreakerState.HALF_OPEN
+            else:
+                raise CircuitBreakerOpenException("Circuit breaker is OPEN. Peer is unresponsive.")
+
+        try:
+            result = await func(*args, **kwargs)
+            # On success, reset the breaker
+            self.reset()
+            return result
+        except Exception as e:
+            if isinstance(e, CircuitBreakerOpenException):
+                raise
+
+            self.record_failure()
+            raise
+
+    def record_failure(self) -> None:
+        """Records a failure and potentially transitions state."""
+        if self.state == CircuitBreakerState.HALF_OPEN:
+            self.state = CircuitBreakerState.OPEN
+            self.last_failure_time = time.time()
+        elif self.state == CircuitBreakerState.CLOSED:
+            self.failure_count += 1
+            if self.failure_count >= self.failure_threshold:
+                self.state = CircuitBreakerState.OPEN
+                self.last_failure_time = time.time()
+
+    def reset(self) -> None:
+        """Resets the circuit breaker to CLOSED state."""
+        self.state = CircuitBreakerState.CLOSED
+        self.failure_count = 0
+        self.last_failure_time = 0.0

--- a/tests/test_a2a_circuit_breaker_v7_v2.py
+++ b/tests/test_a2a_circuit_breaker_v7_v2.py
@@ -1,0 +1,98 @@
+import pytest
+import asyncio
+import time
+from magda_agent.integration.a2a_circuit_breaker_v7_v2 import A2ACircuitBreaker, CircuitBreakerState, CircuitBreakerOpenException
+from unittest.mock import AsyncMock, patch
+
+@pytest.fixture
+def circuit_breaker() -> A2ACircuitBreaker:
+    return A2ACircuitBreaker(failure_threshold=3, reset_timeout=1.0)
+
+@pytest.mark.asyncio
+async def test_successful_call(circuit_breaker: A2ACircuitBreaker) -> None:
+    mock_func = AsyncMock(return_value="success")
+    result = await circuit_breaker.call(mock_func)
+    assert result == "success"
+    assert circuit_breaker.state == CircuitBreakerState.CLOSED
+    assert circuit_breaker.failure_count == 0
+
+@pytest.mark.asyncio
+async def test_failure_records_and_trips(circuit_breaker: A2ACircuitBreaker) -> None:
+    mock_func = AsyncMock(side_effect=RuntimeError("API Error"))
+
+    # Fail 1
+    with pytest.raises(RuntimeError):
+        await circuit_breaker.call(mock_func)
+    assert circuit_breaker.state == CircuitBreakerState.CLOSED
+    assert circuit_breaker.failure_count == 1
+
+    # Fail 2
+    with pytest.raises(RuntimeError):
+        await circuit_breaker.call(mock_func)
+    assert circuit_breaker.state == CircuitBreakerState.CLOSED
+    assert circuit_breaker.failure_count == 2
+
+    # Fail 3 - should trip the breaker
+    with pytest.raises(RuntimeError):
+        await circuit_breaker.call(mock_func)
+    assert circuit_breaker.state == CircuitBreakerState.OPEN
+
+@pytest.mark.asyncio
+async def test_open_circuit_raises_immediately(circuit_breaker: A2ACircuitBreaker) -> None:
+    mock_func = AsyncMock(side_effect=RuntimeError("API Error"))
+
+    # Trip the breaker
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            await circuit_breaker.call(mock_func)
+
+    assert circuit_breaker.state == CircuitBreakerState.OPEN
+
+    # Next call should raise CircuitBreakerOpenException immediately without calling mock_func
+    mock_func.reset_mock()
+    with pytest.raises(CircuitBreakerOpenException, match="Circuit breaker is OPEN"):
+        await circuit_breaker.call(mock_func)
+
+    mock_func.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_recovery_half_open_to_closed(circuit_breaker: A2ACircuitBreaker) -> None:
+    mock_func = AsyncMock(side_effect=RuntimeError("API Error"))
+
+    # Trip the breaker
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            await circuit_breaker.call(mock_func)
+
+    assert circuit_breaker.state == CircuitBreakerState.OPEN
+
+    # Mock time to simulate waiting for reset timeout
+    with patch('time.time', return_value=time.time() + 2.0):
+        # Now we are past reset_timeout
+        # Create a new mock func that succeeds
+        success_func = AsyncMock(return_value="success")
+
+        # This call should succeed and transition to CLOSED
+        result = await circuit_breaker.call(success_func)
+        assert result == "success"
+        assert circuit_breaker.state == CircuitBreakerState.CLOSED
+        assert circuit_breaker.failure_count == 0
+
+@pytest.mark.asyncio
+async def test_half_open_to_open_on_failure(circuit_breaker: A2ACircuitBreaker) -> None:
+    mock_func = AsyncMock(side_effect=RuntimeError("API Error"))
+
+    # Trip the breaker
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            await circuit_breaker.call(mock_func)
+
+    assert circuit_breaker.state == CircuitBreakerState.OPEN
+
+    # Mock time to simulate waiting for reset timeout
+    with patch('time.time', return_value=time.time() + 2.0):
+        # This call will fail again while in HALF_OPEN
+        with pytest.raises(RuntimeError):
+            await circuit_breaker.call(mock_func)
+
+        assert circuit_breaker.state == CircuitBreakerState.OPEN


### PR DESCRIPTION
Implemented the A2A delegation circuit breaker task from `agent_tasks.json` to prevent continuous failures to unresponsive peer agents. 

Also appended two new "todo" tasks based on `docs/trends.md` (Hermes Cron Nightly Backups V1 and OpenClaw Context Engine Hooks V6) to both `agent_tasks.json` and `backlog.md`. All tests passed locally.

---
*PR created automatically by Jules for task [8905319530640387780](https://jules.google.com/task/8905319530640387780) started by @kazah4359-lgtm*