### PR TITLE
Implement MCP Action Tool Governance V6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13152,7 +13152,7 @@
     },
     {
       "id": "mcp-action-tool-governance-v6",
-      "status": "todo",
+      "status": "done",
       "area": "operations",
       "risk": "high",
       "title": "MCP Action Tool Governance V6",
@@ -31174,6 +31174,40 @@
       "acceptance": [
         "Old tokens are identified and summarized.",
         "Tests pass."
+      ]
+    },
+    {
+      "id": "acs-validation-checkpoints-v2-b6161be3-26ef-40e2-9877-b6b9608994f9",
+      "title": "ACS Validation Checkpoints V2",
+      "description": "Inspired by the ACS (Agent Control Specification) trend: Implement 5 validation checkpoints for runtime safety controls.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/acs_validation_v2.py",
+        "tests/test_acs_validation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The 5 validation checkpoints are implemented and correctly enforce runtime safety controls.",
+        "Tests verify each checkpoint successfully blocks invalid behavior."
+      ]
+    },
+    {
+      "id": "multi-agent-orchestration-isolation-v2-420bbc93-2ab1-4f44-8447-b1c0159135eb",
+      "title": "Multi-Agent Orchestration Isolation V2",
+      "description": "Inspired by the Multi-Agent Orchestration trend: Implement hierarchical delegation with isolation.",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/architecture/hierarchical_isolation_v2.py",
+        "tests/test_hierarchical_isolation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Hierarchical delegation successfully isolates subagents.",
+        "Tests mock subagent spawning to ensure proper isolation."
       ]
     }
   ]

--- a/magda_agent/operations/mcp_governance_v6.py
+++ b/magda_agent/operations/mcp_governance_v6.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+
+class MCPGovernanceV6:
+    """
+    Governance layer for intercepting and sandboxing external MCP tool execution calls.
+    """
+
+    def __init__(self, allowed_tools: Optional[List[str]] = None, denied_tools: Optional[List[str]] = None) -> None:
+        """
+        Initializes the governance layer.
+
+        Args:
+            allowed_tools: List of tool names that are explicitly allowed. If None, all tools not in denied_tools are allowed.
+            denied_tools: List of tool names that are explicitly blocked.
+        """
+        self.allowed_tools = allowed_tools
+        self.denied_tools = denied_tools or []
+
+    def intercept_tool_execution(self, name: str, **kwargs: Any) -> None:
+        """
+        Intercepts an external tool call and raises an error if it's blocked by the governance policy.
+
+        Args:
+            name: The name of the tool being executed.
+            **kwargs: Arguments passed to the tool.
+
+        Raises:
+            RuntimeError: If the tool is blocked.
+        """
+        if name in self.denied_tools:
+            logging.warning(f"Governance block: Tool '{name}' is explicitly denied.")
+            raise RuntimeError(f"Tool {name} is blocked by governance policy.")
+
+        if self.allowed_tools is not None and name not in self.allowed_tools:
+            logging.warning(f"Governance block: Tool '{name}' is not in the allowed list.")
+            raise RuntimeError(f"Tool {name} is blocked by governance policy.")

--- a/magda_agent/skills/mcp_client.py
+++ b/magda_agent/skills/mcp_client.py
@@ -1,3 +1,4 @@
+from magda_agent.operations.mcp_governance_v6 import MCPGovernanceV6
 import httpx
 import json
 import uuid
@@ -13,6 +14,7 @@ class MCPClient:
         self.timeout = timeout
         self.registered_tools: Dict[str, Any] = {}
         self.registered_servers: Dict[str, Any] = {}
+        self.governance = MCPGovernanceV6()
 
     def register_mcp_server(self, server_name: str, connection_info: Any) -> None:
         """Register a remote MCP server for prefixed tool routing."""
@@ -59,6 +61,11 @@ class MCPClient:
             if server_name and server_name in self.registered_servers:
                 connection_info = self.registered_servers[server_name]
                 method_name = extracted_method
+
+        try:
+            self.governance.intercept_tool_execution(method_name, **kwargs)
+        except RuntimeError as e:
+            return f"Error: {e}"
 
         if not connection_info:
             return f"Error: Remote MCP skill '{name}' not found."

--- a/tests/test_mcp_governance_v6.py
+++ b/tests/test_mcp_governance_v6.py
@@ -1,0 +1,45 @@
+import pytest
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from magda_agent.operations.mcp_governance_v6 import MCPGovernanceV6
+
+
+def test_governance_allows_valid_tool() -> None:
+    """Tests that the governance layer allows explicitly permitted tools."""
+    governance = MCPGovernanceV6(allowed_tools=["allowed_tool"])
+    # Should not raise an exception
+    governance.intercept_tool_execution("allowed_tool", arg1="value")
+
+
+def test_governance_blocks_invalid_tool() -> None:
+    """Tests that the governance layer blocks unpermitted tools."""
+    governance = MCPGovernanceV6(allowed_tools=["allowed_tool"])
+    with pytest.raises(RuntimeError, match="Tool blocked_tool is blocked by governance policy."):
+        governance.intercept_tool_execution("blocked_tool", arg1="value")
+
+
+def test_governance_blocks_denied_tool() -> None:
+    """Tests that the governance layer blocks explicitly denied tools."""
+    governance = MCPGovernanceV6(denied_tools=["bad_tool"])
+    with pytest.raises(RuntimeError, match="Tool bad_tool is blocked by governance policy."):
+        governance.intercept_tool_execution("bad_tool", arg1="value")
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_interception() -> None:
+    """Tests that the governance layer intercepts MCPClient calls."""
+    from magda_agent.skills.mcp_client import MCPClient
+    from magda_agent.operations.mcp_governance_v6 import MCPGovernanceV6
+
+    client = MCPClient()
+    client.governance = MCPGovernanceV6(allowed_tools=["safe_tool"])
+
+    # Allowed tool shouldn't return a governance error.
+    # It will fail with 'not found' because the remote skill isn't registered, which means it passed governance.
+    result_safe = await client.execute_tool("safe_tool", arg="test")
+    assert "not found" in result_safe
+
+    # Blocked tool should return the governance error string directly from the execute_tool method
+    result_unsafe = await client.execute_tool("unsafe_tool", arg="test")
+    assert "Error: Tool unsafe_tool is blocked by governance policy" in result_unsafe


### PR DESCRIPTION
This PR implements the "MCP Action Tool Governance V6" task. It adds a governance interceptor for remote tool execution that blocks or allows explicitly provided tool names, integrating directly with `MCPClient`. It also marks the original task as completed and defines two new trend-inspired tasks related to ACS Validation Checkpoints and Multi-Agent Orchestration Isolation.

---
*PR created automatically by Jules for task [9314965185850553107](https://jules.google.com/task/9314965185850553107) started by @kazah4359-lgtm*