### PR TITLE
feat: implement OpenClaw RL Canvas Skills Metrics V2

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13510,7 +13510,7 @@
     },
     {
       "id": "openclaw-rl-canvas-skills-metrics-v2-3fd53530-b2f2-4fa2-a905-96e6577ec73c",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw RL Canvas Skills Metrics V2",
@@ -32023,6 +32023,57 @@
       "acceptance": [
         "Capability negotiation module created.",
         "Tests mock tool negotiation correctly."
+      ]
+    },
+    {
+      "id": "claude-code-subagent-evaluation-v6-0f831bc6",
+      "title": "Claude Code Subagent Evaluation V6",
+      "description": "Inspired by Claude Code and Agent Teams: Implement a subagent task capable of evaluating multi-step planner outputs independently before merging results.",
+      "area": "evaluation",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/evaluation/claude_subagent_v6.py",
+        "tests/test_claude_subagent_v6.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Subagent spawns in isolation and evaluates input context.",
+        "Tests mock subagent execution and verify results."
+      ]
+    },
+    {
+      "id": "mcp-server-dynamic-discovery-v15-0c9b2e8d",
+      "title": "MCP Server Dynamic Discovery V15",
+      "description": "Inspired by MCP standard adoption: Implement a background polling mechanism to dynamically discover new MCP capabilities from an external registry without restarting.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/mcp_discovery_v15.py",
+        "tests/test_mcp_discovery_v15.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Mechanism successfully polls and registers new capabilities.",
+        "Tests verify background execution and capability synchronization."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-realtime-rl-v12-6880a606",
+      "title": "OpenClaw Canvas Realtime RL State Visualizer V12",
+      "description": "Inspired by OpenClaw Canvas Live Visualization: Develop an extension for the Canvas server to display RL behavior weights and user interaction penalties in real time.",
+      "area": "visualization",
+      "risk": "low",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_rl_state_v12.py",
+        "tests/test_canvas_rl_state_v12.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "WebSocket updates include live RL weight metrics.",
+        "Tests mock internal RL state changes and assert WebSocket payload validity."
       ]
     }
   ]

--- a/backlog.md
+++ b/backlog.md
@@ -11,6 +11,7 @@
 
 ## 🧠 Архитектура мозга
 
+* [x] FEATURE: OpenClaw RL Canvas Skills Metrics V2 (openclaw-rl-canvas-skills-metrics-v2-3fd53530-b2f2-4fa2-a905-96e6577ec73c)
 * [x] MODULE: **Mirror Neuron System (Система зеркальных нейронов)** — модуль `magda_agent/emotions/mirror_neurons.py`. (2026-06-04)
   Отвечает за базовую эмпатию: анализирует текст пользователя на наличие позитивных/негативных слов и возвращает сдвиг для PAD (Pleasure, Arousal, Dominance).
   Метод `empathize(text)` — возвращает кортеж (p_shift, a_shift, d_shift) в зависимости от тональности.

--- a/magda_agent/learning/canvas_skills_metrics_v2.py
+++ b/magda_agent/learning/canvas_skills_metrics_v2.py
@@ -1,0 +1,98 @@
+"""
+OpenClaw RL Canvas Skills Metrics V2
+
+This module provides a WebSocket handler to broadcast dynamic skill adjustments
+and learning metrics over websockets for real-time visualization.
+"""
+
+import asyncio
+import json
+import time
+from typing import Dict, Any, List
+
+class CanvasSkillsMetricsV2:
+    """
+    Handles streaming of skill metrics and adjustments over WebSockets.
+    """
+
+    def __init__(self):
+        """Initializes the metrics visualizer state."""
+        self.connected_clients: List[Any] = []
+
+    async def register_client(self, websocket: Any) -> None:
+        """
+        Registers a new WebSocket client.
+
+        Args:
+            websocket: The websocket connection to register.
+        """
+        self.connected_clients.append(websocket)
+
+    async def unregister_client(self, websocket: Any) -> None:
+        """
+        Unregisters a WebSocket client.
+
+        Args:
+            websocket: The websocket connection to unregister.
+        """
+        if websocket in self.connected_clients:
+            self.connected_clients.remove(websocket)
+
+    def format_payload(self, event_type: str, data: Dict[str, Any]) -> str:
+        """
+        Formats a metric payload into a JSON string with timestamp.
+
+        Args:
+            event_type: The type of event (e.g., 'skill_adjustment', 'learning_metric').
+            data: The core payload data.
+
+        Returns:
+            str: JSON formatted string payload.
+        """
+        payload = {
+            "timestamp": time.time(),
+            "type": event_type,
+            "data": data
+        }
+        return json.dumps(payload)
+
+    async def broadcast_metric(self, event_type: str, data: Dict[str, Any]) -> None:
+        """
+        Broadcasts a metric event to all connected WebSocket clients.
+
+        Args:
+            event_type: The type of metric event.
+            data: The metric data payload.
+        """
+        if not self.connected_clients:
+            return
+
+        payload = self.format_payload(event_type, data)
+
+        tasks = []
+        for client in self.connected_clients:
+            # Assuming client has a send method compatible with asyncio WebSockets
+            tasks.append(client.send(payload))
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def handle_connection(self, websocket: Any, path: str = "/") -> None:
+        """
+        An async WebSocket handler that receives metrics and forwards them.
+
+        Args:
+            websocket: The WebSocket connection.
+            path: The connection path.
+        """
+        await self.register_client(websocket)
+        try:
+            # Keep connection open and listen for incoming messages if necessary.
+            # Here we just wait for disconnection.
+            async for _ in websocket:
+                pass
+        except Exception as e:
+            # Handle disconnection
+            pass
+        finally:
+            await self.unregister_client(websocket)

--- a/tests/test_canvas_skills_metrics_v2.py
+++ b/tests/test_canvas_skills_metrics_v2.py
@@ -1,0 +1,73 @@
+import pytest
+import json
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from magda_agent.learning.canvas_skills_metrics_v2 import CanvasSkillsMetricsV2
+
+@pytest.fixture
+def metrics_broadcaster():
+    return CanvasSkillsMetricsV2()
+
+@pytest.mark.asyncio
+async def test_register_unregister_client(metrics_broadcaster):
+    mock_websocket = AsyncMock()
+
+    await metrics_broadcaster.register_client(mock_websocket)
+    assert mock_websocket in metrics_broadcaster.connected_clients
+
+    await metrics_broadcaster.unregister_client(mock_websocket)
+    assert mock_websocket not in metrics_broadcaster.connected_clients
+
+def test_format_payload(metrics_broadcaster):
+    with patch('time.time', return_value=12345.0):
+        payload_str = metrics_broadcaster.format_payload('test_event', {'score': 100})
+
+        payload_dict = json.loads(payload_str)
+        assert payload_dict['timestamp'] == 12345.0
+        assert payload_dict['type'] == 'test_event'
+        assert payload_dict['data']['score'] == 100
+
+@pytest.mark.asyncio
+async def test_broadcast_metric(metrics_broadcaster):
+    mock_websocket_1 = AsyncMock()
+    mock_websocket_2 = AsyncMock()
+
+    await metrics_broadcaster.register_client(mock_websocket_1)
+    await metrics_broadcaster.register_client(mock_websocket_2)
+
+    with patch('time.time', return_value=12345.0):
+        await metrics_broadcaster.broadcast_metric('test_metric', {'key': 'value'})
+
+        expected_payload = json.dumps({
+            "timestamp": 12345.0,
+            "type": "test_metric",
+            "data": {"key": "value"}
+        })
+
+        mock_websocket_1.send.assert_called_once_with(expected_payload)
+        mock_websocket_2.send.assert_called_once_with(expected_payload)
+
+@pytest.mark.asyncio
+async def test_handle_connection(metrics_broadcaster):
+    # Simulate a websocket that yields one message then closes
+    class MockWebsocket:
+        def __init__(self):
+            self.send = AsyncMock()
+
+        def __aiter__(self):
+            self._messages = ["msg1"]
+            return self
+
+        async def __anext__(self):
+            if not self._messages:
+                raise StopAsyncIteration
+            return self._messages.pop(0)
+
+    mock_ws = MockWebsocket()
+
+    # Run the connection handler
+    await metrics_broadcaster.handle_connection(mock_ws)
+
+    # Since the iterator finishes, the client should be unregistered
+    assert mock_ws not in metrics_broadcaster.connected_clients


### PR DESCRIPTION
This PR implements the OpenClaw RL Canvas Skills Metrics V2 task. 

It adds the `CanvasSkillsMetricsV2` module to `magda_agent/learning/canvas_skills_metrics_v2.py`, which provides a WebSocket handler to broadcast dynamic skill adjustments and learning metrics. It includes a comprehensive test suite `tests/test_canvas_skills_metrics_v2.py` utilizing `AsyncMock` to verify connection handling and payload formatting.

Additionally, `agent_tasks.json` has been updated to mark the task as done, and 3 new tasks based on Claude Code, MCP, and OpenClaw trends have been appended. `backlog.md` was also appropriately synchronized. All tests pass with no regressions.

---
*PR created automatically by Jules for task [2473164923927141691](https://jules.google.com/task/2473164923927141691) started by @kazah4359-lgtm*