### PR TITLE
feat(safety): implement MCP Action Tool Policy Auditor v11

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13561,7 +13561,7 @@
     },
     {
       "id": "mcp-action-tool-policy-auditor-v11-7b3a0524",
-      "status": "todo",
+      "status": "done",
       "area": "safety",
       "risk": "medium",
       "title": "MCP Action Tool Policy Auditor v11",
@@ -32125,6 +32125,57 @@
       "acceptance": [
         "Graph parsing correctly resolves topological execution order.",
         "Tests mock subagent dispatch and assert order."
+      ]
+    },
+    {
+      "id": "openclaw-canvas-subagent-live-streamer-v1-uuid1",
+      "title": "OpenClaw Canvas Subagent Live Streamer V1",
+      "description": "Inspired by OpenClaw Live Canvas trend (June 2026): Develop a multi-agent streamer that aggregates active context and memory transitions for isolated subagents and streams them into the UI.",
+      "area": "visualization",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/visualization/canvas_subagent_streamer_v1.py",
+        "tests/test_canvas_subagent_streamer_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Streamer successfully serializes subagent graphs.",
+        "Tests pass mocking WebSocket transmission."
+      ]
+    },
+    {
+      "id": "a2a-mesh-protocol-rate-limiter-v1-uuid2",
+      "title": "A2A Mesh Protocol Rate Limiter V1",
+      "description": "Inspired by A2A standard trend (June 2026): Implement an asynchronous rate limiter to prevent localized discovery storms when many agent cards are gossiped concurrently.",
+      "area": "integration",
+      "risk": "medium",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/integration/a2a_mesh_rate_limiter_v1.py",
+        "tests/test_a2a_mesh_rate_limiter_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Rate limiter correctly queues or drops excessive A2A requests.",
+        "Tests verify limiter bounds under mocked high load."
+      ]
+    },
+    {
+      "id": "mcp-action-tool-input-fuzzer-v1-uuid3",
+      "title": "MCP Action Tool Input Fuzzer V1",
+      "description": "Inspired by MCP standards and runtime safety controls (June 2026): Create a fuzz testing harness to periodically evaluate exported MCP tools against malformed or explicitly tainted inputs.",
+      "area": "safety",
+      "risk": "high",
+      "status": "todo",
+      "allowed_paths": [
+        "magda_agent/safety/mcp_fuzzer_v1.py",
+        "tests/test_mcp_fuzzer_v1.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Fuzzer successfully tests registered action tools with corrupted payloads.",
+        "Tests pass verifying that tools reject invalid inputs."
       ]
     }
   ]

--- a/magda_agent/safety/mcp_policy_auditor_v11.py
+++ b/magda_agent/safety/mcp_policy_auditor_v11.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Union
+
+class MCPPolicyAuditorV11:
+    """
+    Auditor component that periodically reviews the AuditTrail or MCPAuditTrailV1
+    for any blocked MCP action tool calls and generates a report of potential
+    policy misconfigurations.
+    """
+
+    def __init__(self, audit_trail: Any) -> None:
+        """
+        Initializes the auditor with a trail instance.
+
+        Args:
+            audit_trail: An instance of AuditTrail or MCPAuditTrailV1.
+        """
+        self.audit_trail = audit_trail
+
+    def audit_blocked_calls(self) -> str:
+        """
+        Reviews the audit logs and generates a markdown-formatted report of
+        blocked MCP action tool calls.
+
+        Returns:
+            A string containing the formatted markdown report.
+        """
+        logs = []
+        if hasattr(self.audit_trail, "get_mcp_logs"):
+            logs = self.audit_trail.get_mcp_logs()
+        elif hasattr(self.audit_trail, "get_all"):
+            logs = self.audit_trail.get_all()
+        else:
+            raise ValueError("Unsupported audit trail type. Must have 'get_mcp_logs' or 'get_all' method.")
+
+        blocked_calls = []
+        for log in logs:
+            is_blocked = False
+            result = log.get("result", "")
+            status = log.get("status", "")
+            why = log.get("why", "")
+
+            # Look for block indicators in strings
+            if isinstance(result, str) and any(keyword in result.lower() for keyword in ["blocked", "denied", "reject"]):
+                is_blocked = True
+            if isinstance(status, str) and any(keyword in status.lower() for keyword in ["error", "blocked", "denied"]):
+                is_blocked = True
+            if isinstance(why, str) and any(keyword in why.lower() for keyword in ["policy violation", "blocked"]):
+                is_blocked = True
+
+            # In standard AuditTrail, sometimes result is dict with error status or similar, but
+            # according to requirements, we check string indicators.
+            if isinstance(result, dict):
+                res_str = str(result).lower()
+                if any(keyword in res_str for keyword in ["blocked", "denied", "reject", "error"]):
+                    is_blocked = True
+
+            if is_blocked:
+                blocked_calls.append(log)
+
+        if not blocked_calls:
+            return "## MCP Policy Audit Report\n\nNo blocked calls found."
+
+        report_lines = [
+            "## MCP Policy Audit Report",
+            "",
+            f"**Total Blocked Calls:** {len(blocked_calls)}",
+            "",
+            "### Breakdown by Tool:"
+        ]
+
+        tool_counts: Dict[str, int] = {}
+        for call in blocked_calls:
+            t_name = call.get("tool_name", "unknown")
+            tool_counts[t_name] = tool_counts.get(t_name, 0) + 1
+
+        for t_name, count in sorted(tool_counts.items(), key=lambda item: item[1], reverse=True):
+            report_lines.append(f"- **{t_name}**: {count} blocked attempt(s)")
+
+        return "\n".join(report_lines)

--- a/tests/test_mcp_policy_auditor_v11.py
+++ b/tests/test_mcp_policy_auditor_v11.py
@@ -1,0 +1,61 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock
+from magda_agent.safety.mcp_policy_auditor_v11 import MCPPolicyAuditorV11
+from magda_agent.safety.audit_trail import AuditTrail
+from magda_agent.safety.mcp_audit_v1 import MCPAuditTrailV1
+
+@pytest.fixture
+def memory_audit_trail():
+    # Use db_path=None to keep it entirely in-memory
+    trail = AuditTrail(db_path=None)
+    trail.log_call("tool_allow", {"arg": 1}, "just because", "Success", 0.1)
+    trail.log_call("tool_block", {"arg": 2}, "policy violation", "Blocked", 0.2)
+    trail.log_call("tool_block", {"arg": 3}, "testing", {"status": "error", "message": "denied"}, 0.1)
+    return trail
+
+@pytest.fixture
+def memory_mcp_audit_trail():
+    trail = MCPAuditTrailV1(db_path=None)
+    return trail
+
+def test_auditor_with_audit_trail(memory_audit_trail):
+    auditor = MCPPolicyAuditorV11(audit_trail=memory_audit_trail)
+    report = auditor.audit_blocked_calls()
+
+    assert "**Total Blocked Calls:** 2" in report
+    assert "- **tool_block**: 2 blocked attempt(s)" in report
+    assert "tool_allow" not in report
+
+@pytest.mark.asyncio
+async def test_auditor_with_mcp_audit_trail(memory_mcp_audit_trail):
+    await memory_mcp_audit_trail.log_mcp_invocation("server1", "mcp_tool_1", {}, "ok", 0.1, "success")
+    await memory_mcp_audit_trail.log_mcp_invocation("server1", "mcp_tool_2", {}, "denied", 0.2, "error")
+    await memory_mcp_audit_trail.log_mcp_invocation("server2", "mcp_tool_2", {}, "failed", 0.3, "blocked")
+
+    auditor = MCPPolicyAuditorV11(audit_trail=memory_mcp_audit_trail)
+    report = auditor.audit_blocked_calls()
+
+    assert "**Total Blocked Calls:** 2" in report
+    assert "- **mcp_tool_2**: 2 blocked attempt(s)" in report
+    assert "mcp_tool_1" not in report
+
+def test_auditor_no_blocked_calls():
+    trail = AuditTrail(db_path=None)
+    trail.log_call("tool_allow", {"arg": 1}, "just because", "Success", 0.1)
+
+    auditor = MCPPolicyAuditorV11(audit_trail=trail)
+    report = auditor.audit_blocked_calls()
+
+    assert "No blocked calls found." in report
+    assert "Total Blocked Calls" not in report
+
+def test_auditor_unsupported_trail():
+    # Use a dummy object that lacks both get_all and get_mcp_logs
+    dummy_trail = MagicMock()
+    del dummy_trail.get_all
+    del dummy_trail.get_mcp_logs
+
+    auditor = MCPPolicyAuditorV11(audit_trail=dummy_trail)
+    with pytest.raises(ValueError, match="Unsupported audit trail type"):
+        auditor.audit_blocked_calls()


### PR DESCRIPTION
Implements `MCPPolicyAuditorV11` to parse the audit logs (from `AuditTrail` or `MCPAuditTrailV1`) to identify blocked MCP action tool calls and generate a markdown summary report. The component includes unit tests via pytest utilizing mocks to ensure no side effects occur. The `agent_tasks.json` has been updated to mark the task as done and three new tasks inspired by June 2026 AI trends have been added.

---
*PR created automatically by Jules for task [13422635222775000756](https://jules.google.com/task/13422635222775000756) started by @kazah4359-lgtm*