### PR TITLE
feat: A2A Peer Task Delegation v1

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13306,7 +13306,7 @@
     },
     {
       "id": "a2a-peer-delegation-v1",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "medium",
       "title": "A2A Peer Task Delegation",
@@ -31593,6 +31593,57 @@
         "Monitor collects traces and metadata from A2A delegation.",
         "Monitor exposes telemetry data in a structured format.",
         "Tests mock A2A transactions and verify tracing output."
+      ]
+    },
+    {
+      "id": "openai-agents-mcp-concurrency-v1",
+      "status": "todo",
+      "area": "skills",
+      "risk": "high",
+      "title": "OpenAI Agents MCP Tool Concurrency V1",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement runtime function tool concurrency to allow the agent to execute multiple MCP tool calls in parallel safely.",
+      "allowed_paths": [
+        "magda_agent/skills/mcp_concurrency_v4.py",
+        "tests/test_mcp_concurrency_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Agent can execute multiple tool calls in parallel using asyncio.gather.",
+        "Tests verify parallel execution logic without true side-effects."
+      ]
+    },
+    {
+      "id": "claude-agent-evaluator-v1",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "medium",
+      "title": "Claude Agent Evaluator Component V1",
+      "description": "Inspired by Claude Agent SDK Planner/Generator/Evaluator architecture: Implement a specialized Evaluator subagent component that reviews generated output before presenting it to the user.",
+      "allowed_paths": [
+        "magda_agent/teams/evaluator_subagent_v1.py",
+        "tests/test_evaluator_subagent_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Evaluator component can score generation artifacts.",
+        "Tests mock LLM evaluations and confirm integration."
+      ]
+    },
+    {
+      "id": "hermes-agent-learning-loop-v1",
+      "status": "todo",
+      "area": "learning",
+      "risk": "high",
+      "title": "Hermes Agent Built-in Learning Loop V1",
+      "description": "Inspired by Hermes Agent trend (self-improving with built-in learning loop): Develop a module that passively listens to user corrections and updates procedural memory weights dynamically.",
+      "allowed_paths": [
+        "magda_agent/learning/learning_loop_v1.py",
+        "tests/test_learning_loop_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module dynamically adjusts weights based on explicit user feedback.",
+        "Tests verify weight adjustments using mock interactions."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_delegation_v1.py
+++ b/magda_agent/integration/a2a_delegation_v1.py
@@ -1,0 +1,109 @@
+from typing import Dict, Any, List, Optional
+import logging
+import httpx
+from magda_agent.integration.a2a_discovery_v3_unique import A2ADiscoveryServiceV3Unique
+from magda_agent.integration.a2a_discovery import AgentCard
+
+logger = logging.getLogger(__name__)
+
+class A2APeerDelegatorV1:
+    """
+    A2A Task Delegation Protocol v1.
+    Handles discovering peers using a discovery service and formatting
+    task payloads for peer-to-peer delegation via API requests.
+    """
+
+    def __init__(self, discovery_service: Optional[A2ADiscoveryServiceV3Unique] = None) -> None:
+        """
+        Initializes the A2APeerDelegatorV1.
+
+        Args:
+            discovery_service: An optional discovery service to use for finding peers.
+                               Defaults to A2ADiscoveryServiceV3Unique if none is provided.
+        """
+        self.discovery_service = discovery_service or A2ADiscoveryServiceV3Unique()
+
+    def discover_peers(self, raw_cards: List[str]) -> None:
+        """
+        Discovers peers from raw agent card JSON strings and registers them.
+
+        Args:
+            raw_cards: A list of JSON strings representing AgentCards.
+        """
+        self.discovery_service.parse_and_register_cards(raw_cards)
+
+    def find_peer_for_capability(self, capability: str) -> Optional[AgentCard]:
+        """
+        Finds a peer agent that supports the given capability.
+
+        Args:
+            capability: The capability to search for.
+
+        Returns:
+            An AgentCard representing the peer if found, else None.
+        """
+        agents = self.discovery_service.find_agents_by_capability(capability)
+        if not agents:
+            return None
+        return agents[0]
+
+    def format_task_payload(self, task_id: str, capability: str, task_parameters: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Formats a task into a structured JSON-RPC style payload.
+
+        Args:
+            task_id: A unique identifier for the task.
+            capability: The capability required to execute the task.
+            task_parameters: A dictionary of parameters for the task.
+
+        Returns:
+            A structured dictionary payload.
+        """
+        return {
+            "jsonrpc": "2.0",
+            "id": task_id,
+            "method": "execute_task",
+            "params": {
+                "capability": capability,
+                "task_parameters": task_parameters
+            }
+        }
+
+    async def delegate_task(self, task_id: str, capability: str, task_parameters: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Discovers an appropriate peer and delegates a formatted task to it.
+
+        Args:
+            task_id: A unique identifier for the task.
+            capability: The capability required to execute the task.
+            task_parameters: A dictionary of parameters for the task.
+
+        Returns:
+            A dictionary containing the response from the peer or an error structure.
+        """
+        target_agent = self.find_peer_for_capability(capability)
+
+        if not target_agent:
+            logger.warning(f"No agents found for capability: {capability}")
+            return {"error": f"No agent found for capability: {capability}", "status": "failed"}
+
+        rpc_endpoint = target_agent.endpoints.get("rpc")
+        if not rpc_endpoint:
+            logger.error(f"Agent {target_agent.name} is missing an RPC endpoint.")
+            return {"error": f"Agent {target_agent.name} missing RPC endpoint", "status": "failed"}
+
+        payload = self.format_task_payload(task_id, capability, task_parameters)
+
+        logger.info(f"Delegating task {task_id} to Agent {target_agent.name} at {rpc_endpoint}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(rpc_endpoint, json=payload, timeout=10.0)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPError as e:
+            logger.error(f"Delegation to {target_agent.name} failed due to network error: {e}")
+            return {"error": f"Network error: {str(e)}", "status": "failed"}
+        except Exception as e:
+            logger.error(f"Delegation to {target_agent.name} failed: {e}")
+            return {"error": f"Internal error: {str(e)}", "status": "failed"}

--- a/tests/test_a2a_delegation_v1.py
+++ b/tests/test_a2a_delegation_v1.py
@@ -1,0 +1,104 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from magda_agent.integration.a2a_delegation_v1 import A2APeerDelegatorV1
+from magda_agent.integration.a2a_discovery import AgentCard
+from magda_agent.integration.a2a_discovery_v3_unique import A2ADiscoveryServiceV3Unique
+import httpx
+
+@pytest.fixture
+def mock_discovery_service():
+    service = MagicMock(spec=A2ADiscoveryServiceV3Unique)
+    return service
+
+@pytest.fixture
+def delegator(mock_discovery_service):
+    return A2APeerDelegatorV1(discovery_service=mock_discovery_service)
+
+def test_discover_peers(delegator, mock_discovery_service):
+    raw_cards = ['{"agent_id": "1"}']
+    delegator.discover_peers(raw_cards)
+    mock_discovery_service.parse_and_register_cards.assert_called_once_with(raw_cards)
+
+def test_find_peer_for_capability(delegator, mock_discovery_service):
+    card = AgentCard(agent_id="test-1", name="TestAgent", description="Test", capabilities=["math"], endpoints={"rpc": "http://test/rpc"})
+    mock_discovery_service.find_agents_by_capability.return_value = [card]
+
+    found_card = delegator.find_peer_for_capability("math")
+    assert found_card == card
+    mock_discovery_service.find_agents_by_capability.assert_called_once_with("math")
+
+def test_find_peer_for_capability_not_found(delegator, mock_discovery_service):
+    mock_discovery_service.find_agents_by_capability.return_value = []
+
+    found_card = delegator.find_peer_for_capability("math")
+    assert found_card is None
+
+def test_format_task_payload(delegator):
+    payload = delegator.format_task_payload("task-1", "math", {"a": 1, "b": 2})
+    assert payload == {
+        "jsonrpc": "2.0",
+        "id": "task-1",
+        "method": "execute_task",
+        "params": {
+            "capability": "math",
+            "task_parameters": {"a": 1, "b": 2}
+        }
+    }
+
+@pytest.mark.asyncio
+async def test_delegate_task_success(delegator, mock_discovery_service):
+    card = AgentCard(agent_id="test-1", name="TestAgent", description="Test", capabilities=["math"], endpoints={"rpc": "http://test/rpc"})
+    mock_discovery_service.find_agents_by_capability.return_value = [card]
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": 3, "status": "success"}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = await delegator.delegate_task("task-1", "math", {"a": 1, "b": 2})
+
+        assert result == {"result": 3, "status": "success"}
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == "http://test/rpc"
+        assert kwargs["json"]["id"] == "task-1"
+
+@pytest.mark.asyncio
+async def test_delegate_task_no_peer(delegator, mock_discovery_service):
+    mock_discovery_service.find_agents_by_capability.return_value = []
+
+    result = await delegator.delegate_task("task-1", "math", {"a": 1, "b": 2})
+    assert result == {"error": "No agent found for capability: math", "status": "failed"}
+
+@pytest.mark.asyncio
+async def test_delegate_task_no_rpc_endpoint(delegator, mock_discovery_service):
+    card = AgentCard(agent_id="test-1", name="TestAgent", description="Test", capabilities=["math"], endpoints={})
+    mock_discovery_service.find_agents_by_capability.return_value = [card]
+
+    result = await delegator.delegate_task("task-1", "math", {"a": 1, "b": 2})
+    assert result == {"error": "Agent TestAgent missing RPC endpoint", "status": "failed"}
+
+@pytest.mark.asyncio
+async def test_delegate_task_http_error(delegator, mock_discovery_service):
+    card = AgentCard(agent_id="test-1", name="TestAgent", description="Test", capabilities=["math"], endpoints={"rpc": "http://test/rpc"})
+    mock_discovery_service.find_agents_by_capability.return_value = [card]
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = httpx.HTTPError("Connection failed")
+
+        result = await delegator.delegate_task("task-1", "math", {"a": 1, "b": 2})
+
+        assert result == {"error": "Network error: Connection failed", "status": "failed"}
+
+@pytest.mark.asyncio
+async def test_delegate_task_general_error(delegator, mock_discovery_service):
+    card = AgentCard(agent_id="test-1", name="TestAgent", description="Test", capabilities=["math"], endpoints={"rpc": "http://test/rpc"})
+    mock_discovery_service.find_agents_by_capability.return_value = [card]
+
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = Exception("Unexpected error")
+
+        result = await delegator.delegate_task("task-1", "math", {"a": 1, "b": 2})
+
+        assert result == {"error": "Internal error: Unexpected error", "status": "failed"}


### PR DESCRIPTION
Implements the `a2a-peer-delegation-v1` task to enable peer-to-peer delegation as inspired by the A2A Protocol trend. 

The update includes:
- Core implementation `magda_agent/integration/a2a_delegation_v1.py` with type hints and docstrings.
- Mocked unit tests via `tests/test_a2a_delegation_v1.py`.
- Status updates and the addition of 3 new AI-trend-inspired tasks in `agent_tasks.json`.

---
*PR created automatically by Jules for task [9025563794664233764](https://jules.google.com/task/9025563794664233764) started by @kazah4359-lgtm*