### PR TITLE
Implement OpenClaw Canvas Live Memory Telemetry

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13101,7 +13101,7 @@
     },
     {
       "id": "openclaw-rl-canvas-live-memory-telemetry-v7-6a29979c-e215-4b3c-a6e3-87be8ab9f990",
-      "status": "todo",
+      "status": "done",
       "area": "telemetry",
       "risk": "low",
       "title": "OpenClaw Canvas Live Memory Telemetry V7",
@@ -31018,6 +31018,57 @@
       "acceptance": [
         "Memory subagent successfully persists user preferences.",
         "Preferences are correctly retrieved for task execution."
+      ]
+    },
+    {
+      "id": "openclaw-context-engine-plugin-v1-173c3cce",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "OpenClaw Context Engine Plugin V1",
+      "description": "Inspired by OpenClaw Context Engine trends: Implement a flexible plugin architecture to hook into memory lifecycle events for context compression.",
+      "allowed_paths": [
+        "magda_agent/memory/context_engine_v1.py",
+        "tests/test_context_engine_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Context engine plugin base class implemented with lifecycle hooks.",
+        "Tests verify that hooks are triggered successfully."
+      ]
+    },
+    {
+      "id": "a2a-task-delegation-discovery-v8-0bb429dc",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Task Delegation Discovery V8",
+      "description": "Inspired by A2A Protocol trends: Implement peer-to-peer discovery and task delegation using Agent Cards to find active agents.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_discovery_v8.py",
+        "tests/test_a2a_discovery_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "A2A task delegation properly discovers active peer agents.",
+        "Tests mock network registry and verify agent card discovery."
+      ]
+    },
+    {
+      "id": "claude-agent-teams-git-worktree-v8-9c59dade",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Agent Teams Git Worktree Subagent V8",
+      "description": "Inspired by Claude Agent Teams: Enhance subagent isolation by automating git worktree provisioning during subagent spawning.",
+      "allowed_paths": [
+        "magda_agent/architecture/agent_teams_v8.py",
+        "tests/test_agent_teams_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent spawning provisions unique git worktrees.",
+        "Tests mock subprocess calls to verify worktree git commands."
       ]
     }
   ]

--- a/magda_agent/telemetry/canvas_memory_v5.py
+++ b/magda_agent/telemetry/canvas_memory_v5.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import time
+import uuid
 from typing import Any, Dict, Optional
 
 class CanvasMemoryTelemetryV5:
@@ -29,6 +30,7 @@ class CanvasMemoryTelemetryV5:
         """
         payload = {
             "type": "episodic_memory_consolidation",
+            "event_id": str(uuid.uuid4()),
             "timestamp": time.time(),
             "data": {
                 "user_id": user_id,
@@ -50,7 +52,7 @@ class CanvasMemoryTelemetryV5:
             return
 
         try:
-            message = json.dumps(payload)
+            message = json.dumps(payload, default=str)
             # Support send_text (standard FastAPI style used in tests)
             if hasattr(self.websocket, "send_text"):
                 await self.websocket.send_text(message)

--- a/tests/test_canvas_memory_v5.py
+++ b/tests/test_canvas_memory_v5.py
@@ -18,8 +18,9 @@ def mock_websocket_send():
     return mock_ws
 
 @pytest.mark.asyncio
+@patch('uuid.uuid4', return_value='12345678-1234-5678-1234-567812345678')
 @patch('time.time', return_value=1234567890.0)
-async def test_broadcast_consolidation_event_with_send_text(mock_time, mock_websocket_send_text):
+async def test_broadcast_consolidation_event_with_send_text(mock_time, mock_uuid, mock_websocket_send_text):
     telemetry = CanvasMemoryTelemetryV5(websocket=mock_websocket_send_text)
     user_id = 42
     memories = [
@@ -31,6 +32,7 @@ async def test_broadcast_consolidation_event_with_send_text(mock_time, mock_webs
 
     expected_payload = {
         "type": "episodic_memory_consolidation",
+        "event_id": "12345678-1234-5678-1234-567812345678",
         "timestamp": 1234567890.0,
         "data": {
             "user_id": 42,
@@ -39,12 +41,13 @@ async def test_broadcast_consolidation_event_with_send_text(mock_time, mock_webs
         }
     }
 
-    expected_json = json.dumps(expected_payload)
+    expected_json = json.dumps(expected_payload, default=str)
     mock_websocket_send_text.send_text.assert_awaited_once_with(expected_json)
 
 @pytest.mark.asyncio
+@patch('uuid.uuid4', return_value='12345678-1234-5678-1234-567812345678')
 @patch('time.time', return_value=1234567890.0)
-async def test_broadcast_consolidation_event_with_send(mock_time, mock_websocket_send):
+async def test_broadcast_consolidation_event_with_send(mock_time, mock_uuid, mock_websocket_send):
     telemetry = CanvasMemoryTelemetryV5(websocket=mock_websocket_send)
     user_id = 42
     memories = [
@@ -55,6 +58,7 @@ async def test_broadcast_consolidation_event_with_send(mock_time, mock_websocket
 
     expected_payload = {
         "type": "episodic_memory_consolidation",
+        "event_id": "12345678-1234-5678-1234-567812345678",
         "timestamp": 1234567890.0,
         "data": {
             "user_id": 42,
@@ -63,7 +67,7 @@ async def test_broadcast_consolidation_event_with_send(mock_time, mock_websocket
         }
     }
 
-    expected_json = json.dumps(expected_payload)
+    expected_json = json.dumps(expected_payload, default=str)
     mock_websocket_send.send.assert_awaited_once_with(expected_json)
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Implemented the `OpenClaw Canvas Live Memory Telemetry V7` task from `agent_tasks.json`.

Changes:
- Modified `magda_agent/telemetry/canvas_memory_v5.py` to include a unique `event_id` in the `episodic_memory_consolidation` broadcast payload.
- Used `uuid.uuid4()` to generate the `event_id`.
- Handled potential JSON serialization issues by adding `default=str` to `json.dumps`.
- Updated `tests/test_canvas_memory_v5.py` to mock `uuid.uuid4` and assert the new payload structure.
- Marked the corresponding task in `agent_tasks.json` as `done`.
- Appended 3 new `todo` tasks to `agent_tasks.json` inspired by OpenClaw Context Engine, A2A Protocol, and Agent Teams trends.
- Validated `agent_tasks.json` successfully using the `validate_agent_tasks.py` script.

---
*PR created automatically by Jules for task [14217501698398127726](https://jules.google.com/task/14217501698398127726) started by @kazah4359-lgtm*