### PR TITLE
feat: implement MCP taint propagation sandbox V4

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13442,7 +13442,7 @@
     },
     {
       "id": "mcp-taint-propagation-sandbox-v4-de7864dd-bb04-421c-8aea-f30c60a7dd60",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Taint Propagation Sandbox V4",
@@ -31815,6 +31815,57 @@
       "acceptance": [
         "The caching module correctly stores and retrieves MCP capabilities.",
         "Tests mock caching logic and ensure faster retrievals."
+      ]
+    },
+    {
+      "id": "hermes-nightly-state-consolidation-v1-a1b2c3d4",
+      "title": "Hermes Nightly State Consolidation Subagent V1",
+      "description": "Inspired by Hermes Agent operations trend: Implement a specialized subagent for nightly compaction of procedural and semantic memory.",
+      "status": "todo",
+      "area": "operations",
+      "risk": "low",
+      "allowed_paths": [
+        "magda_agent/operations/nightly_compaction_v1.py",
+        "tests/test_nightly_compaction_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent successfully aggregates episodic history into semantic graphs.",
+        "Tests pass with mock LLM calls."
+      ]
+    },
+    {
+      "id": "openclaw-context-hook-profiler-v1-d4e5f6g7",
+      "title": "OpenClaw Context Hook Profiler V1",
+      "description": "Inspired by OpenClaw architecture trend: Create a profiler that measures latency and context size of lifecycle hooks in the Context Engine.",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "medium",
+      "allowed_paths": [
+        "magda_agent/architecture/hook_profiler_v1.py",
+        "tests/test_hook_profiler_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Profiler accurately tracks execution time and context deltas for hooks.",
+        "Tests verify profiler stats with mocked hook functions."
+      ]
+    },
+    {
+      "id": "claude-agent-tool-concurrency-taint-isolation-v1-g7h8i9j0",
+      "title": "Claude Agent Tool Concurrency Taint Isolation V1",
+      "description": "Inspired by Claude Agent tool concurrency and taint tracking trends: Implement isolation to prevent taint cross-contamination when multiple tools are run concurrently via asyncio.gather.",
+      "status": "todo",
+      "area": "safety",
+      "risk": "high",
+      "allowed_paths": [
+        "magda_agent/safety/concurrent_taint_isolation_v1.py",
+        "tests/test_concurrent_taint_isolation_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Concurrent tool calls properly isolate their internal context variables for taint.",
+        "Tests verify isolated propagation with asyncio tasks."
       ]
     }
   ]

--- a/magda_agent/safety/taint_sandbox_v4.py
+++ b/magda_agent/safety/taint_sandbox_v4.py
@@ -1,0 +1,130 @@
+"""MCPKernel Taint Tracking Sandbox V4.
+
+Provides an enhanced sandbox execution environment that strictly deep-taints
+outputs (like lists and dicts) when any input was tainted, enforcing strong
+provenance tracking within MCP tools.
+"""
+from typing import Any, Callable, Dict
+
+# We import from v2 to avoid circular imports present in v3 when importing EpisodicMemory -> MemorySystem -> TaintedWorkingMemory -> v3
+from magda_agent.safety.taint_tracking_v2 import (
+    MCPKernelV2,
+    SandboxExecutionEnvironmentV2,
+    TaintTrackerV2,
+)
+from magda_agent.safety.taint import PolicyViolationError
+
+
+class TaintTrackerV4(TaintTrackerV2):
+    """Enhanced TaintTracker inheriting from V2/V3 equivalent.
+
+    Provides strict propagation tracking for sandbox environments.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the TaintTrackerV4."""
+        super().__init__()
+
+
+class SandboxExecutionEnvironmentV4(SandboxExecutionEnvironmentV2):
+    """An enhanced sandbox execution environment using TaintTrackerV4.
+
+    This sandbox ensures that if any inputs to a tool are tainted,
+    the output structures (such as lists or dicts) are deeply tainted
+    with the combined origins of all tainted inputs.
+    """
+
+    def __init__(self, tracker: TaintTrackerV4) -> None:
+        """Initialize the SandboxExecutionEnvironmentV4.
+
+        Args:
+            tracker: The TaintTrackerV4 instance.
+        """
+        super().__init__(tracker=tracker)
+
+    def execute(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute a function in the sandbox.
+
+        Automatically deep-propagates taint from inputs to output structures.
+
+        Args:
+            func: The function to execute.
+            *args: Positional arguments for the function.
+            **kwargs: Keyword arguments for the function.
+
+        Returns:
+            The result of execution, deep-tainted if any inputs were tainted.
+        """
+        origins = set()
+        for arg in args:
+            origins.update(self.tracker.get_origins(arg))
+        for val in kwargs.values():
+            origins.update(self.tracker.get_origins(val))
+
+        result = super().execute(func, *args, **kwargs)
+
+        if origins:
+            return self.tracker.taint_with_origins(result, origins)
+        return result
+
+    async def execute_async(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute an async function in the sandbox.
+
+        Automatically deep-propagates taint from inputs to output structures.
+
+        Args:
+            func: The async function to execute.
+            *args: Positional arguments for the function.
+            **kwargs: Keyword arguments for the function.
+
+        Returns:
+            The awaited result of execution, deep-tainted if any inputs were tainted.
+        """
+        origins = set()
+        for arg in args:
+            origins.update(self.tracker.get_origins(arg))
+        for val in kwargs.values():
+            origins.update(self.tracker.get_origins(val))
+
+        result = await super().execute_async(func, *args, **kwargs)
+
+        if origins:
+            return self.tracker.taint_with_origins(result, origins)
+        return result
+
+
+class MCPKernelV4(MCPKernelV2):
+    """Enhanced Kernel for executing tools safely with V4 taint origin tracking."""
+
+    def __init__(self) -> None:
+        """Initialize the MCPKernelV4."""
+        super().__init__()
+        self.tracker = TaintTrackerV4()
+        self.sandbox = SandboxExecutionEnvironmentV4(self.tracker)
+
+    def execute_tool(self, tool_func: Callable[..., Any], inputs: Dict[str, Any], is_sensitive: bool = False) -> Any:
+        """Executes a tool within the kernel. If is_sensitive is True, tainted inputs will fail.
+
+        Args:
+            tool_func: The tool function.
+            inputs: Dict of input arguments.
+            is_sensitive: Whether the tool is sensitive and should block tainted inputs.
+
+        Returns:
+            The result of tool execution.
+
+        Raises:
+            PolicyViolationError: If a sensitive tool receives tainted inputs.
+            RuntimeError: If execution fails for other reasons.
+        """
+        if is_sensitive:
+            if self.tracker.is_tainted(inputs):
+                origins = self.tracker.get_origins(inputs)
+                raise PolicyViolationError(f"Tainted input to sensitive tool call from origins: {origins}")
+
+        try:
+            return self.sandbox.execute(tool_func, **inputs)
+        except Exception as e:
+            if isinstance(e, PolicyViolationError):
+                raise
+            raise RuntimeError(f"Tool execution failed: {str(e)}")

--- a/tests/test_taint_sandbox_v4.py
+++ b/tests/test_taint_sandbox_v4.py
@@ -1,0 +1,84 @@
+"""Tests for MCPKernel Taint Tracking Sandbox V4."""
+import pytest
+
+from magda_agent.safety.taint import PolicyViolationError
+from magda_agent.safety.taint_sandbox_v4 import (
+    MCPKernelV4,
+    SandboxExecutionEnvironmentV4,
+    TaintTrackerV4,
+)
+from magda_agent.safety.taint_tracking_v2 import TaintedString
+
+
+def test_sandbox_execute_sync_taint_v4() -> None:
+    """Test that SandboxExecutionEnvironmentV4 properly deep taints synchronous list outputs."""
+    tracker = TaintTrackerV4()
+    sandbox = SandboxExecutionEnvironmentV4(tracker)
+
+    def mock_tool(input_str: str) -> list:
+        return ["hello", input_str]
+
+    # Create tainted input
+    tainted_input = tracker.taint("world", "user_input")
+
+    # Execute
+    result = sandbox.execute(mock_tool, tainted_input)
+
+    # Verify result is a list and elements are tainted
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    assert tracker.is_tainted(result[0])
+    assert tracker.is_tainted(result[1])
+
+    origins_0 = tracker.get_origins(result[0])
+    origins_1 = tracker.get_origins(result[1])
+
+    assert "user_input" in origins_0
+    assert "user_input" in origins_1
+
+
+@pytest.mark.asyncio
+async def test_sandbox_execute_async_taint_v4() -> None:
+    """Test that SandboxExecutionEnvironmentV4 properly deep taints async dict outputs."""
+    tracker = TaintTrackerV4()
+    sandbox = SandboxExecutionEnvironmentV4(tracker)
+
+    async def mock_async_tool(input_str: str) -> dict:
+        return {"data": input_str, "status": "ok"}
+
+    # Create tainted input
+    tainted_input = tracker.taint("sensitive_data", "network_call")
+
+    # Execute async
+    result = await sandbox.execute_async(mock_async_tool, tainted_input)
+
+    # Verify dict elements are tainted
+    assert isinstance(result, dict)
+
+    assert tracker.is_tainted(result)
+    assert tracker.is_tainted(result["data"])
+    assert tracker.is_tainted(result["status"])
+
+    assert "network_call" in tracker.get_origins(result["data"])
+    assert "network_call" in tracker.get_origins(result["status"])
+
+
+def test_mcp_kernel_v4_sensitive_block() -> None:
+    """Test that MCPKernelV4 blocks sensitive executions with tainted data."""
+    kernel = MCPKernelV4()
+
+    def sensitive_tool(data: str) -> str:
+        return f"Processed {data}"
+
+    # Tainted input
+    tainted_dict = {"data": kernel.tracker.taint("bad_data", "malicious_actor")}
+
+    # Should raise PolicyViolationError because tool is marked sensitive and input is tainted
+    with pytest.raises(PolicyViolationError, match="Tainted input to sensitive tool call from origins"):
+        kernel.execute_tool(sensitive_tool, tainted_dict, is_sensitive=True)
+
+    # Should succeed if not sensitive
+    result = kernel.execute_tool(sensitive_tool, tainted_dict, is_sensitive=False)
+    assert isinstance(result, TaintedString)
+    assert "malicious_actor" in kernel.tracker.get_origins(result)


### PR DESCRIPTION
Implements task `mcp-taint-propagation-sandbox-v4-de7864dd-bb04-421c-8aea-f30c60a7dd60`.

Added `SandboxExecutionEnvironmentV4` and `MCPKernelV4` derived safely from `V2` (resolving a circular import associated with V3) to actively intercept execution payloads, harvest origins, and recursively deep-taint output variables (such as nested arrays and dictionaries). Also updated tasks in JSON manifest.

---
*PR created automatically by Jules for task [14785343807103164762](https://jules.google.com/task/14785343807103164762) started by @kazah4359-lgtm*