### PR TITLE
Add MCP Dynamic Tool Telemetry v8

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12881,7 +12881,7 @@
     },
     {
       "id": "mcp-dynamic-tool-telemetry-v8",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "medium",
       "title": "MCP Dynamic Tool Telemetry v8",
@@ -30335,6 +30335,57 @@
       ],
       "acceptance": [
         "Scope-based auth delegation implemented.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-user-feedback-v9",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Multimodal User Feedback V9",
+      "description": "Implement online multimodal user feedback signals (image, audio, text) integration for RL policy updates in OpenClaw.",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_multimodal_v9.py",
+        "tests/test_openclaw_rl_multimodal_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Multimodal user feedback is integrated into RL policy.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "a2a-swarm-intelligence-consensus-v5",
+      "status": "todo",
+      "area": "integration",
+      "risk": "high",
+      "title": "A2A Swarm Intelligence Consensus Protocol V5",
+      "description": "Introduce a distributed consensus algorithm (Raft or Paxos variant) over A2A mesh network to agree on complex multi-agent workflows.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_swarm_consensus_v5.py",
+        "tests/test_a2a_swarm_consensus_v5.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A distributed consensus algorithm implemented.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v9",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Negotiation V9",
+      "description": "Implement multi-turn dynamic capability negotiation caching for MCP servers to reduce redundant capability negotiations.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_capability_negotiation_v9.py",
+        "tests/test_mcp_capability_negotiation_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP Capability negotiation with caching implemented.",
         "Tests pass."
       ]
     }

--- a/magda_agent/skills/mcp_export_v7.py
+++ b/magda_agent/skills/mcp_export_v7.py
@@ -3,6 +3,7 @@ import logging
 from typing import Dict, Any, Callable, List, get_origin
 from magda_agent.skills.registry import SkillRegistry
 from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.telemetry.mcp_export_telemetry import MCPExportTelemetryTracker
 
 
 class MCPDynamicExporterV7:
@@ -22,6 +23,7 @@ class MCPDynamicExporterV7:
         self.skill_registry = skill_registry
         self.mcp_registry = mcp_registry
         self.logger = logging.getLogger(__name__)
+        self.telemetry_tracker = MCPExportTelemetryTracker()
 
     def _get_json_schema(self, func: Callable) -> Dict[str, Any]:
         """
@@ -101,6 +103,8 @@ class MCPDynamicExporterV7:
         success = self.mcp_registry.load_tool(mcp_tool_schema)
         if success:
             self.logger.info(f"Successfully exported skill '{skill_name}' to MCPRegistry.")
+            # Telemetry integration
+            self.telemetry_tracker.track_export(skill_name, {"schema": schema, "success": True})
         else:
             self.logger.error(f"Failed to export skill '{skill_name}' to MCPRegistry.")
 

--- a/magda_agent/telemetry/mcp_export_telemetry.py
+++ b/magda_agent/telemetry/mcp_export_telemetry.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Dict, Any, List
+
+logger = logging.getLogger(__name__)
+
+class MCPExportTelemetryTracker:
+    """
+    A telemetry hook for tracking when MCP dynamic tools are exported.
+    Allows visibility into the lifecycle and usage of tools dynamically exported
+    by the agent.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the MCPExportTelemetryTracker.
+        """
+        self.exports: List[Dict[str, Any]] = []
+
+    def track_export(self, tool_name: str, export_metadata: Dict[str, Any]) -> None:
+        """
+        Track an MCP tool export event.
+
+        Args:
+            tool_name (str): The name of the tool being exported.
+            export_metadata (Dict[str, Any]): Additional metadata regarding the export event.
+        """
+        logger.info(f"Tracking MCP tool export: {tool_name}")
+        record = {
+            "tool_name": tool_name,
+            "metadata": export_metadata
+        }
+        self.exports.append(record)

--- a/tests/test_mcp_export_telemetry.py
+++ b/tests/test_mcp_export_telemetry.py
@@ -1,0 +1,38 @@
+import pytest
+import logging
+from magda_agent.telemetry.mcp_export_telemetry import MCPExportTelemetryTracker
+
+def test_mcp_export_telemetry_tracker_initialization():
+    """Test that the tracker initializes with an empty list of exports."""
+    tracker = MCPExportTelemetryTracker()
+    assert tracker.exports == []
+
+def test_track_export():
+    """Test that tracking an export appends the correct data to exports list."""
+    tracker = MCPExportTelemetryTracker()
+    metadata = {"timestamp": "2026-06-25T12:00:00Z", "version": "1.0"}
+    tracker.track_export("my_tool", metadata)
+
+    assert len(tracker.exports) == 1
+    record = tracker.exports[0]
+    assert record["tool_name"] == "my_tool"
+    assert record["metadata"] == metadata
+
+def test_track_export_logging(caplog):
+    """Test that tracking an export logs the correct message."""
+    tracker = MCPExportTelemetryTracker()
+
+    with caplog.at_level(logging.INFO):
+        tracker.track_export("test_tool", {"key": "value"})
+
+    assert "Tracking MCP tool export: test_tool" in caplog.text
+
+def test_track_multiple_exports():
+    """Test tracking multiple tools sequentially."""
+    tracker = MCPExportTelemetryTracker()
+    tracker.track_export("tool_A", {"a": 1})
+    tracker.track_export("tool_B", {"b": 2})
+
+    assert len(tracker.exports) == 2
+    assert tracker.exports[0]["tool_name"] == "tool_A"
+    assert tracker.exports[1]["tool_name"] == "tool_B"


### PR DESCRIPTION
Implemented the task `mcp-dynamic-tool-telemetry-v8` to track when MCP dynamic tools are exported.
- Created `MCPExportTelemetryTracker` to log and record metadata for exported tools.
- Integrated the tracker into `MCPDynamicExporterV7`.
- Wrote pytest tests to verify telemetry tracker functionality.
- Kept tests passing, no regressions introduced.
- Marked task as `done` in `agent_tasks.json`.
- Appended 3 new trend-inspired tasks (OpenClaw Multi-Modal Feedback, A2A Consensus, and MCP dynamic capability negotiation v9) to `agent_tasks.json`.

---
*PR created automatically by Jules for task [11917309558575783775](https://jules.google.com/task/11917309558575783775) started by @kazah4359-lgtm*