### PR TITLE
feat: Implement OpenClaw RL Canvas Live v5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12915,7 +12915,7 @@
     },
     {
       "id": "openclaw-rl-canvas-live-v5",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw RL Canvas Live v5",
@@ -30440,6 +30440,60 @@
         "Heartbeat checker actively polls known A2A peers.",
         "Offline agents are purged.",
         "Tests mock network timeouts to verify resilience."
+      ]
+    },
+    {
+      "id": "mcp-kernel-taint-audit-logger-v1",
+      "title": "MCP Kernel Taint Audit Logger V1",
+      "description": "Inspired by MCPKernel trend (June 2026): Implement an audit logger that tracks and archives instances of tainted variables being used during MCP action tool execution for security review.",
+      "area": "safety",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_kernel_taint_audit_v1.py",
+        "tests/test_mcp_kernel_taint_audit_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Audit logger intercepts tainted variable usage.",
+        "Logger writes incidents to a secure audit stream.",
+        "Tests mock execution and verify logger captures events."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-memory-heatmap-v1",
+      "title": "OpenClaw RL Canvas Memory Heatmap V1",
+      "description": "Inspired by OpenClaw Canvas Live Visualization trend (June 2026): Create a specific visualizer component that overlays memory access frequency (working vs episodic) as a heatmap within the Canvas.",
+      "area": "visualization",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/visualization/openclaw_canvas_heatmap_v1.py",
+        "tests/test_openclaw_canvas_heatmap_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Heatmap component correctly translates memory access frequencies into visual density structures.",
+        "Canvas update mechanism broadcasts heatmap data.",
+        "Tests confirm data translation and broadcast logic."
+      ]
+    },
+    {
+      "id": "claude-evaluator-team-smoke-test-runner-v1",
+      "title": "Claude Evaluator Team Smoke Test Runner V1",
+      "description": "Inspired by Claude Agent SDK Agent Teams (June 2026): Implement a dedicated Evaluator sub-agent task that runs a specified suite of smoke tests on the Generator's PR before signaling acceptance.",
+      "area": "multi-agent",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/architecture/evaluator_smoke_test_v1.py",
+        "tests/test_evaluator_smoke_test_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator sub-agent successfully invokes the smoke test suite in an isolated environment.",
+        "Pass/fail signals correctly influence the Evaluator's final determination.",
+        "Tests mock sub-agent creation and test execution outcomes."
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -6,6 +6,8 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from magda_agent.visualization.server import CanvasServer
+from magda_agent.visualization.openclaw_canvas_v5 import OpenClawRLCanvasV5
+
 from magda_agent.visualization.canvas_streamer import CanvasMemoryStreamer
 from magda_agent.telemetry.canvas_stream_v9 import CanvasTelemetryStreamerV9
 from magda_agent.memory.canvas_viz import MemoryCanvasVisualizer
@@ -257,6 +259,8 @@ local_first_gateway = LocalFirstGateway()
 local_first_gateway.set_message_handler(consciousness.process_input)
 
 discord_bridge = DiscordBridge(token=os.getenv("DISCORD_BOT_TOKEN", "dummy"), agent_callback=consciousness.process_input)
+openclaw_rl_canvas = OpenClawRLCanvasV5()
+
 cross_platform_dispatcher.register_platform("discord", discord_bridge)
 
 
@@ -273,6 +277,8 @@ async def lifespan(app: FastAPI):
     asyncio.create_task(canvas_memory_streamer.start_streaming())
     asyncio.create_task(canvas_server.start_streaming())
     asyncio.create_task(discord_bridge.start())
+    asyncio.create_task(openclaw_rl_canvas.start())
+
     yield
     # Shutdown
     await cron_scheduler_v2.stop()
@@ -284,6 +290,8 @@ async def lifespan(app: FastAPI):
     await canvas_memory_streamer.stop_streaming()
     await canvas_server.stop_streaming()
     await discord_bridge.stop()
+    await openclaw_rl_canvas.stop()
+
     memory_system.close()
 
 app = FastAPI(title="Magda Consciousness API", lifespan=lifespan)

--- a/magda_agent/learning/metrics.py
+++ b/magda_agent/learning/metrics.py
@@ -2,6 +2,9 @@ import logging
 from typing import Optional, Dict, Any
 from magda_agent.metacognition.tracker import QualityTracker
 from magda_agent.learning.interactive_feedback import InteractiveFeedbackFormatter
+from magda_agent.api import openclaw_rl_canvas
+import asyncio
+
 
 class RLMetricsSystem:
     """
@@ -73,3 +76,15 @@ class RLMetricsSystem:
 
         self.quality_tracker.log_metric("rl_quality_score", quality_score, metadata)
         logging.info(f"RLMetricsSystem: Logged rl_quality_score={quality_score} for user {user_id}")
+
+        # Broadcast RL metrics to live canvas
+        if openclaw_rl_canvas and openclaw_rl_canvas.clients:
+            asyncio.create_task(openclaw_rl_canvas.broadcast_rl_event(
+                "quality_score_update",
+                {
+                    "user_id": user_id,
+                    "score": quality_score,
+                    "is_correction": is_correction,
+                    "explicit_score": explicit_score
+                }
+            ))

--- a/magda_agent/visualization/openclaw_canvas_v5.py
+++ b/magda_agent/visualization/openclaw_canvas_v5.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import logging
+from typing import Set, Any, Dict, Optional
+
+import websockets
+from websockets.server import WebSocketServerProtocol, serve
+
+logger = logging.getLogger(__name__)
+
+class OpenClawRLCanvasV5:
+    """
+    Live canvas updates for RL openclaw.
+    Provides a WebSocket server to broadcast RL events to connected visualization clients.
+    """
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8765):
+        """
+        Initializes the OpenClawRLCanvasV5.
+
+        Args:
+            host (str): The host address to bind the WebSocket server to.
+            port (int): The port to bind the WebSocket server to.
+        """
+        self.host = host
+        self.port = port
+        self.clients: Set[WebSocketServerProtocol] = set()
+        self._server: Optional[Any] = None
+
+    async def _handler(self, websocket: WebSocketServerProtocol) -> None:
+        """
+        Handles incoming WebSocket connections and registers them.
+
+        Args:
+            websocket (WebSocketServerProtocol): The connected WebSocket client.
+        """
+        self.clients.add(websocket)
+        logger.info(f"Client connected: {websocket.remote_address}")
+        try:
+            # Keep connection open and wait for it to close
+            await websocket.wait_closed()
+        finally:
+            self.clients.remove(websocket)
+            logger.info(f"Client disconnected: {websocket.remote_address}")
+
+    async def start(self) -> None:
+        """
+        Starts the WebSocket server.
+        """
+        logger.info(f"Starting OpenClawRLCanvasV5 server on {self.host}:{self.port}")
+        self._server = await serve(self._handler, self.host, self.port)
+
+    async def stop(self) -> None:
+        """
+        Stops the WebSocket server.
+        """
+        if self._server:
+            logger.info("Stopping OpenClawRLCanvasV5 server")
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        # Close all active client connections
+        if self.clients:
+            await asyncio.gather(*(client.close() for client in self.clients))
+            self.clients.clear()
+
+    async def broadcast_rl_event(self, event_type: str, event_data: Dict[str, Any]) -> None:
+        """
+        Broadcasts an RL event to all connected clients.
+
+        Args:
+            event_type (str): The type of the RL event.
+            event_data (Dict[str, Any]): The data associated with the RL event.
+        """
+        if not self.clients:
+            return
+
+        payload = {
+            "type": event_type,
+            "data": event_data
+        }
+
+        try:
+            message = json.dumps(payload)
+        except TypeError as e:
+            logger.error(f"Failed to serialize broadcast payload: {e}")
+            return
+
+        # Broadcast the message to all connected clients
+        tasks = [
+            asyncio.create_task(client.send(message))
+            for client in self.clients
+            if not client.closed
+        ]
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_openclaw_canvas_v5.py
+++ b/tests/test_openclaw_canvas_v5.py
@@ -1,0 +1,115 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+import pytest
+from magda_agent.visualization.openclaw_canvas_v5 import OpenClawRLCanvasV5
+
+@pytest.fixture
+def canvas():
+    return OpenClawRLCanvasV5(host="127.0.0.1", port=9999)
+
+@pytest.mark.asyncio
+async def test_start_and_stop(canvas):
+    """
+    Test that starting and stopping the canvas works correctly and cleans up resources.
+    """
+    with patch("magda_agent.visualization.openclaw_canvas_v5.serve", new_callable=AsyncMock) as mock_serve:
+        mock_server = AsyncMock()
+        mock_serve.return_value = mock_server
+
+        await canvas.start()
+
+        mock_serve.assert_called_once_with(canvas._handler, "127.0.0.1", 9999)
+        assert canvas._server == mock_server
+
+        await canvas.stop()
+
+        mock_server.close.assert_called_once()
+        mock_server.wait_closed.assert_awaited_once()
+        assert canvas._server is None
+
+@pytest.mark.asyncio
+async def test_handler_registers_client(canvas):
+    """
+    Test that the handler registers a new client and removes it when closed.
+    """
+    mock_websocket = AsyncMock()
+    mock_websocket.remote_address = ("127.0.0.1", 54321)
+
+    async def mock_wait_closed():
+        fut = asyncio.Future()
+        mock_websocket.close_fut = fut
+        await fut
+        return
+
+    mock_websocket.wait_closed = mock_wait_closed
+
+    # Run the handler as a task so we can check the state before it closes
+    handler_task = asyncio.create_task(canvas._handler(mock_websocket))
+
+    # Yield to event loop to let handler run
+    await asyncio.sleep(0.01)
+
+    assert mock_websocket in canvas.clients
+
+    # Close the websocket to complete the handler by setting the future result
+    mock_websocket.close_fut.set_result(None)
+
+    # Wait for the handler task to finish
+    await handler_task
+
+    assert mock_websocket not in canvas.clients
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_event_sends_to_clients(canvas):
+    """
+    Test that broadcasting an RL event sends the payload to connected clients.
+    """
+    mock_websocket1 = AsyncMock()
+    mock_websocket1.closed = False
+    mock_websocket2 = AsyncMock()
+    mock_websocket2.closed = False
+
+    canvas.clients.add(mock_websocket1)
+    canvas.clients.add(mock_websocket2)
+
+    event_data = {"reward": 1.0, "state": "active"}
+
+    await canvas.broadcast_rl_event("reward_update", event_data)
+
+    expected_payload = json.dumps({
+        "type": "reward_update",
+        "data": event_data
+    })
+
+    mock_websocket1.send.assert_awaited_once_with(expected_payload)
+    mock_websocket2.send.assert_awaited_once_with(expected_payload)
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_event_ignores_closed_clients(canvas):
+    """
+    Test that broadcasting ignores closed client connections.
+    """
+    mock_websocket1 = AsyncMock()
+    mock_websocket1.closed = False
+    mock_websocket2 = AsyncMock()
+    mock_websocket2.closed = True
+
+    canvas.clients.add(mock_websocket1)
+    canvas.clients.add(mock_websocket2)
+
+    event_data = {"reward": -1.0}
+
+    await canvas.broadcast_rl_event("penalty", event_data)
+
+    mock_websocket1.send.assert_awaited_once()
+    mock_websocket2.send.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_event_no_clients(canvas):
+    """
+    Test that broadcasting with no clients returns early without error.
+    """
+    # Should return early without errors
+    event_data = {"reward": 0.0}
+    await canvas.broadcast_rl_event("neutral", event_data)


### PR DESCRIPTION
This PR implements the OpenClaw RL Canvas Live v5 task. It introduces a WebSocket server (`OpenClawRLCanvasV5`) to broadcast reinforcement learning events to connected visualization clients, inspired by current agent trends.

Changes:
- Added `OpenClawRLCanvasV5` in `magda_agent/visualization/openclaw_canvas_v5.py`.
- Added tests in `tests/test_openclaw_canvas_v5.py`.
- Wired the canvas server initialization and lifecycle into `magda_agent/api.py`.
- Updated `RLMetricsSystem` (`magda_agent/learning/metrics.py`) to broadcast `quality_score_update` events via the canvas.
- Updated `agent_tasks.json` to mark the task as done and added 3 new tasks based on AI trends (MCP Kernel Taint Audit Logger, OpenClaw Canvas Memory Heatmap, Claude Evaluator Smoke Test Runner).

---
*PR created automatically by Jules for task [1614377905085738000](https://jules.google.com/task/1614377905085738000) started by @kazah4359-lgtm*