### PR TITLE
feat: implement OpenClaw Semantic Memory Canvas v3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -12998,7 +12998,7 @@
     },
     {
       "id": "openclaw-semantic-memory-canvas-v3",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw Semantic Memory Canvas v3",
@@ -30740,6 +30740,57 @@
       "acceptance": [
         "Prunes context trajectories with cumulative reward below threshold.",
         "Tests verify context memory shrinking based on mocked rewards."
+      ]
+    },
+    {
+      "id": "a2a-enterprise-telemetry-metrics-v1",
+      "title": "A2A Enterprise Telemetry Metrics V1",
+      "description": "Inspired by A2A Protocol and enterprise tracing trends: Implement an enterprise-grade telemetry metrics module that aggregates cross-agent execution times and payload sizes, emitting them to a mock Prometheus sink.",
+      "area": "telemetry",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/telemetry/a2a_metrics_v1.py",
+        "tests/test_a2a_metrics_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Telemetry module aggregates mock payload sizes and times correctly.",
+        "Tests mock the metrics sink and verify data formatting."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-security-policy-v1",
+      "title": "MCP Action Tool Security Policy V1",
+      "description": "Inspired by MCP standards (action tools) and ACS: Create a security policy validator for incoming MCP action tools that blocks tools with unrecognized schema keys or missing security headers.",
+      "area": "safety",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_security_policy_v1.py",
+        "tests/test_mcp_security_policy_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Security policy validator blocks tools failing criteria.",
+        "Tests verify block and allow behavior using mock MCP tools."
+      ]
+    },
+    {
+      "id": "openclaw-rl-implicit-context-scoring-v1",
+      "title": "OpenClaw RL Implicit Context Scoring V1",
+      "description": "Inspired by OpenClaw RL and Context Engine trends: Add a background scorer that uses implicit user engagement signals (like follow-up prompt frequency) to weight active context chunks, aiding in selective retention.",
+      "area": "learning",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/learning/implicit_context_scorer_v1.py",
+        "tests/test_implicit_context_scorer_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Scorer calculates and assigns weights to active context chunks.",
+        "Tests mock interaction frequencies to verify weight adjustments."
       ]
     }
   ]

--- a/magda_agent/visualization/canvas_api_v3.py
+++ b/magda_agent/visualization/canvas_api_v3.py
@@ -1,0 +1,78 @@
+"""
+Canvas API v3
+
+Implements API endpoints for streaming the OpenClaw Semantic Memory Canvas state.
+"""
+
+import logging
+from typing import List, Optional
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+class SemanticCanvasServerV3:
+    """
+    WebSocket server for streaming live visualization of semantic memory relations.
+    """
+    def __init__(self):
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """Accept a websocket connection and add it to the active pool."""
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info(f"Semantic canvas client connected. Total clients: {len(self.active_connections)}")
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        """Remove a websocket connection from the pool."""
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+            logger.info(f"Semantic canvas client disconnected. Total clients: {len(self.active_connections)}")
+
+    async def broadcast_semantic_state(self, state_json: str) -> None:
+        """Broadcast a semantic state message to all active websocket connections."""
+        disconnected = []
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(state_json)
+            except Exception as e:
+                logger.error(f"Failed to send semantic state to canvas client: {e}")
+                disconnected.append(connection)
+
+        for conn in disconnected:
+            self.disconnect(conn)
+
+def get_canvas_v3_router(canvas_server: SemanticCanvasServerV3, token: Optional[str] = None) -> APIRouter:
+    """
+    Returns an APIRouter providing endpoints for live semantic canvas streaming.
+
+    Args:
+        canvas_server (SemanticCanvasServerV3): The initialized canvas server that broadcasts states.
+        token (Optional[str]): Optional auth token for basic websocket authentication.
+
+    Returns:
+        APIRouter: The FastAPI router containing canvas V3 endpoints.
+    """
+    router = APIRouter(prefix="/api/v3/canvas", tags=["Canvas V3 Semantic"])
+
+    @router.websocket("/semantic-stream")
+    async def stream_canvas_v3_semantic(websocket: WebSocket, auth_token: Optional[str] = None) -> None:
+        """
+        WebSocket endpoint for streaming semantic memory updates to connected clients.
+        """
+        if token and auth_token != token:
+            await websocket.close(code=1008)
+            return
+
+        await canvas_server.connect(websocket)
+        try:
+            while True:
+                # Keep the connection open and wait for client messages
+                _data = await websocket.receive_text()
+        except WebSocketDisconnect:
+            canvas_server.disconnect(websocket)
+        except Exception as e:
+            logger.error(f"Semantic canvas stream error: {e}")
+            canvas_server.disconnect(websocket)
+
+    return router

--- a/tests/test_canvas_api_v3.py
+++ b/tests/test_canvas_api_v3.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import WebSocket, WebSocketDisconnect
+
+from magda_agent.visualization.canvas_api_v3 import SemanticCanvasServerV3, get_canvas_v3_router
+
+@pytest.mark.asyncio
+async def test_semantic_canvas_stream_success() -> None:
+    """Tests successful semantic canvas websocket stream connection and message parsing."""
+    mock_canvas_server = MagicMock(spec=SemanticCanvasServerV3)
+    mock_canvas_server.connect = AsyncMock()
+    mock_canvas_server.disconnect = MagicMock()
+
+    router = get_canvas_v3_router(mock_canvas_server, token="secret")
+
+    # Extract the route function directly
+    stream_func = router.routes[0].endpoint
+
+    mock_ws = AsyncMock(spec=WebSocket)
+    # Simulate receiving text once, then disconnecting
+    mock_ws.receive_text.side_effect = [ "ping", WebSocketDisconnect() ]
+
+    await stream_func(mock_ws, auth_token="secret")
+
+    mock_canvas_server.connect.assert_awaited_once_with(mock_ws)
+    mock_canvas_server.disconnect.assert_called_once_with(mock_ws)
+
+@pytest.mark.asyncio
+async def test_semantic_canvas_stream_unauthorized() -> None:
+    """Tests unauthorized connection closing with code 1008."""
+    mock_canvas_server = MagicMock(spec=SemanticCanvasServerV3)
+    mock_canvas_server.connect = AsyncMock()
+
+    router = get_canvas_v3_router(mock_canvas_server, token="secret")
+    stream_func = router.routes[0].endpoint
+
+    mock_ws = AsyncMock(spec=WebSocket)
+
+    await stream_func(mock_ws, auth_token="wrong")
+
+    mock_ws.close.assert_awaited_once_with(code=1008)
+    mock_canvas_server.connect.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_semantic_canvas_server_methods() -> None:
+    """Tests SemanticCanvasServerV3 connect, disconnect, and broadcast."""
+    server = SemanticCanvasServerV3()
+    mock_ws = AsyncMock(spec=WebSocket)
+
+    await server.connect(mock_ws)
+    assert mock_ws in server.active_connections
+    mock_ws.accept.assert_awaited_once()
+
+    await server.broadcast_semantic_state('{"test":"data"}')
+    mock_ws.send_text.assert_awaited_once_with('{"test":"data"}')
+
+    server.disconnect(mock_ws)
+    assert mock_ws not in server.active_connections
+
+@pytest.mark.asyncio
+async def test_semantic_canvas_server_broadcast_disconnect() -> None:
+    """Tests SemanticCanvasServerV3 disconnects client on broadcast error."""
+    server = SemanticCanvasServerV3()
+    mock_ws = AsyncMock(spec=WebSocket)
+    mock_ws.send_text.side_effect = Exception("Broadcast failed")
+
+    await server.connect(mock_ws)
+    assert mock_ws in server.active_connections
+
+    await server.broadcast_semantic_state('{"test":"data"}')
+
+    # Client should be disconnected due to exception
+    assert mock_ws not in server.active_connections


### PR DESCRIPTION
Implements task `openclaw-semantic-memory-canvas-v3` by adding a FastAPI router with a websocket endpoint capable of streaming semantic memory contexts visually. Includes full test coverage and adds three new forward-looking AI trend tasks to the agent tasks manifest.

---
*PR created automatically by Jules for task [16689156512464399241](https://jules.google.com/task/16689156512464399241) started by @kazah4359-lgtm*