### PR TITLE
feat: implement MCP dynamic tool registry sync v11

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13255,7 +13255,7 @@
     },
     {
       "id": "mcp-dynamic-tool-registry-sync-v11",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "MCP Dynamic Tool Registry Synchronization V11",
@@ -31435,6 +31435,59 @@
         "Lifecycle hooks are defined and can be registered.",
         "Hooks are invoked correctly during the context lifecycle.",
         "Tests mock hooks and assert they are called at the right time."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-discovery-v8",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Agent Skills Discovery V8",
+      "description": "Inspired by Hermes Agent trends: Implement an advanced skill discovery mechanism that can dynamically locate and register executable agent skills.",
+      "allowed_paths": [
+        "magda_agent/skills/discovery_v8.py",
+        "tests/test_discovery_v8.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module successfully discovers new skills.",
+        "Tests pass verifying discovery logic."
+      ]
+    },
+    {
+      "id": "openclaw-rl-multimodal-frustration-v2",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "OpenClaw RL Multimodal Frustration V2",
+      "description": "Inspired by OpenClaw-RL trends: Extend frustration detection with multimodal signals processing from user interactions to dynamically adjust RL weights.",
+      "allowed_paths": [
+        "magda_agent/learning/frustration_v2.py",
+        "tests/test_frustration_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Detector processes multimodal interaction sequences for implicit frustration signals.",
+        "Weights are negatively adjusted accordingly.",
+        "Tests pass verifying the multimodal adjustment logic."
+      ]
+    },
+    {
+      "id": "claude-worktree-multi-agent-conflict-resolution-v2",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude Worktree Multi-Agent Conflict Resolution V2",
+      "description": "Inspired by Claude Agent Teams trends: Enhance the Git merge subagent with an evaluator pool to review semantic conflict resolutions.",
+      "allowed_paths": [
+        "magda_agent/architecture/merge_subagent_v2.py",
+        "tests/test_merge_subagent_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator pool reviews and validates merge resolutions before commit.",
+        "Isolated worktree logic handles parallel evaluator tasks.",
+        "Tests mock operations and verify logic."
       ]
     }
   ]

--- a/magda_agent/skills/__init__.py
+++ b/magda_agent/skills/__init__.py
@@ -15,6 +15,9 @@ from magda_agent.skills.web_navigation import web_navigate as web_navigation_ski
 from magda_agent.skills.web_navigation_v2 import web_navigate_v2 as web_navigation_skill_v2
 
 
+from magda_agent.skills.mcp_registry_sync_v11 import MCPRegistrySyncV11
+from magda_agent.skills.mcp_registry import MCPRegistry
+
 def initialize_skills(policy_layer: Optional["PolicyLayer"] = None) -> SkillRegistry:
     registry = SkillRegistry(policy_layer=policy_layer)
 
@@ -211,6 +214,36 @@ def initialize_skills(policy_layer: Optional["PolicyLayer"] = None) -> SkillRegi
         name="marketplace_sync",
         func=sync_marketplace_sync,
         description="Periodically fetches and synchronizes new skills from the external agentskills.io marketplace into the agent's skill registry."
+    )
+
+
+    # MCP Registry Sync V11 setup
+    mcp_registry_sync_registry = MCPRegistry()
+    mcp_registry_sync_v11 = MCPRegistrySyncV11(registry=mcp_registry_sync_registry, mcp_server_url="http://localhost:8080")
+
+    def sync_mcp_registry_v11() -> int:
+        import asyncio
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import threading
+                result = None
+                def run_in_thread():
+                    nonlocal result
+                    result = asyncio.run(mcp_registry_sync_v11.sync_once())
+                t = threading.Thread(target=run_in_thread)
+                t.start()
+                t.join()
+                return 1
+        except RuntimeError:
+            pass
+        asyncio.run(mcp_registry_sync_v11.sync_once())
+        return 1
+
+    registry.register_skill(
+        name="mcp_registry_sync_v11",
+        func=sync_mcp_registry_v11,
+        description="Periodically polls a configured MCP server URL and dynamically registers or unregisters tools in the local MCPRegistry."
     )
 
     return registry

--- a/magda_agent/skills/mcp_registry_sync_v11.py
+++ b/magda_agent/skills/mcp_registry_sync_v11.py
@@ -1,0 +1,132 @@
+import asyncio
+import logging
+from typing import Dict, Any, Optional
+
+import httpx
+
+from magda_agent.skills.mcp_registry import MCPRegistry
+
+
+class MCPRegistrySyncV11:
+    """
+    Background loop that periodically polls a configured MCP server URL
+    and dynamically registers or unregisters tools in the local MCPRegistry.
+    Inspired by MCP Standard trends.
+    """
+
+    def __init__(self, registry: MCPRegistry, mcp_server_url: str, sync_interval: int = 60) -> None:
+        """
+        Initialize the MCPRegistrySyncV11.
+
+        Args:
+            registry (MCPRegistry): The local registry to keep synchronized.
+            mcp_server_url (str): The remote MCP server URL to poll for tools.
+            sync_interval (int): Time in seconds between polling attempts. Defaults to 60.
+        """
+        self.registry = registry
+        self.mcp_server_url = mcp_server_url
+        self.sync_interval = sync_interval
+        self._running = False
+        self._task: Optional[asyncio.Task[None]] = None
+        self.logger = logging.getLogger(__name__)
+
+    async def _sync_loop(self) -> None:
+        """
+        The main background loop that periodically synchronizes the registry.
+        """
+        while self._running:
+            await self.sync_once()
+            if self._running:
+                try:
+                    await asyncio.sleep(self.sync_interval)
+                except asyncio.CancelledError:
+                    break
+
+    async def sync_once(self) -> None:
+        """
+        Performs a single synchronization cycle by querying the remote MCP server.
+        """
+        self.logger.debug(f"Starting sync cycle with MCP server: {self.mcp_server_url}")
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{self.mcp_server_url}/tools")
+                response.raise_for_status()
+                data = response.json()
+        except httpx.RequestError as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: Network error: {e}")
+            return
+        except httpx.HTTPStatusError as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: HTTP error {e.response.status_code}")
+            return
+        except Exception as e:
+            self.logger.error(f"Failed to fetch tools from MCP server {self.mcp_server_url}: {e}")
+            return
+
+        if not isinstance(data, dict) or "tools" not in data or not isinstance(data["tools"], list):
+            self.logger.error(f"Invalid response format from MCP server {self.mcp_server_url}: 'tools' list not found.")
+            return
+
+        remote_tools: Dict[str, Dict[str, Any]] = {}
+        for tool in data["tools"]:
+            if isinstance(tool, dict) and "name" in tool:
+                remote_tools[tool["name"]] = tool
+
+        local_tools_names = set(self.registry.list_tools())
+        remote_tools_names = set(remote_tools.keys())
+
+        # Tools to add or update
+        for name, tool_schema in remote_tools.items():
+            if name not in local_tools_names:
+                # Add new tool
+                try:
+                    success = self.registry.load_tool(tool_schema)
+                    if not success:
+                        self.logger.warning(f"Failed to load new MCP tool: {name}")
+                except Exception as e:
+                    self.logger.error(f"Error loading new MCP tool {name}: {e}")
+            else:
+                # Tool already exists, reload it to ensure we have the latest schema
+                try:
+                    self.registry.reload_tool(tool_schema)
+                except Exception as e:
+                    self.logger.error(f"Error reloading existing MCP tool {name}: {e}")
+
+        # Tools to remove
+        tools_to_remove = local_tools_names - remote_tools_names
+        for name in tools_to_remove:
+            try:
+                self.registry.unload_tool(name)
+                self.logger.info(f"Unloaded MCP tool {name} as it is no longer present on the remote server.")
+            except Exception as e:
+                self.logger.error(f"Error unloading MCP tool {name}: {e}")
+
+    def start(self) -> None:
+        """
+        Starts the background synchronization loop.
+        """
+        if self._running:
+            self.logger.warning("Sync loop is already running.")
+            return
+
+        self._running = True
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._sync_loop())
+        self.logger.info(f"Started MCPRegistrySyncV11 loop with interval {self.sync_interval}s.")
+
+    async def stop(self) -> None:
+        """
+        Stops the background synchronization loop.
+        """
+        if not self._running:
+            return
+
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        self.logger.info("Stopped MCPRegistrySyncV11 loop.")

--- a/tests/test_mcp_registry_sync_v11.py
+++ b/tests/test_mcp_registry_sync_v11.py
@@ -1,0 +1,165 @@
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+import pytest
+
+from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.skills.mcp_registry_sync_v11 import MCPRegistrySyncV11
+
+@pytest.fixture
+def registry() -> MCPRegistry:
+    return MCPRegistry()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_add_tool(registry: MCPRegistry) -> None:
+    sync = MCPRegistrySyncV11(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "tools": [
+            {
+                "name": "test_tool_1",
+                "description": "A test tool"
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert "test_tool_1" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_remove_tool(registry: MCPRegistry) -> None:
+    # Pre-load a tool
+    registry.load_tool({
+        "name": "test_tool_to_remove",
+        "description": "Will be removed"
+    })
+    assert "test_tool_to_remove" in registry.list_tools()
+
+    sync = MCPRegistrySyncV11(registry, "http://mock-mcp-server", sync_interval=60)
+
+    # Remote server returns empty list of tools
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"tools": []}
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert "test_tool_to_remove" not in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_success_update_tool(registry: MCPRegistry) -> None:
+    # Pre-load a tool
+    registry.load_tool({
+        "name": "test_tool_to_update",
+        "description": "Old description"
+    })
+
+    sync = MCPRegistrySyncV11(registry, "http://mock-mcp-server", sync_interval=60)
+
+    # Remote server returns updated tool
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "tools": [
+            {
+                "name": "test_tool_to_update",
+                "description": "New description"
+            }
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    tool = registry.get_tool("test_tool_to_update")
+    assert tool["description"] == "New description"
+
+@pytest.mark.asyncio
+async def test_sync_once_http_request_error(registry: MCPRegistry) -> None:
+    registry.load_tool({
+        "name": "test_tool",
+        "description": "Should remain"
+    })
+
+    sync = MCPRegistrySyncV11(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.side_effect = httpx.RequestError("Network error", request=MagicMock())
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    # Tool should still be there because sync failed
+    assert "test_tool" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_http_status_error(registry: MCPRegistry) -> None:
+    registry.load_tool({
+        "name": "test_tool",
+        "description": "Should remain"
+    })
+
+    sync = MCPRegistrySyncV11(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("404 Not Found", request=MagicMock(), response=mock_response)
+    mock_response.status_code = 404
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    # Tool should still be there because sync failed
+    assert "test_tool" in registry.list_tools()
+
+@pytest.mark.asyncio
+async def test_sync_once_invalid_json(registry: MCPRegistry) -> None:
+    sync = MCPRegistrySyncV11(registry, "http://mock-mcp-server", sync_interval=60)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = ["not", "a", "dict"]
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_response
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await sync.sync_once()
+
+    assert len(registry.list_tools()) == 0
+
+@pytest.mark.asyncio
+async def test_start_stop() -> None:
+    registry = MCPRegistry()
+    sync = MCPRegistrySyncV11(registry, "http://mock-mcp-server", sync_interval=1)
+
+    with patch.object(sync, 'sync_once', new_callable=AsyncMock) as mock_sync_once:
+        sync.start()
+        assert sync._running is True
+        assert sync._task is not None
+
+        # let it run one cycle
+        await asyncio.sleep(0.1)
+
+        await sync.stop()
+        assert sync._running is False
+        assert sync._task is None
+
+        mock_sync_once.assert_called()


### PR DESCRIPTION
This PR resolves the `mcp-dynamic-tool-registry-sync-v11` task. It implements a background loop that periodically synchronizes tools from an external MCP server into the agent's local registry. This ensures the agent always has access to the most up-to-date tools dynamically registered via MCP.

It also fulfills the requirement to identify 3 new AI agent trends and queue them up as new tasks in `agent_tasks.json`.

---
*PR created automatically by Jules for task [1759233120010367734](https://jules.google.com/task/1759233120010367734) started by @kazah4359-lgtm*