### PR TITLE
feat: MCP Dynamic Tool Registry Support

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -30551,7 +30551,7 @@
     {
       "id": "mcp-dynamic-tool-registry-1",
       "title": "MCP Dynamic Tool Registry Support",
-      "status": "todo",
+      "status": "done",
       "description": "Implement an MCP server-prefixed tool registry in the Cognitive Architecture, inspired by OpenAI Agents SDK, allowing runtime function tool concurrency.",
       "area": "skills",
       "risk": "medium",
@@ -30791,6 +30791,61 @@
       "acceptance": [
         "Scorer calculates and assigns weights to active context chunks.",
         "Tests mock interaction frequencies to verify weight adjustments."
+      ]
+    },
+    {
+      "id": "openclaw-rl-trajectory-quality-evaluation-v2-jules-final",
+      "title": "OpenClaw RL Trajectory Quality Evaluation",
+      "status": "todo",
+      "description": "Inspired by OpenClaw-RL (June 2026): Implement trajectory quality evaluation based on long-term user satisfaction signals, helping to refine context engine pruning.",
+      "area": "learning",
+      "risk": "medium",
+      "assigned_to": "codex-worker",
+      "allowed_paths": [
+        "magda_agent/learning/trajectory_evaluation_v2.py",
+        "tests/test_trajectory_evaluation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Trajectory evaluation module properly implemented.",
+        "Module processes user feedback signals and assigns quality scores.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-negotiation-v12-jules-final",
+      "title": "MCP Dynamic Capability Negotiation V12",
+      "status": "todo",
+      "description": "Inspired by MCP standards (June 2026): Implement multi-turn dynamic capability negotiation for MCP tools to ensure both sides support required standard extensions before executing tools.",
+      "area": "skills",
+      "risk": "medium",
+      "assigned_to": "codex-worker",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_dynamic_capability_negotiation_v12.py",
+        "tests/test_mcp_dynamic_capability_negotiation_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Capability negotiation explicitly verified before tool execution.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "claude-worktree-pruning-optimizer-v4-jules-final",
+      "title": "Claude Worktree Pruning and Resource Optimizer V4",
+      "status": "todo",
+      "description": "Inspired by Claude Agent Teams: Optimize git worktree subagent isolation by actively pruning stale resources and aggressively reusing unchanged environments.",
+      "area": "architecture",
+      "risk": "high",
+      "assigned_to": "codex-worker",
+      "allowed_paths": [
+        "magda_agent/architecture/claude_worktree_pruning_v4.py",
+        "tests/test_claude_worktree_pruning_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Optimizer prunes stale git worktrees correctly.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/skills/mcp_dynamic_registry.py
+++ b/magda_agent/skills/mcp_dynamic_registry.py
@@ -1,7 +1,67 @@
 import logging
-from typing import Dict, Any
+import asyncio
+from typing import Dict, Any, List
 
 from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.skills.mcp_client import MCPClient
+
+
+class MCPPrefixedToolRegistry:
+    """
+    Registry for dynamic loading and routing of MCP tools with server prefixes.
+    Supports runtime function concurrency via asyncio.
+    """
+
+    def __init__(self, mcp_client: MCPClient) -> None:
+        """
+        Initialize the prefixed tool registry.
+
+        Args:
+            mcp_client (MCPClient): The MCP client used for tool execution.
+        """
+        self.mcp_client = mcp_client
+
+    async def execute_tool(self, tool_name: str, **kwargs: Any) -> Any:
+        """
+        Executes a remote MCP tool. Handles optional server prefixes.
+        If a prefix exists (e.g., 'server.tool_name'), MCPClient handles it natively.
+
+        Args:
+            tool_name (str): The name of the tool (can be prefixed).
+            kwargs: Arguments for the tool.
+
+        Returns:
+            Any: The execution result.
+        """
+        logging.info(f"Routing execution for tool: {tool_name}")
+        return await self.mcp_client.execute_tool(tool_name, **kwargs)
+
+    async def execute_concurrently(self, tasks: List[Dict[str, Any]]) -> List[Any]:
+        """
+        Executes multiple MCP tools concurrently using asyncio.
+
+        Args:
+            tasks (List[Dict[str, Any]]): A list of task dictionaries. Each dictionary
+                should have 'tool' (str) and 'params' (Dict) keys.
+
+        Returns:
+            List[Any]: A list of results corresponding to the tasks.
+        """
+        logging.info(f"Executing {len(tasks)} MCP tools concurrently.")
+
+        coroutines = []
+        for task in tasks:
+            tool_name = task.get("tool")
+            params = task.get("params", {})
+            if not tool_name:
+                continue
+
+            # Create a coroutine for each tool execution
+            coroutines.append(self.execute_tool(tool_name, **params))
+
+        # Run all coroutines concurrently
+        results = await asyncio.gather(*coroutines, return_exceptions=True)
+        return list(results)
 
 
 class MCPDynamicRegistrarV4:

--- a/tests/test_mcp_dynamic_registry.py
+++ b/tests/test_mcp_dynamic_registry.py
@@ -75,3 +75,60 @@ def test_register_tool_at_runtime_enhanced_validation_failure():
 
     result = registrar.register_tool_at_runtime(invalid_schema_input)
     assert result is False
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from magda_agent.skills.mcp_dynamic_registry import MCPPrefixedToolRegistry
+from magda_agent.skills.mcp_client import MCPClient
+
+@pytest.fixture
+def mcp_client_mock():
+    client = MagicMock(spec=MCPClient)
+    client.execute_tool = AsyncMock()
+    return client
+
+@pytest.fixture
+def prefixed_registry(mcp_client_mock):
+    return MCPPrefixedToolRegistry(mcp_client_mock)
+
+@pytest.mark.asyncio
+async def test_execute_tool_with_prefix(prefixed_registry, mcp_client_mock):
+    mcp_client_mock.execute_tool.return_value = "prefixed result"
+
+    result = await prefixed_registry.execute_tool("serverA.calculator", expr="2+2")
+
+    mcp_client_mock.execute_tool.assert_called_once_with("serverA.calculator", expr="2+2")
+    assert result == "prefixed result"
+
+@pytest.mark.asyncio
+async def test_execute_tool_without_prefix(prefixed_registry, mcp_client_mock):
+    mcp_client_mock.execute_tool.return_value = "global result"
+
+    result = await prefixed_registry.execute_tool("global_tool", p1="val1")
+
+    mcp_client_mock.execute_tool.assert_called_once_with("global_tool", p1="val1")
+    assert result == "global result"
+
+@pytest.mark.asyncio
+async def test_runtime_concurrency(prefixed_registry, mcp_client_mock):
+    # Setup mock to return different things based on input
+    async def mock_execute_tool(tool_name, **kwargs):
+        if tool_name == "tool1":
+            return "result 1"
+        elif tool_name == "tool2":
+            return "result 2"
+        return "unknown"
+
+    mcp_client_mock.execute_tool.side_effect = mock_execute_tool
+
+    tasks = [
+        {"tool": "tool1", "params": {"p1": "v1"}},
+        {"tool": "tool2", "params": {"p2": "v2"}},
+        {"tool": "tool3"} # missing params
+    ]
+
+    results = await prefixed_registry.execute_concurrently(tasks)
+
+    assert len(results) == 3
+    assert results == ["result 1", "result 2", "unknown"]
+    assert mcp_client_mock.execute_tool.call_count == 3


### PR DESCRIPTION
Implemented `MCPPrefixedToolRegistry` in `magda_agent/skills/mcp_dynamic_registry.py` to route tools with an optional server prefix (`server.tool_name`) via `MCPClient`. Also added `execute_concurrently` to dispatch multiple tools asynchronously using `asyncio.gather`. Added corresponding mock tests to `tests/test_mcp_dynamic_registry.py`. Updated `agent_tasks.json` to mark the task as done and appended 3 new trend-inspired tasks to the end of the backlog while ensuring it remained pretty-printed. Cleaned up accidental db artifacts from the staging area.

---
*PR created automatically by Jules for task [7096218735843916126](https://jules.google.com/task/7096218735843916126) started by @kazah4359-lgtm*