### PR TITLE
Implement MCP Dynamic Tool Registry Synchronization V10

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13083,7 +13083,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registry-sync-v10-ab8196e0-d9a4-401f-b9d4-23487568426a",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registry Synchronization V10",

--- a/magda_agent/skills/mcp_registry_sync.py
+++ b/magda_agent/skills/mcp_registry_sync.py
@@ -51,6 +51,12 @@ class MCPRegistrySync:
                 response = await client.get(f"{self.mcp_server_url}/tools")
                 response.raise_for_status()
                 data = response.json()
+        except httpx.RequestError as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: Network error: {e}")
+            return
+        except httpx.HTTPStatusError as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: HTTP error {e.response.status_code}")
+            return
         except Exception as e:
             self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: {e}")
             return

--- a/tests/test_mcp_registry_sync.py
+++ b/tests/test_mcp_registry_sync.py
@@ -91,7 +91,7 @@ async def test_sync_once_success_update_tool(registry: MCPRegistry) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sync_once_http_error(registry: MCPRegistry) -> None:
+async def test_sync_once_request_error(registry: MCPRegistry) -> None:
     registry.load_tool({
         "name": "test_tool",
         "description": "Should remain"
@@ -100,13 +100,51 @@ async def test_sync_once_http_error(registry: MCPRegistry) -> None:
     sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=60)
 
     mock_client = AsyncMock()
-    mock_client.__aenter__.return_value.get.side_effect = httpx.HTTPError("Network error")
+    mock_client.__aenter__.return_value.get.side_effect = httpx.RequestError("Network error", request=MagicMock())
 
     with patch("httpx.AsyncClient", return_value=mock_client):
         await sync.sync_once()
 
     # Tool should still be there because sync failed
     assert "test_tool" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_http_status_error(registry: MCPRegistry) -> None:
+    registry.load_tool({
+        "name": "test_tool",
+        "description": "Should remain"
+    })
+
+    sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("404 Not Found", request=MagicMock(), response=mock_response)
+    mock_response.status_code = 404
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    # Tool should still be there because sync failed
+    assert "test_tool" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_invalid_json(registry: MCPRegistry) -> None:
+    sync = MCPRegistrySync(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = ["not", "a", "dict"]
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert len(registry.list_tools()) == 0
 
 @pytest.mark.asyncio
 async def test_start_stop() -> None:


### PR DESCRIPTION
- Added specific handling for httpx.RequestError and httpx.HTTPStatusError in magda_agent/skills/mcp_registry_sync.py
- Updated tests/test_mcp_registry_sync.py to test request errors, HTTP status errors, and non-dict JSON responses
- Marked task mcp-dynamic-tool-registry-sync-v10-ab8196e0-d9a4-401f-b9d4-23487568426a as done in agent_tasks.json

---
*PR created automatically by Jules for task [4147578860183326278](https://jules.google.com/task/4147578860183326278) started by @kazah4359-lgtm*