### PR TITLE
feat(viz): Implement OpenClaw RL Canvas V6

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13204,7 +13204,7 @@
     },
     {
       "id": "openclaw-rl-canvas-live-v6-299a89d3-1186-43dc-810e-b9ab9d51c9de",
-      "status": "todo",
+      "status": "done",
       "area": "visualization",
       "risk": "low",
       "title": "OpenClaw RL Canvas Live V6",
@@ -31313,6 +31313,58 @@
         "Merge subagent can parse git conflicts and use an LLM to generate resolutions.",
         "Subagent resolves conflicts in an isolated worktree.",
         "Tests mock git operations and verify conflict resolution logic."
+      ]
+    },
+    {
+      "id": "hermes-experience-skill-extractor-v7-299a",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Experience Skill Extractor V7",
+      "description": "Inspired by trend: Skill creation from experience (Hermes). Implement a module to extract skills from past experiences.",
+      "allowed_paths": [
+        "magda_agent/learning/experience_extractor_v7.py",
+        "tests/test_experience_extractor_v7.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module successfully extracts skills from experience.",
+        "Tests verify extraction logic using mocks."
+      ]
+    },
+    {
+      "id": "claude-subagent-orchestrator-v2-299a",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "title": "Claude Agent Teams Subagent Orchestrator V2",
+      "description": "Inspired by trend: Subagent spawning, context compression (Claude Agent SDK). Create an orchestrator to spawn subagents and compress context.",
+      "allowed_paths": [
+        "magda_agent/architecture/subagent_orchestrator_v2.py",
+        "tests/test_subagent_orchestrator_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Orchestrator can spawn subagents.",
+        "Context compression is correctly applied.",
+        "Tests mock subagent spawning."
+      ]
+    },
+    {
+      "id": "openclaw-rl-realtime-feedback-stream-v2-299a",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw RL Real-time Feedback Stream V2",
+      "description": "Inspired by trend: Online RL from user feedback. Implement a real-time feedback stream for RL from user feedback.",
+      "allowed_paths": [
+        "magda_agent/learning/realtime_feedback_stream_v2.py",
+        "tests/test_realtime_feedback_stream_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Feedback stream receives and processes real-time user feedback.",
+        "Tests mock feedback stream input and assert expected behavior."
       ]
     }
   ]

--- a/magda_agent/api.py
+++ b/magda_agent/api.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconn
 from fastapi.responses import JSONResponse
 from magda_agent.visualization.server import CanvasServer
 from magda_agent.visualization.openclaw_canvas_v5 import OpenClawRLCanvasV5
+from magda_agent.visualization.canvas_v4 import OpenClawRLCanvasV6
 from magda_agent.memory.openclaw_canvas_v3 import OpenClawCanvasMemoryVizV3
 
 from magda_agent.visualization.canvas_streamer import CanvasMemoryStreamer
@@ -261,6 +262,7 @@ local_first_gateway.set_message_handler(consciousness.process_input)
 
 discord_bridge = DiscordBridge(token=os.getenv("DISCORD_BOT_TOKEN", "dummy"), agent_callback=consciousness.process_input)
 openclaw_rl_canvas = OpenClawRLCanvasV5()
+openclaw_rl_canvas_v6 = OpenClawRLCanvasV6()
 openclaw_canvas_memory_v3 = OpenClawCanvasMemoryVizV3()
 
 cross_platform_dispatcher.register_platform("discord", discord_bridge)
@@ -280,6 +282,7 @@ async def lifespan(app: FastAPI):
     asyncio.create_task(canvas_server.start_streaming())
     asyncio.create_task(discord_bridge.start())
     asyncio.create_task(openclaw_rl_canvas.start())
+    asyncio.create_task(openclaw_rl_canvas_v6.start())
     asyncio.create_task(openclaw_canvas_memory_v3.start())
 
     yield
@@ -294,6 +297,7 @@ async def lifespan(app: FastAPI):
     await canvas_server.stop_streaming()
     await discord_bridge.stop()
     await openclaw_rl_canvas.stop()
+    await openclaw_rl_canvas_v6.stop()
     await openclaw_canvas_memory_v3.stop()
 
     memory_system.close()

--- a/magda_agent/visualization/canvas_v4.py
+++ b/magda_agent/visualization/canvas_v4.py
@@ -1,0 +1,98 @@
+import asyncio
+import json
+import logging
+from typing import Set, Any, Dict, Optional
+
+import websockets
+from websockets.server import WebSocketServerProtocol, serve
+
+logger = logging.getLogger(__name__)
+
+class OpenClawRLCanvasV6:
+    """
+    Live canvas updates for RL openclaw V6.
+    Provides a WebSocket server to broadcast RL events to connected visualization clients.
+    """
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8765):
+        """
+        Initializes the OpenClawRLCanvasV6.
+
+        Args:
+            host (str): The host address to bind the WebSocket server to.
+            port (int): The port to bind the WebSocket server to.
+        """
+        self.host = host
+        self.port = port
+        self.clients: Set[WebSocketServerProtocol] = set()
+        self._server: Optional[Any] = None
+
+    async def _handler(self, websocket: WebSocketServerProtocol) -> None:
+        """
+        Handles incoming WebSocket connections and registers them.
+
+        Args:
+            websocket (WebSocketServerProtocol): The connected WebSocket client.
+        """
+        self.clients.add(websocket)
+        logger.info(f"Client connected: {websocket.remote_address}")
+        try:
+            # Keep connection open and wait for it to close
+            await websocket.wait_closed()
+        finally:
+            self.clients.remove(websocket)
+            logger.info(f"Client disconnected: {websocket.remote_address}")
+
+    async def start(self) -> None:
+        """
+        Starts the WebSocket server.
+        """
+        logger.info(f"Starting OpenClawRLCanvasV6 server on {self.host}:{self.port}")
+        self._server = await serve(self._handler, self.host, self.port)
+
+    async def stop(self) -> None:
+        """
+        Stops the WebSocket server.
+        """
+        if self._server:
+            logger.info("Stopping OpenClawRLCanvasV6 server")
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        # Close all active client connections
+        if self.clients:
+            await asyncio.gather(*(client.close() for client in self.clients))
+            self.clients.clear()
+
+    async def broadcast_rl_event(self, event_type: str, event_data: Dict[str, Any]) -> None:
+        """
+        Broadcasts an RL event to all connected clients.
+
+        Args:
+            event_type (str): The type of the RL event.
+            event_data (Dict[str, Any]): The data associated with the RL event.
+        """
+        if not self.clients:
+            return
+
+        payload = {
+            "type": event_type,
+            "data": event_data
+        }
+
+        try:
+            message = json.dumps(payload)
+        except TypeError as e:
+            logger.error(f"Failed to serialize broadcast payload: {e}")
+            return
+
+        # Broadcast the message to all connected clients
+        tasks = [
+            asyncio.create_task(client.send(message))
+            for client in self.clients
+            if not client.closed
+        ]
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_canvas_v4.py
+++ b/tests/test_canvas_v4.py
@@ -1,0 +1,117 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+import pytest
+from magda_agent.visualization.canvas_v4 import OpenClawRLCanvasV6
+
+
+@pytest.fixture
+def canvas() -> OpenClawRLCanvasV6:
+    """Fixture to provide a clean OpenClawRLCanvasV6 instance for each test."""
+    return OpenClawRLCanvasV6(host="127.0.0.1", port=8765)
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop(canvas: OpenClawRLCanvasV6) -> None:
+    """Tests starting and stopping the WebSocket server."""
+    with patch('magda_agent.visualization.canvas_v4.serve', new_callable=AsyncMock) as mock_serve:
+        mock_server_instance = AsyncMock()
+        mock_serve.return_value = mock_server_instance
+
+        await canvas.start()
+        mock_serve.assert_called_once_with(canvas._handler, "127.0.0.1", 8765)
+        assert canvas._server is not None
+
+        await canvas.stop()
+        mock_server_instance.close.assert_called_once()
+        mock_server_instance.wait_closed.assert_called_once()
+        assert canvas._server is None
+
+
+@pytest.mark.asyncio
+async def test_handler(canvas: OpenClawRLCanvasV6) -> None:
+    """Tests that the handler registers and unregisters clients correctly."""
+    mock_websocket = AsyncMock()
+    mock_websocket.remote_address = ("127.0.0.1", 12345)
+
+    mock_websocket.wait_closed.return_value = None
+
+    await canvas._handler(mock_websocket)
+
+    assert mock_websocket not in canvas.clients
+
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_event(canvas: OpenClawRLCanvasV6) -> None:
+    """Tests broadcasting an RL event to all connected clients."""
+    mock_client1 = AsyncMock()
+    mock_client1.closed = False
+    mock_client2 = AsyncMock()
+    mock_client2.closed = False
+
+    canvas.clients.add(mock_client1)
+    canvas.clients.add(mock_client2)
+
+    event_type = "reward_update"
+    event_data = {"score": 10.5, "reason": "success"}
+
+    await canvas.broadcast_rl_event(event_type, event_data)
+
+    expected_payload = json.dumps({
+        "type": event_type,
+        "data": event_data
+    })
+
+    mock_client1.send.assert_called_once_with(expected_payload)
+    mock_client2.send.assert_called_once_with(expected_payload)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_event_with_closed_client(canvas: OpenClawRLCanvasV6) -> None:
+    """Tests that closed clients are ignored during broadcasting."""
+    mock_client1 = AsyncMock()
+    mock_client1.closed = False
+    mock_client2 = AsyncMock()
+    mock_client2.closed = True
+
+    canvas.clients.add(mock_client1)
+    canvas.clients.add(mock_client2)
+
+    await canvas.broadcast_rl_event("test", {})
+
+    mock_client1.send.assert_called_once()
+    mock_client2.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_event_no_clients(canvas: OpenClawRLCanvasV6) -> None:
+    """Tests that broadcasting with no clients doesn't cause errors."""
+    await canvas.broadcast_rl_event("test", {})
+
+
+@pytest.mark.asyncio
+async def test_broadcast_rl_event_serialization_error(canvas: OpenClawRLCanvasV6, caplog: pytest.LogCaptureFixture) -> None:
+    """Tests that serialization errors are caught and logged."""
+    mock_client = AsyncMock()
+    mock_client.closed = False
+    canvas.clients.add(mock_client)
+
+    class Unserializable:
+        pass
+
+    await canvas.broadcast_rl_event("test", {"obj": Unserializable()})
+
+    mock_client.send.assert_not_called()
+    assert "Failed to serialize broadcast payload" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stop_with_clients(canvas: OpenClawRLCanvasV6) -> None:
+    """Tests that stopping the server correctly disconnects active clients."""
+    mock_client = AsyncMock()
+    canvas.clients.add(mock_client)
+
+    await canvas.stop()
+
+    mock_client.close.assert_called_once()
+    assert len(canvas.clients) == 0


### PR DESCRIPTION
Resolves the todo task `openclaw-rl-canvas-live-v6-299a89d3-1186-43dc-810e-b9ab9d51c9de`. Implements the OpenClaw RL Live Canvas V6 visualizer, adds proper pytest coverage, wires it into the system's `api.py` module, and updates the task backlog with three new trend-inspired tasks.

---
*PR created automatically by Jules for task [12444836240115204688](https://jules.google.com/task/12444836240115204688) started by @kazah4359-lgtm*