### PR TITLE
feat: Implement MCPKernel Taint Tracking Sandbox V3

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13169,7 +13169,7 @@
     },
     {
       "id": "mcp-kernel-taint-tracking-v3-9077ff09-2e36-4ca9-ba53-99c574098cf7",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCPKernel Taint Tracking V3",
@@ -31208,6 +31208,57 @@
       "acceptance": [
         "Hierarchical delegation successfully isolates subagents.",
         "Tests mock subagent spawning to ensure proper isolation."
+      ]
+    },
+    {
+      "id": "mcp-dynamic-capability-auth-v3-fb3f61fe",
+      "status": "todo",
+      "area": "security",
+      "risk": "medium",
+      "title": "MCP Dynamic Capability Auth V3",
+      "description": "Inspired by MCP standards trend: Implement dynamic capability negotiation authentication to securely authenticate tool usage requests via standard MCP endpoints.",
+      "allowed_paths": [
+        "magda_agent/security/mcp_dynamic_auth_v3.py",
+        "tests/test_mcp_dynamic_auth_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module successfully handles dynamic capability authentication for MCP tools.",
+        "Tests verify correct acceptance of valid requests and blocking of invalid ones."
+      ]
+    },
+    {
+      "id": "a2a-delegation-mesh-retry-v1-8ad4ae84",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "A2A Mesh Retry Strategy V1",
+      "description": "Inspired by A2A Protocol trends: Implement an exponential backoff and retry strategy for peer-to-peer agent delegation failures in the mesh.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mesh_retry_v1.py",
+        "tests/test_a2a_mesh_retry_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Retry logic successfully retries failing A2A delegations using exponential backoff.",
+        "Tests verify retry strategy limits and backoff increments."
+      ]
+    },
+    {
+      "id": "openclaw-multi-agent-canvas-v1-077b74ba",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Multi-Agent Canvas Streamer V1",
+      "description": "Inspired by OpenClaw trends: Create a WebSocket streamer that aggregates and live-streams multi-agent subagent interactions and context swaps.",
+      "allowed_paths": [
+        "magda_agent/visualization/openclaw_multi_agent_canvas_v1.py",
+        "tests/test_openclaw_multi_agent_canvas_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket server successfully created and broadcasts aggregated interaction data.",
+        "Tests pass verifying the payload structure and streaming logic."
       ]
     }
   ]

--- a/magda_agent/safety/taint_tracking_v3.py
+++ b/magda_agent/safety/taint_tracking_v3.py
@@ -6,10 +6,14 @@ across memory boundaries (episodic memory).
 """
 import logging
 import math
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from magda_agent.memory.episodic import EpisodicMemory
-from magda_agent.safety.taint_tracking_v2 import TaintTrackerV2
+from magda_agent.safety.taint_tracking_v2 import (
+    MCPKernelV2,
+    SandboxExecutionEnvironmentV2,
+    TaintTrackerV2,
+)
 
 
 class TaintTrackerV3(TaintTrackerV2):
@@ -18,6 +22,28 @@ class TaintTrackerV3(TaintTrackerV2):
     def __init__(self) -> None:
         """Initialize the TaintTrackerV3."""
         super().__init__()
+
+
+class SandboxExecutionEnvironmentV3(SandboxExecutionEnvironmentV2):
+    """An enhanced sandbox execution environment using TaintTrackerV3."""
+
+    def __init__(self, tracker: TaintTrackerV3) -> None:
+        """Initialize the SandboxExecutionEnvironmentV3.
+
+        Args:
+            tracker: The TaintTrackerV3 instance.
+        """
+        super().__init__(tracker=tracker)
+
+
+class MCPKernelV3(MCPKernelV2):
+    """Enhanced Kernel for executing tools safely with V3 taint origin tracking."""
+
+    def __init__(self) -> None:
+        """Initialize the MCPKernelV3."""
+        super().__init__()
+        self.tracker = TaintTrackerV3()
+        self.sandbox = SandboxExecutionEnvironmentV3(self.tracker)
 
 
 class TaintedEpisodicMemory(EpisodicMemory):

--- a/tests/test_taint_tracking_v3.py
+++ b/tests/test_taint_tracking_v3.py
@@ -1,7 +1,8 @@
 """Tests for MCPKernel Taint Tracking V3 and TaintedEpisodicMemory."""
 import pytest
 
-from magda_agent.safety.taint_tracking_v3 import TaintTrackerV3, TaintedEpisodicMemory
+from magda_agent.safety.taint_tracking_v2 import PolicyViolationError
+from magda_agent.safety.taint_tracking_v3 import MCPKernelV3, TaintedEpisodicMemory, TaintTrackerV3
 
 
 def test_taint_tracker_v3_initialization() -> None:
@@ -52,3 +53,46 @@ def test_tainted_episodic_memory_store_and_recall() -> None:
     assert len(recalled_tainted) == 1
     assert tracker.is_tainted(recalled_tainted[0])
     assert tracker.get_origins(recalled_tainted[0]) == {"untrusted_user"}
+
+
+def test_mcp_kernel_v3_clean_execution() -> None:
+    """Test that MCPKernelV3 successfully executes a clean tool."""
+    kernel = MCPKernelV3()
+
+    def my_clean_tool(data: str) -> str:
+        return f"Processed: {data}"
+
+    result = kernel.execute_tool(my_clean_tool, {"data": "clean_input"}, is_sensitive=True)
+    assert result == "Processed: clean_input"
+    assert not kernel.tracker.is_tainted(result)
+
+
+def test_mcp_kernel_v3_taint_propagation() -> None:
+    """Test that MCPKernelV3 correctly propagates taints when is_sensitive=False."""
+    kernel = MCPKernelV3()
+
+    def my_tool(data: str) -> str:
+        return f"Processed: {data}"
+
+    tainted_input = kernel.tracker.taint("tainted_string", "user_xyz")
+    result = kernel.execute_tool(my_tool, {"data": tainted_input}, is_sensitive=False)
+
+    assert result == "Processed: tainted_string"
+    assert kernel.tracker.is_tainted(result)
+    assert kernel.tracker.get_origins(result) == {"user_xyz"}
+
+
+def test_mcp_kernel_v3_blocks_sensitive() -> None:
+    """Test that MCPKernelV3 blocks sensitive tools when inputs are tainted."""
+    kernel = MCPKernelV3()
+
+    def my_sensitive_tool(data: str) -> str:
+        return f"Executed sensitive action with: {data}"
+
+    tainted_input = kernel.tracker.taint("tainted_command", "malicious_user")
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        kernel.execute_tool(my_sensitive_tool, {"data": tainted_input}, is_sensitive=True)
+
+    assert "Tainted input to sensitive tool call from origins" in str(exc_info.value)
+    assert "malicious_user" in str(exc_info.value)


### PR DESCRIPTION
This PR implements the MCPKernel Taint Tracking Sandbox V3 as described in the `mcp-kernel-taint-tracking-v3` task. It provides a secure sandboxed execution environment that properly tracks taints across execution boundaries and blocks sensitive actions if inputs are tainted. The PR includes comprehensive tests and updates `agent_tasks.json` to mark the task as done while adding three new trend-inspired backlog tasks.

---
*PR created automatically by Jules for task [5548074557263694359](https://jules.google.com/task/5548074557263694359) started by @kazah4359-lgtm*