### PR TITLE
feat(teams): add AgentEvaluatorTeamV4 with strict sandboxing

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12877,7 +12877,7 @@
         "Evaluator team runs in sandbox.",
         "LLM is mocked in tests."
       ],
-      "status": "todo"
+      "status": "done"
     },
     {
       "id": "mcp-dynamic-tool-telemetry-v8",
@@ -30284,6 +30284,58 @@
       "acceptance": [
         "Context sync mechanism successfully updates sub-agent virtual memory states across boundaries.",
         "Tests simulate cross-process state sync using mocks."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-live-v6",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Canvas Live Visualization v6",
+      "description": "Inspired by OpenClaw trend: Implement a Live Canvas visualizer for agent context streams.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_live_v6.py",
+        "tests/test_canvas_live_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Live canvas module added.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-kernel-taint-tracking-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "title": "MCP Kernel Taint Tracking for Secure Execution",
+      "description": "Inspired by MCPKernel trend: Implement taint tracking for variables used during MCP action tool execution to prevent sandbox escapes.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_kernel_taint_v1.py",
+        "tests/test_mcp_kernel_taint_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Taint tracking logic implemented.",
+        "Variables can be marked tainted and verified.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-auth-delegation-v9",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Enterprise Auth Delegation v9",
+      "description": "Inspired by A2A Protocol trend: Enhance A2A auth token delegation to support scope-based enterprise authorization.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_auth_v9.py",
+        "tests/test_a2a_auth_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scope-based auth delegation implemented.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/architecture/agent_teams_v4.py
+++ b/magda_agent/architecture/agent_teams_v4.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import uuid
 import time
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List, Dict, Tuple, Any
 
 
 class GitWorktreeError(Exception):
@@ -200,3 +200,81 @@ class AgentTeamManagerV4:
         agents_to_disband = list(self.agents)
         for agent_id in agents_to_disband:
             await self.disband_agent(agent_id)
+
+class AgentEvaluatorTeamV4:
+    """
+    Subagent evaluator pool that can test generator team code iteratively with strict sandboxing.
+    Inspired by Claude Agent SDK trend.
+    """
+
+    def __init__(self, evaluators: List[str], team_manager: Optional[AgentTeamManagerV4] = None) -> None:
+        """
+        Initialize the evaluator team.
+
+        Args:
+            evaluators (List[str]): The list of evaluator IDs.
+            team_manager (Optional[AgentTeamManagerV4]): Manager for strict sandboxing.
+        """
+        self.evaluators = evaluators
+        self.team_manager = team_manager or AgentTeamManagerV4()
+
+    async def evaluate_code(self, code: str, context: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Evaluate generator code iteratively within strict sandboxes.
+
+        Args:
+            code (str): The code to evaluate.
+            context (Dict[str, Any]): Additional context.
+
+        Returns:
+            Dict[str, Any]: The evaluation results.
+        """
+        results = []
+        for evaluator in self.evaluators:
+            # Sandbox setup
+            try:
+                worktree_path, isolated_env = await self.team_manager.spawn_agent(evaluator)
+            except ValueError:
+                # If already spawned, get the environment
+                isolated_env = self.team_manager.get_agent_env(evaluator) or {}
+
+            try:
+                result = await self._call_llm_evaluator(evaluator, code, context, isolated_env)
+                results.append(result)
+            finally:
+                # Ensure teardown for strict sandboxing
+                await self.team_manager.disband_agent(evaluator)
+
+        passed = bool(results) and all(r.get("passed", False) for r in results)
+
+        return {
+            "passed": passed,
+            "results": results,
+            "overall_score": sum(r.get("score", 0) for r in results) / len(results) if results else 0.0
+        }
+
+    async def _call_llm_evaluator(self, evaluator_id: str, code: str, context: Dict[str, Any], isolated_env: Dict[str, str]) -> Dict[str, Any]:
+        """
+        Call the LLM for evaluation.
+
+        Args:
+            evaluator_id (str): Evaluator identifier.
+            code (str): The code to evaluate.
+            context (Dict[str, Any]): Additional context.
+            isolated_env (Dict[str, str]): Environment details from sandbox.
+
+        Returns:
+            Dict[str, Any]: Evaluation result parsed from LLM response.
+        """
+        from magda_agent.llm_client import LLMClient
+        client = LLMClient()
+        prompt = f"Evaluate this code:\n{code}\nContext: {context}\nEvaluator ID: {evaluator_id}\nSandbox: {isolated_env.get('MAGDA_WORKTREE_PATH')}"
+
+        response = await client.generate(prompt=prompt)
+
+        return {
+            "evaluator_id": evaluator_id,
+            "passed": "PASSED" in response,
+            "score": 100 if "PASSED" in response else 50,
+            "feedback": response
+        }

--- a/tests/test_agent_teams_v4.py
+++ b/tests/test_agent_teams_v4.py
@@ -9,6 +9,7 @@ from magda_agent.architecture.agent_teams_v4 import (
     AgentWorktreeIsolationV4,
     AgentTeamManagerV4,
     GitWorktreeError,
+    AgentEvaluatorTeamV4,
 )
 
 @pytest.fixture
@@ -136,3 +137,67 @@ async def test_team_manager_disband_all(team_manager: AgentTeamManagerV4) -> Non
         assert mock_disband.call_count == 2
         mock_disband.assert_any_call("agent1")
         mock_disband.assert_any_call("agent2")
+
+
+@pytest.mark.asyncio
+async def test_agent_evaluator_team_v4(team_manager: AgentTeamManagerV4) -> None:
+    evaluators = ["eval1", "eval2"]
+    team = AgentEvaluatorTeamV4(evaluators=evaluators, team_manager=team_manager)
+
+    # Mock the LLM call using AsyncMock
+    with patch("magda_agent.llm_client.LLMClient.generate", new_callable=AsyncMock) as mock_generate, \
+         patch.object(team_manager, "spawn_agent", new_callable=AsyncMock) as mock_spawn, \
+         patch.object(team_manager, "disband_agent", new_callable=AsyncMock) as mock_disband:
+
+        mock_generate.side_effect = [
+            "PASSED: Code is good",
+            "PASSED: Looks fine"
+        ]
+
+        mock_spawn.side_effect = [
+            ("/tmp/eval1", {"MAGDA_WORKTREE_PATH": "/tmp/eval1"}),
+            ("/tmp/eval2", {"MAGDA_WORKTREE_PATH": "/tmp/eval2"})
+        ]
+
+        result = await team.evaluate_code("def foo(): pass", {"context": "test"})
+
+        assert result["passed"] is True
+        assert result["overall_score"] == 100
+        assert len(result["results"]) == 2
+
+        assert mock_generate.call_count == 2
+        assert mock_spawn.call_count == 2
+        assert mock_disband.call_count == 2
+
+        mock_spawn.assert_any_call("eval1")
+        mock_spawn.assert_any_call("eval2")
+        mock_disband.assert_any_call("eval1")
+        mock_disband.assert_any_call("eval2")
+
+
+@pytest.mark.asyncio
+async def test_agent_evaluator_team_v4_failed_eval(team_manager: AgentTeamManagerV4) -> None:
+    evaluators = ["eval1", "eval2"]
+    team = AgentEvaluatorTeamV4(evaluators=evaluators, team_manager=team_manager)
+
+    with patch("magda_agent.llm_client.LLMClient.generate", new_callable=AsyncMock) as mock_generate, \
+         patch.object(team_manager, "spawn_agent", new_callable=AsyncMock) as mock_spawn, \
+         patch.object(team_manager, "disband_agent", new_callable=AsyncMock) as mock_disband:
+
+        mock_generate.side_effect = [
+            "PASSED: Good",
+            "FAILED: Syntax Error"
+        ]
+
+        mock_spawn.side_effect = [
+            ("/tmp/eval1", {"MAGDA_WORKTREE_PATH": "/tmp/eval1"}),
+            ("/tmp/eval2", {"MAGDA_WORKTREE_PATH": "/tmp/eval2"})
+        ]
+
+        result = await team.evaluate_code("def foo() pass", {"context": "test"})
+
+        assert result["passed"] is False
+        assert result["overall_score"] == 75.0  # (100 + 50) / 2
+        assert len(result["results"]) == 2
+
+        assert mock_disband.call_count == 2


### PR DESCRIPTION
Implements the `claude-evaluator-subagent-teams-v4` task from the `agent_tasks.json` backlog.

- `AgentEvaluatorTeamV4` iteratively evaluates generated code across sandboxed agent environments.
- Ensured teardowns occur properly, restoring pristine git worktrees.
- Updated `agent_tasks.json` and added trend-inspired features:
  - OpenClaw Live Canvas Visualizer
  - MCP Kernel Taint Tracking
  - A2A Auth Delegation (Scope-based)
- Achieved 100% test passing locally.

---
*PR created automatically by Jules for task [10406832167095494459](https://jules.google.com/task/10406832167095494459) started by @kazah4359-lgtm*