### PR TITLE
Implement claude-context-compression-v7 and append new trend tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12981,7 +12981,7 @@
     },
     {
       "id": "claude-context-compression-v7",
-      "status": "todo",
+      "status": "done",
       "area": "memory",
       "risk": "medium",
       "title": "Claude Context Compression v7",
@@ -30689,6 +30689,57 @@
       "acceptance": [
         "Swarm architecture module supports hierarchical delegation.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-server-streaming-export-v2",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Server Streaming Export v2",
+      "description": "Inspired by MCP standard trend (June 2026): Implement an MCP tool exporter that supports JSON-RPC streaming, enabling Magda to yield progressive results for long-running tools.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_streaming_v2.py",
+        "tests/test_mcp_streaming_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter formats Python yields into MCP streaming chunks.",
+        "Tests verify chunk buffering."
+      ]
+    },
+    {
+      "id": "a2a-mesh-network-telemetry-v1",
+      "status": "todo",
+      "area": "telemetry",
+      "risk": "low",
+      "title": "A2A Mesh Network Telemetry V1",
+      "description": "Inspired by A2A Protocol tracing (June 2026): Implement an OpenTelemetry-compatible module to collect distributed metrics across the A2A mesh network.",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_mesh_telemetry_v1.py",
+        "tests/test_a2a_mesh_telemetry_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module collects overhead and communication metrics.",
+        "Tests mock OpenTelemetry sinks and verify formatting."
+      ]
+    },
+    {
+      "id": "openclaw-rl-interaction-pruning-v4",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Interaction Pruning V4",
+      "description": "Inspired by OpenClaw RL patterns (June 2026): Add a mechanism to dynamically prune low-reward conversational trajectories from active context to optimize context engine.",
+      "allowed_paths": [
+        "magda_agent/learning/interaction_pruning_v4.py",
+        "tests/test_interaction_pruning_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Prunes context trajectories with cumulative reward below threshold.",
+        "Tests verify context memory shrinking based on mocked rewards."
       ]
     }
   ]

--- a/magda_agent/memory/compression_v7.py
+++ b/magda_agent/memory/compression_v7.py
@@ -67,14 +67,11 @@ class ClaudeContextCompressorV7:
             try:
                 logging.info(f"Compressing {len(pruned_entries)} entries with semantic context.")
                 prompt = (
+                    f"You are a memory context compressor. Output only the summarized text. "
                     f"Summarize the following memory context, maintaining key facts and semantic relationships "
                     f"within {token_limit} tokens.\n\n{combined_text}"
                 )
-                messages = [
-                    {"role": "system", "content": "You are a memory context compressor. Output only the summarized text."},
-                    {"role": "user", "content": prompt}
-                ]
-                compressed_text = await self.llm.chat_completion(messages, temperature=0.2)
+                compressed_text = await self.llm.generate(prompt, temperature=0.2)
                 compressed_text = compressed_text.strip()
             except Exception as e:
                 logging.error(f"Compression failed: {e}")

--- a/tests/test_compression_v7.py
+++ b/tests/test_compression_v7.py
@@ -4,22 +4,20 @@ from typing import List, Dict, Any, Optional
 from magda_agent.memory.compression_v7 import ClaudeContextCompressorV7
 from magda_agent.memory.working import MemoryEntry
 from magda_agent.emotions.engine import PADState
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, patch
 
-class MockLLMClientV7:
-    """Mock LLM client for testing V7 compression without real API calls."""
-    async def chat_completion(self, messages: List[Dict[str, Any]], temperature: float = 0.0) -> str:
-        """Mocks the chat completion endpoint."""
-        for msg in messages:
-            if "Summarize the following memory context" in msg.get("content", ""):
-                return "V7 Compressed summary."
-        return "V7 fallback summary."
-
+def llm_generate_side_effect(prompt, temperature=0.0):
+    if "Summarize the following memory context" in prompt:
+        return "V7 Compressed summary."
+    return "V7 fallback summary."
 
 @pytest.mark.asyncio
-async def test_v7_compress_entries_with_retrieval() -> None:
+@patch('magda_agent.llm_client.LLMClient.generate', new_callable=AsyncMock)
+async def test_v7_compress_entries_with_retrieval(mock_generate) -> None:
     """Tests that entries exceeding the limit are first pruned by the retriever and then compressed via LLM."""
-    llm = MockLLMClientV7()
+    mock_generate.side_effect = llm_generate_side_effect
+    from magda_agent.llm_client import LLMClient
+    llm = LLMClient()
 
     mock_retriever = AsyncMock()
     # Mock retriever to prune the entries down to a smaller set
@@ -48,9 +46,12 @@ async def test_v7_compress_entries_with_retrieval() -> None:
     mock_retriever.prune_context.assert_called_once_with([e1, e2], max_tokens=5, query="architecture")
 
 @pytest.mark.asyncio
-async def test_v7_compress_entries_without_retrieval() -> None:
+@patch('magda_agent.llm_client.LLMClient.generate', new_callable=AsyncMock)
+async def test_v7_compress_entries_without_retrieval(mock_generate) -> None:
     """Tests that entries are compressed properly when no retriever is provided."""
-    llm = MockLLMClientV7()
+    mock_generate.side_effect = llm_generate_side_effect
+    from magda_agent.llm_client import LLMClient
+    llm = LLMClient()
 
     compressor = ClaudeContextCompressorV7(llm_client=llm)
     state = PADState(0, 0, 0)
@@ -67,9 +68,12 @@ async def test_v7_compress_entries_without_retrieval() -> None:
 
 
 @pytest.mark.asyncio
-async def test_v7_compress_entries_within_limit() -> None:
+@patch('magda_agent.llm_client.LLMClient.generate', new_callable=AsyncMock)
+async def test_v7_compress_entries_within_limit(mock_generate) -> None:
     """Tests that entries within the limit are not unnecessarily summarized via LLM if they fit."""
-    llm = MockLLMClientV7()
+    mock_generate.side_effect = llm_generate_side_effect
+    from magda_agent.llm_client import LLMClient
+    llm = LLMClient()
 
     mock_retriever = AsyncMock()
     state = PADState(0, 0, 0)


### PR DESCRIPTION
Implement `claude-context-compression-v7` from `agent_tasks.json`:
- Mark task as `done`.
- Append three new concrete action-oriented tasks inspired by `docs/trends.md`.
- Fix `magda_agent/memory/compression_v7.py` to use `LLMClient.generate()` rather than `.chat_completion()` as it doesn't support system prompts.
- Refactor `tests/test_compression_v7.py` to dynamically use `@patch` for mocking LLM calls.
- Run full suite of tests to prevent regressions.

---
*PR created automatically by Jules for task [14285260811101116294](https://jules.google.com/task/14285260811101116294) started by @kazah4359-lgtm*