### PR TITLE
feat(a2a): implement secure auth token delegation v4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12745,7 +12745,7 @@
     },
     {
       "id": "a2a-auth-token-delegation-v4",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "high",
       "title": "A2A Auth Token Delegation v4",
@@ -29989,6 +29989,57 @@
       "acceptance": [
         "Evaluator subagent can parse diffs and assess their semantic risk.",
         "Tests mock diffs and verify that destructive changes are blocked."
+      ]
+    },
+    {
+      "id": "openclaw-virtual-context-swapping-v12",
+      "status": "todo",
+      "area": "memory",
+      "risk": "high",
+      "title": "OpenClaw Virtual Context Swapping V12",
+      "description": "Inspired by OpenClaw trends: Implement a more advanced virtual context swapping mechanism that transparently offloads inactive conversational threads to disk and restores them upon semantic hit.",
+      "allowed_paths": [
+        "magda_agent/memory/virtual_context_swapping_v12.py",
+        "tests/test_virtual_context_swapping_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context pages out to disk cleanly when inactive.",
+        "Tests mock file I/O to verify state swapping logic."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-auth-negotiation-v10",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Dynamic Auth Negotiation V10",
+      "description": "Inspired by MCP standards: Implement multi-turn authentication negotiation for exported MCP tools, ensuring dynamic validation of role claims before execution.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_auth_negotiation_v10.py",
+        "tests/test_mcp_auth_negotiation_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP authentication securely negotiates and verifies roles.",
+        "Tests verify successful and rejected negotiations."
+      ]
+    },
+    {
+      "id": "hermes-agent-scheduled-reflection-v5",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Agent Scheduled Reflection V5",
+      "description": "Inspired by Hermes Agent trends: Implement a cron-like scheduler for delayed episodic memory reflection to extract generalized procedural skills during idle periods.",
+      "allowed_paths": [
+        "magda_agent/learning/scheduled_reflection_v5.py",
+        "tests/test_scheduled_reflection_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scheduler periodically invokes reflection functions.",
+        "Tests simulate idle triggers and verify reflection invocations."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -271,6 +271,7 @@
 
 
 ## 📡 A2A mDNS & Self-Improvement Loops (June 2026 Trends)
+* [x] FEATURE: A2A Auth Token Delegation v4 (a2a-auth-token-delegation-v4)
 * [x] FEATURE: MCP Dynamic Skill Marketplace Sync v2 (mcp-skill-marketplace-sync-v2)
 * [x] FEATURE: MCP Kernel Sandboxing V2 (mcp-kernel-sandboxing-v2-94a2f1b0)
 * [ ] FEATURE: OpenClaw Virtual Context Lifecycle Manager V3 (openclaw-virtual-context-v3-7d8e9cfa)

--- a/magda_agent/integration/a2a_auth.py
+++ b/magda_agent/integration/a2a_auth.py
@@ -1,4 +1,4 @@
-import uuid
+import secrets
 import logging
 from typing import Set
 
@@ -18,7 +18,7 @@ class A2AAuthTokenDelegation:
         Returns:
             str: The generated token prefixed with 'a2a_auth_'.
         """
-        token = f"a2a_auth_{uuid.uuid4().hex}"
+        token = f"a2a_auth_{secrets.token_hex(32)}"
         self._active_tokens.add(token)
         logging.info(f"Generated new A2A auth token (redacted: {token[:12]}...)")
         return token

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -7,7 +7,7 @@ def test_a2a_auth_token_delegation_generate_token():
     token = auth_delegation.generate_token()
 
     assert token.startswith("a2a_auth_")
-    assert len(token) > len("a2a_auth_")
+    assert len(token) == len("a2a_auth_") + 64
     assert token in auth_delegation._active_tokens
 
 def test_a2a_auth_token_delegation_validate_token_success():


### PR DESCRIPTION
This PR implements the `a2a-auth-token-delegation-v4` task as outlined in `agent_tasks.json`. 

Specifically:
- Refactored `A2AAuthTokenDelegation` in `magda_agent/integration/a2a_auth.py` to use Python's `secrets` module for cryptographically secure token generation, replacing the previous `uuid4` implementation.
- Updated `tests/test_a2a_auth.py` to correctly test the new 64-character token length.
- Set the status of `a2a-auth-token-delegation-v4` to `done` in `agent_tasks.json`.
- Appended 3 new trend-inspired (OpenClaw, MCP, Hermes) tasks to `agent_tasks.json`.
- Validated `agent_tasks.json` structure using `scripts/validate_agent_tasks.py`.
- Checked off the corresponding feature item in `backlog.md` under the 'A2A mDNS & Self-Improvement Loops (June 2026 Trends)' section.
- Ensured all tests pass and no local/temporary database files are leaked into the tree.

---
*PR created automatically by Jules for task [10913649835053987310](https://jules.google.com/task/10913649835053987310) started by @kazah4359-lgtm*