### PR TITLE
Feature: Implement A2ADiscoveryMeshV8 for Agent Card Broadcasting

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13357,7 +13357,7 @@
     },
     {
       "id": "a2a-discovery-mesh-cards-v8-0ee4892e-796f-4470-b084-0579481e265e",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "medium",
       "title": "A2A Discovery Mesh Cards V8",
@@ -31678,6 +31678,58 @@
       "acceptance": [
         "Cron job is configured to perform nightly backups.",
         "Tests verify the backup logic without actually writing backup files."
+      ]
+    },
+    {
+      "id": "hermes-skill-market-export-v3-d67b3ca2",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Skill Market Export V3",
+      "description": "Inspired by Hermes Agent trends: Implement a tool exporter to package learned skills for the agentskills.io standard marketplace.",
+      "allowed_paths": [
+        "magda_agent/skills/hermes_export_v3.py",
+        "tests/test_hermes_export_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Exporter module successfully packages local skills into compatible format.",
+        "Tests pass using mock skills."
+      ]
+    },
+    {
+      "id": "openclaw-live-canvas-telemetry-v9-895dcf05",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "medium",
+      "title": "OpenClaw Live Canvas Telemetry V9",
+      "description": "Inspired by OpenClaw trends: Expose a websocket server to broadcast live local reinforcement learning telemetry and PAD shifts.",
+      "allowed_paths": [
+        "magda_agent/operations/live_rl_v9.py",
+        "tests/test_live_rl_v9.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Websocket server broadcasts PAD telemetry correctly.",
+        "Tests pass mimicking WebSocket connections."
+      ]
+    },
+    {
+      "id": "claude-worktree-multi-agent-planning-v4-133b6ecd",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "Claude Worktree Multi-Agent Planning V4",
+      "description": "Inspired by Claude Agent Teams: Build a dependency graph orchestrator for the Planner subagent to distribute subtasks across isolated git worktrees.",
+      "allowed_paths": [
+        "magda_agent/teams/planner_graph_v4.py",
+        "tests/test_planner_graph_v4.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Planner parses task dependency graph correctly.",
+        "Planner orchestrates parallel tasks across worktrees.",
+        "Tests verify graph resolution and coordination."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_discovery_mesh_v8.py
+++ b/magda_agent/integration/a2a_discovery_mesh_v8.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+from typing import List, Dict, Any
+from dataclasses import asdict
+import httpx
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+
+class A2ADiscoveryMeshV8:
+    """
+    Manages an A2A discovery mesh based on the A2A Protocol trend.
+    It facilitates finding peers with required capabilities using AgentCards,
+    propagates gossip about known peers to other nodes, and allows local
+    processing of broadcasted cards via an asyncio Queue.
+    """
+
+    def __init__(self, discovery: A2ADiscovery) -> None:
+        """
+        Initializes the A2ADiscoveryMeshV8.
+
+        Args:
+            discovery: The core A2ADiscovery instance containing local_card and _discovered_agents.
+        """
+        self.discovery = discovery
+        self.local_broadcast_queue: asyncio.Queue[List[Dict[str, Any]]] = asyncio.Queue()
+
+    def aggregate_cards(self) -> List[AgentCard]:
+        """
+        Aggregates the local agent's card and all discovered peer cards.
+
+        Returns:
+            A list of AgentCard instances known to this mesh node.
+        """
+        cards = [self.discovery.local_card]
+        cards.extend(list(self.discovery._discovered_agents.values()))
+        return cards
+
+    async def broadcast_gossip(self, endpoint_urls: List[str]) -> None:
+        """
+        Broadcasts all known agent cards (gossip) to the specified endpoints.
+        Also puts the aggregated cards into the local_broadcast_queue so they
+        are received locally.
+
+        Args:
+            endpoint_urls: A list of HTTP endpoints (e.g., 'http://192.168.1.10:8000/gossip') to send the cards to.
+        """
+        aggregated_cards = self.aggregate_cards()
+        cards_data = [asdict(card) for card in aggregated_cards]
+
+        # Enqueue for local reception
+        await self.local_broadcast_queue.put(cards_data)
+
+        async with httpx.AsyncClient() as client:
+            for url in endpoint_urls:
+                try:
+                    response = await client.post(url, json=cards_data)
+                    response.raise_for_status()
+                    logging.info(f"Successfully gossiped {len(aggregated_cards)} cards to {url}")
+                except Exception as e:
+                    logging.error(f"Failed to gossip cards to {url}: {e}")
+
+    def receive_gossip(self, cards_data: List[Dict[str, Any]]) -> None:
+        """
+        Receives gossip data (a list of agent card dictionaries) and registers
+        new or updated agents into the discovery service.
+
+        Args:
+            cards_data: A list of dictionaries, each representing an AgentCard.
+        """
+        registered_count = 0
+        for card_dict in cards_data:
+            try:
+                card = AgentCard(**card_dict)
+                # Don't register ourselves if we receive our own card back
+                if card.agent_id != self.discovery.local_card.agent_id:
+                    self.discovery._register_agent(card)
+                    registered_count += 1
+            except Exception as e:
+                logging.error(f"Failed to parse or register agent card from gossip: {e}")
+
+        logging.info(f"Registered {registered_count} cards from gossip.")

--- a/tests/test_a2a_discovery_mesh_v8.py
+++ b/tests/test_a2a_discovery_mesh_v8.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from dataclasses import asdict
+
+from magda_agent.integration.a2a_discovery import A2ADiscovery, AgentCard
+from magda_agent.integration.a2a_discovery_mesh_v8 import A2ADiscoveryMeshV8
+
+@pytest.fixture
+def local_card():
+    return AgentCard(
+        agent_id="local-1",
+        name="Local Agent",
+        description="Local agent for testing",
+        capabilities=["test-cap-1"],
+        endpoints={"gossip": "http://localhost:8000"}
+    )
+
+@pytest.fixture
+def remote_card():
+    return AgentCard(
+        agent_id="remote-1",
+        name="Remote Agent",
+        description="Remote agent for testing",
+        capabilities=["test-cap-2"],
+        endpoints={"gossip": "http://remote:8000"}
+    )
+
+@pytest.fixture
+def discovery(local_card, remote_card):
+    disc = A2ADiscovery(local_card=local_card)
+    disc._register_agent(remote_card)
+    return disc
+
+@pytest.fixture
+def mesh(discovery):
+    return A2ADiscoveryMeshV8(discovery)
+
+def test_aggregate_cards(mesh, local_card, remote_card):
+    cards = mesh.aggregate_cards()
+    assert len(cards) == 2
+    assert local_card in cards
+    assert remote_card in cards
+
+@pytest.mark.asyncio
+async def test_broadcast_gossip_success(mesh, local_card, remote_card):
+    endpoints = ["http://test:8000/gossip"]
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = mock_client.return_value.__aenter__.return_value
+        mock_post = mock_instance.post
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        await mesh.broadcast_gossip(endpoints)
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == endpoints[0]
+        assert "json" in kwargs
+        assert len(kwargs["json"]) == 2
+
+        # Test local broadcast queue
+        assert mesh.local_broadcast_queue.qsize() == 1
+        queue_items = await mesh.local_broadcast_queue.get()
+        assert len(queue_items) == 2
+        assert queue_items[0]["agent_id"] == "local-1"
+
+@pytest.mark.asyncio
+async def test_broadcast_gossip_failure(mesh, local_card, remote_card):
+    endpoints = ["http://test:8000/gossip"]
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = mock_client.return_value.__aenter__.return_value
+        mock_post = mock_instance.post
+        mock_post.side_effect = Exception("Network error")
+
+        # Should not raise exception
+        await mesh.broadcast_gossip(endpoints)
+        mock_post.assert_called_once()
+
+        # Should still enqueue locally
+        assert mesh.local_broadcast_queue.qsize() == 1
+
+def test_receive_gossip(mesh, local_card):
+    # Create a new agent card data
+    new_card_data = {
+        "agent_id": "new-agent-1",
+        "name": "New Agent",
+        "description": "New agent",
+        "capabilities": ["new-cap"],
+        "endpoints": {},
+        "protocol_version": "2.0"
+    }
+
+    # Receive our own card + new card
+    cards_data = [asdict(local_card), new_card_data]
+
+    mesh.receive_gossip(cards_data)
+
+    # Should only register the new agent, not local one again
+    assert "new-agent-1" in mesh.discovery._discovered_agents
+    assert mesh.discovery.get_agent_by_id("new-agent-1").name == "New Agent"


### PR DESCRIPTION
This PR addresses the "A2A Discovery Mesh Cards V8" task from the backlog.

### Changes
1.  **A2A Discovery Mesh V8**: Implemented `magda_agent/integration/a2a_discovery_mesh_v8.py` to handle propagating gossip about known peers to other nodes via HTTP and allows local processing of broadcasted cards using an `asyncio.Queue`.
2.  **Testing**: Implemented a comprehensive test suite in `tests/test_a2a_discovery_mesh_v8.py` using `pytest` and mocked HTTP requests using `unittest.mock.patch` for `httpx.AsyncClient`.
3.  **Task Manifest Updates**: 
    - Set the `a2a-discovery-mesh-cards-v8-0ee4892e-796f-4470-b084-0579481e265e` task to `done`.
    - Added three new trend-inspired tasks to `agent_tasks.json`:
        - `hermes-skill-market-export-v3`
        - `openclaw-live-canvas-telemetry-v9`
        - `claude-worktree-multi-agent-planning-v4`

### Validation
- All pytest tests pass successfully without regressions.
- `agent_tasks.json` passes validation via `scripts/validate_agent_tasks.py`.

---
*PR created automatically by Jules for task [5938975647040565580](https://jules.google.com/task/5938975647040565580) started by @kazah4359-lgtm*