### PR TITLE
Implement OpenClaw RL Canvas Live Metrics v8

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13340,7 +13340,7 @@
     },
     {
       "id": "openclaw-rl-canvas-live-metrics-v8-dbdf3a77-d78e-47b0-8c8a-7f683d60b2e7",
-      "status": "todo",
+      "status": "done",
       "area": "skills",
       "risk": "low",
       "title": "OpenClaw RL Canvas Live Metrics v8",

--- a/magda_agent/skills/canvas_metrics_v8.py
+++ b/magda_agent/skills/canvas_metrics_v8.py
@@ -1,0 +1,256 @@
+import json
+import logging
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+class CanvasMemoryMetricsExporterV8:
+    """
+    Handles tracking, aggregation, and formatting of memory consolidation metrics
+    for live Canvas UI visualization, inspired by OpenClaw trends.
+    """
+
+    def __init__(self, max_events: int = 50) -> None:
+        """
+        Initializes the CanvasMemoryMetricsExporterV8.
+
+        Args:
+            max_events (int): Maximum number of recent consolidation events to retain.
+        """
+        self.events: List[Dict[str, Any]] = []
+        self.max_events = max_events
+
+    def record_consolidation(
+        self,
+        user_id: Union[int, str],
+        memories: List[Dict[str, Any]],
+        importance_scores: Optional[List[float]] = None,
+        compression_ratio: float = 1.0,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Records a single memory consolidation event and calculates metrics.
+
+        Args:
+            user_id (Union[int, str]): The user or session ID associated with the memories.
+            memories (List[Dict[str, Any]]): The list of memory objects being consolidated.
+            importance_scores (Optional[List[float]]): Optional importance scores for each memory.
+            compression_ratio (float): Ratio of consolidated size/tokens to raw size/tokens.
+            metadata (Optional[Dict[str, Any]]): Additional contextual metadata.
+
+        Returns:
+            Dict[str, Any]: The recorded event entry with calculated metrics.
+        """
+        scores = importance_scores or []
+        avg_importance = (
+            sum(scores) / len(scores) if scores else 0.0
+        )
+
+        event_entry = {
+            "event_id": str(uuid.uuid4()),
+            "timestamp": time.time(),
+            "user_id": user_id,
+            "consolidated_count": len(memories),
+            "importance_scores": scores,
+            "average_importance": round(avg_importance, 4),
+            "compression_ratio": round(compression_ratio, 4),
+            "memories": memories,
+            "metadata": metadata or {},
+        }
+
+        self.events.append(event_entry)
+        if len(self.events) > self.max_events:
+            self.events.pop(0)
+
+        return event_entry
+
+    def get_metrics_summary(self) -> Dict[str, Any]:
+        """
+        Aggregates overall memory consolidation statistics across recorded events.
+
+        Returns:
+            Dict[str, Any]: Summary metrics including total count, average importance,
+                           and average compression ratio.
+        """
+        if not self.events:
+            return {
+                "total_events": 0,
+                "total_consolidated_memories": 0,
+                "global_average_importance": 0.0,
+                "global_average_compression_ratio": 0.0,
+                "recent_event_count": 0,
+            }
+
+        total_events = len(self.events)
+        total_memories = sum(e["consolidated_count"] for e in self.events)
+
+        all_importance = [
+            e["average_importance"] for e in self.events if e["average_importance"] > 0.0
+        ]
+        global_avg_importance = (
+            sum(all_importance) / len(all_importance) if all_importance else 0.0
+        )
+
+        all_compression = [e["compression_ratio"] for e in self.events]
+        global_avg_compression = (
+            sum(all_compression) / len(all_compression) if all_compression else 0.0
+        )
+
+        return {
+            "total_events": total_events,
+            "total_consolidated_memories": total_memories,
+            "global_average_importance": round(global_avg_importance, 4),
+            "global_average_compression_ratio": round(global_avg_compression, 4),
+            "recent_event_count": total_events,
+        }
+
+    def get_canvas_payload(
+        self,
+        event_type: str = "memory_consolidation_metrics",
+        latest_event: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Formats the accumulated metrics into a structured payload for Canvas UI ingestion.
+
+        Args:
+            event_type (str): Type identifier for the Canvas UI event.
+            latest_event (Optional[Dict[str, Any]]): The most recent event payload if available.
+
+        Returns:
+            Dict[str, Any]: Standardized Canvas UI payload dictionary.
+        """
+        summary = self.get_metrics_summary()
+        recent = [
+            {
+                "event_id": e["event_id"],
+                "timestamp": e["timestamp"],
+                "user_id": e["user_id"],
+                "consolidated_count": e["consolidated_count"],
+                "average_importance": e["average_importance"],
+                "compression_ratio": e["compression_ratio"],
+            }
+            for e in self.events[-10:]
+        ]
+
+        return {
+            "type": event_type,
+            "event_id": str(uuid.uuid4()),
+            "timestamp": time.time(),
+            "status": "active",
+            "data": {
+                "summary": summary,
+                "latest_event": latest_event,
+                "recent_events": recent,
+            },
+        }
+
+    def export_json(self) -> str:
+        """
+        Exports the formatted Canvas payload as a JSON string.
+
+        Returns:
+            str: JSON string of the Canvas UI payload.
+        """
+        return json.dumps(self.get_canvas_payload())
+
+
+class CanvasMetricsBroadcasterV8:
+    """
+    An export module to broadcast memory consolidation metrics
+    to a live dashboard via WebSockets.
+    """
+
+    def __init__(
+        self,
+        websocket: Optional[Any] = None,
+        exporter: Optional[CanvasMemoryMetricsExporterV8] = None,
+    ) -> None:
+        """
+        Initializes the CanvasMetricsBroadcasterV8.
+
+        Args:
+            websocket (Optional[Any]): An open asynchronous WebSocket connection.
+            exporter (Optional[CanvasMemoryMetricsExporterV8]): Metrics exporter instance.
+        """
+        self.websocket = websocket
+        self.exporter = exporter or CanvasMemoryMetricsExporterV8()
+        self.logger = logging.getLogger(__name__)
+
+    async def broadcast_consolidation_metrics(
+        self,
+        user_id: Union[int, str],
+        memories: List[Dict[str, Any]],
+        importance_scores: Optional[List[float]] = None,
+        compression_ratio: float = 1.0,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Records a memory consolidation event, updates metrics, and broadcasts
+        the updated Canvas payload over WebSocket.
+
+        Args:
+            user_id (Union[int, str]): User or session ID.
+            memories (List[Dict[str, Any]]): List of consolidated memories.
+            importance_scores (Optional[List[float]]): Memory importance scores.
+            compression_ratio (float): Compression ratio.
+            metadata (Optional[Dict[str, Any]]): Additional metadata.
+
+        Returns:
+            Dict[str, Any]: The recorded consolidation event.
+        """
+        event_entry = self.exporter.record_consolidation(
+            user_id=user_id,
+            memories=memories,
+            importance_scores=importance_scores,
+            compression_ratio=compression_ratio,
+            metadata=metadata,
+        )
+
+        payload = self.exporter.get_canvas_payload(latest_event=event_entry)
+        await self._broadcast(payload)
+        return event_entry
+
+    async def broadcast_metrics(self, payload: Optional[Dict[str, Any]] = None) -> bool:
+        """
+        Broadcasts the current memory metrics payload to the Canvas UI.
+
+        Args:
+            payload (Optional[Dict[str, Any]]): Optional custom payload to send.
+
+        Returns:
+            bool: True if broadcast succeeded, False otherwise.
+        """
+        if payload is None:
+            payload = self.exporter.get_canvas_payload()
+        return await self._broadcast(payload)
+
+    async def _broadcast(self, payload: Dict[str, Any]) -> bool:
+        """
+        Helper method to serialize and send JSON payload over WebSocket.
+
+        Args:
+            payload (Dict[str, Any]): Event payload dictionary.
+
+        Returns:
+            bool: True if sent successfully, False otherwise.
+        """
+        if self.websocket is None:
+            self.logger.debug(
+                f"Skipping broadcast for {payload.get('type')} - no websocket connected."
+            )
+            return False
+
+        try:
+            message = json.dumps(payload)
+            if hasattr(self.websocket, "send_text"):
+                await self.websocket.send_text(message)
+            else:
+                await self.websocket.send(message)
+            self.logger.debug(f"Successfully broadcasted {payload.get('type')} event.")
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to broadcast {payload.get('type')} event: {e}")
+            return False

--- a/tests/test_canvas_metrics_v8.py
+++ b/tests/test_canvas_metrics_v8.py
@@ -1,0 +1,159 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from magda_agent.skills.canvas_metrics_v8 import (
+    CanvasMemoryMetricsExporterV8,
+    CanvasMetricsBroadcasterV8,
+)
+
+
+def test_exporter_initialization() -> None:
+    """Test default initialization of CanvasMemoryMetricsExporterV8."""
+    exporter = CanvasMemoryMetricsExporterV8(max_events=5)
+    assert exporter.events == []
+    assert exporter.max_events == 5
+
+    summary = exporter.get_metrics_summary()
+    assert summary["total_events"] == 0
+    assert summary["total_consolidated_memories"] == 0
+    assert summary["global_average_importance"] == 0.0
+    assert summary["global_average_compression_ratio"] == 0.0
+
+
+def test_exporter_record_consolidation() -> None:
+    """Test recording memory consolidation events and metric aggregation."""
+    exporter = CanvasMemoryMetricsExporterV8(max_events=3)
+
+    memories_1 = [{"id": "m1", "text": "hello"}, {"id": "m2", "text": "world"}]
+    event_1 = exporter.record_consolidation(
+        user_id="user_123",
+        memories=memories_1,
+        importance_scores=[0.8, 0.6],
+        compression_ratio=0.5,
+        metadata={"category": "user_preferences"},
+    )
+
+    assert event_1["user_id"] == "user_123"
+    assert event_1["consolidated_count"] == 2
+    assert event_1["average_importance"] == 0.7
+    assert event_1["compression_ratio"] == 0.5
+    assert len(exporter.events) == 1
+
+    memories_2 = [{"id": "m3", "text": "foo"}]
+    event_2 = exporter.record_consolidation(
+        user_id="user_123",
+        memories=memories_2,
+        importance_scores=[0.9],
+        compression_ratio=0.3,
+    )
+
+    summary = exporter.get_metrics_summary()
+    assert summary["total_events"] == 2
+    assert summary["total_consolidated_memories"] == 3
+    assert summary["global_average_importance"] == 0.8
+    assert summary["global_average_compression_ratio"] == 0.4
+
+
+def test_exporter_max_events_trimming() -> None:
+    """Test that events beyond max_events are trimmed."""
+    exporter = CanvasMemoryMetricsExporterV8(max_events=2)
+
+    for i in range(5):
+        exporter.record_consolidation(
+            user_id=f"user_{i}",
+            memories=[{"id": f"m_{i}"}],
+            importance_scores=[0.5],
+            compression_ratio=1.0,
+        )
+
+    assert len(exporter.events) == 2
+    assert exporter.events[0]["user_id"] == "user_3"
+    assert exporter.events[1]["user_id"] == "user_4"
+
+
+def test_exporter_payload_and_json() -> None:
+    """Test Canvas UI payload generation and JSON export."""
+    exporter = CanvasMemoryMetricsExporterV8()
+    exporter.record_consolidation(
+        user_id="u1",
+        memories=[{"id": "m1"}],
+        importance_scores=[0.7],
+        compression_ratio=0.6,
+    )
+
+    payload = exporter.get_canvas_payload()
+    assert payload["type"] == "memory_consolidation_metrics"
+    assert payload["status"] == "active"
+    assert "event_id" in payload
+    assert "timestamp" in payload
+    assert "data" in payload
+    assert payload["data"]["summary"]["total_events"] == 1
+    assert len(payload["data"]["recent_events"]) == 1
+
+    json_str = exporter.export_json()
+    parsed = json.loads(json_str)
+    assert parsed["type"] == "memory_consolidation_metrics"
+
+
+@pytest.mark.asyncio
+async def test_broadcaster_send_text() -> None:
+    """Test broadcasting via WebSocket with send_text interface."""
+    mock_websocket = AsyncMock()
+    mock_websocket.send_text = AsyncMock()
+
+    broadcaster = CanvasMetricsBroadcasterV8(websocket=mock_websocket)
+
+    memories = [{"id": "m1", "text": "consolidated text"}]
+    with patch("time.time", return_value=1700000000.0):
+        event = await broadcaster.broadcast_consolidation_metrics(
+            user_id="user_abc",
+            memories=memories,
+            importance_scores=[0.85],
+            compression_ratio=0.4,
+        )
+
+    assert event["user_id"] == "user_abc"
+    assert mock_websocket.send_text.await_count == 1
+
+    sent_data = json.loads(mock_websocket.send_text.call_args[0][0])
+    assert sent_data["type"] == "memory_consolidation_metrics"
+    assert sent_data["data"]["latest_event"]["user_id"] == "user_abc"
+
+
+@pytest.mark.asyncio
+async def test_broadcaster_fallback_send() -> None:
+    """Test broadcasting via WebSocket with fallback send interface."""
+    mock_websocket = AsyncMock()
+    del mock_websocket.send_text
+    mock_websocket.send = AsyncMock()
+
+    broadcaster = CanvasMetricsBroadcasterV8(websocket=mock_websocket)
+
+    success = await broadcaster.broadcast_metrics()
+    assert success is True
+    assert mock_websocket.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcaster_no_websocket() -> None:
+    """Test broadcasting when no WebSocket connection is provided."""
+    broadcaster = CanvasMetricsBroadcasterV8(websocket=None)
+    broadcaster.logger = MagicMock()
+
+    success = await broadcaster.broadcast_metrics()
+    assert success is False
+    broadcaster.logger.debug.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_broadcaster_exception_handling() -> None:
+    """Test handling of exceptions raised during WebSocket broadcasting."""
+    mock_websocket = AsyncMock()
+    mock_websocket.send_text = AsyncMock(side_effect=RuntimeError("Connection closed"))
+
+    broadcaster = CanvasMetricsBroadcasterV8(websocket=mock_websocket)
+    broadcaster.logger = MagicMock()
+
+    success = await broadcaster.broadcast_metrics()
+    assert success is False
+    broadcaster.logger.error.assert_called_once()


### PR DESCRIPTION
Adds CanvasMemoryMetricsExporterV8 and CanvasMetricsBroadcasterV8 in magda_agent/skills/canvas_metrics_v8.py for exporting and broadcasting live memory consolidation metrics via WebSockets, with unit tests and task status update.

---
*PR created automatically by Jules for task [17020937742577899500](https://jules.google.com/task/17020937742577899500) started by @kazah4359-lgtm*