### PR TITLE
feat: Implement A2A Enterprise Tracing v8

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12898,7 +12898,7 @@
     },
     {
       "id": "a2a-enterprise-tracing-v8",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Enterprise Tracing v8",
@@ -30387,6 +30387,59 @@
       "acceptance": [
         "MCP Capability negotiation with caching implemented.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "openclaw-rl-realtime-feedback-stream-v1",
+      "title": "OpenClaw RL Real-time Feedback Stream V1",
+      "description": "Inspired by OpenClaw RL trend (June 2026): Implement real-time streaming of feedback signals to update RL policy models incrementally.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/openclaw_rl_realtime_v1.py",
+        "tests/test_openclaw_rl_realtime_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Real-time feedback stream ingests user signals.",
+        "Policy incremental update methods are called securely.",
+        "Tests mock RL behavior."
+      ]
+    },
+    {
+      "id": "mcp-server-context-propagation-v1",
+      "title": "MCP Server Context Propagation V1",
+      "description": "Inspired by MCP standards (June 2026): Propagate subagent execution context parameters gracefully to child MCP servers during dynamic tool discovery.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_context_propagation_v1.py",
+        "tests/test_mcp_context_propagation_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "MCP context metadata propagated.",
+        "Tests verify that discovery uses the passed context securely."
+      ]
+    },
+    {
+      "id": "a2a-mesh-network-resilience-heartbeat-v1",
+      "title": "A2A Mesh Network Resilience Heartbeat V1",
+      "description": "Inspired by A2A standard trend (June 2026): Implement an asynchronous heartbeat checker to drop offline agents from the local discovery cache quickly.",
+      "area": "integration",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mesh_heartbeat_v1.py",
+        "tests/test_a2a_mesh_heartbeat_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Heartbeat checker actively polls known A2A peers.",
+        "Offline agents are purged.",
+        "Tests mock network timeouts to verify resilience."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_enterprise_v8.py
+++ b/magda_agent/integration/a2a_enterprise_v8.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict
 
 from magda_agent.integration.a2a_auth import A2AAuthTokenDelegation
-from magda_agent.integration.a2a_tracing_v4 import A2ATracingV4
+from magda_agent.integration.a2a_tracing_v8 import A2ATracerV8
 
 class A2AEnterpriseClientV8:
     """
@@ -40,12 +40,12 @@ class A2AEnterpriseClientV8:
         token = self.auth_delegation.generate_token()
 
         # 2. Securely Log the Delegation
-        trace_id = A2ATracingV4.securely_log_delegation_event(
-            target_agent_id=target_agent_id,
-            capability=capability,
-            context=context,
-            token=token
-        )
+
+        tracer = A2ATracerV8()
+        trace_id = tracer.start_trace(f"delegate_to_{target_agent_id}")
+        tracer.set_baggage(trace_id, "capability", capability)
+        tracer.set_baggage(trace_id, "token", token)
+
 
         # 3. (Simulation of JSON-RPC client call would happen here, injecting the token)
         # We simulate the network call and assume it completes.

--- a/magda_agent/integration/a2a_tracing_v8.py
+++ b/magda_agent/integration/a2a_tracing_v8.py
@@ -1,0 +1,236 @@
+import uuid
+import time
+import json
+import random
+from typing import Dict, Any, List, Optional
+
+class A2ATracerV8:
+    """
+    Enterprise tracing and distributed monitoring support for A2A delegated tasks v8.
+
+    This module provides tracing capabilities by generating trace IDs, span IDs,
+    tracking distributed A2A execution status, and supporting parent-child trace
+    correlation across delegated tasks in the agent mesh. It also includes
+    probabilistic sampling and context injection/extraction for distributed tracing.
+    """
+
+    def __init__(self, sample_rate: float = 1.0) -> None:
+        """
+        Initializes the A2ATracerV8.
+
+        Args:
+            sample_rate: The probability (0.0 to 1.0) that a trace will be sampled.
+        """
+        self.traces: Dict[str, Dict[str, Any]] = {}
+        self.delegated_tasks: Dict[str, str] = {} # Maps task_id to trace_id
+        self.sample_rate = sample_rate
+
+    def should_sample(self) -> bool:
+        """
+        Determines whether a new trace should be sampled based on the sample_rate.
+
+        Returns:
+            bool: True if the trace should be sampled, False otherwise.
+        """
+        return random.random() <= self.sample_rate
+
+    def start_trace(self, task_name: str, parent_trace_id: Optional[str] = None) -> Optional[str]:
+        """
+        Starts a new trace for a given task, optionally linked to a parent trace.
+        Obeys the configured sample rate.
+
+        Args:
+            task_name: The name of the task being traced.
+            parent_trace_id: The optional parent trace ID for distributed correlation.
+
+        Returns:
+            The generated trace ID if sampled, else None.
+        """
+        if not self.should_sample() and not parent_trace_id:
+            # If there's a parent trace, we usually want to continue it.
+            # If not sampled and no parent, we don't start a trace.
+            return None
+
+        trace_id = str(uuid.uuid4())
+        self.traces[trace_id] = {
+            "task_name": task_name,
+            "parent_trace_id": parent_trace_id,
+            "start_time": time.time(),
+            "end_time": None,
+            "status": "in_progress",
+            "spans": [],
+            "monitoring_events": [],
+            "baggage": {}
+        }
+        return trace_id
+
+    def end_trace(self, trace_id: str, status: str = "completed") -> None:
+        """
+        Ends an existing trace.
+
+        Args:
+            trace_id: The ID of the trace to end.
+            status: The final status of the trace (e.g., 'completed', 'failed', 'timeout').
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        self.traces[trace_id]["end_time"] = time.time()
+        self.traces[trace_id]["status"] = status
+
+    def add_span(self, trace_id: str, span_name: str, duration_ms: float) -> str:
+        """
+        Adds a span to an existing trace.
+
+        Args:
+            trace_id: The ID of the trace.
+            span_name: The name of the span or operation.
+            duration_ms: The duration of the operation in milliseconds.
+
+        Returns:
+            The generated span ID.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        span_id = str(uuid.uuid4())
+        span = {
+            "span_id": span_id,
+            "span_name": span_name,
+            "duration_ms": duration_ms,
+            "timestamp": time.time()
+        }
+        self.traces[trace_id]["spans"].append(span)
+        return span_id
+
+    def inject_context(self, trace_id: str, carrier: Dict[str, Any]) -> None:
+        """
+        Injects the trace context into a carrier (e.g., HTTP headers or JSON-RPC context)
+        to propagate it across distributed boundaries.
+
+        Args:
+            trace_id: The ID of the trace.
+            carrier: The dictionary to inject the context into.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        carrier["x-a2a-trace-id"] = trace_id
+        baggage = self.traces[trace_id].get("baggage", {})
+        if baggage:
+            carrier["x-a2a-baggage"] = json.dumps(baggage)
+
+    def extract_context(self, carrier: Dict[str, Any]) -> Optional[str]:
+        """
+        Extracts the trace context from a carrier.
+
+        Args:
+            carrier: The dictionary containing the context.
+
+        Returns:
+            The extracted trace ID if present, else None.
+        """
+        trace_id = carrier.get("x-a2a-trace-id")
+        return trace_id
+
+    def set_baggage(self, trace_id: str, key: str, value: Any) -> None:
+        """
+        Sets a baggage item for a trace, which will be propagated across services.
+
+        Args:
+            trace_id: The ID of the trace.
+            key: The baggage key.
+            value: The baggage value.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        self.traces[trace_id]["baggage"][key] = value
+
+    def get_baggage(self, trace_id: str, key: str) -> Optional[Any]:
+        """
+        Gets a baggage item for a trace.
+
+        Args:
+            trace_id: The ID of the trace.
+            key: The baggage key.
+
+        Returns:
+            The baggage value, or None if not found.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        return self.traces[trace_id]["baggage"].get(key)
+
+    def attach_delegated_task(self, trace_id: str, task_id: str) -> None:
+        """
+        Attaches an A2A delegated task to a trace for tracking.
+
+        Args:
+            trace_id: The ID of the trace.
+            task_id: The delegated task ID.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+        self.delegated_tasks[task_id] = trace_id
+
+    def get_trace_for_task(self, task_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Retrieves the trace associated with a specific delegated task.
+
+        Args:
+            task_id: The ID of the delegated task.
+
+        Returns:
+            The trace dictionary, or None if not found.
+        """
+        trace_id = self.delegated_tasks.get(task_id)
+        if not trace_id:
+            return None
+        return self.traces.get(trace_id)
+
+    def get_trace(self, trace_id: str) -> Dict[str, Any]:
+        """
+        Retrieves the details of a trace.
+
+        Args:
+            trace_id: The ID of the trace.
+
+        Returns:
+            A dictionary containing the trace details.
+
+        Raises:
+            KeyError: If the trace_id does not exist.
+        """
+        if trace_id not in self.traces:
+            raise KeyError(f"Trace ID {trace_id} not found.")
+
+        return self.traces[trace_id]
+
+    def export_traces(self) -> str:
+        """
+        Exports all traces as a JSON string.
+
+        Returns:
+            A JSON string representing all traces.
+        """
+        return json.dumps(self.traces)

--- a/tests/test_a2a_enterprise_v8.py
+++ b/tests/test_a2a_enterprise_v8.py
@@ -17,7 +17,8 @@ def test_delegate_task_securely_logs_and_manages_token() -> None:
 
     with patch("magda_agent.integration.a2a_enterprise_v8.A2AAuthTokenDelegation.generate_token") as mock_generate_token, \
          patch("magda_agent.integration.a2a_enterprise_v8.A2AAuthTokenDelegation.revoke_token") as mock_revoke_token, \
-         patch("magda_agent.integration.a2a_enterprise_v8.A2ATracingV4.securely_log_delegation_event") as mock_log_event:
+         patch("magda_agent.integration.a2a_enterprise_v8.A2ATracerV8.start_trace") as mock_log_event, \
+         patch("magda_agent.integration.a2a_enterprise_v8.A2ATracerV8.set_baggage") as mock_set_baggage:
 
         mock_generate_token.return_value = "mock_token_123"
         mock_log_event.return_value = "trace_abc123"
@@ -32,12 +33,9 @@ def test_delegate_task_securely_logs_and_manages_token() -> None:
         mock_generate_token.assert_called_once()
 
         # Verify secure logging was called with the correct parameters, including the token
-        mock_log_event.assert_called_once_with(
-            target_agent_id=target_agent_id,
-            capability=capability,
-            context=context,
-            token="mock_token_123"
-        )
+        mock_log_event.assert_called_once_with(f"delegate_to_{target_agent_id}")
+        mock_set_baggage.assert_any_call("trace_abc123", "capability", capability)
+        mock_set_baggage.assert_any_call("trace_abc123", "token", "mock_token_123")
 
         # Verify token was revoked after
         mock_revoke_token.assert_called_once_with("mock_token_123")
@@ -49,7 +47,8 @@ def test_delegate_task_with_real_auth_manager() -> None:
     auth_delegation = A2AAuthTokenDelegation()
     client = A2AEnterpriseClientV8(auth_delegation=auth_delegation)
 
-    with patch("magda_agent.integration.a2a_enterprise_v8.A2ATracingV4.securely_log_delegation_event") as mock_log_event:
+    with patch("magda_agent.integration.a2a_enterprise_v8.A2ATracerV8.start_trace") as mock_log_event, \
+         patch("magda_agent.integration.a2a_enterprise_v8.A2ATracerV8.set_baggage") as mock_set_baggage:
         mock_log_event.return_value = "trace_real_auth"
 
         # Execute
@@ -58,9 +57,10 @@ def test_delegate_task_with_real_auth_manager() -> None:
         # Assert trace id returned
         assert trace_id == "trace_real_auth"
 
-        # Assert the logger was called with a real token (starts with a2a_auth_)
-        called_args = mock_log_event.call_args[1]
-        token_used = called_args["token"]
+        # Assert the baggage setter was called with a real token
+        baggage_calls = mock_set_baggage.call_args_list
+        token_call = next(call for call in baggage_calls if call[0][1] == "token")
+        token_used = token_call[0][2]
         assert token_used.startswith("a2a_auth_")
 
         # The token should have been revoked, so it should not be active

--- a/tests/test_a2a_tracing_v8.py
+++ b/tests/test_a2a_tracing_v8.py
@@ -1,0 +1,109 @@
+import pytest
+import json
+from magda_agent.integration.a2a_tracing_v8 import A2ATracerV8
+
+def test_start_trace_sampled():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    assert trace_id in tracer.traces
+    assert tracer.traces[trace_id]["task_name"] == "test_task"
+    assert tracer.traces[trace_id]["parent_trace_id"] is None
+    assert tracer.traces[trace_id]["status"] == "in_progress"
+
+def test_start_trace_not_sampled():
+    tracer = A2ATracerV8(sample_rate=0.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is None
+
+def test_start_trace_not_sampled_with_parent():
+    tracer = A2ATracerV8(sample_rate=0.0)
+    # Even if sample rate is 0, if there's a parent, we want to trace it.
+    # We might have an explicit parent passed.
+    # But current implementation says `not self.should_sample() and not parent_trace_id` -> returns None
+    # So if there is a parent trace id, it should return a trace id.
+    trace_id = tracer.start_trace("test_task", parent_trace_id="parent_123")
+    assert trace_id is not None
+    assert tracer.traces[trace_id]["parent_trace_id"] == "parent_123"
+
+def test_end_trace():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    tracer.end_trace(trace_id, "success")
+    assert tracer.traces[trace_id]["status"] == "success"
+    assert tracer.traces[trace_id]["end_time"] is not None
+
+def test_end_trace_not_found():
+    tracer = A2ATracerV8()
+    with pytest.raises(KeyError):
+        tracer.end_trace("invalid_id")
+
+def test_add_span():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    span_id = tracer.add_span(trace_id, "db_query", 15.5)
+
+    assert len(tracer.traces[trace_id]["spans"]) == 1
+    span = tracer.traces[trace_id]["spans"][0]
+    assert span["span_id"] == span_id
+    assert span["span_name"] == "db_query"
+    assert span["duration_ms"] == 15.5
+
+def test_inject_context():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    tracer.set_baggage(trace_id, "user_id", "456")
+
+    carrier = {}
+    tracer.inject_context(trace_id, carrier)
+
+    assert carrier.get("x-a2a-trace-id") == trace_id
+    baggage_json = carrier.get("x-a2a-baggage")
+    assert baggage_json is not None
+    baggage = json.loads(baggage_json)
+    assert baggage.get("user_id") == "456"
+
+def test_extract_context():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    carrier = {"x-a2a-trace-id": "trace_999"}
+    extracted_id = tracer.extract_context(carrier)
+    assert extracted_id == "trace_999"
+
+def test_set_and_get_baggage():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    tracer.set_baggage(trace_id, "tenant_id", "t-123")
+
+    val = tracer.get_baggage(trace_id, "tenant_id")
+    assert val == "t-123"
+
+def test_attach_delegated_task():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    tracer.attach_delegated_task(trace_id, "task_001")
+
+    assert tracer.delegated_tasks["task_001"] == trace_id
+
+def test_get_trace_for_task():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    tracer.attach_delegated_task(trace_id, "task_001")
+
+    trace = tracer.get_trace_for_task("task_001")
+    assert trace is not None
+    assert trace["task_name"] == "test_task"
+
+def test_export_traces():
+    tracer = A2ATracerV8(sample_rate=1.0)
+    trace_id = tracer.start_trace("test_task")
+    assert trace_id is not None
+    exported = tracer.export_traces()
+    data = json.loads(exported)
+    assert trace_id in data
+    assert data[trace_id]["task_name"] == "test_task"


### PR DESCRIPTION
This PR addresses the `a2a-enterprise-tracing-v8` task by introducing enterprise-grade distributed tracing enhancements for A2A communications.

Key changes:
1. Created `A2ATracerV8` providing span tracking, probabilistic sampling (configurable `sample_rate`), and context injection/extraction to allow propagating trace IDs and metadata (baggage) across network boundaries.
2. Wired `A2ATracerV8` into `A2AEnterpriseClientV8`, replacing the older static v4 logging with proper trace lifecycle and baggage handling.
3. Added robust unit tests verifying both the tracing core and its integration within the enterprise client.
4. Appended three new trend-inspired tasks to `agent_tasks.json`:
   - OpenClaw RL Real-time Feedback Stream V1
   - MCP Server Context Propagation V1
   - A2A Mesh Network Resilience Heartbeat V1

---
*PR created automatically by Jules for task [1018135429376205796](https://jules.google.com/task/1018135429376205796) started by @kazah4359-lgtm*