### PR TITLE
feat(visualization): add openclaw semantic memory canvas v2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12948,7 +12948,7 @@
     },
     {
       "id": "openclaw-semantic-memory-canvas-v2-1",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw Semantic Memory Canvas V2",
@@ -30546,6 +30546,63 @@
         "Persistent logging for MCP actions implemented.",
         "Logs are signed correctly.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-tool-registry-1",
+      "title": "MCP Dynamic Tool Registry Support",
+      "status": "todo",
+      "description": "Implement an MCP server-prefixed tool registry in the Cognitive Architecture, inspired by OpenAI Agents SDK, allowing runtime function tool concurrency.",
+      "area": "skills",
+      "risk": "medium",
+      "assigned_to": "codex-worker",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_dynamic_registry.py",
+        "tests/test_mcp_dynamic_registry.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A registry that dynamically loads MCP tools and routes them with a server prefix.",
+        "Supports runtime concurrency using asyncio.",
+        "Passes pytest validations with mocked MCP tool responses."
+      ]
+    },
+    {
+      "id": "claude-context-compression-v7-1",
+      "title": "Claude Context Compressor V7",
+      "status": "todo",
+      "description": "Create a new ClaudeContextCompressorV7 that builds on V6 but introduces 'Selective Retrieval V3' for better clustering of semantic context before summarization.",
+      "area": "memory",
+      "risk": "medium",
+      "assigned_to": "codex-worker",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v7.py",
+        "tests/test_compression_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Implements ClaudeContextCompressorV7 with enhanced clustering logic.",
+        "Truncates/summarizes older context while keeping recent intact.",
+        "pytest suite using mocked LLMClient verifies compression thresholds."
+      ]
+    },
+    {
+      "id": "acs-guardrail-checkpoint-2",
+      "title": "ACS Guardrail Checkpoint 2 (State Validation)",
+      "status": "todo",
+      "description": "Implement Agent Control Specification (ACS) checkpoint 2 for runtime state validation during task execution, adhering to 2026 AI Agent trends.",
+      "area": "safety",
+      "risk": "high",
+      "assigned_to": "codex-worker",
+      "allowed_paths": [
+        "magda_agent/safety/acs_guard_v6.py",
+        "tests/test_acs_guard_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "ACSGuardV6 implements checkpoint 2 (state validation).",
+        "Validates current and proposed states against allowed workflow transitions.",
+        "Unit tests confirm transitions are blocked when invalid."
       ]
     }
   ]

--- a/magda_agent/visualization/openclaw_semantic_canvas_v2.py
+++ b/magda_agent/visualization/openclaw_semantic_canvas_v2.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import logging
+from typing import Set, Any, Dict, Optional
+
+import websockets
+from websockets.server import WebSocketServerProtocol, serve
+
+logger = logging.getLogger(__name__)
+
+class OpenClawSemanticCanvasV2:
+    """
+    Live canvas updates for Semantic Memory.
+    Provides a WebSocket server to broadcast semantic memory events to connected visualization clients.
+    """
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8766):
+        """
+        Initializes the OpenClawSemanticCanvasV2.
+
+        Args:
+            host (str): The host address to bind the WebSocket server to.
+            port (int): The port to bind the WebSocket server to. Default 8766.
+        """
+        self.host = host
+        self.port = port
+        self.clients: Set[WebSocketServerProtocol] = set()
+        self._server: Optional[Any] = None
+
+    async def _handler(self, websocket: WebSocketServerProtocol) -> None:
+        """
+        Handles incoming WebSocket connections and registers them.
+
+        Args:
+            websocket (WebSocketServerProtocol): The connected WebSocket client.
+        """
+        self.clients.add(websocket)
+        logger.info(f"Client connected: {websocket.remote_address}")
+        try:
+            # Keep connection open and wait for it to close
+            await websocket.wait_closed()
+        finally:
+            self.clients.remove(websocket)
+            logger.info(f"Client disconnected: {websocket.remote_address}")
+
+    async def start(self) -> None:
+        """
+        Starts the WebSocket server.
+        """
+        logger.info(f"Starting OpenClawSemanticCanvasV2 server on {self.host}:{self.port}")
+        self._server = await serve(self._handler, self.host, self.port)
+
+    async def stop(self) -> None:
+        """
+        Stops the WebSocket server.
+        """
+        if self._server:
+            logger.info("Stopping OpenClawSemanticCanvasV2 server")
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        # Close all active client connections
+        if self.clients:
+            await asyncio.gather(*(client.close() for client in self.clients))
+            self.clients.clear()
+
+    async def broadcast_semantic_event(self, event_type: str, event_data: Dict[str, Any]) -> None:
+        """
+        Broadcasts a semantic memory event to all connected clients.
+
+        Args:
+            event_type (str): The type of the semantic memory event (e.g., 'concept_added', 'relation_updated').
+            event_data (Dict[str, Any]): The data associated with the event.
+        """
+        if not self.clients:
+            return
+
+        payload = {
+            "type": event_type,
+            "data": event_data
+        }
+
+        try:
+            message = json.dumps(payload)
+        except TypeError as e:
+            logger.error(f"Failed to serialize broadcast payload: {e}")
+            return
+
+        # Broadcast the message to all connected clients
+        tasks = [
+            asyncio.create_task(client.send(message))
+            for client in self.clients
+            if not client.closed
+        ]
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_openclaw_semantic_canvas_v2.py
+++ b/tests/test_openclaw_semantic_canvas_v2.py
@@ -1,0 +1,93 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from magda_agent.visualization.openclaw_semantic_canvas_v2 import OpenClawSemanticCanvasV2
+
+@pytest.fixture
+def canvas() -> OpenClawSemanticCanvasV2:
+    return OpenClawSemanticCanvasV2(host="127.0.0.1", port=8766)
+
+@pytest.mark.asyncio
+async def test_canvas_handler_adds_removes_clients(canvas: OpenClawSemanticCanvasV2) -> None:
+    mock_websocket = AsyncMock()
+    mock_websocket.remote_address = ("127.0.0.1", 12345)
+
+    # Run the handler but control wait_closed execution
+    future = asyncio.Future()
+
+    async def wait_closed_impl():
+        assert mock_websocket in canvas.clients
+        future.set_result(True)
+        return None
+
+    mock_websocket.wait_closed.side_effect = wait_closed_impl
+
+    await canvas._handler(mock_websocket)
+
+    assert future.done()
+    assert mock_websocket not in canvas.clients
+
+import json
+
+@pytest.mark.asyncio
+async def test_canvas_start_stop(canvas: OpenClawSemanticCanvasV2) -> None:
+    with patch("magda_agent.visualization.openclaw_semantic_canvas_v2.serve", new_callable=AsyncMock) as mock_serve:
+        mock_server = MagicMock()
+        mock_server.wait_closed = AsyncMock()
+        mock_serve.return_value = mock_server
+
+        await canvas.start()
+        mock_serve.assert_called_once_with(canvas._handler, "127.0.0.1", 8766)
+
+        await canvas.stop()
+        mock_server.close.assert_called_once()
+        mock_server.wait_closed.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_broadcast_semantic_event_no_clients(canvas: OpenClawSemanticCanvasV2) -> None:
+    await canvas.broadcast_semantic_event("test_event", {"key": "value"})
+
+@pytest.mark.asyncio
+async def test_broadcast_semantic_event_with_clients(canvas: OpenClawSemanticCanvasV2) -> None:
+    mock_client1 = AsyncMock()
+    mock_client1.closed = False
+    mock_client2 = AsyncMock()
+    mock_client2.closed = False
+
+    canvas.clients.add(mock_client1)
+    canvas.clients.add(mock_client2)
+
+    event_type = "concept_added"
+    event_data = {"concept": "agent", "confidence": 0.9}
+
+    await canvas.broadcast_semantic_event(event_type, event_data)
+
+    expected_message = json.dumps({"type": event_type, "data": event_data})
+
+    mock_client1.send.assert_awaited_once_with(expected_message)
+    mock_client2.send.assert_awaited_once_with(expected_message)
+
+@pytest.mark.asyncio
+async def test_broadcast_semantic_event_serialization_error(canvas: OpenClawSemanticCanvasV2) -> None:
+    mock_client = AsyncMock()
+    mock_client.closed = False
+    canvas.clients.add(mock_client)
+
+    class UnserializableObject:
+        pass
+
+    await canvas.broadcast_semantic_event("test", {"obj": UnserializableObject()})
+
+    mock_client.send.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_stop_closes_active_clients(canvas: OpenClawSemanticCanvasV2) -> None:
+    mock_client = AsyncMock()
+    canvas.clients.add(mock_client)
+
+    with patch("magda_agent.visualization.openclaw_semantic_canvas_v2.serve", new_callable=AsyncMock):
+        await canvas.stop()
+
+    mock_client.close.assert_awaited_once()
+    assert len(canvas.clients) == 0


### PR DESCRIPTION
- Adds `OpenClawSemanticCanvasV2` class in `magda_agent/visualization/openclaw_semantic_canvas_v2.py`.
- Adds comprehensive unit tests using pytest and AsyncMock in `tests/test_openclaw_semantic_canvas_v2.py`.
- Updates `agent_tasks.json` by marking task `openclaw-semantic-memory-canvas-v2-1` as done.
- Follows the instructions strictly by appending 3 new actionable, trend-based todo tasks using `acceptance` field format to ensure `scripts/validate_agent_tasks.py` validation passes.

---
*PR created automatically by Jules for task [9414784857143444072](https://jules.google.com/task/9414784857143444072) started by @kazah4359-lgtm*