### PR TITLE
feat(integration): implement A2ATracerV6 for enterprise tracing

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12843,7 +12843,7 @@
         "Delegated tasks include trace IDs.",
         "Tests mock A2A calls and trace data."
       ],
-      "status": "todo"
+      "status": "done"
     },
     {
       "id": "openclaw-rl-habit-decay-v4",
@@ -30233,6 +30233,57 @@
       "acceptance": [
         "Tracker systematically records the test outcome metrics.",
         "Tests use mocked data points to guarantee accuracy."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-capabilities-sync-v1",
+      "title": "MCP Action Tool Capabilities Sync V1",
+      "description": "Inspired by MCP standards (June 2026): Implement an active syncing mechanism that negotiates available action capabilities between two distinct MCP tools before execution.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_capabilities_sync_v1.py",
+        "tests/test_mcp_capabilities_sync_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Sync mechanism properly identifies and matches MCP capabilities.",
+        "Tests mock valid and invalid capability negotiation payloads."
+      ]
+    },
+    {
+      "id": "openclaw-rl-conversational-loop-v5",
+      "title": "OpenClaw RL Conversational Loop Extensions V5",
+      "description": "Inspired by OpenClaw RL (June 2026): Create conversational loop extensions that adapt tool selection priorities based on explicit conversational RL reward parameters.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/rl_conversational_loop_v5.py",
+        "tests/test_rl_conversational_loop_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "RL conversational loop captures explicit rewards and adapts tool selection appropriately.",
+        "Tests mock RL environments and verify tool selection adjustment."
+      ]
+    },
+    {
+      "id": "agent-teams-subagent-context-sync-v2",
+      "title": "Agent Teams Sub-Agent Context Syncing V2",
+      "description": "Inspired by Claude Agent SDK Agent Teams (June 2026): Implement a synchronization service for Agent Teams that ensures sub-agent virtual working memory is kept consistently in sync across distributed processes.",
+      "area": "multi-agent",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/subagent_context_sync_v2.py",
+        "tests/test_subagent_context_sync_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context sync mechanism successfully updates sub-agent virtual memory states across boundaries.",
+        "Tests simulate cross-process state sync using mocks."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_tracing_v6.py
+++ b/magda_agent/integration/a2a_tracing_v6.py
@@ -1,0 +1,167 @@
+import uuid
+import time
+from typing import Dict, Any, List, Optional
+import json
+
+class A2ATracerV6:
+    """
+    Enhanced enterprise tracing and distributed monitoring support for A2A delegated tasks.
+
+    This module provides tracing capabilities by generating trace IDs, span IDs,
+    tracking distributed A2A execution status, and supporting parent-child trace
+    correlation across delegated tasks in the agent mesh.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the A2ATracerV6 with an empty dictionary of traces and active delegations.
+        """
+        self.traces: Dict[str, Dict[str, Any]] = {}
+        self.delegated_tasks: Dict[str, str] = {} # Maps task_id to trace_id
+
+    def start_trace(self, task_name: str, parent_trace_id: Optional[str] = None) -> str:
+        """
+        Starts a new trace for a given task, optionally linked to a parent trace.
+
+        Args:
+            task_name: The name of the task being traced.
+            parent_trace_id: The optional parent trace ID for distributed correlation.
+
+        Returns:
+            The generated trace ID.
+        """
+        trace_id = str(uuid.uuid4())
+        self.traces[trace_id] = {
+            "task_name": task_name,
+            "parent_trace_id": parent_trace_id,
+            "start_time": time.time(),
+            "end_time": None,
+            "status": "in_progress",
+            "spans": [],
+            "monitoring_events": []
+        }
+        return trace_id
+
+    def end_trace(self, trace_id: str, status: str = "completed") -> None:
+        """
+        Ends an existing trace.
+
+        Args:
+            trace_id: The ID of the trace to end.
+            status: The final status of the trace (e.g., 'completed', 'failed', 'timeout').
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        self.traces[trace_id]["end_time"] = time.time()
+        self.traces[trace_id]["status"] = status
+
+    def add_span(self, trace_id: str, span_name: str, duration_ms: float) -> str:
+        """
+        Adds a span to an existing trace.
+
+        Args:
+            trace_id: The ID of the trace.
+            span_name: The name of the span or operation.
+            duration_ms: The duration of the operation in milliseconds.
+
+        Returns:
+            The generated span ID.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        span_id = str(uuid.uuid4())
+        span = {
+            "span_id": span_id,
+            "span_name": span_name,
+            "duration_ms": duration_ms,
+            "timestamp": time.time()
+        }
+        self.traces[trace_id]["spans"].append(span)
+        return span_id
+
+    def log_monitoring_event(self, trace_id: str, event_type: str, details: Dict[str, Any]) -> None:
+        """
+        Logs a distributed monitoring event associated with a trace.
+
+        Args:
+            trace_id: The ID of the trace.
+            event_type: Type of the event (e.g., 'network_latency', 'node_failure').
+            details: Additional details about the event.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        event = {
+            "event_type": event_type,
+            "timestamp": time.time(),
+            "details": details
+        }
+        self.traces[trace_id]["monitoring_events"].append(event)
+
+    def attach_delegated_task(self, trace_id: str, task_id: str) -> None:
+        """
+        Attaches an A2A delegated task to a trace for tracking.
+
+        Args:
+            trace_id: The ID of the trace.
+            task_id: The delegated task ID.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+        self.delegated_tasks[task_id] = trace_id
+
+    def get_trace_for_task(self, task_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Retrieves the trace associated with a specific delegated task.
+
+        Args:
+            task_id: The ID of the delegated task.
+
+        Returns:
+            The trace dictionary, or None if not found.
+        """
+        trace_id = self.delegated_tasks.get(task_id)
+        if not trace_id:
+            return None
+        return self.traces.get(trace_id)
+
+    def get_trace(self, trace_id: str) -> Dict[str, Any]:
+        """
+        Retrieves the details of a trace.
+
+        Args:
+            trace_id: The ID of the trace.
+
+        Returns:
+            A dictionary containing the trace details.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        return self.traces[trace_id]
+
+    def export_traces(self) -> str:
+        """
+        Exports all traces as a JSON string.
+
+        Returns:
+            A JSON string representing all traces.
+        """
+        return json.dumps(self.traces)

--- a/tests/test_a2a_tracing_v6.py
+++ b/tests/test_a2a_tracing_v6.py
@@ -1,0 +1,85 @@
+import pytest
+import json
+from unittest.mock import patch, MagicMock
+from magda_agent.integration.a2a_tracing_v6 import A2ATracerV6
+
+def test_start_trace():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id in tracer.traces
+    assert tracer.traces[trace_id]["task_name"] == "test_task"
+    assert tracer.traces[trace_id]["parent_trace_id"] is None
+    assert tracer.traces[trace_id]["status"] == "in_progress"
+
+def test_start_trace_with_parent():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("child_task", "parent_123")
+    assert tracer.traces[trace_id]["parent_trace_id"] == "parent_123"
+
+def test_end_trace():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    tracer.end_trace(trace_id, "success")
+    assert tracer.traces[trace_id]["status"] == "success"
+    assert tracer.traces[trace_id]["end_time"] is not None
+
+def test_end_trace_not_found():
+    tracer = A2ATracerV6()
+    with pytest.raises(KeyError):
+        tracer.end_trace("invalid_id")
+
+def test_add_span():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    span_id = tracer.add_span(trace_id, "db_query", 15.5)
+
+    assert len(tracer.traces[trace_id]["spans"]) == 1
+    span = tracer.traces[trace_id]["spans"][0]
+    assert span["span_id"] == span_id
+    assert span["span_name"] == "db_query"
+    assert span["duration_ms"] == 15.5
+
+def test_log_monitoring_event():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    tracer.log_monitoring_event(trace_id, "network_latency", {"latency_ms": 120})
+
+    assert len(tracer.traces[trace_id]["monitoring_events"]) == 1
+    event = tracer.traces[trace_id]["monitoring_events"][0]
+    assert event["event_type"] == "network_latency"
+    assert event["details"]["latency_ms"] == 120
+
+def test_attach_delegated_task():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    tracer.attach_delegated_task(trace_id, "task_001")
+
+    assert tracer.delegated_tasks["task_001"] == trace_id
+
+def test_get_trace_for_task():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    tracer.attach_delegated_task(trace_id, "task_001")
+
+    trace = tracer.get_trace_for_task("task_001")
+    assert trace is not None
+    assert trace["task_name"] == "test_task"
+
+def test_get_trace_for_task_not_found():
+    tracer = A2ATracerV6()
+    trace = tracer.get_trace_for_task("invalid_task")
+    assert trace is None
+
+def test_get_trace():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    trace = tracer.get_trace(trace_id)
+    assert trace["task_name"] == "test_task"
+
+def test_export_traces():
+    tracer = A2ATracerV6()
+    trace_id = tracer.start_trace("test_task")
+    exported = tracer.export_traces()
+    data = json.loads(exported)
+    assert trace_id in data
+    assert data[trace_id]["task_name"] == "test_task"


### PR DESCRIPTION
Implemented A2A Enterprise Tracing V6 based on A2A Protocol trends. This includes creating the A2ATracerV6 class which generates trace IDs, span IDs, and tracks distributed A2A execution status, including parent-child relationships. Comprehensive tests are provided, and the task manifest was updated, alongside the addition of 3 new trend-inspired tasks.

---
*PR created automatically by Jules for task [17539074423704513029](https://jules.google.com/task/17539074423704513029) started by @kazah4359-lgtm*