### PR TITLE
feat(integration): add A2A Agent Discovery v5 health filtering

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12796,7 +12796,7 @@
     },
     {
       "id": "a2a-agent-discovery-v5-health",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Agent Discovery v5 Health",
@@ -30127,6 +30127,60 @@
       "acceptance": [
         "Taint tracker marks variables correctly.",
         "Tests verify policy blocks execution of tainted variables."
+      ]
+    },
+    {
+      "id": "a2a-mdns-security-token-v1-implementation",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A mDNS Security Token Implementation v1",
+      "description": "Inspired by trend: A2A mDNS Security. Implement secure token authentication for mDNS discovery in A2A protocol. Offline agents should be ignored.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mdns_security_v1.py",
+        "tests/test_a2a_mdns_security_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "mDNS discovery service uses authentication tokens.",
+        "Invalid tokens are rejected.",
+        "Pytest coverage added."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v5-caching",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Capability Negotiation v5 Caching",
+      "description": "Inspired by MCP capability negotiation trends and OpenAI Agents SDK schema caching. Implement caching for negotiated MCP capabilities.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_negotiation_v5.py",
+        "tests/test_mcp_negotiation_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Capability negotiation caches results based on agent ID.",
+        "Subsequent negotiations retrieve from cache.",
+        "Cache can be invalidated."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v1-auto",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Worktree Pruning Optimizer V1",
+      "description": "Inspired by Claude SDK Agent Teams Git Worktree Isolation. Implement an automated optimizer to prune stale agent git worktrees to free up disk space.",
+      "allowed_paths": [
+        "magda_agent/architecture/worktree_pruning_v1.py",
+        "tests/test_worktree_pruning_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Automated task runs to identify stale git worktrees.",
+        "Stale worktrees are cleanly removed.",
+        "Safe operation to avoid deleting active worktrees."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_discovery_v5.py
+++ b/magda_agent/integration/a2a_discovery_v5.py
@@ -18,6 +18,7 @@ class AgentCardV5:
     capabilities: List[str]
     endpoints: Dict[str, str]
     protocol_version: str = "v5"
+    health_status: str = "online"
 
     def to_json(self) -> str:
         """
@@ -104,12 +105,12 @@ class A2ADiscoveryServiceV5:
 
     def get_all_agents(self) -> List[AgentCardV5]:
         """
-        Returns a list of all discovered agent cards.
+        Returns a list of all discovered agent cards, filtering out offline agents.
 
         Returns:
-            List[AgentCardV5]: A list of all AgentCardV5 objects in the registry.
+            List[AgentCardV5]: A list of online AgentCardV5 objects in the registry.
         """
-        return list(self._registry.values())
+        return [card for card in self._registry.values() if card.health_status != "offline"]
 
     async def discover_from_network(self, network_endpoint: str, auth_token: Optional[str] = None) -> List[AgentCardV5]:
         """

--- a/tests/test_a2a_discovery_v5.py
+++ b/tests/test_a2a_discovery_v5.py
@@ -12,7 +12,8 @@ def valid_card_dict() -> dict:
         "description": "A test agent card v5",
         "capabilities": ["test_capability_1", "test_capability_2"],
         "endpoints": {"rpc": "http://localhost:8080/rpc"},
-        "protocol_version": "v5"
+        "protocol_version": "v5",
+        "health_status": "online"
     }
 
 @pytest.fixture
@@ -38,6 +39,30 @@ def test_agent_card_v5_serialization(valid_card_dict: dict, valid_card_json: str
     assert re_dict["agent_id"] == "test-agent-005"
     assert re_dict["name"] == "TestAgentV5"
     assert re_dict["protocol_version"] == "v5"
+    assert re_dict["health_status"] == "online"
+
+def test_service_filters_offline_agents(valid_card_dict: dict) -> None:
+    """
+    Test that the service filters out offline agents correctly.
+    """
+    service = A2ADiscoveryServiceV5()
+
+    online_card = AgentCardV5.from_json(json.dumps(valid_card_dict))
+    service.register_agent(online_card)
+
+    offline_dict = valid_card_dict.copy()
+    offline_dict["agent_id"] = "offline-agent-001"
+    offline_dict["health_status"] = "offline"
+    offline_card = AgentCardV5.from_json(json.dumps(offline_dict))
+    service.register_agent(offline_card)
+
+    all_agents = service.get_all_agents()
+    assert len(all_agents) == 1
+    assert all_agents[0].agent_id == "test-agent-005"
+
+    retrieved = service.get_agent_card("offline-agent-001")
+    assert retrieved is not None
+    assert retrieved.health_status == "offline"
 
 def test_service_register_and_get(valid_card_json: str) -> None:
     """


### PR DESCRIPTION
Implemented the `a2a-agent-discovery-v5-health` task to filter out offline agents from the A2A network discovery service. 
- Adds `health_status` tracking to `AgentCardV5`.
- `A2ADiscoveryServiceV5` properly omits `"offline"` agents when fetching the full list.
- Adds 3 new agent tasks based on trends.

---
*PR created automatically by Jules for task [14045917571776228251](https://jules.google.com/task/14045917571776228251) started by @kazah4359-lgtm*