### PR TITLE
feat: implement A2ADiscoveryMeshV6 and add new AI trend tasks

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13135,7 +13135,7 @@
     },
     {
       "id": "a2a-discovery-mesh-cards-v6",
-      "status": "todo",
+      "status": "done",
       "area": "operations",
       "risk": "medium",
       "title": "A2A Discovery Mesh Cards V6",
@@ -31123,6 +31123,57 @@
         "Module analyzes interactions to propose new Python skills.",
         "LLM integrations are properly mocked in testing.",
         "Tests verify extraction of skill structures."
+      ]
+    },
+    {
+      "id": "openclaw-rl-canvas-metrics-v8",
+      "status": "todo",
+      "area": "operations",
+      "risk": "medium",
+      "title": "OpenClaw RL Canvas Metrics V8",
+      "description": "Inspired by OpenClaw-RL trend: Create a WebSocket server to stream live telemetry metrics directly from next-state signals.",
+      "allowed_paths": [
+        "magda_agent/operations/live_rl_v8.py",
+        "tests/test_live_rl_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket server successfully created.",
+        "Tests pass."
+      ]
+    },
+    {
+      "id": "hermes-skill-creator-v6",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "Hermes Skill Creator V6",
+      "description": "Inspired by Hermes Agent trend: Dynamically extract new skills directly from recent chat history and serialize as MCP json schemas.",
+      "allowed_paths": [
+        "magda_agent/learning/skills_creation_v6.py",
+        "tests/test_skills_creation_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "LLM client used to extract Python skill and schema.",
+        "Tests pass using mocked LLM."
+      ]
+    },
+    {
+      "id": "claude-context-compressor-v8",
+      "status": "todo",
+      "area": "memory",
+      "risk": "medium",
+      "title": "Claude Context Compressor V8",
+      "description": "Inspired by Claude Agent SDK context management trend: Develop an explicit summarizer logic that dynamically trims out older token windows.",
+      "allowed_paths": [
+        "magda_agent/memory/compression_v8.py",
+        "tests/test_compression_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Old tokens are identified and summarized.",
+        "Tests pass."
       ]
     }
   ]

--- a/magda_agent/operations/a2a_discovery_mesh_v6.py
+++ b/magda_agent/operations/a2a_discovery_mesh_v6.py
@@ -1,0 +1,73 @@
+from typing import List, Dict, Any
+import logging
+import httpx
+from dataclasses import asdict
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+
+class A2ADiscoveryMeshV6:
+    """
+    Manages an A2A discovery mesh based on the A2A Protocol trend.
+    It facilitates finding peers with required capabilities using AgentCards,
+    and propagates gossip about known peers to other nodes.
+    """
+
+    def __init__(self, discovery: A2ADiscovery) -> None:
+        """
+        Initializes the A2ADiscoveryMeshV6.
+
+        Args:
+            discovery: The core A2ADiscovery instance containing local_card and _discovered_agents.
+        """
+        self.discovery = discovery
+
+    def aggregate_cards(self) -> List[AgentCard]:
+        """
+        Aggregates the local agent's card and all discovered peer cards.
+
+        Returns:
+            A list of AgentCard instances known to this mesh node.
+        """
+        cards = [self.discovery.local_card]
+        cards.extend(list(self.discovery._discovered_agents.values()))
+        return cards
+
+    async def broadcast_gossip(self, endpoint_urls: List[str]) -> None:
+        """
+        Broadcasts all known agent cards (gossip) to the specified endpoints.
+
+        Args:
+            endpoint_urls: A list of HTTP endpoints (e.g., 'http://192.168.1.10:8000/gossip') to send the cards to.
+        """
+        aggregated_cards = self.aggregate_cards()
+        cards_data = [asdict(card) for card in aggregated_cards]
+
+        async with httpx.AsyncClient() as client:
+            for url in endpoint_urls:
+                try:
+                    response = await client.post(url, json=cards_data)
+                    response.raise_for_status()
+                    logging.info(f"Successfully gossiped {len(aggregated_cards)} cards to {url}")
+                except Exception as e:
+                    logging.error(f"Failed to gossip cards to {url}: {e}")
+
+    def receive_gossip(self, cards_data: List[Dict[str, Any]]) -> None:
+        """
+        Receives gossip data (a list of agent card dictionaries) and registers
+        new or updated agents into the discovery service.
+
+        Args:
+            cards_data: A list of dictionaries, each representing an AgentCard.
+        """
+        registered_count = 0
+        for card_dict in cards_data:
+            try:
+                card = AgentCard(**card_dict)
+                # Don't register ourselves if we receive our own card back
+                if card.agent_id != self.discovery.local_card.agent_id:
+                    self.discovery._register_agent(card)
+                    registered_count += 1
+            except Exception as e:
+                logging.error(f"Failed to parse or register agent card from gossip: {e}")
+
+        logging.info(f"Registered {registered_count} cards from gossip.")

--- a/tests/test_a2a_discovery_mesh_v6.py
+++ b/tests/test_a2a_discovery_mesh_v6.py
@@ -1,0 +1,131 @@
+import pytest
+import httpx
+from unittest.mock import AsyncMock, patch
+from dataclasses import asdict
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.operations.a2a_discovery_mesh_v6 import A2ADiscoveryMeshV6
+
+
+@pytest.fixture
+def local_card():
+    return AgentCard(
+        agent_id="agent-local-1",
+        name="Local Agent",
+        description="I am the local agent",
+        capabilities=["chat", "planning"],
+        endpoints={"gossip": "http://localhost:8000/gossip"}
+    )
+
+
+@pytest.fixture
+def peer_card():
+    return AgentCard(
+        agent_id="agent-peer-2",
+        name="Peer Agent",
+        description="I am a remote peer",
+        capabilities=["coding"],
+        endpoints={"gossip": "http://192.168.1.10:8000/gossip"}
+    )
+
+
+@pytest.fixture
+def discovery_service(local_card, peer_card):
+    service = A2ADiscovery(local_card=local_card)
+    service._register_agent(peer_card)
+    return service
+
+
+@pytest.fixture
+def mesh(discovery_service):
+    return A2ADiscoveryMeshV6(discovery=discovery_service)
+
+
+def test_aggregate_cards(mesh, local_card, peer_card):
+    cards = mesh.aggregate_cards()
+    assert len(cards) == 2
+    assert local_card in cards
+    assert peer_card in cards
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+async def test_broadcast_gossip_success(mock_post, mesh, local_card, peer_card):
+    # Setup mock response
+    from unittest.mock import MagicMock
+    mock_post.return_value.raise_for_status = MagicMock()
+
+    endpoints = ["http://192.168.1.10:8000/gossip", "http://192.168.1.11:8000/gossip"]
+    await mesh.broadcast_gossip(endpoints)
+
+    assert mock_post.call_count == 2
+
+    # Check what was sent
+    expected_data = [asdict(local_card), asdict(peer_card)]
+
+    # First call args
+    first_call_args, first_call_kwargs = mock_post.call_args_list[0]
+    assert first_call_args[0] == "http://192.168.1.10:8000/gossip"
+    assert first_call_kwargs["json"] == expected_data
+
+    # Second call args
+    second_call_args, second_call_kwargs = mock_post.call_args_list[1]
+    assert second_call_args[0] == "http://192.168.1.11:8000/gossip"
+    assert second_call_kwargs["json"] == expected_data
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+async def test_broadcast_gossip_failure(mock_post, mesh):
+    # Setup mock to simulate a network error
+    mock_post.side_effect = httpx.RequestError("Network error", request=AsyncMock())
+
+    endpoints = ["http://192.168.1.10:8000/gossip"]
+    # Should not raise an exception, just log the error
+    await mesh.broadcast_gossip(endpoints)
+
+    mock_post.assert_called_once()
+
+
+def test_receive_gossip_new_peer(mesh):
+    new_peer_data = {
+        "agent_id": "agent-peer-3",
+        "name": "New Peer",
+        "description": "Just joined the mesh",
+        "capabilities": ["search"],
+        "endpoints": {"gossip": "http://192.168.1.12:8000/gossip"},
+        "protocol_version": "2.0"
+    }
+
+    mesh.receive_gossip([new_peer_data])
+
+    # Verify it was registered in the discovery service
+    discovered_agent = mesh.discovery.get_agent_by_id("agent-peer-3")
+    assert discovered_agent is not None
+    assert discovered_agent.name == "New Peer"
+    assert "search" in discovered_agent.capabilities
+
+
+def test_receive_gossip_ignores_local_card(mesh, local_card):
+    # Receive gossip containing our own card
+    gossip_data = [asdict(local_card)]
+
+    # To check if it was ignored, we can monitor the call to _register_agent
+    # However, since _register_agent is a simple method, we just verify the state doesn't break
+    with patch.object(mesh.discovery, '_register_agent') as mock_register:
+        mesh.receive_gossip(gossip_data)
+
+        # Should not have called register for our own card
+        mock_register.assert_not_called()
+
+
+def test_receive_gossip_invalid_data(mesh):
+    invalid_data = [
+        {"not_an_agent_id": "missing_required_fields"}
+    ]
+
+    # Should handle the exception internally and not raise
+    mesh.receive_gossip(invalid_data)
+
+    # Should still just have the initial 1 peer registered during fixture setup
+    assert len(mesh.discovery._discovered_agents) == 1


### PR DESCRIPTION
Implements the A2ADiscoveryMeshV6 based on A2A trends.

Changes:
1. Created `A2ADiscoveryMeshV6` in `magda_agent/operations/a2a_discovery_mesh_v6.py` with methods for aggregation and gossip broadcasting/receiving.
2. Created `tests/test_a2a_discovery_mesh_v6.py` with mocks testing the success, failure, and edge cases (e.g. invalid json, ignoring local card) of the mesh module.
3. Updated `agent_tasks.json`, completing the first "todo" task and appending 3 new generated tasks from current AI trends.

---
*PR created automatically by Jules for task [17331661055271380586](https://jules.google.com/task/17331661055271380586) started by @kazah4359-lgtm*