### PR TITLE
feat(learning): implement OpenClaw-RL PAD shift analysis module

### DIFF
--- a/agent_tasks.json
+++ b/agent_tasks.json
@@ -13579,7 +13579,7 @@
     },
     {
       "id": "trend-openclaw-rl-pad-shift-analysis-0667e36f",
-      "status": "todo",
+      "status": "done",
       "area": "learning",
       "risk": "medium",
       "title": "OpenClaw-RL PAD Shift Analysis Module",
@@ -32176,6 +32176,40 @@
       "acceptance": [
         "Fuzzer successfully tests registered action tools with corrupted payloads.",
         "Tests pass verifying that tools reject invalid inputs."
+      ]
+    },
+    {
+      "id": "openclaw-rl-dynamic-weight-scaling-v2-8d5d9e8b",
+      "status": "todo",
+      "area": "learning",
+      "risk": "medium",
+      "title": "OpenClaw-RL Dynamic Weight Scaling V2",
+      "description": "Inspired by OpenClaw-RL trend: Dynamically scale learning rates and reinforcement weights based on empathy magnitude and user interaction length.",
+      "allowed_paths": [
+        "magda_agent/learning/dynamic_weight_scaling_v2.py",
+        "tests/test_dynamic_weight_scaling_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Module dynamic weight scaling factors properly calculated.",
+        "Tests correctly verify weight boundaries and limits."
+      ]
+    },
+    {
+      "id": "claude-triad-agent-sandbox-v2-fba52c65",
+      "status": "todo",
+      "area": "architecture",
+      "risk": "high",
+      "title": "Claude Triad Agent Sandbox V2",
+      "description": "Inspired by Claude Agent SDK triad architecture: Expand planner-evaluator isolation to allow for intermediate checkpointing and rollback during failure states.",
+      "allowed_paths": [
+        "magda_agent/architecture/triad_agent_sandbox_v2.py",
+        "tests/test_triad_agent_sandbox_v2.py",
+        "agent_tasks.json"
+      ],
+      "acceptance": [
+        "Triad agent correctly checkpoints internal states.",
+        "Rollback mechanism recovers prior state successfully in mock workflows."
       ]
     }
   ]

--- a/magda_agent/learning/pad_shift_analyzer.py
+++ b/magda_agent/learning/pad_shift_analyzer.py
@@ -1,0 +1,94 @@
+from typing import List, Dict, Optional, Tuple
+import logging
+
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+
+class PADShiftAnalyzer:
+    """
+    Analytics module to track Pleasure, Arousal, Dominance (PAD) shifts
+    across user interactions and measure overall agent behavior adaptability.
+    """
+
+    def __init__(self, mirror_neurons: MirrorNeurons) -> None:
+        """
+        Initializes the PADShiftAnalyzer.
+
+        Args:
+            mirror_neurons (MirrorNeurons): The module for computing PAD shifts.
+        """
+        self.mirror_neurons = mirror_neurons
+
+    def analyze_interaction(self, user_reply: str, tool_output: Optional[str] = None) -> Dict[str, float]:
+        """
+        Analyzes a single interaction to extract PAD shifts.
+
+        Args:
+            user_reply (str): The user's input string.
+            tool_output (Optional[str], optional): The tool output string. Defaults to None.
+
+        Returns:
+            Dict[str, float]: A dictionary containing the p, a, d shifts.
+        """
+        signal_text = user_reply
+        if tool_output:
+            signal_text += f" [Tool Output: {tool_output}]"
+
+        p_shift, a_shift, d_shift = self.mirror_neurons.empathize(signal_text)
+        return {
+            "p_shift": p_shift,
+            "a_shift": a_shift,
+            "d_shift": d_shift
+        }
+
+    def aggregate_shifts(self, interaction_logs: List[Dict[str, Optional[str]]]) -> Dict[str, float]:
+        """
+        Aggregates PAD shifts over a list of interaction logs and calculates an adaptability score.
+
+        Args:
+            interaction_logs (List[Dict[str, Optional[str]]]): A list of dicts, each with
+                'user_reply' and optionally 'tool_output'.
+
+        Returns:
+            Dict[str, float]: Aggregated metrics including total shifts, averages, and an adaptability score.
+        """
+        if not interaction_logs:
+            return {
+                "total_p_shift": 0.0,
+                "total_a_shift": 0.0,
+                "total_d_shift": 0.0,
+                "avg_p_shift": 0.0,
+                "avg_a_shift": 0.0,
+                "avg_d_shift": 0.0,
+                "adaptability_score": 0.0
+            }
+
+        total_p, total_a, total_d = 0.0, 0.0, 0.0
+
+        for log in interaction_logs:
+            reply = log.get("user_reply", "")
+            output = log.get("tool_output", None)
+            shifts = self.analyze_interaction(reply, output)
+            total_p += shifts["p_shift"]
+            total_a += shifts["a_shift"]
+            total_d += shifts["d_shift"]
+
+        n = len(interaction_logs)
+        avg_p = total_p / n
+        avg_a = total_a / n
+        avg_d = total_d / n
+
+        # Adaptability is measured by the absolute magnitude of overall shifts.
+        # More empathetic responsiveness implies higher adaptability.
+        adaptability_score = abs(avg_p) + abs(avg_a) + abs(avg_d)
+
+        logging.info(f"Aggregated {n} logs. Adaptability score: {adaptability_score:.4f}")
+
+        return {
+            "total_p_shift": total_p,
+            "total_a_shift": total_a,
+            "total_d_shift": total_d,
+            "avg_p_shift": avg_p,
+            "avg_a_shift": avg_a,
+            "avg_d_shift": avg_d,
+            "adaptability_score": adaptability_score
+        }

--- a/tests/test_pad_shift_analyzer.py
+++ b/tests/test_pad_shift_analyzer.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import MagicMock
+from typing import Dict, Optional
+
+from magda_agent.emotions.mirror_neurons import MirrorNeurons
+from magda_agent.learning.pad_shift_analyzer import PADShiftAnalyzer
+
+@pytest.fixture
+def mock_mirror_neurons() -> MagicMock:
+    """Provides a mocked MirrorNeurons instance."""
+    return MagicMock(spec=MirrorNeurons)
+
+@pytest.fixture
+def analyzer(mock_mirror_neurons: MagicMock) -> PADShiftAnalyzer:
+    """Provides a PADShiftAnalyzer with a mocked MirrorNeurons dependency."""
+    return PADShiftAnalyzer(mirror_neurons=mock_mirror_neurons)
+
+def test_analyze_interaction_without_tool_output(analyzer: PADShiftAnalyzer, mock_mirror_neurons: MagicMock) -> None:
+    """Tests analyzing a single interaction without tool output."""
+    user_reply = "I am happy"
+    mock_mirror_neurons.empathize.return_value = (0.2, 0.1, 0.0)
+
+    result = analyzer.analyze_interaction(user_reply)
+
+    mock_mirror_neurons.empathize.assert_called_once_with(user_reply)
+    assert result == {"p_shift": 0.2, "a_shift": 0.1, "d_shift": 0.0}
+
+def test_analyze_interaction_with_tool_output(analyzer: PADShiftAnalyzer, mock_mirror_neurons: MagicMock) -> None:
+    """Tests analyzing a single interaction with tool output."""
+    user_reply = "I am sad"
+    tool_output = "No results found"
+    mock_mirror_neurons.empathize.return_value = (-0.2, 0.2, 0.1)
+
+    result = analyzer.analyze_interaction(user_reply, tool_output)
+
+    expected_text = f"{user_reply} [Tool Output: {tool_output}]"
+    mock_mirror_neurons.empathize.assert_called_once_with(expected_text)
+    assert result == {"p_shift": -0.2, "a_shift": 0.2, "d_shift": 0.1}
+
+def test_aggregate_shifts_empty(analyzer: PADShiftAnalyzer) -> None:
+    """Tests aggregating empty interaction logs returns zeros."""
+    result = analyzer.aggregate_shifts([])
+    assert result["total_p_shift"] == 0.0
+    assert result["adaptability_score"] == 0.0
+
+def test_aggregate_shifts(analyzer: PADShiftAnalyzer, mock_mirror_neurons: MagicMock) -> None:
+    """Tests aggregating a list of interaction logs."""
+    # Setup mock to return different values for different calls
+    mock_mirror_neurons.empathize.side_effect = [
+        (0.2, 0.1, 0.0),   # Call 1
+        (-0.4, 0.3, 0.1),  # Call 2
+    ]
+
+    logs: list[Dict[str, Optional[str]]] = [
+        {"user_reply": "Good job", "tool_output": "Success"},
+        {"user_reply": "Bad job", "tool_output": None}
+    ]
+
+    result = analyzer.aggregate_shifts(logs)
+
+    assert mock_mirror_neurons.empathize.call_count == 2
+
+    # Total calculations
+    # p: 0.2 - 0.4 = -0.2
+    # a: 0.1 + 0.3 = 0.4
+    # d: 0.0 + 0.1 = 0.1
+    assert result["total_p_shift"] == pytest.approx(-0.2)
+    assert result["total_a_shift"] == pytest.approx(0.4)
+    assert result["total_d_shift"] == pytest.approx(0.1)
+
+    # Averages
+    assert result["avg_p_shift"] == pytest.approx(-0.1)
+    assert result["avg_a_shift"] == pytest.approx(0.2)
+    assert result["avg_d_shift"] == pytest.approx(0.05)
+
+    # Adaptability Score = abs(-0.1) + abs(0.2) + abs(0.05) = 0.35
+    assert result["adaptability_score"] == pytest.approx(0.35)


### PR DESCRIPTION
This PR implements the OpenClaw-RL PAD Shift Analysis Module as defined by the first todo task in `agent_tasks.json` (`trend-openclaw-rl-pad-shift-analysis-0667e36f`).

**Changes include:**
- Created `PADShiftAnalyzer` in `magda_agent/learning/pad_shift_analyzer.py` to compute and aggregate PAD shifts (pleasure, arousal, dominance).
- Implemented an `adaptability_score` aggregation metric based on empathy shift magnitudes.
- Added corresponding pytest tests in `tests/test_pad_shift_analyzer.py` that fully mock the `MirrorNeurons` component.
- Updated `agent_tasks.json`:
  - Marked the PAD shift analysis task as `done`.
  - Added 2 new tasks inspired by `docs/trends.md` ("OpenClaw-RL Dynamic Weight Scaling V2" and "Claude Triad Agent Sandbox V2").
- Ran and passed the full test suite (`python -m pytest`) ensuring no regressions were introduced.

---
*PR created automatically by Jules for task [15327894333732355794](https://jules.google.com/task/15327894333732355794) started by @kazah4359-lgtm*