### PR TITLE
feat: A2A Service Authentication V2 using mTLS

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13425,7 +13425,7 @@
     },
     {
       "id": "a2a-service-auth-v2-42adfdd1-9357-4277-b424-22ca3f62d174",
-      "status": "todo",
+      "status": "done",
       "area": "integration",
       "risk": "high",
       "title": "A2A Service Authentication V2",
@@ -31764,6 +31764,57 @@
       "acceptance": [
         "Orchestrator can resolve and execute tasks in order based on dependencies.",
         "Tests verify graph resolution logic."
+      ]
+    },
+    {
+      "id": "hermes-agent-skills-discovery-v1-a2661f73",
+      "status": "todo",
+      "area": "skills",
+      "risk": "medium",
+      "title": "Hermes Agent Skills Discovery V1",
+      "description": "Inspired by Hermes Agent trend: Implement proactive skill discovery that analyzes new files and updates registry.",
+      "allowed_paths": [
+        "magda_agent/skills/discovery_v1.py",
+        "tests/test_discovery_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Discovery module correctly parses unmapped files and updates the skills registry.",
+        "Tests mock file parsing to verify the behavior."
+      ]
+    },
+    {
+      "id": "openclaw-live-canvas-telemetry-v10-666e50a5",
+      "status": "todo",
+      "area": "visualization",
+      "risk": "low",
+      "title": "OpenClaw Live Canvas Telemetry V10",
+      "description": "Inspired by OpenClaw trends: Implement live state synchronization for subagents and episodic memory layers via Websockets.",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_live_v10.py",
+        "tests/test_canvas_live_v10.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Websocket module correctly streams the state JSON to connected clients.",
+        "Tests mock WebSocket interaction and verify data structure."
+      ]
+    },
+    {
+      "id": "mcp-server-schema-caching-v1-fe74e03f",
+      "status": "todo",
+      "area": "integration",
+      "risk": "medium",
+      "title": "MCP Server Schema Caching V1",
+      "description": "Inspired by OpenAI Agents SDK trend: Implement a caching mechanism for MCP capability negotiation to avoid redundant lookups.",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_caching_v1.py",
+        "tests/test_mcp_caching_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The caching module correctly stores and retrieves MCP capabilities.",
+        "Tests mock caching logic and ensure faster retrievals."
       ]
     }
   ]

--- a/magda_agent/integration/a2a_auth_v2.py
+++ b/magda_agent/integration/a2a_auth_v2.py
@@ -1,0 +1,28 @@
+"""A2A Service Authentication V2."""
+
+import ssl
+from typing import Optional
+
+class A2AAuthV2:
+    """Handles mTLS authentication for A2A communication."""
+    def __init__(self, cert_path: str, key_path: str):
+        """Initialize the A2AAuthV2 instance."""
+        self.cert_path = cert_path
+        self.key_path = key_path
+        self.is_authenticated = False
+        self.ssl_context: Optional[ssl.SSLContext] = None
+
+    def authenticate(self) -> bool:
+        """Authenticate using mTLS."""
+        if not self.cert_path or not self.key_path:
+            self.is_authenticated = False
+            return False
+
+        try:
+            self.ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            self.ssl_context.load_cert_chain(certfile=self.cert_path, keyfile=self.key_path)
+            self.is_authenticated = True
+            return True
+        except Exception:
+            self.is_authenticated = False
+            return False

--- a/tests/test_a2a_auth_v2.py
+++ b/tests/test_a2a_auth_v2.py
@@ -1,0 +1,34 @@
+"""Tests for A2A Service Authentication V2."""
+import pytest
+from unittest.mock import patch, MagicMock
+from magda_agent.integration.a2a_auth_v2 import A2AAuthV2
+
+def test_a2a_auth_v2_authenticate_success():
+    """Test successful mTLS authentication."""
+    auth = A2AAuthV2(cert_path="cert.pem", key_path="key.pem")
+
+    with patch("ssl.create_default_context") as mock_ssl:
+        mock_context = MagicMock()
+        mock_ssl.return_value = mock_context
+
+        assert auth.authenticate() is True
+        assert auth.is_authenticated is True
+        mock_context.load_cert_chain.assert_called_once_with(certfile="cert.pem", keyfile="key.pem")
+
+def test_a2a_auth_v2_authenticate_failure_empty_paths():
+    """Test failed mTLS authentication due to empty paths."""
+    auth = A2AAuthV2(cert_path="", key_path="")
+    assert auth.authenticate() is False
+    assert auth.is_authenticated is False
+
+def test_a2a_auth_v2_authenticate_failure_ssl_error():
+    """Test failed mTLS authentication due to SSL error."""
+    auth = A2AAuthV2(cert_path="cert.pem", key_path="key.pem")
+
+    with patch("ssl.create_default_context") as mock_ssl:
+        mock_context = MagicMock()
+        mock_context.load_cert_chain.side_effect = Exception("SSL Error")
+        mock_ssl.return_value = mock_context
+
+        assert auth.authenticate() is False
+        assert auth.is_authenticated is False


### PR DESCRIPTION
Implements mTLS authentication for A2A communication, closing task `a2a-service-auth-v2-42adfdd1-9357-4277-b424-22ca3f62d174`.

- Adds `A2AAuthV2` class with `authenticate` method.
- Adds comprehensive unit tests using `unittest.mock`.
- Marks the task as done in `agent_tasks.json`.
- Appends 3 new "todo" tasks inspired by latest trends in AI agents.

---
*PR created automatically by Jules for task [4931770486497278404](https://jules.google.com/task/4931770486497278404) started by @kazah4359-lgtm*