### PR TITLE
Implement Prempti Tool Interception Logger V1

### DIFF
--- a/magda_agent/safety/prempti_logger_v1.py
+++ b/magda_agent/safety/prempti_logger_v1.py
@@ -1,0 +1,152 @@
+import time
+import inspect
+from functools import wraps
+from typing import Any, Callable, Dict, Optional, TypeVar, cast
+from magda_agent.safety.audit_trail import AuditTrail
+from magda_agent.safety.taint import is_tainted
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+class PremptiToolLoggerV1:
+    """
+    Low-level logger inspired by Prempti (Falco).
+    Intercepts dynamic tool executions and records pre-execution metadata
+    into the AuditTrail prior to executing (or without executing) the tool.
+    """
+
+    def __init__(self, audit_trail: Optional[AuditTrail] = None) -> None:
+        """
+        Initializes the PremptiToolLoggerV1.
+
+        Args:
+            audit_trail: Optional AuditTrail instance for logging. If None, a default
+                         in-memory AuditTrail instance is created.
+        """
+        if audit_trail is None:
+            self.audit_trail = AuditTrail(db_path=None)
+        else:
+            self.audit_trail = audit_trail
+
+    def _extract_args(self, func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Dict[str, Any]:
+        """Extracts and binds arguments passed to a function using its signature."""
+        try:
+            sig = inspect.signature(func)
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            return dict(bound.arguments)
+        except Exception:
+            extracted: Dict[str, Any] = {}
+            for i, v in enumerate(args):
+                extracted[f"arg_{i}"] = v
+            extracted.update(kwargs)
+            return extracted
+
+    def log_pre_execution(
+        self,
+        tool_name: str,
+        kwargs: Dict[str, Any],
+        why: str = "pre-execution interception"
+    ) -> Dict[str, Any]:
+        """
+        Logs a tool call into the AuditTrail prior to execution.
+
+        Args:
+            tool_name: Name of the tool or action.
+            kwargs: Arguments passed to the tool.
+            why: Context or reason for interception.
+
+        Returns:
+            Dict[str, Any]: The pre-execution metadata dictionary logged to AuditTrail.
+        """
+        has_taint = any(is_tainted(v) for v in kwargs.values())
+        log_args = dict(kwargs)
+        log_args["_tainted_boundary_crossover"] = has_taint
+
+        self.audit_trail.log_call(
+            tool_name=tool_name,
+            kwargs=log_args,
+            why=why,
+            result="pre_execution",
+            duration=0.0
+        )
+        return {
+            "tool_name": tool_name,
+            "kwargs": log_args,
+            "why": why,
+            "status": "pre_execution",
+            "timestamp": time.time()
+        }
+
+    def intercept(
+        self,
+        tool_name: Optional[str] = None,
+        why: str = "intercepted call",
+        execute_tool: bool = True
+    ) -> Callable[[F], F]:
+        """
+        A decorator that intercepts dynamic tool execution, logs pre-execution metadata
+        to AuditTrail, and conditionally executes the underlying tool.
+
+        Args:
+            tool_name: Name of the tool. If None, uses func.__name__.
+            why: Reason or context for interception.
+            execute_tool: If True, executes the tool and logs the result.
+                          If False, logs pre-execution and skips execution.
+        """
+        def decorator(func: F) -> F:
+            name_to_use = tool_name if tool_name else func.__name__
+
+            if inspect.iscoroutinefunction(func):
+                @wraps(func)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    all_args = self._extract_args(func, args, kwargs)
+                    self.log_pre_execution(name_to_use, all_args, why=f"{why} (pre-execution)")
+
+                    if not execute_tool:
+                        return None
+
+                    start_time = time.time()
+                    try:
+                        result = await func(*args, **kwargs)
+                        duration = time.time() - start_time
+                        has_taint = any(is_tainted(v) for v in all_args.values()) or is_tainted(result)
+                        log_args = dict(all_args)
+                        log_args["_tainted_boundary_crossover"] = has_taint
+                        self.audit_trail.log_call(name_to_use, log_args, why, result, duration)
+                        return result
+                    except Exception as e:
+                        duration = time.time() - start_time
+                        has_taint = any(is_tainted(v) for v in all_args.values())
+                        log_args = dict(all_args)
+                        log_args["_tainted_boundary_crossover"] = has_taint
+                        self.audit_trail.log_call(name_to_use, log_args, f"{why} (failed)", str(e), duration)
+                        raise
+                return cast(F, async_wrapper)
+            else:
+                @wraps(func)
+                def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    all_args = self._extract_args(func, args, kwargs)
+                    self.log_pre_execution(name_to_use, all_args, why=f"{why} (pre-execution)")
+
+                    if not execute_tool:
+                        return None
+
+                    start_time = time.time()
+                    try:
+                        result = func(*args, **kwargs)
+                        duration = time.time() - start_time
+                        has_taint = any(is_tainted(v) for v in all_args.values()) or is_tainted(result)
+                        log_args = dict(all_args)
+                        log_args["_tainted_boundary_crossover"] = has_taint
+                        self.audit_trail.log_call(name_to_use, log_args, why, result, duration)
+                        return result
+                    except Exception as e:
+                        duration = time.time() - start_time
+                        has_taint = any(is_tainted(v) for v in all_args.values())
+                        log_args = dict(all_args)
+                        log_args["_tainted_boundary_crossover"] = has_taint
+                        self.audit_trail.log_call(name_to_use, log_args, f"{why} (failed)", str(e), duration)
+                        raise
+                return cast(F, sync_wrapper)
+
+        return decorator

--- a/tests/test_prempti_logger_v1.py
+++ b/tests/test_prempti_logger_v1.py
@@ -1,0 +1,126 @@
+import pytest
+from magda_agent.safety.audit_trail import AuditTrail
+from magda_agent.safety.prempti_logger_v1 import PremptiToolLoggerV1
+from magda_agent.safety.taint import mark_tainted
+
+
+@pytest.fixture
+def audit_trail():
+    return AuditTrail(max_capacity=100, db_path=None)
+
+
+@pytest.fixture
+def logger(audit_trail):
+    return PremptiToolLoggerV1(audit_trail=audit_trail)
+
+
+def test_log_pre_execution_directly(logger, audit_trail):
+    metadata = logger.log_pre_execution(
+        tool_name="test_tool",
+        kwargs={"param1": "value1", "param2": 123},
+        why="manual test"
+    )
+
+    assert metadata["tool_name"] == "test_tool"
+    assert metadata["status"] == "pre_execution"
+    assert metadata["why"] == "manual test"
+
+    logs = audit_trail.get_all()
+    assert len(logs) == 1
+    log = logs[0]
+    assert log["tool_name"] == "test_tool"
+    assert log["result"] == "pre_execution"
+    assert log["kwargs"]["param1"] == "value1"
+    assert log["kwargs"]["param2"] == 123
+    assert log["kwargs"]["_tainted_boundary_crossover"] is False
+
+
+def test_intercept_without_execution(logger, audit_trail):
+    executed = False
+
+    @logger.intercept(tool_name="no_exec_tool", why="skip exec", execute_tool=False)
+    def dummy_func(x: int):
+        nonlocal executed
+        executed = True
+        return x * 2
+
+    res = dummy_func(10)
+    assert res is None
+    assert executed is False
+
+    logs = audit_trail.get_all()
+    assert len(logs) == 1
+    log = logs[0]
+    assert log["tool_name"] == "no_exec_tool"
+    assert log["result"] == "pre_execution"
+    assert log["why"] == "skip exec (pre-execution)"
+    assert log["kwargs"]["x"] == 10
+
+
+def test_intercept_sync_execution(logger, audit_trail):
+    @logger.intercept(tool_name="sync_tool", why="normal execution")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    res = add(3, 4)
+    assert res == 7
+
+    logs = audit_trail.get_all()
+    assert len(logs) == 2  # 1 pre-execution, 1 execution
+    assert logs[0]["result"] == "pre_execution"
+    assert logs[1]["result"] == 7
+    assert logs[1]["tool_name"] == "sync_tool"
+    assert logs[1]["kwargs"]["a"] == 3
+    assert logs[1]["kwargs"]["b"] == 4
+
+
+def test_intercept_tainted_arguments_and_result(logger, audit_trail):
+    @logger.intercept(tool_name="tainted_tool")
+    def process(data: str) -> str:
+        return mark_tainted(f"processed_{data}")
+
+    res = process(mark_tainted("dirty_input"))
+
+    logs = audit_trail.get_all()
+    assert len(logs) == 2
+    pre_log = logs[0]
+    post_log = logs[1]
+
+    assert pre_log["kwargs"]["_tainted_boundary_crossover"] is True
+    assert post_log["kwargs"]["_tainted_boundary_crossover"] is True
+
+
+@pytest.mark.asyncio
+async def test_intercept_async_execution(logger, audit_trail):
+    @logger.intercept(tool_name="async_tool")
+    async def multiply_async(val: int):
+        return val * 3
+
+    res = await multiply_async(4)
+    assert res == 12
+
+    logs = audit_trail.get_all()
+    assert len(logs) == 2
+    assert logs[0]["result"] == "pre_execution"
+    assert logs[1]["result"] == 12
+    assert logs[1]["tool_name"] == "async_tool"
+
+
+@pytest.mark.asyncio
+async def test_intercept_async_without_execution(logger, audit_trail):
+    executed = False
+
+    @logger.intercept(tool_name="async_no_exec", execute_tool=False)
+    async def async_dummy(val: int):
+        nonlocal executed
+        executed = True
+        return val
+
+    res = await async_dummy(100)
+    assert res is None
+    assert executed is False
+
+    logs = audit_trail.get_all()
+    assert len(logs) == 1
+    assert logs[0]["result"] == "pre_execution"
+    assert logs[0]["tool_name"] == "async_no_exec"


### PR DESCRIPTION
Implements PremptiToolLoggerV1 in magda_agent/safety/prempti_logger_v1.py, providing low-level pre-execution tool interception, metadata logging into AuditTrail, taint boundary checking, and support for sync/async execution with optional tool skipping. Added comprehensive unit tests in tests/test_prempti_logger_v1.py and updated task status in agent_tasks.json.

---
*PR created automatically by Jules for task [3592233294001341877](https://jules.google.com/task/3592233294001341877) started by @kazah4359-lgtm*