### PR TITLE
feat(safety): implement MCPAuditTrailV1 for action tools

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13476,7 +13476,7 @@
     },
     {
       "id": "mcp-agent-action-tools-audit-v1-68f664a0-eec9-49f9-ab30-330a32f42c16",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Agent Action Tools Audit V1",
@@ -31917,6 +31917,59 @@
       "acceptance": [
         "Aggregator generates accurate activity strings from dummy database items.",
         "Tests mock DB records and assert output format."
+      ]
+    },
+    {
+      "id": "acs-guard-memory-v1-0943e5c6",
+      "status": "todo",
+      "area": "safety",
+      "risk": "medium",
+      "title": "ACS Memory Governance Guard V1",
+      "description": "Inspired by ACS controls trend: Implement a specialized ACS governance guard that specifically filters and verifies memory retrieval operations to prevent taint poisoning.",
+      "allowed_paths": [
+        "magda_agent/safety/acs_memory_guard_v1.py",
+        "tests/test_acs_memory_guard_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "The memory guard intercepts and sanitizes retrieved memory context based on taint annotations.",
+        "Tests verify the guard accurately filters or blocks poisoned memory snippets without executing actual LLM requests."
+      ]
+    },
+    {
+      "id": "a2a-skill-delegation-protocol-v3-6442ba2c",
+      "status": "todo",
+      "area": "multi-agent",
+      "risk": "high",
+      "title": "A2A Skill Delegation Protocol V3",
+      "description": "Inspired by A2A Protocol trends: Implement a discovery and delegation protocol that maps local procedural skills to generic Agent Cards for multi-agent peer delegation over HTTP.",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_skill_delegation_v3.py",
+        "tests/test_a2a_skill_delegation_v3.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Protocol correctly formats local skills into valid A2A Agent Cards.",
+        "Delegator can dispatch a structured HTTP request representing a skill execution to a peer agent.",
+        "Tests pass using mocked httpx responses and mocked skills."
+      ]
+    },
+    {
+      "id": "hermes-procedural-memory-consolidation-v2-40dbd7ad",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "Hermes Procedural Memory Consolidation V2",
+      "description": "Inspired by Hermes Agent self-improving loops: Create an offline sub-routine that evaluates the audit trail of tool invocations (using AuditTrail and MCPAuditTrailV1) to detect successful patterns and consolidate them into new procedural memory skills.",
+      "allowed_paths": [
+        "magda_agent/learning/hermes_procedural_consolidation_v2.py",
+        "tests/test_hermes_procedural_consolidation_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Routine extracts sequences of successful tool calls from the audit logs.",
+        "Routine generates proposed new procedural skill definitions from those patterns.",
+        "Tests mock the audit log and LLM summarizer correctly."
       ]
     }
   ]

--- a/magda_agent/safety/mcp_audit_v1.py
+++ b/magda_agent/safety/mcp_audit_v1.py
@@ -1,0 +1,186 @@
+import json
+import logging
+import sqlite3
+import time
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional
+
+class MCPAuditTrailV1:
+    """
+    Records and queries MCP specific tool invocations to track tool usage frequency and execution results.
+    Includes in-memory buffering and optional SQLite persistence.
+    """
+
+    def __init__(self, max_capacity: int = 1000, db_path: Optional[str] = "mcp_audit_trail_v1.db") -> None:
+        """
+        Initializes the MCPAuditTrailV1 with a fixed capacity and an SQLite database for persistence.
+
+        Args:
+            max_capacity: Maximum number of entries to keep in the in-memory trail.
+            db_path: Path to the SQLite database file. If None, only in-memory logging is used.
+        """
+        self.max_capacity = max_capacity
+        self.trail: Deque[Dict[str, Any]] = deque(maxlen=max_capacity)
+        self.db_path = db_path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Initializes the SQLite database schema if a path is provided."""
+        if not self.db_path:
+            return
+
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    CREATE TABLE IF NOT EXISTS mcp_audit_logs (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp REAL NOT NULL,
+                        server_name TEXT NOT NULL,
+                        tool_name TEXT NOT NULL,
+                        arguments TEXT NOT NULL,
+                        result TEXT NOT NULL,
+                        duration REAL NOT NULL,
+                        status TEXT NOT NULL
+                    )
+                    '''
+                )
+                conn.commit()
+        except sqlite3.Error as e:
+            logging.error(f"Failed to initialize SQLite mcp audit database at {self.db_path}: {e}")
+
+    async def log_mcp_invocation(self, server_name: str, tool_name: str, arguments: Dict[str, Any], result: Any, duration: float, status: str = "success") -> None:
+        """
+        Logs an MCP tool invocation.
+
+        Args:
+            server_name: The name of the MCP server.
+            tool_name: The name of the executed tool.
+            arguments: The arguments passed to the tool.
+            result: The outcome of the execution.
+            duration: Time taken in seconds.
+            status: The status of the invocation (e.g. "success", "error").
+        """
+        timestamp = time.time()
+
+        # Simple sanitization or just deepcopying could be done here similar to standard audit.
+        # Assuming arguments and results are JSON serializable.
+
+        entry = {
+            "timestamp": timestamp,
+            "server_name": server_name,
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "result": result,
+            "duration": duration,
+            "status": status
+        }
+
+        self.trail.append(entry)
+
+        if self.db_path:
+            import asyncio
+            def _log():
+                try:
+                    with sqlite3.connect(self.db_path) as conn:
+                        cursor = conn.cursor()
+                        cursor.execute(
+                            '''
+                            INSERT INTO mcp_audit_logs (timestamp, server_name, tool_name, arguments, result, duration, status)
+                            VALUES (?, ?, ?, ?, ?, ?, ?)
+                            ''',
+                            (
+                                timestamp,
+                                server_name,
+                                tool_name,
+                                json.dumps(arguments),
+                                json.dumps(result) if not isinstance(result, str) else result,
+                                duration,
+                                status
+                            )
+                        )
+                        conn.commit()
+                except sqlite3.Error as e:
+                    logging.error(f"Failed to log to SQLite mcp audit database at {self.db_path}: {e}")
+            await asyncio.to_thread(_log)
+
+    def get_mcp_logs(self, server_name: Optional[str] = None, tool_name: Optional[str] = None, status: Optional[str] = None) -> List[Dict[str, Any]]:
+        """
+        Queries the audit logs from the SQLite database.
+
+        Args:
+            server_name: Filter by MCP server name.
+            tool_name: Filter by tool name.
+            status: Filter by execution status.
+
+        Returns:
+            A list of matching audit log entries.
+        """
+        if not self.db_path:
+            results = list(self.trail)
+            if server_name:
+                results = [r for r in results if r["server_name"] == server_name]
+            if tool_name:
+                results = [r for r in results if r["tool_name"] == tool_name]
+            if status:
+                results = [r for r in results if r["status"] == status]
+            return results
+
+        results = []
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                query = "SELECT timestamp, server_name, tool_name, arguments, result, duration, status FROM mcp_audit_logs WHERE 1=1"
+                params = []
+
+                if server_name:
+                    query += " AND server_name = ?"
+                    params.append(server_name)
+                if tool_name:
+                    query += " AND tool_name = ?"
+                    params.append(tool_name)
+                if status:
+                    query += " AND status = ?"
+                    params.append(status)
+
+                cursor.execute(query, tuple(params))
+                rows = cursor.fetchall()
+
+                for row in rows:
+                    try:
+                        args_dict = json.loads(row[3])
+                    except json.JSONDecodeError:
+                        args_dict = row[3]
+
+                    try:
+                        res_obj = json.loads(row[4])
+                    except (json.JSONDecodeError, TypeError):
+                        res_obj = row[4]
+
+                    results.append({
+                        "timestamp": row[0],
+                        "server_name": row[1],
+                        "tool_name": row[2],
+                        "arguments": args_dict,
+                        "result": res_obj,
+                        "duration": row[5],
+                        "status": row[6]
+                    })
+        except sqlite3.Error as e:
+            logging.error(f"Failed to query SQLite mcp audit database at {self.db_path}: {e}")
+
+        return results
+
+    def clear(self) -> None:
+        """Clears all entries from the in-memory trail and the SQLite database."""
+        self.trail.clear()
+
+        if self.db_path:
+            try:
+                with sqlite3.connect(self.db_path) as conn:
+                    cursor = conn.cursor()
+                    cursor.execute("DELETE FROM mcp_audit_logs")
+                    conn.commit()
+            except sqlite3.Error as e:
+                logging.error(f"Failed to clear SQLite mcp audit database at {self.db_path}: {e}")

--- a/magda_agent/skills/mcp_registry_sync_v11.py
+++ b/magda_agent/skills/mcp_registry_sync_v11.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Optional
 import httpx
 
 from magda_agent.skills.mcp_registry import MCPRegistry
+from magda_agent.safety.mcp_audit_v1 import MCPAuditTrailV1
 
 
 class MCPRegistrySyncV11:
@@ -29,6 +30,7 @@ class MCPRegistrySyncV11:
         self._running = False
         self._task: Optional[asyncio.Task[None]] = None
         self.logger = logging.getLogger(__name__)
+        self.mcp_audit = MCPAuditTrailV1()
 
     async def _sync_loop(self) -> None:
         """
@@ -130,3 +132,30 @@ class MCPRegistrySyncV11:
                 pass
             self._task = None
         self.logger.info("Stopped MCPRegistrySyncV11 loop.")
+
+    async def execute_tool(self, tool_name: str, **kwargs: Any) -> Any:
+        """
+        Executes a synchronized tool and logs the execution to the MCP audit trail.
+
+        Args:
+            tool_name (str): The name of the tool to execute.
+            kwargs: Arguments to pass to the tool.
+
+        Returns:
+            The result of the tool execution.
+        """
+        import time
+        start_time = time.time()
+        status = "success"
+        result = None
+        try:
+            result = await self.registry.execute_tool(tool_name, **kwargs)
+            return result
+        except Exception as e:
+            status = "error"
+            result = {"error": str(e)}
+            self.logger.error(f"Error executing synced tool '{tool_name}': {e}")
+            raise
+        finally:
+            duration = time.time() - start_time
+            await self.mcp_audit.log_mcp_invocation(server_name=self.mcp_server_url, tool_name=tool_name, arguments=kwargs, result=result, duration=duration, status=status)

--- a/tests/test_mcp_audit_v1.py
+++ b/tests/test_mcp_audit_v1.py
@@ -1,0 +1,113 @@
+import pytest
+import sqlite3
+import os
+from magda_agent.safety.mcp_audit_v1 import MCPAuditTrailV1
+
+@pytest.fixture
+def temp_db_path(tmp_path):
+    db_file = tmp_path / "test_mcp_audit.db"
+    yield str(db_file)
+    if db_file.exists():
+        db_file.unlink()
+
+@pytest.fixture
+def mcp_audit(temp_db_path):
+    audit = MCPAuditTrailV1(db_path=temp_db_path)
+    yield audit
+    audit.clear()
+
+@pytest.mark.asyncio
+async def test_log_and_get_mcp_logs(mcp_audit):
+    # Log some invocations
+    await mcp_audit.log_mcp_invocation(
+        server_name="test_server_1",
+        tool_name="test_tool_A",
+        arguments={"arg1": "val1"},
+        result={"res": "ok"},
+        duration=1.2,
+        status="success"
+    )
+
+    await mcp_audit.log_mcp_invocation(
+        server_name="test_server_1",
+        tool_name="test_tool_B",
+        arguments={"arg2": "val2"},
+        result={"error": "failed"},
+        duration=0.5,
+        status="error"
+    )
+
+    await mcp_audit.log_mcp_invocation(
+        server_name="test_server_2",
+        tool_name="test_tool_C",
+        arguments={"arg3": "val3"},
+        result="success_str",
+        duration=2.1,
+        status="success"
+    )
+
+    # Test get all logs
+    logs = mcp_audit.get_mcp_logs()
+    assert len(logs) == 3
+
+    # Test filtering by server_name
+    logs_server_1 = mcp_audit.get_mcp_logs(server_name="test_server_1")
+    assert len(logs_server_1) == 2
+    assert all(log["server_name"] == "test_server_1" for log in logs_server_1)
+
+    # Test filtering by tool_name
+    logs_tool_B = mcp_audit.get_mcp_logs(tool_name="test_tool_B")
+    assert len(logs_tool_B) == 1
+    assert logs_tool_B[0]["tool_name"] == "test_tool_B"
+    assert logs_tool_B[0]["status"] == "error"
+
+    # Test filtering by status
+    logs_success = mcp_audit.get_mcp_logs(status="success")
+    assert len(logs_success) == 2
+    assert all(log["status"] == "success" for log in logs_success)
+
+    # Check data integrity
+    log_a = mcp_audit.get_mcp_logs(tool_name="test_tool_A")[0]
+    assert log_a["arguments"] == {"arg1": "val1"}
+    assert log_a["result"] == {"res": "ok"}
+    assert log_a["duration"] == 1.2
+
+@pytest.mark.asyncio
+async def test_mcp_audit_in_memory_only():
+    audit = MCPAuditTrailV1(db_path=None)
+
+    await audit.log_mcp_invocation(
+        server_name="mem_server",
+        tool_name="mem_tool",
+        arguments={"k": "v"},
+        result="ok",
+        duration=0.1,
+        status="success"
+    )
+
+    logs = audit.get_mcp_logs(server_name="mem_server")
+    assert len(logs) == 1
+    assert logs[0]["tool_name"] == "mem_tool"
+
+    audit.clear()
+    assert len(audit.get_mcp_logs()) == 0
+
+@pytest.mark.asyncio
+async def test_mcp_audit_persistence(temp_db_path):
+    audit1 = MCPAuditTrailV1(db_path=temp_db_path)
+    await audit1.log_mcp_invocation(
+        server_name="persistent_server",
+        tool_name="persistent_tool",
+        arguments={"k": "v"},
+        result="ok",
+        duration=0.1,
+        status="success"
+    )
+
+    # Re-initialize with same path to test persistence
+    audit2 = MCPAuditTrailV1(db_path=temp_db_path)
+    logs = audit2.get_mcp_logs()
+
+    assert len(logs) == 1
+    assert logs[0]["server_name"] == "persistent_server"
+    assert logs[0]["tool_name"] == "persistent_tool"

--- a/tests/test_mcp_registry_sync_v11.py
+++ b/tests/test_mcp_registry_sync_v11.py
@@ -6,6 +6,7 @@ import pytest
 
 from magda_agent.skills.mcp_registry import MCPRegistry
 from magda_agent.skills.mcp_registry_sync_v11 import MCPRegistrySyncV11
+from unittest.mock import AsyncMock
 
 @pytest.fixture
 def registry() -> MCPRegistry:
@@ -163,3 +164,40 @@ async def test_start_stop() -> None:
         assert sync._task is None
 
         mock_sync_once.assert_called()
+
+@pytest.mark.asyncio
+async def test_execute_tool(registry):
+
+    sync_instance = MCPRegistrySyncV11(registry, "http://example.com")
+    registry.execute_tool = AsyncMock(return_value="mock_result")
+
+    # Mock the audit trail
+    sync_instance.mcp_audit.log_mcp_invocation = AsyncMock()
+
+    result = await sync_instance.execute_tool("my_tool", arg1="val1")
+
+    assert result == "mock_result"
+    registry.execute_tool.assert_called_once_with("my_tool", arg1="val1")
+    sync_instance.mcp_audit.log_mcp_invocation.assert_called_once()
+    args, kwargs = sync_instance.mcp_audit.log_mcp_invocation.call_args
+    assert kwargs["server_name"] == "http://example.com"
+    assert kwargs["tool_name"] == "my_tool"
+    assert kwargs["arguments"] == {"arg1": "val1"}
+    assert kwargs["result"] == "mock_result"
+    assert kwargs["status"] == "success"
+
+@pytest.mark.asyncio
+async def test_execute_tool_error(registry):
+
+    sync_instance = MCPRegistrySyncV11(registry, "http://example.com")
+    registry.execute_tool = AsyncMock(side_effect=Exception("mock_error"))
+
+    sync_instance.mcp_audit.log_mcp_invocation = AsyncMock()
+
+    with pytest.raises(Exception):
+        await sync_instance.execute_tool("my_tool", arg1="val1")
+
+    sync_instance.mcp_audit.log_mcp_invocation.assert_called_once()
+    args, kwargs = sync_instance.mcp_audit.log_mcp_invocation.call_args
+    assert kwargs["status"] == "error"
+    assert kwargs["result"] == {"error": "mock_error"}


### PR DESCRIPTION
Inspired by MCP Standard trends, this adds `MCPAuditTrailV1` inside `magda_agent/safety/mcp_audit_v1.py` with in-memory buffers and SQLite persistence, safely using `asyncio.to_thread`. Integrates into `MCPRegistrySyncV11.execute_tool` to proxy tool logs securely. Also appended new tasks based on trends.

---
*PR created automatically by Jules for task [3804752996617441309](https://jules.google.com/task/3804752996617441309) started by @kazah4359-lgtm*