### PR TITLE
feat(safety): Implement ACS State Transition Checkpoint V5

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12932,7 +12932,7 @@
     },
     {
       "id": "acs-state-transition-checkpoint-v5-1",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "ACS State Transition Checkpoint V5",
@@ -30494,6 +30494,58 @@
         "Evaluator sub-agent successfully invokes the smoke test suite in an isolated environment.",
         "Pass/fail signals correctly influence the Evaluator's final determination.",
         "Tests mock sub-agent creation and test execution outcomes."
+      ]
+    },
+    {
+      "id": "openclaw-rl-swarm-multi-agent-v1",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "OpenClaw RL Swarm Multi-Agent V1",
+      "description": "Inspired by OpenClaw-RL (June 2026): Implement multi-agent swarm architecture utilizing RL for task delegation and dynamic role assignment across swarm agents.",
+      "allowed_paths": [
+        "magda_agent/architecture/openclaw_rl_swarm_v1.py",
+        "tests/test_openclaw_rl_swarm_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Swarm architecture module added using RL for delegation.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-git-worktree-isolation-v2",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "Claude Git Worktree Isolation V2",
+      "description": "Inspired by Claude Agent SDK Agent Teams (June 2026): Implement strict Git worktree isolation for sub-agent workspaces to prevent cross-contamination.",
+      "allowed_paths": [
+        "magda_agent/safety/claude_git_worktree_v2.py",
+        "tests/test_claude_git_worktree_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Git worktree isolation logic implemented for subagents.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-persistent-logging-audit-v1",
+      "status": "todo",
+      "area": "safety",
+      "risk": "low",
+      "title": "MCP Persistent Logging Audit V1",
+      "description": "Inspired by MCP standards (June 2026): Add persistent logging and auditing of all MCP tool executions with cryptographic signing of logs.",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_persistent_logging_v1.py",
+        "tests/test_mcp_persistent_logging_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Persistent logging for MCP actions implemented.",
+        "Logs are signed correctly.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/safety/acs_guard_v5.py
+++ b/magda_agent/safety/acs_guard_v5.py
@@ -103,6 +103,11 @@ class ACSGuardV5:
         return guard.evaluate(workflow_data)
 
     def checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        from magda_agent.safety.acs_state_transition_v5 import ACSStateTransitionV5
+        guard = ACSStateTransitionV5()
+        return guard.checkpoint_4_state_transition(workflow_data)
+
+    def _old_checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Checkpoint 4: State Transition.
         Ensures the proposed state transition is valid within the cognitive architecture.

--- a/magda_agent/safety/acs_guard_v6.py
+++ b/magda_agent/safety/acs_guard_v6.py
@@ -116,6 +116,11 @@ class ACSGuardV6:
         return True, "Tool policy passed."
 
     def checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        from magda_agent.safety.acs_state_transition_v5 import ACSStateTransitionV5
+        guard = ACSStateTransitionV5()
+        return guard.checkpoint_4_state_transition(workflow_data)
+
+    def _old_checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
         """
         Checkpoint 4: State Transition.
         Ensures the proposed state transition is valid within the cognitive architecture.

--- a/magda_agent/safety/acs_state_transition_v5.py
+++ b/magda_agent/safety/acs_state_transition_v5.py
@@ -1,0 +1,42 @@
+from typing import Dict, Any, Tuple
+
+class ACSStateTransitionV5:
+    """
+    Microsoft ACS state transition guardrail V5.
+    Implements checkpoint 4 to validate state transitions within the cognitive architecture.
+    """
+
+    def checkpoint_4_state_transition(self, workflow_data: Dict[str, Any]) -> Tuple[bool, str]:
+        """
+        Checkpoint 4: State Transition.
+        Ensures the proposed state transition is valid within the cognitive architecture.
+
+        Args:
+            workflow_data: A dictionary containing 'current_state' and 'next_state'.
+
+        Returns:
+            A tuple containing a boolean indicating if the transition is allowed, and a string explanation.
+        """
+        current_state = workflow_data.get("current_state", "idle")
+        next_state = workflow_data.get("next_state")
+
+        if not next_state:
+            return True, "State transition passed: next_state not provided."
+
+        allowed_transitions = {
+            "idle": ["planning", "reflecting", "analyzing", "executing"],
+            "planning": ["executing", "idle"],
+            "executing": ["evaluating", "idle"],
+            "evaluating": ["idle", "planning"],
+            "reflecting": ["idle"],
+            "analyzing": ["idle", "planning"],
+            "error": ["idle"]
+        }
+
+        if current_state not in allowed_transitions:
+            return False, f"State transition failed: unknown current_state '{current_state}'."
+
+        if next_state not in allowed_transitions[current_state] and next_state != "error":
+            return False, f"State transition failed: cannot transition from '{current_state}' to '{next_state}'."
+
+        return True, "State transition passed."

--- a/tests/test_acs_state_transition_v5.py
+++ b/tests/test_acs_state_transition_v5.py
@@ -1,0 +1,51 @@
+import pytest
+from magda_agent.safety.acs_state_transition_v5 import ACSStateTransitionV5
+
+def test_checkpoint_4_state_transition_no_next_state():
+    """Test that transition is allowed when next_state is not provided."""
+    guardrail = ACSStateTransitionV5()
+    workflow_data = {"current_state": "idle"}
+    passed, reason = guardrail.checkpoint_4_state_transition(workflow_data)
+    assert passed is True
+    assert "not provided" in reason
+
+def test_checkpoint_4_state_transition_valid_transition():
+    """Test that a valid transition is allowed."""
+    guardrail = ACSStateTransitionV5()
+    workflow_data = {"current_state": "idle", "next_state": "planning"}
+    passed, reason = guardrail.checkpoint_4_state_transition(workflow_data)
+    assert passed is True
+    assert reason == "State transition passed."
+
+def test_checkpoint_4_state_transition_valid_error_transition():
+    """Test that transition to error state is allowed from any known state."""
+    guardrail = ACSStateTransitionV5()
+    workflow_data = {"current_state": "planning", "next_state": "error"}
+    passed, reason = guardrail.checkpoint_4_state_transition(workflow_data)
+    assert passed is True
+    assert reason == "State transition passed."
+
+def test_checkpoint_4_state_transition_invalid_transition():
+    """Test that an invalid transition is blocked."""
+    guardrail = ACSStateTransitionV5()
+    workflow_data = {"current_state": "reflecting", "next_state": "executing"}
+    passed, reason = guardrail.checkpoint_4_state_transition(workflow_data)
+    assert passed is False
+    assert "cannot transition" in reason
+
+def test_checkpoint_4_state_transition_unknown_current_state():
+    """Test that an unknown current_state is blocked."""
+    guardrail = ACSStateTransitionV5()
+    workflow_data = {"current_state": "unknown_state", "next_state": "idle"}
+    passed, reason = guardrail.checkpoint_4_state_transition(workflow_data)
+    assert passed is False
+    assert "unknown current_state" in reason
+
+def test_checkpoint_4_state_transition_default_current_state():
+    """Test that default current_state 'idle' is correctly handled."""
+    guardrail = ACSStateTransitionV5()
+    # Missing current_state implies "idle"
+    workflow_data = {"next_state": "planning"}
+    passed, reason = guardrail.checkpoint_4_state_transition(workflow_data)
+    assert passed is True
+    assert reason == "State transition passed."


### PR DESCRIPTION
This pull request implements the Microsoft ACS state transition guardrail V5 (checkpoint 4) as defined in task `acs-state-transition-checkpoint-v5-1`.

Changes include:
- Creating `ACSStateTransitionV5` to validate transitions such as "idle" -> "planning".
- Updating the ACSGuard classes (`v5` and `v6`) to utilize the new class via local imports to avoid circular dependencies while retaining the old implementations temporarily for fallback reference.
- Implementing extensive `pytest` testing for the new guardrail functionality.
- Resolving the task in `agent_tasks.json` and adding three new tasks based on AI agent trends (OpenClaw RL Swarm, Claude Worktree Isolation, and MCP Persistent Logging).

---
*PR created automatically by Jules for task [2981427336945363236](https://jules.google.com/task/2981427336945363236) started by @kazah4359-lgtm*