### PR TITLE
feat: Implement A2A Discovery Mesh Cards V7

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13238,7 +13238,7 @@
     },
     {
       "id": "a2a-discovery-mesh-cards-v7",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Discovery Mesh Cards V7",
@@ -31399,6 +31399,42 @@
       "acceptance": [
         "Tool calls are intercepted and evaluated against policy.",
         "Tests verify that policy violations are blocked and valid ones pass."
+      ]
+    },
+    {
+      "id": "agent-guard-runtime-governance-v1-2e71d88d",
+      "title": "Agent Guard Runtime Governance V1",
+      "description": "Inspired by the Agent Guard trend: Implement a runtime governance layer between the agent and the external world to intercept and evaluate every tool call against policy rules.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/runtime_governance_v1.py",
+        "tests/test_runtime_governance_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Tool calls are intercepted by the governance layer.",
+        "Policy rules are evaluated.",
+        "Tests verify that blocked calls are not executed."
+      ]
+    },
+    {
+      "id": "context-engine-lifecycle-hooks-v1-1e5434e2",
+      "title": "Context Engine Lifecycle Hooks V1",
+      "description": "Inspired by Context Engine trends: Add a plugin interface with lifecycle hooks (e.g., pre-summarize, post-retrieve) to the context engine.",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/architecture/context_engine_lifecycle_v1.py",
+        "tests/test_context_engine_lifecycle_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Lifecycle hooks are defined and can be registered.",
+        "Hooks are invoked correctly during the context lifecycle.",
+        "Tests mock hooks and assert they are called at the right time."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_discovery_mesh_v7.py
+++ b/magda_agent/integration/a2a_discovery_mesh_v7.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+from typing import List, Dict, Any
+from dataclasses import asdict
+import httpx
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+
+class A2ADiscoveryMeshV7:
+    """
+    Manages an A2A discovery mesh based on the A2A Protocol trend.
+    It facilitates finding peers with required capabilities using AgentCards,
+    propagates gossip about known peers to other nodes, and allows local
+    processing of broadcasted cards via an asyncio Queue.
+    """
+
+    def __init__(self, discovery: A2ADiscovery) -> None:
+        """
+        Initializes the A2ADiscoveryMeshV7.
+
+        Args:
+            discovery: The core A2ADiscovery instance containing local_card and _discovered_agents.
+        """
+        self.discovery = discovery
+        self.local_broadcast_queue: asyncio.Queue[List[Dict[str, Any]]] = asyncio.Queue()
+
+    def aggregate_cards(self) -> List[AgentCard]:
+        """
+        Aggregates the local agent's card and all discovered peer cards.
+
+        Returns:
+            A list of AgentCard instances known to this mesh node.
+        """
+        cards = [self.discovery.local_card]
+        cards.extend(list(self.discovery._discovered_agents.values()))
+        return cards
+
+    async def broadcast_gossip(self, endpoint_urls: List[str]) -> None:
+        """
+        Broadcasts all known agent cards (gossip) to the specified endpoints.
+        Also puts the aggregated cards into the local_broadcast_queue so they
+        are received locally.
+
+        Args:
+            endpoint_urls: A list of HTTP endpoints (e.g., 'http://192.168.1.10:8000/gossip') to send the cards to.
+        """
+        aggregated_cards = self.aggregate_cards()
+        cards_data = [asdict(card) for card in aggregated_cards]
+
+        # Enqueue for local reception
+        await self.local_broadcast_queue.put(cards_data)
+
+        async with httpx.AsyncClient() as client:
+            for url in endpoint_urls:
+                try:
+                    response = await client.post(url, json=cards_data)
+                    response.raise_for_status()
+                    logging.info(f"Successfully gossiped {len(aggregated_cards)} cards to {url}")
+                except Exception as e:
+                    logging.error(f"Failed to gossip cards to {url}: {e}")
+
+    def receive_gossip(self, cards_data: List[Dict[str, Any]]) -> None:
+        """
+        Receives gossip data (a list of agent card dictionaries) and registers
+        new or updated agents into the discovery service.
+
+        Args:
+            cards_data: A list of dictionaries, each representing an AgentCard.
+        """
+        registered_count = 0
+        for card_dict in cards_data:
+            try:
+                card = AgentCard(**card_dict)
+                # Don't register ourselves if we receive our own card back
+                if card.agent_id != self.discovery.local_card.agent_id:
+                    self.discovery._register_agent(card)
+                    registered_count += 1
+            except Exception as e:
+                logging.error(f"Failed to parse or register agent card from gossip: {e}")
+
+        logging.info(f"Registered {registered_count} cards from gossip.")

--- a/tests/test_a2a_discovery_mesh_v7.py
+++ b/tests/test_a2a_discovery_mesh_v7.py
@@ -1,0 +1,124 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_discovery_mesh_v7 import A2ADiscoveryMeshV7
+
+
+@pytest.fixture
+def local_card() -> AgentCard:
+    """Fixture providing a mock local AgentCard."""
+    return AgentCard(
+        agent_id="local-agent-123",
+        name="LocalAgent",
+        description="A local test agent",
+        capabilities=["test", "local"],
+        endpoints={"gossip": "http://localhost:8000/gossip"}
+    )
+
+
+@pytest.fixture
+def peer_card() -> AgentCard:
+    """Fixture providing a mock peer AgentCard."""
+    return AgentCard(
+        agent_id="peer-agent-456",
+        name="PeerAgent",
+        description="A peer test agent",
+        capabilities=["test", "peer"],
+        endpoints={"gossip": "http://peer:8000/gossip"}
+    )
+
+
+@pytest.fixture
+def discovery(local_card: AgentCard, peer_card: AgentCard) -> A2ADiscovery:
+    """Fixture providing an A2ADiscovery instance with one registered peer."""
+    d = A2ADiscovery(local_card)
+    d._register_agent(peer_card)
+    return d
+
+
+@pytest.fixture
+def mesh(discovery: A2ADiscovery) -> A2ADiscoveryMeshV7:
+    """Fixture providing the A2ADiscoveryMeshV7 instance to test."""
+    return A2ADiscoveryMeshV7(discovery)
+
+
+def test_aggregate_cards(mesh: A2ADiscoveryMeshV7, local_card: AgentCard, peer_card: AgentCard) -> None:
+    """Test that aggregate_cards returns both local and peer cards."""
+    cards = mesh.aggregate_cards()
+    assert len(cards) == 2
+    agent_ids = [c.agent_id for c in cards]
+    assert local_card.agent_id in agent_ids
+    assert peer_card.agent_id in agent_ids
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.post")
+async def test_broadcast_gossip_network(mock_post: AsyncMock, mesh: A2ADiscoveryMeshV7) -> None:
+    """Test that broadcast_gossip sends HTTP POST requests."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    endpoints = ["http://test1:8000/gossip", "http://test2:8000/gossip"]
+    await mesh.broadcast_gossip(endpoints)
+
+    assert mock_post.call_count == 2
+    # Check that it tried to post to both endpoints
+    call_args_list = mock_post.call_args_list
+    called_urls = [call[0][0] for call in call_args_list]
+    assert "http://test1:8000/gossip" in called_urls
+    assert "http://test2:8000/gossip" in called_urls
+
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.post")
+async def test_broadcast_gossip_local_queue(mock_post: AsyncMock, mesh: A2ADiscoveryMeshV7) -> None:
+    """Test that broadcast_gossip enqueues the cards for local reception."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    await mesh.broadcast_gossip(["http://dummy"])
+
+    assert not mesh.local_broadcast_queue.empty()
+    queued_data = await mesh.local_broadcast_queue.get()
+
+    assert isinstance(queued_data, list)
+    assert len(queued_data) == 2  # Local + 1 peer
+
+
+def test_receive_gossip(mesh: A2ADiscoveryMeshV7) -> None:
+    """Test that receive_gossip registers new agents properly."""
+    new_card_data = {
+        "agent_id": "new-agent-789",
+        "name": "NewAgent",
+        "description": "Brand new agent",
+        "capabilities": ["new"],
+        "endpoints": {"gossip": "http://new:8000/gossip"},
+        "protocol_version": "2.0"
+    }
+
+    assert "new-agent-789" not in mesh.discovery._discovered_agents
+
+    mesh.receive_gossip([new_card_data])
+
+    assert "new-agent-789" in mesh.discovery._discovered_agents
+    registered_card = mesh.discovery._discovered_agents["new-agent-789"]
+    assert registered_card.name == "NewAgent"
+
+
+def test_receive_gossip_ignores_self(mesh: A2ADiscoveryMeshV7, local_card: AgentCard) -> None:
+    """Test that receive_gossip ignores the local agent's card."""
+    # Temporarily remove local agent from discovered if it somehow got there
+    # (it shouldn't be in discovered_agents, only in local_card, but let's be sure)
+    mesh.discovery._discovered_agents.pop(local_card.agent_id, None)
+
+    from dataclasses import asdict
+    self_card_data = asdict(local_card)
+
+    mesh.receive_gossip([self_card_data])
+
+    # Still shouldn't be in discovered_agents
+    assert local_card.agent_id not in mesh.discovery._discovered_agents


### PR DESCRIPTION
This PR implements the `A2ADiscoveryMeshV7` class as required by the `a2a-discovery-mesh-cards-v7` task. It supports HTTP-based gossip propagation of `AgentCard` data and properly queues the payload locally for validation. Full test coverage using `pytest` with mocked async interactions guarantees isolated verification. Finally, `agent_tasks.json` is updated and new tasks derived from agent trends have been introduced.

---
*PR created automatically by Jules for task [3606877745307626991](https://jules.google.com/task/3606877745307626991) started by @kazah4359-lgtm*